### PR TITLE
Add flag for logging SMT trace

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -5,7 +5,9 @@ import Mica.Engine.Driver
 private def bold (s : String) : String := s!"\x1b[1m{s}\x1b[0m"
 
 def main (args : List String) : IO Unit := do
-  match args with
+  let verbose := args.contains "-v" || args.contains "--verbose"
+  let fileArgs := args.filter (fun a => a != "-v" && a != "--verbose")
+  match fileArgs with
   | [filename] =>
     let contents ← IO.FS.readFile filename
     match TinyML.parseFile contents with
@@ -13,9 +15,9 @@ def main (args : List String) : IO Unit := do
     | .ok prog =>
       let strategy := Program.verify prog
       let session ← SmtSession.create
-      let outcome ← run (log := false) strategy session
+      let outcome ← run (log := verbose) strategy session
       session.close
       match outcome with
       | .ok () => IO.println s!"{bold "Status:"} all declarations verified"
       | .error msg => IO.println s!"{bold "Status:"} failed: {msg}"
-  | _ => IO.eprintln "usage: mica <file.ml>"
+  | _ => IO.eprintln "usage: mica [-v|--verbose] <file.ml>"


### PR DESCRIPTION
This PR adds the flags `-v` and `--verbose` to enable logging of the SMT session, which makes debugging easier.