### PR TITLE
Refactor atoms

### DIFF
--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -1,5 +1,6 @@
 import Mica.FOL.Printing
 import Mica.FOL.Subst
+import Mica.Verifier.Monad
 
 /-!
 # Atoms
@@ -188,3 +189,24 @@ theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {Δ Δ' : VarCtx}
   cases p with
   | isint t  => exact Term.subst_wfIn hp hσ
   | isbool t => exact Term.subst_wfIn hp hσ
+
+
+-- ---------------------------------------------------------------------------
+-- VerifM integration
+-- ---------------------------------------------------------------------------
+
+/-- Look up an atom in the assertion context via `VerifM.ctx`. -/
+def VerifM.resolve (a : Atom τ) : VerifM (Option (Term τ)) :=
+  .ctx (a.resolve ·)
+
+theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
+    {Q : Option (Term τ) → TransState → Env → Prop}
+    (h : VerifM.eval (VerifM.resolve pred) st ρ Q) :
+    ∃ result : Option (Term τ),
+      Q result st ρ
+      ∧ (∀ t, result = some t → (pred.toFormula t).eval ρ)
+      ∧ (∀ t, result = some t → t.wfIn st.decls) := by
+  have ⟨hq, hholds, hwf⟩ := VerifM.eval_ctx h
+  refine ⟨_, hq, fun t ht => ?_, fun t ht => ?_⟩
+  · exact Atom.resolve_correct ht ρ hholds
+  · exact Atom.resolve_wfIn ht hwf

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -1,6 +1,5 @@
 import Mica.Engine.Driver
 import Mica.Verifier.Scoped
-import Mica.Verifier.Atoms
 import Mica.Base.Fresh
 
 
@@ -34,9 +33,6 @@ inductive VerifM : Type → Type 1 where
   | all : List α → VerifM α
   /-- Try branches in order; succeed if any branch succeeds (non-fatally). -/
   | any : List α → VerifM α
-  /-- Look up an atom in the assertion context.
-      Returns `some t` if a matching assertion is found, `none` otherwise. -/
-  | resolve : Atom τ → VerifM (Option (Term τ))
   /-- Read the current assertion context. -/
   | ctx : (List Formula → α) → VerifM α
   /-- Run a scoped computation: declarations and assertions from the body
@@ -152,8 +148,6 @@ def VerifM.translate :
   | .any items, st, k => translateAny items st k
   | .ctx f, st, k =>
       k (.ok (f st.asserts)) st
-  | .resolve pred, st, k =>
-      k (.ok (pred.resolve st.asserts)) st
   | .seq m m2, st, k =>
       .bracket
         (m.translate st (fun a _ => ScopedM.ret a))
@@ -176,7 +170,6 @@ def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState �
   | .all items, st, ρ, P => ∀ a ∈ items, P a st ρ
   | .any items, st, ρ, P => ∃ a ∈ items, P a st ρ
   | .ctx f, st, ρ, P => P (f st.asserts) st ρ
-  | .resolve pred, st, ρ, P => P (pred.resolve st.asserts) st ρ
   | .seq m m2, st, ρ, P =>
       m.eval_rec st ρ (fun () _ _ => True) ∧ m2.eval_rec st ρ P
 
@@ -213,8 +206,6 @@ theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : 
     obtain ⟨a, ha, hp⟩ := h
     exact ⟨a, ha, hPQ _ _ _ (List.Subset.refl _) (Env.agreeOn_refl) hp⟩
   | ctx =>
-    exact hPQ _ _ _ (List.Subset.refl _) (Env.agreeOn_refl) h
-  | resolve =>
     exact hPQ _ _ _ (List.Subset.refl _) (Env.agreeOn_refl) h
   | seq m m2 ihm ihf =>
     exact ⟨ihm ρ st h.1 fun () _ _ _ _ ha => trivial,
@@ -283,9 +274,6 @@ theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
     obtain ⟨a, ha, hp⟩ := h
     exact ⟨a, ha, g, hwf, hp⟩
   | ctx =>
-    simp only [VerifM.eval_rec] at h ⊢
-    exact ⟨g, hwf, h⟩
-  | resolve =>
     simp only [VerifM.eval_rec] at h ⊢
     exact ⟨g, hwf, h⟩
   | seq m m2 ihm ihf =>
@@ -400,9 +388,6 @@ theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
     obtain ⟨a, ha, Δ', heval⟩ := translateAny_eval items st f hf Δ h
     exact ⟨a, ha, _, heval⟩
   | ctx f =>
-    simp only [VerifM.translate] at h
-    exact ⟨_, h⟩
-  | resolve pred =>
     simp only [VerifM.translate] at h
     exact ⟨_, h⟩
   | seq m m2 ihm ihk =>
@@ -523,17 +508,6 @@ theorem VerifM.eval_ctx {f : List Formula → α} {st : TransState} {ρ : Env}
     ∧ st.holdsFor ρ
     ∧ st.asserts.wfIn st.decls :=
   ⟨h.2.2.2.2, h.2.1, h.1.assertsWf⟩
-
-theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
-    {Q : Option (Term τ) → TransState → Env → Prop}
-    (h : VerifM.eval (.resolve pred) st ρ Q) :
-    ∃ result : Option (Term τ),
-      Q result st ρ
-      ∧ (∀ t, result = some t → (pred.toFormula t).eval ρ)
-      ∧ (∀ t, result = some t → t.wfIn st.decls) := by
-  refine ⟨_, h.2.2.2.2, fun t ht => ?_, fun t ht => ?_⟩
-  · exact Atom.resolve_correct ht ρ h.2.1
-  · exact Atom.resolve_wfIn ht h.1.assertsWf
 
 theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : Env}
     {Q : β → TransState → Env → Prop}


### PR DESCRIPTION
This PR refactors the `Atom` definition to invert the dependency order between atoms and the verifier monad. This allows us in the future to use the Verifier monad to implement `VerifM.resolve` for individual atoms.