### PR TITLE
Add spatial context

### DIFF
--- a/Mica/SeparationLogic.lean
+++ b/Mica/SeparationLogic.lean
@@ -1,1 +1,2 @@
 import Mica.SeparationLogic.Axioms
+import Mica.SeparationLogic.Contexts

--- a/Mica/SeparationLogic.lean
+++ b/Mica/SeparationLogic.lean
@@ -1,2 +1,3 @@
 import Mica.SeparationLogic.Axioms
-import Mica.SeparationLogic.Contexts
+import Mica.SeparationLogic.SpatialAtom
+import Mica.SeparationLogic.Interpretations

--- a/Mica/SeparationLogic/Contexts.lean
+++ b/Mica/SeparationLogic/Contexts.lean
@@ -1,0 +1,235 @@
+import Mica.SeparationLogic.Axioms
+import Mica.FOL.Terms
+
+open Iris Iris.BI
+
+/-! # Spatial Atoms and Contexts
+
+A `SpatialAtom` is a syntactic ownership item stored in the verifier state.
+A `SpatialContext` is a list of such items. We define their Iris interpretation
+and basic operations (insert = cons, lookup+remove). -/
+
+/-- A syntactic ownership item. Initially, only points-to assertions. -/
+inductive SpatialAtom where
+  | pointsTo : Term .value → Term .value → SpatialAtom
+  deriving DecidableEq
+
+/-- The spatial part of the verifier state: a list of ownership items. -/
+abbrev SpatialContext := List SpatialAtom
+
+namespace SpatialAtom
+
+/-- A spatial atom is well-formed in a signature when all terms it mentions are. -/
+def wfIn : SpatialAtom → Signature → Prop
+  | .pointsTo l v, Δ => l.wfIn Δ ∧ v.wfIn Δ
+
+/-- Well-formedness is stable under signature extension. -/
+theorem wfIn_mono {a : SpatialAtom} {Δ Δ' : Signature}
+    (h : a.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : a.wfIn Δ' := by
+  cases a with
+  | pointsTo l v => exact ⟨Term.wfIn_mono l h.1 hsub hwf, Term.wfIn_mono v h.2 hsub hwf⟩
+
+/-- Iris interpretation of a single spatial atom. -/
+def interp (ρ : Env) : SpatialAtom → iProp
+  | .pointsTo l v => ∃ (loc : Runtime.Location),
+      ⌜Term.eval ρ l = .loc loc⌝ ∗ loc ↦ Term.eval ρ v
+
+/-- Interpreting a well-formed atom only depends on the environment values of
+    symbols in the ambient signature. -/
+theorem interp_env_agree {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
+    (hwf : a.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
+    interp ρ a = interp ρ' a := by
+  cases a with
+  | pointsTo l v =>
+    simp only [interp]
+    rw [Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
+
+/-- If a points-to atom's location term evaluates to `loc`, its interpretation
+    is equivalent to the raw points-to assertion for `loc`. -/
+theorem interp_pointsTo {ρ : Env} {lt vt : Term .value} {loc : Runtime.Location}
+    (hloc : Term.eval ρ lt = .loc loc) :
+    interp ρ (.pointsTo lt vt) ⊣⊢ loc ↦ Term.eval ρ vt := by
+  constructor
+  · simp only [interp]
+    istart
+    iintro ⟨%loc', %Hloc', Hpt⟩
+    have : loc' = loc := Runtime.Val.loc.inj (Hloc'.symm.trans hloc)
+    subst this
+    iexact Hpt
+  · simp only [interp]
+    istart
+    iintro Hpt
+    iexists loc
+    isplitr
+    · ipure_intro
+      exact hloc
+    · iexact Hpt
+
+end SpatialAtom
+
+namespace SpatialContext
+
+/-- A spatial context is well-formed when each of its atoms is. -/
+def wfIn (ctx : SpatialContext) (Δ : Signature) : Prop :=
+  ∀ a ∈ ctx, a.wfIn Δ
+
+@[simp] theorem wfIn_nil (Δ : Signature) : wfIn ([] : SpatialContext) Δ := by
+  intro a ha
+  cases ha
+
+@[simp] theorem wfIn_cons (a : SpatialAtom) (ctx : SpatialContext) (Δ : Signature) :
+    wfIn (a :: ctx) Δ ↔ a.wfIn Δ ∧ wfIn ctx Δ := by
+  constructor
+  · intro h
+    refine ⟨h a (by simp), ?_⟩
+    intro b hb
+    exact h b (by simp [hb])
+  · intro h b hb
+    simp at hb
+    rcases hb with rfl | hb
+    · exact h.1
+    · exact h.2 b hb
+
+/-- Well-formedness is stable under signature extension. -/
+theorem wfIn_mono {ctx : SpatialContext} {Δ Δ' : Signature}
+    (h : wfIn ctx Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : wfIn ctx Δ' :=
+  fun a ha => SpatialAtom.wfIn_mono (h a ha) hsub hwf
+
+/-- Iris interpretation of a spatial context: the separating conjunction of all items. -/
+def interp (ρ : Env) : SpatialContext → iProp
+  | []     => emp
+  | a :: Γ => a.interp ρ ∗ interp ρ Γ
+
+/-- Interpreting a well-formed context only depends on the environment values of
+    symbols in the ambient signature. -/
+theorem interp_env_agree {ctx : SpatialContext} {Δ : Signature} {ρ ρ' : Env}
+    (hwf : wfIn ctx Δ) (hagree : Env.agreeOn Δ ρ ρ') :
+    interp ρ ctx = interp ρ' ctx := by
+  induction ctx with
+  | nil => simp [interp]
+  | cons a ctx ih =>
+    have ha : SpatialAtom.interp ρ a = SpatialAtom.interp ρ' a :=
+      SpatialAtom.interp_env_agree (hwf a (by simp)) hagree
+    have htail : wfIn ctx Δ := (wfIn_cons a ctx Δ).1 hwf |>.2
+    have hctx : interp ρ ctx = interp ρ' ctx :=
+      ih htail
+    simp [interp, ha, hctx]
+
+@[simp] theorem interp_nil (ρ : Env) : interp ρ [] = emp := rfl
+@[simp] theorem interp_cons (ρ : Env) (a : SpatialAtom) (Γ : SpatialContext) :
+    interp ρ (a :: Γ) = (a.interp ρ ∗ interp ρ Γ) := rfl
+
+/-- Insert an atom into the context (just cons). -/
+abbrev insert (a : SpatialAtom) (ctx : SpatialContext) : SpatialContext := a :: ctx
+
+@[simp] theorem wfIn_insert {a : SpatialAtom} {ctx : SpatialContext} {Δ : Signature} :
+    wfIn (insert a ctx) Δ ↔ a.wfIn Δ ∧ wfIn ctx Δ := by
+  simp [insert, wfIn_cons]
+
+@[simp] theorem interp_insert (ρ : Env) (a : SpatialAtom) (ctx : SpatialContext) :
+    interp ρ (insert a ctx) = (a.interp ρ ∗ interp ρ ctx) := rfl
+
+/-- Remove the atom at index `n`, returning the atom and remaining context. -/
+def remove : List SpatialAtom → Nat → Option (SpatialAtom × List SpatialAtom)
+  | [],     _     => none
+  | a :: Γ, 0     => some (a, Γ)
+  | a :: Γ, n + 1 => (remove Γ n).map fun (b, Γ') => (b, a :: Γ')
+
+@[simp] theorem remove_nil (n : Nat) : remove [] n = none := by
+  cases n <;> simp [remove]
+
+@[simp] theorem remove_cons_zero (a : SpatialAtom) (Γ : List SpatialAtom) :
+    remove (a :: Γ) 0 = some (a, Γ) := rfl
+
+@[simp] theorem remove_cons_succ (a : SpatialAtom) (Γ : List SpatialAtom) (n : Nat) :
+    remove (a :: Γ) (n + 1) = (remove Γ n).map fun (b, Γ') => (b, a :: Γ') := rfl
+
+/-- Find the index of the first occurrence of `a` in the context. -/
+def find (a : SpatialAtom) : SpatialContext → Option Nat
+  | []     => none
+  | b :: Γ => if a == b then some 0 else (find a Γ).map (· + 1)
+
+@[simp] theorem find_nil (a : SpatialAtom) : find a [] = none := rfl
+
+theorem find_remove {a : SpatialAtom} {ctx : SpatialContext} {n : Nat}
+    (h : find a ctx = some n) :
+    ∃ rest, remove ctx n = some (a, rest) := by
+  induction ctx generalizing n with
+  | nil => simp at h
+  | cons b Γ ih =>
+    simp only [find] at h
+    split at h
+    · next heq =>
+      simp at h; subst h
+      simp [remove, beq_iff_eq.mp heq]
+    · next hne =>
+      match hm : find a Γ, h with
+      | some m, h =>
+        simp at h; subst h
+        obtain ⟨rest, hr⟩ := ih hm
+        exact ⟨b :: rest, by simp [remove, hr]⟩
+
+theorem find_remove_eq {a b : SpatialAtom} {ctx : SpatialContext} {n : Nat} {rest : SpatialContext}
+    (hf : find a ctx = some n) (hr : remove ctx n = some (b, rest)) : a = b := by
+  obtain ⟨rest', hr'⟩ := find_remove hf
+  simp [hr] at hr'; exact hr'.1.symm
+
+/-- Removing an entry from a well-formed context preserves well-formedness of
+    both the removed atom and the remaining context. -/
+theorem wfIn_remove {ctx : SpatialContext} {Δ : Signature} {n : Nat}
+    {a : SpatialAtom} {rest : SpatialContext}
+    (hctx : wfIn ctx Δ) (hrem : remove ctx n = some (a, rest)) :
+    a.wfIn Δ ∧ wfIn rest Δ := by
+  induction ctx generalizing n a rest with
+  | nil => simp at hrem
+  | cons b ctx ih =>
+    cases n with
+    | zero =>
+      simp [remove] at hrem
+      obtain ⟨rfl, rfl⟩ := hrem
+      simpa [wfIn_cons] using hctx
+    | succ n =>
+      have htail : wfIn ctx Δ := (wfIn_cons b ctx Δ).1 hctx |>.2
+      have hhead : b.wfIn Δ := (wfIn_cons b ctx Δ).1 hctx |>.1
+      simp only [remove_cons_succ] at hrem
+      match hr : remove ctx n with
+      | none => simp [hr] at hrem
+      | some (a', rest') =>
+        simp [hr] at hrem
+        obtain ⟨rfl, rfl⟩ := hrem
+        obtain ⟨ha, hrest⟩ := ih htail hr
+        exact ⟨ha, (wfIn_cons b rest' Δ).2 ⟨hhead, hrest⟩⟩
+
+/-- Looking up an atom in a well-formed context yields a well-formed atom. -/
+theorem wfIn_find {ctx : SpatialContext} {Δ : Signature} {a : SpatialAtom} {n : Nat}
+    (hctx : wfIn ctx Δ) (hfind : find a ctx = some n) : a.wfIn Δ := by
+  obtain ⟨rest, hrem⟩ := find_remove hfind
+  have := wfIn_remove hctx hrem
+  simpa [find_remove_eq hfind hrem] using this.1
+
+private theorem sep_comm3 {A B C : iProp} : A ∗ (B ∗ C) ⊣⊢ B ∗ (A ∗ C) :=
+  ⟨sep_assoc.2 |>.trans (sep_mono_l sep_comm.1) |>.trans sep_assoc.1,
+   sep_assoc.2 |>.trans (sep_mono_l sep_comm.2) |>.trans sep_assoc.1⟩
+
+/-- The interpretation of a context is equivalent to splitting off the atom at index `n`. -/
+theorem interp_remove (ρ : Env) (ctx : SpatialContext) (n : Nat)
+    (a : SpatialAtom) (rest : SpatialContext)
+    (h : remove ctx n = some (a, rest)) :
+    interp ρ ctx ⊣⊢ a.interp ρ ∗ interp ρ rest := by
+  induction ctx generalizing n a rest with
+  | nil => simp at h
+  | cons x xs ih =>
+    cases n with
+    | zero =>
+      simp [remove] at h; obtain ⟨rfl, rfl⟩ := h; simp [interp]
+    | succ n =>
+      simp only [remove_cons_succ] at h
+      match hr : remove xs n, h with
+      | some (b, rest'), h =>
+        simp at h
+        obtain ⟨rfl, rfl⟩ := h
+        exact ⟨sep_mono_r (ih n b rest' hr).1 |>.trans sep_comm3.1,
+               sep_comm3.2 |>.trans (sep_mono_r (ih n b rest' hr).2)⟩
+
+
+end SpatialContext

--- a/Mica/SeparationLogic/Interpretations.lean
+++ b/Mica/SeparationLogic/Interpretations.lean
@@ -1,0 +1,106 @@
+import Mica.SeparationLogic.Axioms
+import Mica.SeparationLogic.SpatialAtom
+
+open Iris Iris.BI
+
+/-! # Spatial Atoms and Contexts — Iris Interpretation
+
+The syntactic definitions (`SpatialAtom`, `SpatialContext`, `wfIn`, `find`,
+`remove`) live in `Mica.SeparationLogic.SpatialAtom`. This file adds the
+Iris-level interpretation and related lemmas. -/
+
+namespace SpatialAtom
+
+/-- Iris interpretation of a single spatial atom. -/
+def interp (ρ : Env) : SpatialAtom → iProp
+  | .pointsTo l v => ∃ (loc : Runtime.Location),
+      ⌜Term.eval ρ l = .loc loc⌝ ∗ loc ↦ Term.eval ρ v
+
+/-- Interpreting a well-formed atom only depends on the environment values of
+    symbols in the ambient signature. -/
+theorem interp_env_agree {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
+    (hwf : a.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
+    interp ρ a = interp ρ' a := by
+  cases a with
+  | pointsTo l v =>
+    simp only [interp]
+    rw [Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
+
+/-- If a points-to atom's location term evaluates to `loc`, its interpretation
+    is equivalent to the raw points-to assertion for `loc`. -/
+theorem interp_pointsTo {ρ : Env} {lt vt : Term .value} {loc : Runtime.Location}
+    (hloc : Term.eval ρ lt = .loc loc) :
+    interp ρ (.pointsTo lt vt) ⊣⊢ loc ↦ Term.eval ρ vt := by
+  constructor
+  · simp only [interp]
+    istart
+    iintro ⟨%loc', %Hloc', Hpt⟩
+    have : loc' = loc := Runtime.Val.loc.inj (Hloc'.symm.trans hloc)
+    subst this
+    iexact Hpt
+  · simp only [interp]
+    istart
+    iintro Hpt
+    iexists loc
+    isplitr
+    · ipure_intro
+      exact hloc
+    · iexact Hpt
+
+end SpatialAtom
+
+namespace SpatialContext
+
+/-- Iris interpretation of a spatial context: the separating conjunction of all items. -/
+def interp (ρ : Env) : SpatialContext → iProp
+  | []     => emp
+  | a :: Γ => a.interp ρ ∗ interp ρ Γ
+
+/-- Interpreting a well-formed context only depends on the environment values of
+    symbols in the ambient signature. -/
+theorem interp_env_agree {ctx : SpatialContext} {Δ : Signature} {ρ ρ' : Env}
+    (hwf : wfIn ctx Δ) (hagree : Env.agreeOn Δ ρ ρ') :
+    interp ρ ctx = interp ρ' ctx := by
+  induction ctx with
+  | nil => simp [interp]
+  | cons a ctx ih =>
+    have ha : SpatialAtom.interp ρ a = SpatialAtom.interp ρ' a :=
+      SpatialAtom.interp_env_agree (hwf a (by simp)) hagree
+    have htail : wfIn ctx Δ := (wfIn_cons a ctx Δ).1 hwf |>.2
+    have hctx : interp ρ ctx = interp ρ' ctx :=
+      ih htail
+    simp [interp, ha, hctx]
+
+@[simp] theorem interp_nil (ρ : Env) : interp ρ [] = emp := rfl
+@[simp] theorem interp_cons (ρ : Env) (a : SpatialAtom) (Γ : SpatialContext) :
+    interp ρ (a :: Γ) = (a.interp ρ ∗ interp ρ Γ) := rfl
+
+@[simp] theorem interp_insert (ρ : Env) (a : SpatialAtom) (ctx : SpatialContext) :
+    interp ρ (insert a ctx) = (a.interp ρ ∗ interp ρ ctx) := rfl
+
+private theorem sep_comm3 {A B C : iProp} : A ∗ (B ∗ C) ⊣⊢ B ∗ (A ∗ C) :=
+  ⟨sep_assoc.2 |>.trans (sep_mono_l sep_comm.1) |>.trans sep_assoc.1,
+   sep_assoc.2 |>.trans (sep_mono_l sep_comm.2) |>.trans sep_assoc.1⟩
+
+/-- The interpretation of a context is equivalent to splitting off the atom at index `n`. -/
+theorem interp_remove (ρ : Env) (ctx : SpatialContext) (n : Nat)
+    (a : SpatialAtom) (rest : SpatialContext)
+    (h : remove ctx n = some (a, rest)) :
+    interp ρ ctx ⊣⊢ a.interp ρ ∗ interp ρ rest := by
+  induction ctx generalizing n a rest with
+  | nil => simp at h
+  | cons x xs ih =>
+    cases n with
+    | zero =>
+      simp [remove] at h; obtain ⟨rfl, rfl⟩ := h; simp [interp]
+    | succ n =>
+      simp only [remove_cons_succ] at h
+      match hr : remove xs n, h with
+      | some (b, rest'), h =>
+        simp at h
+        obtain ⟨rfl, rfl⟩ := h
+        exact ⟨sep_mono_r (ih n b rest' hr).1 |>.trans sep_comm3.1,
+               sep_comm3.2 |>.trans (sep_mono_r (ih n b rest' hr).2)⟩
+
+
+end SpatialContext

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -1,4 +1,4 @@
-import Mica.SeparationLogic.Contexts
+import Mica.SeparationLogic.Interpretations
 
 open Iris Iris.BI
 

--- a/Mica/SeparationLogic/SpatialAtom.lean
+++ b/Mica/SeparationLogic/SpatialAtom.lean
@@ -1,13 +1,11 @@
-import Mica.SeparationLogic.Axioms
 import Mica.FOL.Terms
 
-open Iris Iris.BI
-
-/-! # Spatial Atoms and Contexts
+/-! # Spatial Atoms and Contexts (Syntactic)
 
 A `SpatialAtom` is a syntactic ownership item stored in the verifier state.
-A `SpatialContext` is a list of such items. We define their Iris interpretation
-and basic operations (insert = cons, lookup+remove). -/
+A `SpatialContext` is a list of such items. We define their well-formedness
+and basic operations (insert = cons, lookup+remove). The Iris interpretation
+lives in `Mica.SeparationLogic.Contexts`. -/
 
 /-- A syntactic ownership item. Initially, only points-to assertions. -/
 inductive SpatialAtom where
@@ -28,42 +26,6 @@ theorem wfIn_mono {a : SpatialAtom} {Δ Δ' : Signature}
     (h : a.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : a.wfIn Δ' := by
   cases a with
   | pointsTo l v => exact ⟨Term.wfIn_mono l h.1 hsub hwf, Term.wfIn_mono v h.2 hsub hwf⟩
-
-/-- Iris interpretation of a single spatial atom. -/
-def interp (ρ : Env) : SpatialAtom → iProp
-  | .pointsTo l v => ∃ (loc : Runtime.Location),
-      ⌜Term.eval ρ l = .loc loc⌝ ∗ loc ↦ Term.eval ρ v
-
-/-- Interpreting a well-formed atom only depends on the environment values of
-    symbols in the ambient signature. -/
-theorem interp_env_agree {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
-    (hwf : a.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    interp ρ a = interp ρ' a := by
-  cases a with
-  | pointsTo l v =>
-    simp only [interp]
-    rw [Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
-
-/-- If a points-to atom's location term evaluates to `loc`, its interpretation
-    is equivalent to the raw points-to assertion for `loc`. -/
-theorem interp_pointsTo {ρ : Env} {lt vt : Term .value} {loc : Runtime.Location}
-    (hloc : Term.eval ρ lt = .loc loc) :
-    interp ρ (.pointsTo lt vt) ⊣⊢ loc ↦ Term.eval ρ vt := by
-  constructor
-  · simp only [interp]
-    istart
-    iintro ⟨%loc', %Hloc', Hpt⟩
-    have : loc' = loc := Runtime.Val.loc.inj (Hloc'.symm.trans hloc)
-    subst this
-    iexact Hpt
-  · simp only [interp]
-    istart
-    iintro Hpt
-    iexists loc
-    isplitr
-    · ipure_intro
-      exact hloc
-    · iexact Hpt
 
 end SpatialAtom
 
@@ -95,39 +57,12 @@ theorem wfIn_mono {ctx : SpatialContext} {Δ Δ' : Signature}
     (h : wfIn ctx Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : wfIn ctx Δ' :=
   fun a ha => SpatialAtom.wfIn_mono (h a ha) hsub hwf
 
-/-- Iris interpretation of a spatial context: the separating conjunction of all items. -/
-def interp (ρ : Env) : SpatialContext → iProp
-  | []     => emp
-  | a :: Γ => a.interp ρ ∗ interp ρ Γ
-
-/-- Interpreting a well-formed context only depends on the environment values of
-    symbols in the ambient signature. -/
-theorem interp_env_agree {ctx : SpatialContext} {Δ : Signature} {ρ ρ' : Env}
-    (hwf : wfIn ctx Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    interp ρ ctx = interp ρ' ctx := by
-  induction ctx with
-  | nil => simp [interp]
-  | cons a ctx ih =>
-    have ha : SpatialAtom.interp ρ a = SpatialAtom.interp ρ' a :=
-      SpatialAtom.interp_env_agree (hwf a (by simp)) hagree
-    have htail : wfIn ctx Δ := (wfIn_cons a ctx Δ).1 hwf |>.2
-    have hctx : interp ρ ctx = interp ρ' ctx :=
-      ih htail
-    simp [interp, ha, hctx]
-
-@[simp] theorem interp_nil (ρ : Env) : interp ρ [] = emp := rfl
-@[simp] theorem interp_cons (ρ : Env) (a : SpatialAtom) (Γ : SpatialContext) :
-    interp ρ (a :: Γ) = (a.interp ρ ∗ interp ρ Γ) := rfl
-
 /-- Insert an atom into the context (just cons). -/
 abbrev insert (a : SpatialAtom) (ctx : SpatialContext) : SpatialContext := a :: ctx
 
 @[simp] theorem wfIn_insert {a : SpatialAtom} {ctx : SpatialContext} {Δ : Signature} :
     wfIn (insert a ctx) Δ ↔ a.wfIn Δ ∧ wfIn ctx Δ := by
   simp [insert, wfIn_cons]
-
-@[simp] theorem interp_insert (ρ : Env) (a : SpatialAtom) (ctx : SpatialContext) :
-    interp ρ (insert a ctx) = (a.interp ρ ∗ interp ρ ctx) := rfl
 
 /-- Remove the atom at index `n`, returning the atom and remaining context. -/
 def remove : List SpatialAtom → Nat → Option (SpatialAtom × List SpatialAtom)
@@ -206,30 +141,5 @@ theorem wfIn_find {ctx : SpatialContext} {Δ : Signature} {a : SpatialAtom} {n :
   obtain ⟨rest, hrem⟩ := find_remove hfind
   have := wfIn_remove hctx hrem
   simpa [find_remove_eq hfind hrem] using this.1
-
-private theorem sep_comm3 {A B C : iProp} : A ∗ (B ∗ C) ⊣⊢ B ∗ (A ∗ C) :=
-  ⟨sep_assoc.2 |>.trans (sep_mono_l sep_comm.1) |>.trans sep_assoc.1,
-   sep_assoc.2 |>.trans (sep_mono_l sep_comm.2) |>.trans sep_assoc.1⟩
-
-/-- The interpretation of a context is equivalent to splitting off the atom at index `n`. -/
-theorem interp_remove (ρ : Env) (ctx : SpatialContext) (n : Nat)
-    (a : SpatialAtom) (rest : SpatialContext)
-    (h : remove ctx n = some (a, rest)) :
-    interp ρ ctx ⊣⊢ a.interp ρ ∗ interp ρ rest := by
-  induction ctx generalizing n a rest with
-  | nil => simp at h
-  | cons x xs ih =>
-    cases n with
-    | zero =>
-      simp [remove] at h; obtain ⟨rfl, rfl⟩ := h; simp [interp]
-    | succ n =>
-      simp only [remove_cons_succ] at h
-      match hr : remove xs n, h with
-      | some (b, rest'), h =>
-        simp at h
-        obtain ⟨rfl, rfl⟩ := h
-        exact ⟨sep_mono_r (ih n b rest' hr).1 |>.trans sep_comm3.1,
-               sep_comm3.2 |>.trans (sep_mono_r (ih n b rest' hr).2)⟩
-
 
 end SpatialContext

--- a/Mica/SeparationLogic/SpatialAtom.lean
+++ b/Mica/SeparationLogic/SpatialAtom.lean
@@ -5,7 +5,7 @@ import Mica.FOL.Terms
 A `SpatialAtom` is a syntactic ownership item stored in the verifier state.
 A `SpatialContext` is a list of such items. We define their well-formedness
 and basic operations (insert = cons, lookup+remove). The Iris interpretation
-lives in `Mica.SeparationLogic.Contexts`. -/
+lives in `Mica.SeparationLogic.Interpretation`. -/
 
 /-- A syntactic ownership item. Initially, only points-to assertions. -/
 inductive SpatialAtom where

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -330,7 +330,7 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
       ∧ (∀ t, result = some t → t.wfIn st.decls) := by
   unfold VerifM.resolve at h
   have hb1 := VerifM.eval_bind _ _ _ _ h
-  have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctx hb1
+  have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
   cases hres : pred.resolve st.asserts with
   | some t =>
     simp [hres] at hctx_q

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -316,7 +316,7 @@ private theorem VerifM.eval_tryCandidates
     Tier 1: syntactic search through the context.
     Tier 2: try candidate resolutions via the SMT solver. -/
 def VerifM.resolve (a : Atom τ) : VerifM (Option (Term τ)) := do
-  match ← VerifM.ctx (a.resolve ·) with
+  match ← VerifM.ctxPure (a.resolve ·) with
   | some t => pure (some t)
   | none => VerifM.tryCandidates a.candidates
 

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -621,7 +621,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
         fresh_not_mem _ _ (addNumbers_injective _)
       set st₂ : TransState :=
         { decls := st₁.decls.addConst v,
-          asserts := (Formula.eq .value (.const (.uninterpreted v.name .value)) se) :: st₁.asserts }
+          asserts := (Formula.eq .value (.const (.uninterpreted v.name .value)) se) :: st₁.asserts,
+          owns := st₁.owns }
       set ρ_body := ρ_e.updateConst .value v.name v_e
       set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
       suffices wp (body.runtime.subst γ_body) Φ by
@@ -909,7 +910,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (branch : Binder × Expr) (S
     have heval_inst := hdecl payload
     have heval_assume := VerifM.eval_bind _ _ _ _ heval_inst
     have hassume := VerifM.eval_assume heval_assume
-    let st₁ : TransState := { decls := st.decls.addConst xv, asserts := st.asserts }
+    let st₁ : TransState := { decls := st.decls.addConst xv, asserts := st.asserts, owns := st.owns }
     let ρ₁ := ρ.updateConst .value xv.name payload
     have hxv_fresh : xv.name ∉ st.decls.allNames :=
       fresh_not_mem _ _ (addNumbers_injective _)

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -18,6 +18,11 @@ inductive VerifError where
       Always propagates. -/
   | fatal : String → VerifError
 
+structure TransState where
+  decls   : Signature
+  asserts : Context
+  owns    : SpatialContext
+
 inductive VerifM : Type → Type 1 where
   | ret : α → VerifM α
   | bind : VerifM α → (α → VerifM β) → VerifM β
@@ -36,8 +41,8 @@ inductive VerifM : Type → Type 1 where
   | all : List α → VerifM α
   /-- Try branches in order; succeed if any branch succeeds (non-fatally). -/
   | any : List α → VerifM α
-  /-- Read the current assertion context. -/
-  | ctx : (List Formula → α) → VerifM α
+  /-- Inspect the full verifier state; may update the spatial context. -/
+  | ctx : (TransState → α × SpatialContext) → VerifM α
   /-- Run a scoped computation: declarations and assertions from the body
       are discarded after it completes. Only the return value is kept. -/
   | seq : VerifM Unit → VerifM β → VerifM β
@@ -45,6 +50,10 @@ inductive VerifM : Type → Type 1 where
 instance : Monad VerifM where
   pure := VerifM.ret
   bind := VerifM.bind
+
+/-- Read the current pure assertion context (backwards-compatible wrapper around `ctx`). -/
+def VerifM.ctxPure (f : List Formula → α) : VerifM α :=
+  VerifM.ctx (fun st => (f st.asserts, st.owns))
 
 /-- Assert-and-check: check φ is provable, fail if not. -/
 def VerifM.assert (φ : Formula) : VerifM Unit := do
@@ -68,11 +77,6 @@ def VerifM.assumeAll : List Formula → VerifM Unit
   | φ :: φs => do VerifM.assume φ; VerifM.assumeAll φs
 
 /-! ### Translation to ScopedM -/
-
-structure TransState where
-  decls   : Signature
-  asserts : Context
-  owns    : SpatialContext
 
 def TransState.toFlatCtx (st : TransState) : FlatCtx :=
   ⟨st.decls, st.asserts⟩
@@ -186,7 +190,8 @@ def VerifM.translate :
   | .all items, st, k => translateAll items st k
   | .any items, st, k => translateAny items st k
   | .ctx f, st, k =>
-      k (.ok (f st.asserts)) st
+      let (a, owns') := f st
+      k (.ok a) { st with owns := owns' }
   | .seq m m2, st, k =>
       .bracket
         (m.translate st (fun a _ => ScopedM.ret a))
@@ -208,7 +213,9 @@ def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState �
   | .failed _, _, _, _ => False
   | .all items, st, ρ, P => ∀ a ∈ items, P a st ρ
   | .any items, st, ρ, P => ∃ a ∈ items, P a st ρ
-  | .ctx f, st, ρ, P => P (f st.asserts) st ρ
+  | .ctx f, st, ρ, P =>
+      let (a, owns') := f st
+      owns'.wfIn st.decls → P a { st with owns := owns' } ρ
   | .seq m m2, st, ρ, P =>
       m.eval_rec st ρ (fun () _ _ => True) ∧ m2.eval_rec st ρ P
 
@@ -242,8 +249,9 @@ theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : 
   | any items =>
     obtain ⟨a, ha, hp⟩ := h
     exact ⟨a, ha, hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) hp⟩
-  | ctx =>
-    exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) h
+  | ctx f =>
+    intro howns
+    exact hPQ _ _ _ (Signature.Subset.refl _) Env.agreeOn_refl (h howns)
   | seq m m2 ihm ihf =>
     exact ⟨ihm ρ st h.1 fun () _ _ _ _ ha => trivial,
            ihf ρ st h.2 hPQ⟩
@@ -305,9 +313,10 @@ theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
     simp only [VerifM.eval_rec] at h ⊢
     obtain ⟨a, ha, hp⟩ := h
     exact ⟨a, ha, g, hwf, hp⟩
-  | ctx =>
+  | ctx f =>
     simp only [VerifM.eval_rec] at h ⊢
-    exact ⟨g, hwf, h⟩
+    intro howns
+    exact ⟨g, ⟨hwf.assertsWf, hwf.namesDisjoint, howns⟩, h howns⟩
   | seq m m2 ihm ihf =>
     simp only [VerifM.eval_rec] at h ⊢
     exact ⟨(ihm st ρ h.1 g hwf).mono fun () _ _ _ => trivial,
@@ -421,6 +430,7 @@ theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
     exact ⟨a, ha, _, heval⟩
   | ctx f =>
     simp only [VerifM.translate] at h
+    intro _
     exact ⟨_, h⟩
   | seq m m2 ihm ihk =>
     simp only [VerifM.translate] at h
@@ -596,13 +606,24 @@ theorem VerifM.eval_any {items : List α} {st : TransState} {ρ : Env}
   let ⟨a, ha, _, _, hq⟩ := h.2.2; ⟨a, ha, hq⟩
 
 
-theorem VerifM.eval_ctx {f : List Formula → α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_ctx {f : TransState → α × SpatialContext}
+    {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (.ctx f) st ρ Q) :
+    let (a, owns') := f st
+    (owns'.wfIn st.decls → Q a { st with owns := owns' } ρ)
+    ∧ st.owns.wfIn st.decls
+    ∧ st.holdsFor ρ
+    ∧ st.asserts.wfIn st.decls :=
+  ⟨fun howns => (h.2.2 howns).2.2, h.1.ownsWf, h.2.1, h.1.assertsWf⟩
+
+theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : Env}
+    {Q : α → TransState → Env → Prop}
+    (h : VerifM.eval (.ctx (fun st => (f st.asserts, st.owns))) st ρ Q) :
     Q (f st.asserts) st ρ
     ∧ st.holdsFor ρ
     ∧ st.asserts.wfIn st.decls :=
-  ⟨h.2.2.2.2, h.2.1, h.1.assertsWf⟩
+  let ⟨hq, howns, hg, hwf⟩ := VerifM.eval_ctx h
+  ⟨hq howns, hg, hwf⟩
 
 theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : Env}
     {Q : β → TransState → Env → Prop}

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -2,6 +2,7 @@ import Mica.Engine.Driver
 import Mica.Verifier.Scoped
 import Mica.Verifier.Utils
 import Mica.Base.Fresh
+import Mica.SeparationLogic.SpatialAtom
 
 
 /-! ## Verification Monad
@@ -68,9 +69,32 @@ def VerifM.assumeAll : List Formula → VerifM Unit
 
 /-! ### Translation to ScopedM -/
 
--- We will revisit the trans state in the future. For now, we keep it simply as an alias.
-abbrev TransState := FlatCtx
-def TransState.toFlatCtx (x : TransState) := x
+structure TransState where
+  decls   : Signature
+  asserts : Context
+  owns    : SpatialContext
+
+def TransState.toFlatCtx (st : TransState) : FlatCtx :=
+  ⟨st.decls, st.asserts⟩
+
+@[simp] theorem TransState.toFlatCtx_decls (st : TransState) :
+    st.toFlatCtx.decls = st.decls := rfl
+
+@[simp] theorem TransState.toFlatCtx_asserts (st : TransState) :
+    st.toFlatCtx.asserts = st.asserts := rfl
+
+@[simp] theorem TransState.toFlatCtx_addConst (st : TransState) (c : FOL.Const) :
+    { st with decls := st.decls.addConst c }.toFlatCtx = st.toFlatCtx.addConst c.name c.sort := by
+  simp [toFlatCtx, FlatCtx.addConst]
+
+@[simp] theorem TransState.toFlatCtx_addAssert (st : TransState) (φ : Formula) :
+    { st with asserts := φ :: st.asserts }.toFlatCtx = st.toFlatCtx.addAssert φ := by
+  simp [toFlatCtx, FlatCtx.addAssert]
+
+def TransState.empty : TransState := ⟨Signature.empty, [], []⟩
+
+@[simp] theorem TransState.empty_toFlatCtx : TransState.empty.toFlatCtx = FlatCtx.empty := rfl
+
 def TransState.holdsFor (st : TransState) (ρ : Env) := ∀ φ ∈ st.asserts, φ.eval ρ
 
 theorem TransState.holdsFor_mono {st st' : TransState} {ρ : Env}
@@ -80,6 +104,7 @@ theorem TransState.holdsFor_mono {st st' : TransState} {ρ : Env}
 structure TransState.wf (st : TransState) : Prop where
   assertsWf : st.asserts.wfIn st.decls
   namesDisjoint : st.decls.allNames.Nodup
+  ownsWf : st.owns.wfIn st.decls
 
 def TransState.freshConst (hint : Option String) (t : Srt) (st : TransState) : FOL.Const :=
   let base := hint.getD "_v"
@@ -90,12 +115,13 @@ theorem TransState.freshConst.wf {hint t} (st : TransState) :
   TransState.wf st →
   TransState.wf { st with decls := st.decls.addConst (st.freshConst hint t) } := by
   intro hwf
+  have hfresh : (st.freshConst hint t).name ∉ st.decls.allNames :=
+    fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _)
+  have hwf' := Signature.wf_addConst hwf.namesDisjoint hfresh
   constructor
-  · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addConst _ _)
-      (Signature.wf_addConst hwf.namesDisjoint
-        (fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _)))
-  · have hfresh := fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _)
-    exact Signature.nodup_allNames_addConst hwf.namesDisjoint hfresh
+  · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addConst _ _) hwf'
+  · exact Signature.nodup_allNames_addConst hwf.namesDisjoint hfresh
+  · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addConst _ _) hwf'
 
 theorem TransState.addAssert.wf (st : TransState) :
   TransState.wf st →
@@ -109,6 +135,7 @@ theorem TransState.addAssert.wf (st : TransState) :
     · exact hφ
     · exact hwf.assertsWf ψ hψ
   · exact hwf.namesDisjoint
+  · exact hwf.ownsWf
 
 
 def TransCont α := α → TransState → ScopedM (Except VerifError Unit)
@@ -117,19 +144,19 @@ def translateAll (items : List α) (st : TransState) (k : TransCont (Except Veri
     ScopedM (Except VerifError Unit) :=
   match items with
   | [] => ScopedM.ret (.ok ())
-  | a :: as =>
+  | a :: rest =>
       .bracket (k (.ok a) st) (fun
         | .error e => ScopedM.ret (.error e)
-        | .ok () => translateAll as st k)
+        | .ok () => translateAll rest st k)
 
 def translateAny (items : List α) (st : TransState) (k : TransCont (Except VerifError α)) :
     ScopedM (Except VerifError Unit) :=
   match items with
   | [] => k (.error (.failed "no alternative")) st
-  | a :: as =>
+  | a :: rest =>
       .bracket (k (.ok a) st) (fun
         | .ok () => ScopedM.ret (.ok ())
-        | .error (.failed _) => translateAny as st k
+        | .error (.failed _) => translateAny rest st k
         | .error (.fatal msg) => ScopedM.ret (.error (.fatal msg)))
 
 def VerifM.translate :
@@ -639,7 +666,7 @@ theorem VerifM.eval_of_translate (m : VerifM Unit) (st : TransState) (ρ : Env) 
   (translate_eval m st ρ topCont topCont_error_propagates Δ h g hwf).mono fun _ _ _ _ => trivial
 
 def VerifM.strategy (m : VerifM Unit) :=
-  let verif := VerifM.translate m { decls := Signature.empty, asserts := [] } VerifM.topCont
+  let verif := VerifM.translate m TransState.empty VerifM.topCont
   let verif' := ScopedM.bind verif fun
     | .ok () => ScopedM.ret (Except.ok ())
     | .error (.failed msg) => ScopedM.ret (Except.error msg)

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -262,20 +262,21 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
   | .error e =>
     cases e <;> simp [ScopedM.eval_ret] at hcont
   | .ok () =>
-    have hholdsFor : TransState.holdsFor FlatCtx.empty default :=
-      fun φ hφ => by simp [FlatCtx.empty] at hφ
-    have hwf : TransState.wf FlatCtx.empty :=
-      ⟨fun φ hφ => by simp [FlatCtx.empty] at hφ,
-       by simp [FlatCtx.empty, Signature.empty, Signature.allNames]⟩
+    have hholdsFor : TransState.holdsFor TransState.empty default :=
+      fun φ hφ => by simp [TransState.empty] at hφ
+    have hwf : TransState.wf TransState.empty :=
+      ⟨fun φ hφ => by simp [TransState.empty] at hφ,
+       by simp [TransState.empty, Signature.empty, Signature.allNames],
+       fun a ha => by simp [TransState.empty] at ha⟩
     have hverifM := VerifM.eval_of_translate
                       (do
                         let (Θ, typed) ← Program.prepare p
                         Program.check Θ ∅ typed)
-                      FlatCtx.empty default ctx_mid hverif hholdsFor hwf
+                      TransState.empty default ctx_mid hverif hholdsFor hwf
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
-    obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p FlatCtx.empty default hbind
+    obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty default hbind
     have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
                        (SpecMap.empty_satisfiedBy _) (SpecMap.empty_wfIn _)
-                       FlatCtx.empty default hcheck
+                       TransState.empty default hcheck
     rw [Runtime.Program.subst_id] at hcorrect
     simpa [hrt] using hcorrect


### PR DESCRIPTION
This PR adds a spatial context to the verifier monad state, but it doesn't make use of it yet. This is in preparation for fully switching over to SL (#17). 