### PR TITLE
Add nominal types

### DIFF
--- a/Examples/recursive_types.ml
+++ b/Examples/recursive_types.ml
@@ -1,0 +1,42 @@
+(* Examples using recursive types.
+   `ilist` is an integer list: `Nil` (tag 0) or `Cons of int * ilist` (tag 1). *)
+
+type ilist = Nil | Cons of int * ilist
+
+(* Return the head of the list, or 0 if empty. *)
+let head_or_zero (l: ilist) : int =
+  match l with
+  | Nil -> 0
+  | Cons x -> x.0
+[@@spec fun l ->
+  bind (isinj 1 2 l) @@ fun payload ->
+  bind (isint payload.0) @@ fun n ->
+  ret (fun v ->
+    bind (isint v) @@ fun r ->
+    assert (r = n))];;
+
+(* Length is non-negative. *)
+let rec list_length (l: ilist) : int =
+  match l with
+  | Nil -> 0
+  | Cons x -> 1 + list_length x.1
+[@@spec fun l ->
+  ret (fun v ->
+    bind (isint v) @@ fun r ->
+    assert (r >= 0))];;
+
+
+let result = list_length (Cons (1, Cons (2, Cons (3, Cons (4, Cons (5, Nil))))));;
+
+(* Requires matching on x.1, which has type Typ.named "ilist" []. *)
+(* let second_or_zero (l: ilist) : int =
+  match l with
+  | Nil -> 0
+  | Cons x ->
+    match x.1 with
+    | Nil -> 0
+    | Cons y -> y.0
+[@@spec fun l ->
+  ret (fun v ->
+    bind (isint v) @@ fun r ->
+    assert (r >= 0))];; *)

--- a/Examples/recursive_types.ml
+++ b/Examples/recursive_types.ml
@@ -29,14 +29,14 @@ let rec list_length (l: ilist) : int =
 let result = list_length (Cons (1, Cons (2, Cons (3, Cons (4, Cons (5, Nil))))));;
 
 (* Requires matching on x.1, which has type Typ.named "ilist" []. *)
-(* let second_or_zero (l: ilist) : int =
+let second_or_zero (l: ilist) : int =
   match l with
   | Nil -> 0
   | Cons x ->
     match x.1 with
     | Nil -> 0
-    | Cons y -> y.0
+    | Cons y -> if y.0 <= 0 then 0 else y.0
 [@@spec fun l ->
   ret (fun v ->
     bind (isint v) @@ fun r ->
-    assert (r >= 0))];; *)
+    assert (r >= 0))];; 

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -13,7 +13,6 @@ inductive ElaborateErrorKind where
   | duplicateConstructor (name : String)
   | duplicateType (name : String)
   | duplicateField (name : String)
-  | polymorphicTypeDecl (name : String)
   | unsupportedChar
   | unsupportedRecordUpdate
   | unsupportedPattern (desc : String)
@@ -38,7 +37,6 @@ def ElaborateErrorKind.toString : ElaborateErrorKind → String
   | .duplicateType name => s!"duplicate type name '{name}'"
   | .duplicateField name =>
     s!"duplicate field '{name}' (shadowing fields from a previous type is not supported)"
-  | .polymorphicTypeDecl name => s!"polymorphic type declarations are not supported: '{name}'"
   | .unsupportedChar => "char literals are not supported"
   | .unsupportedRecordUpdate => "record update expressions are not supported"
   | .unsupportedPattern desc => s!"unsupported pattern: {desc}"
@@ -59,12 +57,6 @@ instance : ToString ElaborateError := ⟨ElaborateError.toString⟩
 -- ---------------------------------------------------------------------------
 -- Elaboration environment (association lists)
 
-private def alookup [BEq α] (key : α) : List (α × β) → Option β
-  | [] => none
-  | (k, v) :: rest => if k == key then some v else alookup key rest
-
-private def acontains [BEq α] (key : α) (m : List (α × β)) : Bool :=
-  (alookup key m).isSome
 
 structure ElabEnv where
   types   : List TypeConstructor                             := []
@@ -131,11 +123,10 @@ private def patternToBinder (pat : Pattern) : ElabM Untyped.Binder :=
 private def patternToBinderTyped (env : ElabEnv) (pat : Pattern) : ElabM Untyped.Binder :=
   match pat.kind with
   | .wildcard => .ok .none
-  | .binder name ty => do
+  | .binder none _ => .ok .none
+  | .binder (some n) ty => do
     let ty' ← elaborateOptTyp env ty
-    match name with
-    | some n => .ok (.named n ty')
-    | none => .ok .none
+    .ok (.named n ty')
   | _ => err pat.loc (.unsupportedPattern "expected a simple binder (variable or wildcard)")
 
 -- ---------------------------------------------------------------------------
@@ -159,7 +150,7 @@ private def insertBranch (env : ElabEnv) (loc : Location) (arity : Nat)
     (acc : List (Option (Untyped.Binder × Untyped.Expr)))
     (name : Constructor) (binder : Option Untyped.Binder) (body : Untyped.Expr)
     : ElabM (List (Option (Untyped.Binder × Untyped.Expr))) :=
-  match alookup name env.ctors with
+  match List.lookup name env.ctors with
   | none => .error { loc, kind := .unknownConstructor name }
   | some (tag, arity') =>
     if arity' != arity then
@@ -195,7 +186,7 @@ private def elaborateBinOp (loc : Location) : BinOp → ElabM TinyML.BinOp
 -- Helper to elaborate a constructor lookup (not recursive)
 private def elaborateCtorLookup (env : ElabEnv) (loc : Location) (name : String)
     (arg : Option Untyped.Expr) : ElabM Untyped.Expr :=
-  match alookup name env.ctors with
+  match List.lookup name env.ctors with
   | some (tag, arity) => .ok (.inj tag arity (arg.getD (.const .unit)))
   | none => err loc (.unknownConstructor name)
 
@@ -210,7 +201,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     match name with
     | "ref" | "not" => err loc (.bareSpecialIdentifier name)
     | _ =>
-      match alookup name env.ctors with
+      match List.lookup name env.ctors with
       | some (tag, arity) => .ok (.inj tag arity (.const .unit))
       | none => .ok (.var name)
 
@@ -228,7 +219,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     let arg' ← ExprKind.elaborate env al ak
     elaborateCtorLookup env loc name (some arg')
   | .app ⟨_, .ctor name⟩ args =>
-    match alookup name env.ctors with
+    match List.lookup name env.ctors with
     | some _ => err loc (.arityMismatch 1 args.length)
     | none => err loc (.unknownConstructor name)
   | .app ⟨fnLoc, fnKind⟩ args => do
@@ -272,7 +263,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     let e' ← ExprKind.elaborate env el ek
     .ok (.unop (.proj n) e')
   | .unop (.field name) ⟨el, ek⟩ =>
-    match alookup name env.fields with
+    match List.lookup name env.fields with
     | some (_, idx) => do
       let e' ← ExprKind.elaborate env el ek
       .ok (.unop (.proj idx) e')
@@ -315,7 +306,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     match arms' with
     | [] => err loc .emptyMatch
     | (ctorName, _, _) :: _ =>
-      match alookup ctorName env.ctors with
+      match List.lookup ctorName env.ctors with
       | none => err loc (.unknownConstructor ctorName)
       | some (_, arity) => do
         let init : List (Option (Untyped.Binder × Untyped.Expr)) := List.replicate arity none
@@ -333,10 +324,10 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     match flds with
     | [] => err loc (.unsupportedFeature "empty record")
     | (name, _) :: _ =>
-      match alookup name env.fields with
+      match List.lookup name env.fields with
       | none => err loc (.unknownField name)
       | some (tyName, _) =>
-        match alookup tyName env.records with
+        match List.lookup tyName env.records with
         | none => err loc (.unknownType tyName)
         | some fieldOrder => do
           let elaborated ← RecordFieldList.elaborate env flds
@@ -345,9 +336,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
 
   | .recordUpdate _ _ => err loc .unsupportedRecordUpdate
 
-  | .annot ⟨il, ik⟩ ty => do
-    let _ ← Typ.elaborate env ty
-    ExprKind.elaborate env il ik
+  | .annot ⟨il, ik⟩ _ => ExprKind.elaborate env il ik
 
 def ExprList.elaborate (env : ElabEnv) : List Expr → ElabM (List Untyped.Expr)
   | [] => .ok []
@@ -402,7 +391,7 @@ private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
   match ctorDefs with
   | [] => .ok ([], [])
   | (ctorName, payloadTy) :: rest => do
-    if acontains ctorName env.ctors then
+    if (List.lookup ctorName env.ctors).isSome then
       err loc (.duplicateConstructor ctorName)
     else do
     let payloadTy' ← match payloadTy with
@@ -428,22 +417,21 @@ private def elaborateVariant (env : ElabEnv) (loc : Location) (name : TypeConstr
 
 private def elaborateFieldDefs (env : ElabEnv) (loc : Location) (tyName : TypeConstructor)
     (fieldDefs : List (FieldName × Typ)) (idx : Nat)
-    : ElabM (List TinyML.Typ × List (FieldName × (TypeConstructor × Nat))) :=
+    : ElabM (List (FieldName × (TypeConstructor × Nat))) :=
   match fieldDefs with
-  | [] => .ok ([], [])
-  | (fieldName, ty) :: rest => do
-    if acontains fieldName env.fields then
+  | [] => .ok []
+  | (fieldName, _) :: rest => do
+    if (List.lookup fieldName env.fields).isSome then
       err loc (.duplicateField fieldName)
     else do
-    let ty' ← Typ.elaborate env ty
-    let (restTypes, restFields) ← elaborateFieldDefs env loc tyName rest (idx + 1)
-    .ok (ty' :: restTypes, (fieldName, (tyName, idx)) :: restFields)
+    let restFields ← elaborateFieldDefs env loc tyName rest (idx + 1)
+    .ok ((fieldName, (tyName, idx)) :: restFields)
 
 private def elaborateRecordDecl (env : ElabEnv) (loc : Location) (name : TypeConstructor)
     (fieldDefs : List (FieldName × Typ)) : ElabM ElabEnv := do
   if env.types.elem name then
     return ← err loc (.duplicateType name)
-  let (_, newFields) ← elaborateFieldDefs env loc name fieldDefs 0
+  let newFields ← elaborateFieldDefs env loc name fieldDefs 0
   let fieldNames := fieldDefs.map Prod.fst
   .ok { env with
     types := name :: env.types

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -67,10 +67,10 @@ private def acontains [BEq α] (key : α) (m : List (α × β)) : Bool :=
   (alookup key m).isSome
 
 structure ElabEnv where
-  types   : List (TypeConstructor × TinyML.Typ)                      := []
-  ctors   : List (Constructor × (Nat × Nat × Option TinyML.Typ))    := []
-  fields  : List (FieldName × (TypeConstructor × Nat))                 := []
-  records : List (TypeConstructor × List FieldName)                    := []
+  types   : List TypeConstructor                             := []
+  ctors   : List (Constructor × (Nat × Nat))                := []
+  fields  : List (FieldName × (TypeConstructor × Nat))      := []
+  records : List (TypeConstructor × List FieldName)         := []
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -93,7 +93,7 @@ def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyM
     | "bool" => if args'.isEmpty then .ok .bool else err loc (.arityMismatch 0 args'.length)
     | "unit" => if args'.isEmpty then .ok .unit else err loc (.arityMismatch 0 args'.length)
     | _ =>
-      if acontains name env.types then .ok (.named name args')
+      if env.types.elem name then .ok (.named name args')
       else err loc (.unknownType name)
   | .arrow ⟨dloc, dkind⟩ ⟨cloc, ckind⟩ => do
     let dom' ← TypKind.elaborate env dloc dkind
@@ -161,7 +161,7 @@ private def insertBranch (env : ElabEnv) (loc : Location) (arity : Nat)
     : ElabM (List (Option (Untyped.Binder × Untyped.Expr))) :=
   match alookup name env.ctors with
   | none => .error { loc, kind := .unknownConstructor name }
-  | some (tag, arity', _) =>
+  | some (tag, arity') =>
     if arity' != arity then
       .error { loc, kind := .arityMismatch arity arity' }
     else
@@ -196,7 +196,7 @@ private def elaborateBinOp (loc : Location) : BinOp → ElabM TinyML.BinOp
 private def elaborateCtorLookup (env : ElabEnv) (loc : Location) (name : String)
     (arg : Option Untyped.Expr) : ElabM Untyped.Expr :=
   match alookup name env.ctors with
-  | some (tag, arity, _) => .ok (.inj tag arity (arg.getD (.const .unit)))
+  | some (tag, arity) => .ok (.inj tag arity (arg.getD (.const .unit)))
   | none => err loc (.unknownConstructor name)
 
 mutual
@@ -211,7 +211,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     | "ref" | "not" => err loc (.bareSpecialIdentifier name)
     | _ =>
       match alookup name env.ctors with
-      | some (tag, arity, _) => .ok (.inj tag arity (.const .unit))
+      | some (tag, arity) => .ok (.inj tag arity (.const .unit))
       | none => .ok (.var name)
 
   | .ctor name => elaborateCtorLookup env loc name none
@@ -317,7 +317,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     | (ctorName, _, _) :: _ =>
       match alookup ctorName env.ctors with
       | none => err loc (.unknownConstructor ctorName)
-      | some (_, arity, _) => do
+      | some (_, arity) => do
         let init : List (Option (Untyped.Binder × Untyped.Expr)) := List.replicate arity none
         let filled ← arms'.foldlM
           (fun acc (name, binder, body) => insertBranch env loc arity acc name binder body)
@@ -398,7 +398,7 @@ def Expr.elaborate (env : ElabEnv) (e : Expr) : ElabM Untyped.Expr :=
 
 private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
     (ctorDefs : List (Constructor × Option Typ)) (tag : Nat) (arity : Nat)
-    : ElabM (List TinyML.Typ × List (Constructor × (Nat × Nat × Option TinyML.Typ))) :=
+    : ElabM (List TinyML.Typ × List (Constructor × (Nat × Nat))) :=
   match ctorDefs with
   | [] => .ok ([], [])
   | (ctorName, payloadTy) :: rest => do
@@ -410,17 +410,17 @@ private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
       | none => .ok .unit
     let (restTypes, restCtors) ← elaborateCtorDefs env loc rest (tag + 1) arity
     .ok (payloadTy' :: restTypes,
-         (ctorName, (tag, arity, some payloadTy')) :: restCtors)
+         (ctorName, (tag, arity)) :: restCtors)
 
 private def elaborateVariant (env : ElabEnv) (loc : Location) (name : TypeConstructor)
     (tparams : List TinyML.TyVar) (ctorDefs : List (Constructor × Option Typ))
     : ElabM (ElabEnv × Untyped.TypeDecl) := do
-  if acontains name env.types then
+  if env.types.elem name then
     return ← err loc (.duplicateType name)
   let arity := ctorDefs.length
   -- Register the type name as a named reference so both recursive self-references in
   -- constructor payloads and later uses resolve to the named type (not the inlined sum).
-  let envWithSelf := { env with types := (name, .named name []) :: env.types }
+  let envWithSelf := { env with types := name :: env.types }
   let (payloadTypes, newCtors) ← elaborateCtorDefs envWithSelf loc ctorDefs 0 arity
   let env' := { envWithSelf with ctors := newCtors ++ env.ctors }
   let decl : Untyped.TypeDecl := { name, body := { tparams, payloads := payloadTypes } }
@@ -441,13 +441,12 @@ private def elaborateFieldDefs (env : ElabEnv) (loc : Location) (tyName : TypeCo
 
 private def elaborateRecordDecl (env : ElabEnv) (loc : Location) (name : TypeConstructor)
     (fieldDefs : List (FieldName × Typ)) : ElabM ElabEnv := do
-  if acontains name env.types then
+  if env.types.elem name then
     return ← err loc (.duplicateType name)
-  let (fieldTypes, newFields) ← elaborateFieldDefs env loc name fieldDefs 0
-  let tupleTy := TinyML.Typ.tuple fieldTypes
+  let (_, newFields) ← elaborateFieldDefs env loc name fieldDefs 0
   let fieldNames := fieldDefs.map Prod.fst
   .ok { env with
-    types := (name, tupleTy) :: env.types
+    types := name :: env.types
     records := (name, fieldNames) :: env.records
     fields := newFields ++ env.fields }
 

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -416,15 +416,17 @@ private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
          (ctorName, (tag, arity, some payloadTy')) :: restCtors)
 
 private def elaborateVariant (env : ElabEnv) (loc : Location) (name : TypeConstructor)
-    (ctorDefs : List (Constructor × Option Typ)) : ElabM ElabEnv := do
+    (ctorDefs : List (Constructor × Option Typ)) : ElabM (ElabEnv × Untyped.TypeDecl) := do
   if acontains name env.types then
     return ← err loc (.duplicateType name)
   let arity := ctorDefs.length
   let (payloadTypes, newCtors) ← elaborateCtorDefs env loc ctorDefs 0 arity
   let sumTy := TinyML.Typ.sum payloadTypes
-  .ok { env with
+  let env' := { env with
     types := (name, sumTy) :: env.types
     ctors := newCtors ++ env.ctors }
+  let decl : Untyped.TypeDecl := { name, body := { tparams := [], payloads := payloadTypes } }
+  .ok (env', decl)
 
 private def elaborateFieldDefs (env : ElabEnv) (loc : Location) (tyName : TypeConstructor)
     (fieldDefs : List (FieldName × Typ)) (idx : Nat)
@@ -452,12 +454,16 @@ private def elaborateRecordDecl (env : ElabEnv) (loc : Location) (name : TypeCon
     fields := newFields ++ env.fields }
 
 def TypeDecl.elaborate (env : ElabEnv) (loc : Location) (decl : TypeDecl)
-    : ElabM ElabEnv := do
+    : ElabM (ElabEnv × Option Untyped.TypeDecl) := do
   if !decl.params.isEmpty then
     return ← err loc (.polymorphicTypeDecl decl.name)
   match decl.body with
-  | .variant ctors => elaborateVariant env loc decl.name ctors
-  | .record fields => elaborateRecordDecl env loc decl.name fields
+  | .variant ctors => do
+      let (env', decl') ← elaborateVariant env loc decl.name ctors
+      .ok (env', some decl')
+  | .record fields => do
+      let env' ← elaborateRecordDecl env loc decl.name fields
+      .ok (env', none)
 
 -- ---------------------------------------------------------------------------
 -- Value declaration elaboration
@@ -465,7 +471,7 @@ def TypeDecl.elaborate (env : ElabEnv) (loc : Location) (decl : TypeDecl)
 def ValDecl.elaborate (env : ElabEnv) (loc : Location)
     (isRec : Bool) (binders : List Pattern) (retTy : Option Typ) (body : Expr)
     (spec : Option Untyped.Expr)
-    : ElabM (Untyped.Decl Untyped.Expr) := do
+    : ElabM (Untyped.ValDecl Untyped.Expr) := do
   match binders with
   | [] => err loc (.unsupportedFeature "declaration with no binders")
   | [pat] =>
@@ -498,12 +504,12 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
     : ElabM (ElabEnv × Option (Untyped.Decl Untyped.Expr)) := do
   match decl.kind with
   | .type_ tdecl => do
-    let env' ← TypeDecl.elaborate env decl.loc tdecl
-    .ok (env', none)
+    let (env', tdecl') ← TypeDecl.elaborate env decl.loc tdecl
+    .ok (env', tdecl'.map Untyped.Decl.type_)
   | .val_ isRec binders retTy body => do
     let spec ← elaborateSpec env decl.attrs
     let d ← ValDecl.elaborate env decl.loc isRec binders retTy body spec
-    .ok (env, some d)
+    .ok (env, some (.val_ d))
 
 private def elaborateDecls (env : ElabEnv) :
     List Decl → ElabM (List (Untyped.Decl Untyped.Expr))

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -420,7 +420,10 @@ private def elaborateVariant (env : ElabEnv) (loc : Location) (name : TypeConstr
   if acontains name env.types then
     return ← err loc (.duplicateType name)
   let arity := ctorDefs.length
-  let (payloadTypes, newCtors) ← elaborateCtorDefs env loc ctorDefs 0 arity
+  -- Pre-register the type name as a named reference so recursive self-references in
+  -- constructor payloads (e.g. `Cons of int * ilist`) resolve correctly.
+  let envWithSelf := { env with types := (name, .named name []) :: env.types }
+  let (payloadTypes, newCtors) ← elaborateCtorDefs envWithSelf loc ctorDefs 0 arity
   let sumTy := TinyML.Typ.sum payloadTypes
   let env' := { env with
     types := (name, sumTy) :: env.types

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -85,19 +85,16 @@ private def err (loc : Location) (kind : ElaborateErrorKind) : ElabM α :=
 
 mutual
 def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyML.Typ
-  | .var _ => err loc (.polymorphicTypeDecl "type variable")
-  | .con name args =>
-    match args with
-    | [] =>
-      match name with
-      | "int"  => .ok .int
-      | "bool" => .ok .bool
-      | "unit" => .ok .unit
-      | _      =>
-        match alookup name env.types with
-        | some ty => .ok ty
-        | none => err loc (.unknownType name)
-    | _ => err loc (.polymorphicTypeDecl name)
+  | .var v => .ok (.tvar v)
+  | .con name args => do
+    let args' ← TypList.elaborate env args
+    match name with
+    | "int"  => if args'.isEmpty then .ok .int  else err loc (.arityMismatch 0 args'.length)
+    | "bool" => if args'.isEmpty then .ok .bool else err loc (.arityMismatch 0 args'.length)
+    | "unit" => if args'.isEmpty then .ok .unit else err loc (.arityMismatch 0 args'.length)
+    | _ =>
+      if acontains name env.types then .ok (.named name args')
+      else err loc (.unknownType name)
   | .arrow ⟨dloc, dkind⟩ ⟨cloc, ckind⟩ => do
     let dom' ← TypKind.elaborate env dloc dkind
     let cod' ← TypKind.elaborate env cloc ckind
@@ -416,19 +413,17 @@ private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
          (ctorName, (tag, arity, some payloadTy')) :: restCtors)
 
 private def elaborateVariant (env : ElabEnv) (loc : Location) (name : TypeConstructor)
-    (ctorDefs : List (Constructor × Option Typ)) : ElabM (ElabEnv × Untyped.TypeDecl) := do
+    (tparams : List TinyML.TyVar) (ctorDefs : List (Constructor × Option Typ))
+    : ElabM (ElabEnv × Untyped.TypeDecl) := do
   if acontains name env.types then
     return ← err loc (.duplicateType name)
   let arity := ctorDefs.length
-  -- Pre-register the type name as a named reference so recursive self-references in
-  -- constructor payloads (e.g. `Cons of int * ilist`) resolve correctly.
+  -- Register the type name as a named reference so both recursive self-references in
+  -- constructor payloads and later uses resolve to the named type (not the inlined sum).
   let envWithSelf := { env with types := (name, .named name []) :: env.types }
   let (payloadTypes, newCtors) ← elaborateCtorDefs envWithSelf loc ctorDefs 0 arity
-  let sumTy := TinyML.Typ.sum payloadTypes
-  let env' := { env with
-    types := (name, sumTy) :: env.types
-    ctors := newCtors ++ env.ctors }
-  let decl : Untyped.TypeDecl := { name, body := { tparams := [], payloads := payloadTypes } }
+  let env' := { envWithSelf with ctors := newCtors ++ env.ctors }
+  let decl : Untyped.TypeDecl := { name, body := { tparams, payloads := payloadTypes } }
   .ok (env', decl)
 
 private def elaborateFieldDefs (env : ElabEnv) (loc : Location) (tyName : TypeConstructor)
@@ -457,12 +452,10 @@ private def elaborateRecordDecl (env : ElabEnv) (loc : Location) (name : TypeCon
     fields := newFields ++ env.fields }
 
 def TypeDecl.elaborate (env : ElabEnv) (loc : Location) (decl : TypeDecl)
-    : ElabM (ElabEnv × Option Untyped.TypeDecl) := do
-  if !decl.params.isEmpty then
-    return ← err loc (.polymorphicTypeDecl decl.name)
+    : ElabM (ElabEnv × Option Untyped.TypeDecl) :=
   match decl.body with
   | .variant ctors => do
-      let (env', decl') ← elaborateVariant env loc decl.name ctors
+      let (env', decl') ← elaborateVariant env loc decl.name decl.params ctors
       .ok (env', some decl')
   | .record fields => do
       let env' ← elaborateRecordDecl env loc decl.name fields

--- a/Mica/TinyML/Common.lean
+++ b/Mica/TinyML/Common.lean
@@ -14,6 +14,8 @@ inductive Typ where
   | empty   -- bottom type (uninhabited)
   | value   -- top type (all runtime values)
   | tuple (ts : List Typ)
+  | tvar (v : TyVar)
+  | named (T : TypeName) (args : List Typ)
   deriving Repr
 
 def Typ.decEq : (a b : Typ) → Decidable (a = b)
@@ -32,25 +34,47 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
   | .tuple ss, .tuple ts => match typesDecEq ss ts with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .tvar v, .tvar w => match (inferInstance : DecidableEq TyVar) v w with
+    | isTrue h => isTrue (by subst h; rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .named T args, .named U params =>
+    match (inferInstance : DecidableEq TypeName) T U, typesDecEq args params with
+    | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .unit, .bool | .unit, .int | .unit, .sum .. | .unit, .arrow ..
   | .unit, .ref .. | .unit, .empty | .unit, .value | .unit, .tuple ..
+  | .unit, .tvar .. | .unit, .named ..
   | .bool, .unit | .bool, .int | .bool, .sum .. | .bool, .arrow ..
   | .bool, .ref .. | .bool, .empty | .bool, .value | .bool, .tuple ..
+  | .bool, .tvar .. | .bool, .named ..
   | .int, .unit | .int, .bool | .int, .sum .. | .int, .arrow ..
   | .int, .ref .. | .int, .empty | .int, .value | .int, .tuple ..
+  | .int, .tvar .. | .int, .named ..
   | .sum .., .unit | .sum .., .bool | .sum .., .int
   | .sum .., .arrow .. | .sum .., .ref .. | .sum .., .empty | .sum .., .value | .sum .., .tuple ..
+  | .sum .., .tvar .. | .sum .., .named ..
   | .arrow .., .unit | .arrow .., .bool | .arrow .., .int
   | .arrow .., .sum .. | .arrow .., .ref .. | .arrow .., .empty | .arrow .., .value | .arrow .., .tuple ..
+  | .arrow .., .tvar .. | .arrow .., .named ..
   | .ref .., .unit | .ref .., .bool | .ref .., .int
   | .ref .., .sum .. | .ref .., .arrow .. | .ref .., .empty | .ref .., .value | .ref .., .tuple ..
+  | .ref .., .tvar .. | .ref .., .named ..
   | .empty, .unit | .empty, .bool | .empty, .int | .empty, .sum ..
   | .empty, .arrow .. | .empty, .ref .. | .empty, .value | .empty, .tuple ..
+  | .empty, .tvar .. | .empty, .named ..
   | .value, .unit | .value, .bool | .value, .int | .value, .sum ..
   | .value, .arrow .. | .value, .ref .. | .value, .empty | .value, .tuple ..
+  | .value, .tvar .. | .value, .named ..
   | .tuple .., .unit | .tuple .., .bool | .tuple .., .int
   | .tuple .., .sum .. | .tuple .., .arrow .. | .tuple .., .ref .. | .tuple .., .empty
-  | .tuple .., .value => isFalse (by intro h; cases h)
+  | .tuple .., .value | .tuple .., .tvar .. | .tuple .., .named ..
+  | .tvar .., .unit | .tvar .., .bool | .tvar .., .int | .tvar .., .sum ..
+  | .tvar .., .arrow .. | .tvar .., .ref .. | .tvar .., .empty | .tvar .., .value | .tvar .., .tuple ..
+  | .tvar .., .named ..
+  | .named .., .unit | .named .., .bool | .named .., .int | .named .., .sum ..
+  | .named .., .arrow .. | .named .., .ref .. | .named .., .empty | .named .., .value | .named .., .tuple ..
+  | .named .., .tvar .. => isFalse (by intro h; cases h)
 where
   typesDecEq : (as bs : List Typ) → Decidable (as = bs)
     | [], [] => isTrue rfl
@@ -61,6 +85,7 @@ where
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
 
 instance : DecidableEq Typ := Typ.decEq
+
 instance : BEq Typ := ⟨fun a b => decide (a = b)⟩
 instance : LawfulBEq Typ where
   eq_of_beq h := of_decide_eq_true h
@@ -82,6 +107,8 @@ def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
   | .empty => .empty
   | .value => .value
   | .tuple ts => .tuple (ts.map (Typ.subst _σ))
+  | .tvar v => _σ v
+  | .named T args => .named T (args.map (Typ.subst _σ))
 
 structure DataDecl where
   tparams : List TyVar
@@ -100,7 +127,7 @@ def DataDecl.instantiate (d : DataDecl) (args : List Typ) : Typ :=
   let σ := fun v =>
     match (d.tparams.zip args).find? (fun p => p.1 == v) with
     | some (_, ty) => ty
-    | none => .value
+    | none => .tvar v
   .sum (d.payloads.map (Typ.subst σ))
 
 def TypeName.unfold (Θ : TypeEnv) (T : TypeName) (args : List Typ) : Option Typ :=

--- a/Mica/TinyML/Common.lean
+++ b/Mica/TinyML/Common.lean
@@ -1,6 +1,8 @@
 namespace TinyML
 
 abbrev Var := String
+abbrev TyVar := String
+abbrev TypeName := String
 
 inductive Typ where
   | unit
@@ -63,6 +65,46 @@ instance : BEq Typ := ⟨fun a b => decide (a = b)⟩
 instance : LawfulBEq Typ where
   eq_of_beq h := of_decide_eq_true h
   rfl := by simp [BEq.beq]
+
+/--
+Substitution over `Typ`.
+
+This is currently structural-only scaffolding. It becomes meaningfully
+variable-sensitive once `Typ` grows `tvar`/`named`.
+-/
+def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
+  | .unit => .unit
+  | .bool => .bool
+  | .int => .int
+  | .sum ts => .sum (ts.map (Typ.subst _σ))
+  | .arrow t1 t2 => .arrow (Typ.subst _σ t1) (Typ.subst _σ t2)
+  | .ref t => .ref (Typ.subst _σ t)
+  | .empty => .empty
+  | .value => .value
+  | .tuple ts => .tuple (ts.map (Typ.subst _σ))
+
+structure DataDecl where
+  tparams : List TyVar
+  payloads : List Typ
+  deriving Repr, Inhabited, DecidableEq
+
+abbrev TypeEnv := TypeName → Option DataDecl
+
+def TypeEnv.empty : TypeEnv := fun _ => none
+
+/--
+Instantiation is also scaffolding for now: until `Typ` can contain type
+variables, substitution has no observable effect.
+-/
+def DataDecl.instantiate (d : DataDecl) (args : List Typ) : Typ :=
+  let σ := fun v =>
+    match (d.tparams.zip args).find? (fun p => p.1 == v) with
+    | some (_, ty) => ty
+    | none => .value
+  .sum (d.payloads.map (Typ.subst σ))
+
+def TypeName.unfold (Θ : TypeEnv) (T : TypeName) (args : List Typ) : Option Typ :=
+  (Θ T).map (·.instantiate args)
 
 inductive BinOp where
   | add | sub | mul | div | mod

--- a/Mica/TinyML/Erasure.lean
+++ b/Mica/TinyML/Erasure.lean
@@ -61,11 +61,15 @@ where
     | [] => []
     | (b, e) :: rest => Runtime.Expr.fix .none [b.runtime] e.runtime :: branchListRuntime rest
 
-def Decl.runtime {S : Type} (d : Typed.Decl S) : Runtime.Decl :=
+def ValDecl.runtime {S : Type} (d : Typed.ValDecl S) : Runtime.Decl :=
   { name := d.name.runtime, body := d.body.runtime }
 
+def Decl.runtime {S : Type} : Typed.Decl S → Option Runtime.Decl
+  | .val_ d => some d.runtime
+  | .type_ _ => none
+
 def Program.runtime {S : Type} (prog : Typed.Program S) : Runtime.Program :=
-  prog.map Decl.runtime
+  prog.filterMap Decl.runtime
 
 theorem Expr.branchListRuntime_eq_map (branches : List (Typed.Binder × Typed.Expr)) :
     Expr.runtime.branchListRuntime branches =
@@ -122,10 +126,14 @@ where
     | [] => []
     | (b, e) :: rest => Runtime.Expr.fix .none [b.runtime] e.runtime :: branchListRuntime rest
 
-def Decl.runtime {S : Type} (d : Untyped.Decl S) : Runtime.Decl :=
+def ValDecl.runtime {S : Type} (d : Untyped.ValDecl S) : Runtime.Decl :=
   { name := d.name.runtime, body := d.body.runtime }
 
+def Decl.runtime {S : Type} : Untyped.Decl S → Option Runtime.Decl
+  | .val_ d => some d.runtime
+  | .type_ _ => none
+
 def Program.runtime {S : Type} (prog : Untyped.Program S) : Runtime.Program :=
-  prog.map Decl.runtime
+  prog.filterMap Decl.runtime
 
 end Untyped

--- a/Mica/TinyML/Erasure.lean
+++ b/Mica/TinyML/Erasure.lean
@@ -64,12 +64,8 @@ where
 def ValDecl.runtime {S : Type} (d : Typed.ValDecl S) : Runtime.Decl :=
   { name := d.name.runtime, body := d.body.runtime }
 
-def Decl.runtime {S : Type} : Typed.Decl S → Option Runtime.Decl
-  | .val_ d => some d.runtime
-  | .type_ _ => none
-
 def Program.runtime {S : Type} (prog : Typed.Program S) : Runtime.Program :=
-  prog.filterMap Decl.runtime
+  prog.map ValDecl.runtime
 
 theorem Expr.branchListRuntime_eq_map (branches : List (Typed.Binder × Typed.Expr)) :
     Expr.runtime.branchListRuntime branches =

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -134,7 +134,7 @@ end
 
 def Expr.print (e : Untyped.Expr) : String := printExpr e
 
-def Decl.print (d : Untyped.Decl Untyped.Expr) : String :=
+def ValDecl.print (d : Untyped.ValDecl Untyped.Expr) : String :=
   let decl := match d.body with
     | .fix (.named f _) args _ inner =>
       let (allArgs, innerBody) := collectFixArgs f args inner
@@ -150,6 +150,15 @@ def Decl.print (d : Untyped.Decl Untyped.Expr) : String :=
   match d.spec with
   | .none => decl
   | .some e => s!"{decl} [@@spec {printExpr e}]"
+
+def TypeDecl.print (d : Untyped.TypeDecl) : String :=
+  let payloads := (List.range d.body.payloads.length).zip d.body.payloads |>.map
+    (fun (i, ty) => s!"C{i} of {repr ty}")
+  s!"type {d.name} = {" | ".intercalate payloads}"
+
+def Decl.print : Untyped.Decl Untyped.Expr → String
+  | .val_ d => d.print
+  | .type_ d => d.print
 
 def Program.print (p : Untyped.Program Untyped.Expr) : String :=
   "\n;;\n".intercalate (p.map Decl.print)

--- a/Mica/TinyML/Typed.lean
+++ b/Mica/TinyML/Typed.lean
@@ -226,20 +226,6 @@ instance [Inhabited S] : Inhabited (ValDecl S) := ⟨{ name := default, body := 
 def ValDecl.mapSpec {S T : Type} (f : S → Option T) (d : ValDecl S) : ValDecl T :=
   { name := d.name, body := d.body, spec := d.spec.bind f }
 
-structure TypeDecl where
-  name : TypeName
-  body : DataDecl
-  deriving Repr, BEq, Inhabited
-
-inductive Decl (S : Type) where
-  | val_ (d : ValDecl S)
-  | type_ (d : TypeDecl)
-  deriving Repr, BEq, Inhabited
-
-def Decl.mapSpec {S T : Type} (f : S → Option T) : Decl S → Decl T
-  | .val_ d => .val_ (d.mapSpec f)
-  | .type_ d => .type_ d
-
-abbrev Program (S : Type) := List (Decl S)
+abbrev Program (S : Type) := List (ValDecl S)
 
 end Typed

--- a/Mica/TinyML/Typed.lean
+++ b/Mica/TinyML/Typed.lean
@@ -215,16 +215,30 @@ def Expr.ty : Expr → Typ
   | .match_ _ _ ty => ty
   | .cast _ ty => ty
 
-structure Decl (S : Type) where
+structure ValDecl (S : Type) where
   name : Binder
   body : Expr
   spec : Option S
   deriving Repr, BEq
 
-instance [Inhabited S] : Inhabited (Decl S) := ⟨{ name := default, body := default, spec := default }⟩
+instance [Inhabited S] : Inhabited (ValDecl S) := ⟨{ name := default, body := default, spec := default }⟩
 
-def Decl.mapSpec {S T : Type} (f : S → Option T) (d : Decl S) : Decl T :=
+def ValDecl.mapSpec {S T : Type} (f : S → Option T) (d : ValDecl S) : ValDecl T :=
   { name := d.name, body := d.body, spec := d.spec.bind f }
+
+structure TypeDecl where
+  name : TypeName
+  body : DataDecl
+  deriving Repr, BEq, Inhabited
+
+inductive Decl (S : Type) where
+  | val_ (d : ValDecl S)
+  | type_ (d : TypeDecl)
+  deriving Repr, BEq, Inhabited
+
+def Decl.mapSpec {S T : Type} (f : S → Option T) : Decl S → Decl T
+  | .val_ d => .val_ (d.mapSpec f)
+  | .type_ d => .type_ d
 
 abbrev Program (S : Type) := List (Decl S)
 

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -147,10 +147,10 @@ mutual
             else match s, t with
               | .named T args, _ => match TypeName.unfold Θ T args with
                   | some s' => recur s' t
-              | none => false
+                  | none => false
               | _, .named T args => match TypeName.unfold Θ T args with
                   | some t' => recur s t'
-              | none => false
+                  | none => false
               | _, _ => false
   termination_by s t => Typ.weight s + Typ.weight t
   decreasing_by
@@ -252,7 +252,7 @@ mutual
             exact .named_right hunfold (hrecur h)
           · cases h
         · -- neither named
-            cases h
+          cases h
   termination_by Typ.weight s + Typ.weight t
   decreasing_by
     all_goals
@@ -641,6 +641,7 @@ mutual
         .ok (.sum ((List.replicate arity .empty).set tag ty), .inj tag arity payload')
     | .match_ scrutinee branches => do
         let (scrutTy, scrut') ← infer Θ Γ scrutinee
+        -- Resolve the scrutinee type: accept sum directly, or unfold a named type and insert a cast.
         match scrutTy with
         | .sum ts =>
                 if _h : ts.length = branches.length then
@@ -652,6 +653,20 @@ mutual
                   .ok (ty, .match_ scrut' branches'' ty)
                 else
                   .error (.arityMismatch ts.length branches.length)
+        | .named T args =>
+                match TypeName.unfold Θ T args with
+                | some (.sum ts) =>
+                    if _h : ts.length = branches.length then
+                      let branches' ← inferBranches Θ Γ ts branches
+                      let ty := joinAll Θ (branches'.map (fun p => p.2.ty))
+                      let branches'' := branches'.map fun
+                        | (binder, body) =>
+                            (binder, if body.ty == ty then body else .cast body ty)
+                      -- Insert a cast to unfold the named type before matching.
+                      .ok (ty, .match_ (.cast scrut' (.sum ts)) branches'' ty)
+                    else
+                      .error (.arityMismatch ts.length branches.length)
+                | _ => .error (.notASum scrutTy)
         | _ => .error (.notASum scrutTy)
 
   def check (Θ : TypeEnv) (Γ : TinyML.TyCtx) (e : Untyped.Expr) (expected : Typ) : Except TypeError Typed.Expr := do
@@ -975,6 +990,33 @@ mutual
               · exact ihScrut _ hscrut
               · exact hcast_branches.trans (ihBranches ts _ hbranches)
             · simp [hlen] at hcont
+          | named T args =>
+            cases hunfold : TypeName.unfold Θ T args with
+            | none => simp [hunfold] at hcont
+            | some body =>
+              cases body with
+              | sum ts =>
+                simp only [hunfold] at hcont
+                by_cases hlen : ts.length = branches.length
+                · simp [hlen] at hcont
+                  have ⟨branches', hbranches, hcont⟩ := Except.bind_ok hcont
+                  rcases (by simpa [hbranches] using hcont) with ⟨rfl, rfl⟩
+                  have hcast_branches :
+                      Expr.runtime.branchListRuntime
+                        (List.map
+                          (fun x =>
+                            (x.1,
+                              if x.2.ty = joinAll Θ (List.map (fun p => p.2.ty) branches') then x.2
+                              else x.2.cast (joinAll Θ (List.map (fun p => p.2.ty) branches'))))
+                          branches') =
+                      Expr.runtime.branchListRuntime branches' := by
+                    simpa [BEq.beq] using
+                      Typed.Expr.branchListRuntime_castBodies
+                        (joinAll Θ (List.map (fun p => p.2.ty) branches')) branches'
+                  simp [Expr.runtime, Untyped.Expr.runtime, ihScrut _ hscrut]
+                  exact hcast_branches.trans (ihBranches ts _ hbranches)
+                · simp [hlen] at hcont
+              | _ => simp [hunfold] at hcont
           | _ =>
             simp at hcont
 

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -439,6 +439,7 @@ open TinyML
 
 inductive TypeError where
   | undefinedVar (name : Var)
+  | duplicateType (name : TypeName)
   | operatorMismatch (op : BinOp) (lhs rhs : Typ)
   | unaryMismatch (op : UnOp) (arg : Typ)
   | notAFunction (ty : Typ)
@@ -453,6 +454,7 @@ inductive TypeError where
 instance : ToString TypeError where
   toString
     | .undefinedVar name => s!"undefined variable: {name}"
+    | .duplicateType name => s!"duplicate type: {name}"
     | .operatorMismatch op lhs rhs =>
         s!"operator {repr op} cannot be applied to {repr lhs} and {repr rhs}"
     | .unaryMismatch op arg =>
@@ -487,6 +489,11 @@ def extendTyped (Γ : TinyML.TyCtx) (b : Typed.Binder) : TinyML.TyCtx :=
 def joinAll (Θ : TypeEnv) : List Typ → Typ
   | [] => .value
   | t :: ts => ts.foldl (Typ.join Θ) t
+
+def extendTypeEnv (Θ : TypeEnv) (name : TypeName) (body : DataDecl) : Except TypeError TypeEnv :=
+  match Θ name with
+  | some _ => .error (.duplicateType name)
+  | none => .ok (fun query => if query == name then some body else Θ query)
 
 mutual
   def infer (Θ : TypeEnv) (Γ : TinyML.TyCtx) : Untyped.Expr → Except TypeError (Typ × Typed.Expr)
@@ -629,26 +636,21 @@ def ValDecl.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped
     | _ => bodyTy
   .ok { name := Typed.Binder.ofUntyped d.name nameTy, body := body', spec := d.spec }
 
-def Decl.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.Decl S) :
-    Except TypeError (Typed.Decl S) := do
-  match d with
-  | .val_ d =>
-      return .val_ (← ValDecl.elaborate Θ Γ d)
-  | .type_ d =>
-      return .type_ { name := d.name, body := d.body }
-
-def Program.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) : Untyped.Program S → Except TypeError (Typed.Program S)
-  | [] => .ok []
+def Program.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
+    Untyped.Program S → Except TypeError (TypeEnv × Typed.Program S)
+  | [] => .ok (Θ, [])
   | d :: ds => do
-      let d' ← Decl.elaborate Θ Γ d
-      let Γ' := match d' with
-        | .val_ d =>
-            match d.name.name with
-            | some x => Γ.extend x d.name.ty
+      match d with
+      | .type_ dty =>
+          let Θ' ← extendTypeEnv Θ dty.name dty.body
+          Program.elaborate Θ' Γ ds
+      | .val_ dval =>
+          let d' ← ValDecl.elaborate Θ Γ dval
+          let Γ' := match d'.name.name with
+            | some x => Γ.extend x d'.name.ty
             | none => Γ
-        | .type_ _ => Γ
-      let ds' ← Program.elaborate Θ Γ' ds
-      .ok (d' :: ds')
+          let (Θ', ds') ← Program.elaborate Θ Γ' ds
+          .ok (Θ', d' :: ds')
 
 -- The main issue in this block is not the mathematical argument, but convincing
 -- Lean's termination checker that the mutual proof recursion is well-founded.
@@ -998,102 +1000,84 @@ mutual
           · simp [Typed.inferBranches, binderTy, hsub] at h
 end
 
-theorem Decl.elaborate_runtime {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.Decl S) :
-    ∀ {d' : Typed.Decl S},
-      Typed.Decl.elaborate Θ Γ d = .ok d' →
+theorem ValDecl.elaborate_runtime {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.ValDecl S) :
+    ∀ {d' : Typed.ValDecl S},
+      Typed.ValDecl.elaborate Θ Γ d = .ok d' →
       d'.runtime = d.runtime := by
-  intro d' h
-  cases d with
-  | val_ dval =>
-    simp [Decl.elaborate] at h
-    have ⟨dval', helab, hret⟩ := Except.bind_ok h
-    cases hret
-    cases hname : dval.name with
-    | none =>
-      cases hinfer : Typed.infer Θ Γ dval.body with
-      | error err =>
+  intro d' helab
+  cases hname : d.name with
+  | none =>
+    cases hinfer : Typed.infer Θ Γ d.body with
+    | error err =>
+      simp [ValDecl.elaborate, hname, hinfer] at helab
+      cases helab
+    | ok p =>
+      cases p with
+      | mk bodyTy body' =>
         simp [ValDecl.elaborate, hname, hinfer] at helab
+        cases helab
+        simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
+          infer_runtime Θ Γ d.body _ hinfer, Binder.ofUntyped_runtime, hname]
+  | named x ann =>
+    cases hann : ann with
+    | none =>
+      cases hinfer : Typed.infer Θ Γ d.body with
+      | error err =>
+        simp [ValDecl.elaborate, hname, hann, hinfer] at helab
         cases helab
       | ok p =>
         cases p with
         | mk bodyTy body' =>
-          simp [ValDecl.elaborate, hname, hinfer] at helab
-          cases helab
-          simp [Typed.Decl.runtime, Untyped.Decl.runtime, Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
-            infer_runtime Θ Γ dval.body _ hinfer, Binder.ofUntyped_runtime, hname]
-    | named x ann =>
-      cases hann : ann with
-      | none =>
-        cases hinfer : Typed.infer Θ Γ dval.body with
-        | error err =>
           simp [ValDecl.elaborate, hname, hann, hinfer] at helab
           cases helab
-        | ok p =>
-          cases p with
-          | mk bodyTy body' =>
-            simp [ValDecl.elaborate, hname, hann, hinfer] at helab
-            cases helab
-            simp [Typed.Decl.runtime, Untyped.Decl.runtime, Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
-              infer_runtime Θ Γ dval.body _ hinfer, Binder.ofUntyped_runtime, hname, hann]
-      | some ty =>
-        cases hcheck : Typed.check Θ Γ dval.body ty with
-        | error err =>
-          simp [ValDecl.elaborate, hname, hann, hcheck] at helab
-          cases helab
-        | ok body' =>
-          simp [ValDecl.elaborate, hname, hann, hcheck] at helab
-          cases helab
-          simp [Typed.Decl.runtime, Untyped.Decl.runtime, Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
-            check_runtime Θ Γ dval.body ty _ hcheck, Binder.ofUntyped_runtime, hname, hann]
-  | type_ dty =>
-    simp [Decl.elaborate] at h
-    cases h
-    simp [Typed.Decl.runtime, Untyped.Decl.runtime]
+          simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
+            infer_runtime Θ Γ d.body _ hinfer, Binder.ofUntyped_runtime, hname, hann]
+    | some ty =>
+      cases hcheck : Typed.check Θ Γ d.body ty with
+      | error err =>
+        simp [ValDecl.elaborate, hname, hann, hcheck] at helab
+        cases helab
+      | ok body' =>
+        simp [ValDecl.elaborate, hname, hann, hcheck] at helab
+        cases helab
+        simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
+          check_runtime Θ Γ d.body ty _ hcheck, Binder.ofUntyped_runtime, hname, hann]
 
 theorem Program.elaborate_runtime {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (prog : Untyped.Program S) :
-    ∀ {prog' : Typed.Program S},
-      Typed.Program.elaborate Θ Γ prog = .ok prog' →
+    ∀ {Θ' : TypeEnv} {prog' : Typed.Program S},
+      Typed.Program.elaborate Θ Γ prog = .ok (Θ', prog') →
       prog'.runtime = prog.runtime := by
-  induction prog generalizing Γ with
+  induction prog generalizing Θ Γ with
   | nil =>
-    intro prog' h
+    intro Θ' prog' h
     simp [Typed.Program.elaborate] at h
-    cases h
-    rfl
+    rcases h with ⟨rfl, rfl⟩
+    simp [Typed.Program.runtime, Untyped.Program.runtime]
   | cons d ds ih =>
-    intro prog' h
+    intro Θ' prog' h
     cases d with
-    | val_ dval =>
-      unfold Typed.Program.elaborate at h
-      have ⟨d', hdecl, hcont⟩ := Except.bind_ok h
-      cases d' with
-      | val_ dval' =>
-        let Γ' := match dval'.name.name with
-          | some x => Γ.extend x dval'.name.ty
-          | none => Γ
-        have ⟨ds', htail, hcont⟩ := Except.bind_ok hcont
-        simp at hcont
-        cases hcont
-        have hdecl_rt : dval'.runtime = dval.runtime := by
-          simpa [Typed.Decl.runtime, Untyped.Decl.runtime] using
-            (Decl.elaborate_runtime Θ Γ (.val_ dval) hdecl)
-        simp [Typed.Program.runtime, Typed.Decl.runtime, Untyped.Program.runtime, Untyped.Decl.runtime]
-        constructor
-        · exact hdecl_rt
-        · exact ih Γ' htail
-      | type_ dty =>
-        cases hval : ValDecl.elaborate Θ Γ dval <;> simp [Decl.elaborate, hval] at hdecl
     | type_ dty =>
       unfold Typed.Program.elaborate at h
-      have ⟨d', hdecl, hcont⟩ := Except.bind_ok h
-      cases d' with
-      | val_ dval' =>
-        cases hdecl
-      | type_ dty' =>
-        have ⟨ds', htail, hcont⟩ := Except.bind_ok hcont
-        simp at hcont
-        cases hcont
-        simpa [Typed.Program.runtime, Typed.Decl.runtime, Untyped.Program.runtime, Untyped.Decl.runtime]
-          using ih Γ htail
+      cases hext : extendTypeEnv Θ dty.name dty.body with
+      | error err =>
+        simp [hext] at h
+        cases h
+      | ok Θ1 =>
+        simp [hext] at h
+        exact ih Θ1 Γ h
+    | val_ dval =>
+      unfold Typed.Program.elaborate at h
+      have ⟨dval', hdecl, hcont⟩ := Except.bind_ok h
+      let Γ' := match dval'.name.name with
+        | some x => Γ.extend x dval'.name.ty
+        | none => Γ
+      have ⟨tail, htail, hcont⟩ := Except.bind_ok hcont
+      rcases tail with ⟨Θ'', ds'⟩
+      simp at hcont
+      cases hcont
+      have hdecl_rt : dval'.runtime = dval.runtime := ValDecl.elaborate_runtime Θ Γ dval hdecl
+      subst prog'
+      simp [Typed.Program.runtime, Untyped.Program.runtime, hdecl_rt]
+      exact congrArg (List.cons dval.runtime) (ih Θ Γ' htail)
 
 end Typed

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -67,18 +67,160 @@ theorem TyCtx.foldl_extend_stable
 
 /-! ## Subtyping -/
 
+inductive UnfoldSide where
+  | left
+  | right
+  deriving Repr, DecidableEq
+
+def UnfoldSide.flip : UnfoldSide → UnfoldSide
+  | .left => .right
+  | .right => .left
+
+mutual
+  @[reducible]
+  def Typ.weight : Typ → Nat
+    | .unit | .bool | .int | .empty | .value | .tvar _ => 1
+    | .sum ts => 1 + Typ.weights ts
+    | .arrow t1 t2 => 1 + Typ.weight t1 + Typ.weight t2
+    | .ref t => 1 + Typ.weight t
+    | .tuple ts => 1 + Typ.weights ts
+    | .named _ args => 1 + Typ.weights args
+
+  @[reducible]
+  def Typ.weights : List Typ → Nat
+    | [] => 0
+    | t :: ts => Typ.weight t + Typ.weights ts
+end
+
+mutual
+  @[reducible]
+  def Typ.depth : Typ → Nat
+    | .unit | .bool | .int | .empty | .value | .tvar _ => 1
+    | .sum ts => 1 + Typ.depths ts
+    | .arrow t1 t2 => 1 + max (Typ.depth t1) (Typ.depth t2)
+    | .ref t => 1 + Typ.depth t
+    | .tuple ts => 1 + Typ.depths ts
+    | .named _ args => 1 + Typ.depths args
+
+  @[reducible]
+  def Typ.depths : List Typ → Nat
+    | [] => 0
+    | t :: ts => max (Typ.depth t) (Typ.depths ts)
+end
+
+theorem Typ.weight_pos (t : Typ) : 0 < Typ.weight t := by
+  cases t <;> simp [Typ.weight] <;> omega
+
+theorem Typ.weight_pair_lt_sum (ss ts : List Typ) :
+    1 + Typ.weights ss + Typ.weights ts < Typ.weight (.sum ss) + Typ.weight (.sum ts) := by
+  simp [Typ.weight]
+
+theorem Typ.weight_pair_lt_arrow_dom (s1 s2 t1 t2 : Typ) :
+    Typ.weight t1 + Typ.weight s1 <
+      Typ.weight (.arrow s1 s2) + Typ.weight (.arrow t1 t2) := by
+  simp [Typ.weight]
+  omega
+
+theorem Typ.weight_pair_lt_arrow_codom (s1 s2 t1 t2 : Typ) :
+    Typ.weight s2 + Typ.weight t2 <
+      Typ.weight (.arrow s1 s2) + Typ.weight (.arrow t1 t2) := by
+  simp [Typ.weight]
+  omega
+
+theorem Typ.weight_pair_lt_list_head (s : Typ) (ss : List Typ) (t : Typ) (ts : List Typ) :
+    Typ.weight s + Typ.weight t < 1 + Typ.weights (s :: ss) + Typ.weights (t :: ts) := by
+  simp [Typ.weights]
+  omega
+
+theorem Typ.weight_pair_lt_list_tail (s : Typ) (ss : List Typ) (t : Typ) (ts : List Typ) :
+    1 + Typ.weights ss + Typ.weights ts < 1 + Typ.weights (s :: ss) + Typ.weights (t :: ts) := by
+  have hs : 0 < Typ.weight s := Typ.weight_pos s
+  have ht : 0 < Typ.weight t := Typ.weight_pos t
+  simp [Typ.weights]
+  omega
+
+set_option linter.unnecessarySimpa false in
+mutual
+
+  def Typ.subBody (Θ : TypeEnv) (recur : UnfoldSide → Typ → Typ → Bool) :
+      UnfoldSide → Typ → Typ → Bool :=
+      fun side s t =>
+        match s, t with
+        | .empty, _ => true
+        | _, .value => true
+        | .sum ss, .sum ts => Typ.subListBody Θ recur side ss ts
+        | .arrow s1 s2, .arrow t1 t2 =>
+            Typ.subBody Θ recur side.flip t1 s1 && Typ.subBody Θ recur side s2 t2
+        | .tuple ss, .tuple ts => Typ.subListBody Θ recur side ss ts
+        | .named T args, t =>
+            if .named T args == t then true
+            else if side ≠ .left then false
+            else match TypeName.unfold Θ T args with
+              | some s => recur .left s t
+              | none => false
+        | s, .named T args =>
+            if s == .named T args then true
+            else if side ≠ .right then false
+            else match TypeName.unfold Θ T args with
+              | some t => recur .right s t
+              | none => false
+        | s, t => s == t
+  termination_by _ s t => Typ.weight s + Typ.weight t
+  decreasing_by
+    all_goals
+      first
+        | simpa [Typ.weight] using Typ.weight_pair_lt_sum _ _
+        | simpa [Typ.weight] using Typ.weight_pair_lt_arrow_dom _ _ _ _
+        | simpa [Typ.weight] using Typ.weight_pair_lt_arrow_codom _ _ _ _
+
+  def Typ.subListBody (Θ : TypeEnv) (recur : UnfoldSide → Typ → Typ → Bool) :
+      UnfoldSide → List Typ → List Typ → Bool
+    | _, [], [] => true
+    | side, s :: ss, t :: ts => Typ.subBody Θ recur side s t && Typ.subListBody Θ recur side ss ts
+    | _, _, _ => false
+  termination_by _ ss ts => 1 + Typ.weights ss + Typ.weights ts
+  decreasing_by
+    all_goals
+      first
+        | exact Typ.weight_pair_lt_list_head _ _ _ _
+        | exact Typ.weight_pair_lt_list_tail _ _ _ _
+end
+
+def Typ.subi (Θ : TypeEnv) (steps : Nat) : UnfoldSide → Typ → Typ → Bool :=
+  match steps with
+  | 0 => fun _ _ _ => false
+  | n + 1 => Typ.subBody Θ (Typ.subi Θ n)
+
+def Typ.subListi (Θ : TypeEnv) (steps : Nat) : UnfoldSide → List Typ → List Typ → Bool :=
+  match steps with
+  | 0 => fun _ _ _ => false
+  | n + 1 => Typ.subListBody Θ (Typ.subi Θ n)
+
+def Typ.sub (Θ : TypeEnv) : UnfoldSide → Typ → Typ → Bool :=
+  fun side s t => Typ.subi Θ (max (Typ.depth s) (Typ.depth t)) side s t
+
+def Typ.subList (Θ : TypeEnv) : UnfoldSide → List Typ → List Typ → Bool :=
+  fun side ss ts => Typ.subListi Θ (max (Typ.depths ss) (Typ.depths ts)) side ss ts
+
 mutual
   inductive Typ.Sub (Θ : TypeEnv) : Typ → Typ → Prop where
     | refl  : Typ.Sub Θ t t
-    | bot   : Typ.Sub Θ (Typ.empty) t
-    | top   : Typ.Sub Θ t (Typ.value)
+    | bot   : Typ.Sub Θ .empty t
+    | top   : Typ.Sub Θ t .value
     | trans : Typ.Sub Θ s t → Typ.Sub Θ t u → Typ.Sub Θ s u
     | sum   : Typ.SubList Θ ss ts
-            → Typ.Sub Θ (Typ.sum ss) (Typ.sum ts)
-    | arrow : Typ.Sub Θ t1 s1 → Typ.Sub Θ s2 t2
-            → Typ.Sub Θ (Typ.arrow s1 s2) (Typ.arrow t1 t2)
+            → Typ.Sub Θ (.sum ss) (.sum ts)
+    | arrow : Typ.Sub Θ t1 s1
+            → Typ.Sub Θ s2 t2
+            → Typ.Sub Θ (.arrow s1 s2) (.arrow t1 t2)
     | tuple : Typ.SubList Θ ss ts
-            → Typ.Sub Θ (Typ.tuple ss) (Typ.tuple ts)
+            → Typ.Sub Θ (.tuple ss) (.tuple ts)
+    | named_left : TypeName.unfold Θ T args = some ty
+                 → Typ.Sub Θ ty t
+                 → Typ.Sub Θ (.named T args) t
+    | named_right : TypeName.unfold Θ T args = some ty
+                  → Typ.Sub Θ s ty
+                  → Typ.Sub Θ s (.named T args)
 
   inductive Typ.SubList (Θ : TypeEnv) : List Typ → List Typ → Prop where
     | nil  : Typ.SubList Θ [] []
@@ -89,205 +231,147 @@ theorem Typ.SubList.length_eq : Typ.SubList Θ ss ts → ss.length = ts.length
   | .nil => rfl
   | .cons _ h => by simp [List.length_cons, h.length_eq]
 
+-- Forward direction: decision procedure is sound.
+set_option linter.unnecessarySimpa false in
 mutual
-  def Typ.join (_Θ : TypeEnv) : Typ → Typ → Typ
+  private theorem Typ.subBody_sound {Θ : TypeEnv} {recur : UnfoldSide → Typ → Typ → Bool}
+      (hrecur : ∀ {side s t}, recur side s t = true → Typ.Sub Θ s t)
+      {side : UnfoldSide} {s t : Typ} (h : Typ.subBody Θ recur side s t = true) : Typ.Sub Θ s t := by
+    unfold Typ.subBody at h
+    split at h
+    · exact .bot
+    · exact .top
+    · exact .sum (subListBody_sound hrecur h)
+    · simp [Bool.and_eq_true] at h
+      exact .arrow (subBody_sound hrecur h.1) (subBody_sound hrecur h.2)
+    · exact .tuple (subListBody_sound hrecur h)
+    · split at h
+      · rename_i T args _ hbeq
+        have heq : .named T args = t := by simpa using hbeq
+        cases heq
+        exact .refl
+      · split at h
+        · rename_i T args _ hneq hside
+          simp at h
+        · split at h
+          · rename_i T args _ hneq hside ty hunfold
+            exact .named_left hunfold (hrecur h)
+          · rename_i T args _ hneq hside hunfold
+            cases h
+    · split at h
+      · rename_i T args _ _ hbeq
+        have heq : s = .named T args := by simpa using hbeq
+        cases heq
+        exact .refl
+      · split at h
+        · rename_i T args _ _ hneq hside
+          simp at h
+        · split at h
+          · rename_i T args _ _ hneq hside ty hunfold
+            exact .named_right hunfold (hrecur h)
+          · rename_i T args _ _ hneq hside hunfold
+            cases h
+    · have hst : s = t := by
+        simpa using h
+      subst hst
+      exact .refl
+  termination_by Typ.weight s + Typ.weight t
+  decreasing_by
+    all_goals
+      subst_vars
+      try simp [Typ.weight]
+      try omega
+
+  private theorem Typ.subListBody_sound {Θ : TypeEnv} {recur : UnfoldSide → Typ → Typ → Bool}
+      (hrecur : ∀ {side s t}, recur side s t = true → Typ.Sub Θ s t)
+      {side : UnfoldSide} {ss ts : List Typ}
+      (h : Typ.subListBody Θ recur side ss ts = true) : Typ.SubList Θ ss ts := by
+    match ss, ts with
+    | [], [] =>
+        exact .nil
+    | s :: ss, t :: ts =>
+        simp [Typ.subListBody, Bool.and_eq_true] at h
+        exact .cons (subBody_sound hrecur h.1) (subListBody_sound hrecur h.2)
+    | [], _ :: _ | _ :: _, [] =>
+        simp [Typ.subListBody] at h
+  termination_by 1 + Typ.weights ss + Typ.weights ts
+  decreasing_by
+    all_goals
+      first
+        | exact Typ.weight_pair_lt_list_head _ _ _ _
+        | exact Typ.weight_pair_lt_list_tail _ _ _ _
+
+  private theorem Typ.subi_sound {Θ : TypeEnv} {steps : Nat} {side : UnfoldSide} {s t : Typ}
+      (h : Typ.subi Θ steps side s t = true) : Typ.Sub Θ s t := by
+    induction steps generalizing side s t with
+    | zero =>
+      simp [Typ.subi] at h
+    | succ n ih =>
+      simpa [Typ.subi] using
+        (Typ.subBody_sound (Θ := Θ) (recur := Typ.subi Θ n) (hrecur := fun {side s t} h => ih h) h)
+
+  private theorem Typ.subListi_sound {Θ : TypeEnv} {steps : Nat} {side : UnfoldSide}
+      {ss ts : List Typ} (h : Typ.subListi Θ steps side ss ts = true) : Typ.SubList Θ ss ts := by
+    induction steps generalizing side ss ts with
+    | zero =>
+      simp [Typ.subListi] at h
+    | succ n ih =>
+      simpa [Typ.subListi] using
+        (Typ.subListBody_sound (Θ := Θ) (recur := Typ.subi Θ n) (hrecur := fun {side s t} h => Typ.subi_sound h) h)
+end
+
+theorem Typ.sub_sound {Θ : TypeEnv} {side : UnfoldSide} {s t : Typ}
+    (h : Typ.sub Θ side s t = true) : Typ.Sub Θ s t := by
+  exact Typ.subi_sound (Θ := Θ) (steps := max (Typ.depth s) (Typ.depth t)) h
+
+theorem Typ.subList_sound {Θ : TypeEnv} {side : UnfoldSide} {ss ts : List Typ}
+    (h : Typ.subList Θ side ss ts = true) : Typ.SubList Θ ss ts := by
+  exact Typ.subListi_sound (Θ := Θ) (steps := max (Typ.depths ss) (Typ.depths ts)) h
+
+mutual
+  def Typ.join (Θ : TypeEnv) : Typ → Typ → Typ
     | .empty, t | t, .empty => t
     | .value, _ | _, .value => .value
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
-                                    then .sum (Typ.joinList _Θ ss ts)
+                                    then .sum (Typ.joinList Θ ss ts)
                                     else .value
-    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.meet _Θ s1 t1) (Typ.join _Θ s2 t2)
+    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.meet Θ s1 t1) (Typ.join Θ s2 t2)
     | .ref s,       .ref t       => if s == t then .ref s else .value
     | .tuple ss,    .tuple ts    => if ss.length == ts.length
-                                    then .tuple (Typ.joinList _Θ ss ts)
+                                    then .tuple (Typ.joinList Θ ss ts)
                                     else .value
-    | t, t'                      => if t == t' then t else .value
+    | s, t =>
+        if Typ.sub Θ .left s t || Typ.sub Θ .right s t then t
+        else if Typ.sub Θ .left t s || Typ.sub Θ .right t s then s
+        else .value
 
-  def Typ.meet (_Θ : TypeEnv) : Typ → Typ → Typ
+  def Typ.meet (Θ : TypeEnv) : Typ → Typ → Typ
     | .value, t | t, .value => t
     | .empty, _ | _, .empty => .empty
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
-                                    then .sum (Typ.meetList _Θ ss ts)
+                                    then .sum (Typ.meetList Θ ss ts)
                                     else .empty
-    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.join _Θ s1 t1) (Typ.meet _Θ s2 t2)
+    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.join Θ s1 t1) (Typ.meet Θ s2 t2)
     | .ref s,       .ref t       => if s == t then .ref s else .empty
     | .tuple ss,    .tuple ts    => if ss.length == ts.length
-                                    then .tuple (Typ.meetList _Θ ss ts)
+                                    then .tuple (Typ.meetList Θ ss ts)
                                     else .empty
-    | t, t'                      => if t == t' then t else .empty
+    | s, t =>
+        if Typ.sub Θ .left s t || Typ.sub Θ .right s t then s
+        else if Typ.sub Θ .left t s || Typ.sub Θ .right t s then t
+        else .empty
 
-  def Typ.joinList (_Θ : TypeEnv) : List Typ → List Typ → List Typ
-    | s :: ss, t :: ts => Typ.join _Θ s t :: Typ.joinList _Θ ss ts
+  def Typ.joinList (Θ : TypeEnv) : List Typ → List Typ → List Typ
+    | s :: ss, t :: ts => Typ.join Θ s t :: Typ.joinList Θ ss ts
     | _, _             => []
 
-  def Typ.meetList (_Θ : TypeEnv) : List Typ → List Typ → List Typ
-    | s :: ss, t :: ts => Typ.meet _Θ s t :: Typ.meetList _Θ ss ts
+  def Typ.meetList (Θ : TypeEnv) : List Typ → List Typ → List Typ
+    | s :: ss, t :: ts => Typ.meet Θ s t :: Typ.meetList Θ ss ts
     | _, _             => []
 end
 
-mutual
-  def Typ.sub (_Θ : TypeEnv) (s t : Typ) : Bool :=
-    match s, t with
-    | .empty, _      => true
-    | _, .value      => true
-    | .sum  ss,     .sum  ts     => Typ.subList _Θ ss ts
-    | .arrow s1 s2, .arrow t1 t2 => Typ.sub _Θ t1 s1 && Typ.sub _Θ s2 t2
-    | .tuple ss,    .tuple ts    => Typ.subList _Θ ss ts
-    | t, t'                      => t == t'
-  termination_by sizeOf s + sizeOf t
-  decreasing_by all_goals simp +arith [*]
 
-  def Typ.subList (_Θ : TypeEnv) (ss ts : List Typ) : Bool :=
-    match ss, ts with
-    | [], [] => true
-    | s :: ss, t :: ts => Typ.sub _Θ s t && Typ.subList _Θ ss ts
-    | _, _ => false
-  termination_by sizeOf ss + sizeOf ts
-  decreasing_by all_goals simp +arith [*]
-end
-
--- Forward direction: decision procedure is sound.
-mutual
-  private theorem Typ.sub_sound {Θ : TypeEnv} {s t : Typ} (h : Typ.sub Θ s t = true) : Typ.Sub Θ s t := by
-    cases s with
-    | empty => exact .bot
-    | sum ss =>
-        cases t with
-        | value => exact .top
-        | sum ts =>
-            simp [Typ.sub] at h
-            exact .sum (subList_sound h)
-        | _ => exact absurd h (by simp [Typ.sub])
-    | arrow s1 s2 =>
-        cases t with
-        | value => exact .top
-        | arrow t1 t2 =>
-            simp [Typ.sub, Bool.and_eq_true] at h
-            exact .arrow (sub_sound h.1) (sub_sound h.2)
-        | _ => exact absurd h (by simp [Typ.sub])
-    | tuple ss =>
-        cases t with
-        | value => exact .top
-        | tuple ts =>
-            simp [Typ.sub] at h
-            exact .tuple (subList_sound h)
-        | _ => exact absurd h (by simp [Typ.sub])
-    | _ =>
-        cases t with
-        | value => exact .top
-        | _ => simp_all [Typ.sub] <;> exact .refl
-  termination_by sizeOf s + sizeOf t
-  decreasing_by all_goals simp +arith [*]
-
-  private theorem Typ.subList_sound {Θ : TypeEnv} {ss ts : List Typ}
-      (h : Typ.subList Θ ss ts = true) : Typ.SubList Θ ss ts := by
-    match ss, ts with
-    | [], [] => exact .nil
-    | [], _ :: _ | _ :: _, [] => simp [Typ.subList] at h
-    | s :: ss, t :: ts =>
-      simp [Typ.subList, Bool.and_eq_true] at h
-      exact .cons (sub_sound h.1) (subList_sound h.2)
-  termination_by sizeOf ss + sizeOf ts
-  decreasing_by all_goals simp +arith [*]
-end
-
--- Reflexivity of the decision procedure (needed for completeness)
-mutual
-  private theorem Typ.sub_refl (Θ : TypeEnv) : ∀ (t : Typ), Typ.sub Θ t t = true
-    | .unit | .bool | .int | .empty | .value => by simp [Typ.sub]
-    | .sum  ts     => by simp [Typ.sub, subList_refl Θ ts]
-    | .arrow t1 t2 => by simp [Typ.sub, sub_refl Θ t1, sub_refl Θ t2]
-    | .ref t       => by simp [Typ.sub]
-    | .tuple ts    => by simp [Typ.sub, subList_refl Θ ts]
-
-  private theorem Typ.subList_refl (Θ : TypeEnv) : ∀ (ts : List Typ), Typ.subList Θ ts ts = true
-    | [] => by simp [Typ.subList]
-    | t :: ts => by simp [Typ.subList, sub_refl Θ t, subList_refl Θ ts]
-end
-
--- Transitivity of the decision procedure (needed for completeness of trans rule).
--- Proved by recursion on t (the middle type).
-mutual
-  private theorem Typ.sub_trans {Θ : TypeEnv} {s t u : Typ}
-      (h1 : Typ.sub Θ s t = true) (h2 : Typ.sub Θ t u = true) :
-      Typ.sub Θ s u = true := by
-    match t with
-    | .empty | .value | .unit | .bool | .int => cases s <;> cases u <;> simp_all [Typ.sub, beq_iff_eq]
-    | .ref _ => cases s <;> cases u <;> simp_all [Typ.sub, beq_iff_eq]
-    | .sum ts =>
-        cases s with
-        | empty => simp [Typ.sub]
-        | sum ss =>
-            cases u with
-            | value => simp [Typ.sub]
-            | sum us =>
-                simp [Typ.sub] at h1 h2 ⊢
-                exact subList_trans h1 h2
-            | _ => simp [Typ.sub] at h2
-        | _ => simp [Typ.sub] at h1
-    | .arrow t1 t2 =>
-        cases s with
-        | empty => simp [Typ.sub]
-        | arrow ss1 ss2 =>
-            cases u with
-            | value => simp [Typ.sub]
-            | arrow u1 u2 =>
-                simp [Typ.sub, Bool.and_eq_true] at h1 h2 ⊢
-                exact ⟨sub_trans h2.1 h1.1, sub_trans h1.2 h2.2⟩
-            | _ => simp [Typ.sub] at h2
-        | _ => simp [Typ.sub] at h1
-    | .tuple ts =>
-        cases s with
-        | empty => simp [Typ.sub]
-        | tuple ss =>
-            cases u with
-            | value => simp [Typ.sub]
-            | tuple us =>
-                simp [Typ.sub] at h1 h2 ⊢
-                exact subList_trans h1 h2
-            | _ => simp [Typ.sub] at h2
-        | _ => simp [Typ.sub] at h1
-  termination_by sizeOf t
-  decreasing_by all_goals simp +arith [*]
-
-  private theorem Typ.subList_trans {Θ : TypeEnv} {ss ts us : List Typ}
-      (h1 : Typ.subList Θ ss ts = true) (h2 : Typ.subList Θ ts us = true) :
-      Typ.subList Θ ss us = true := by
-    match ss, ts, us with
-    | [], [], [] => simp [Typ.subList]
-    | [], [], _ :: _ => simp [Typ.subList] at h2
-    | [], _ :: _, _ | _ :: _, [], _ => simp [Typ.subList] at h1
-    | _ :: _, _ :: _, [] => simp [Typ.subList] at h2
-    | s :: ss, t :: ts, u :: us =>
-      simp [Typ.subList, Bool.and_eq_true] at h1 h2 ⊢
-      exact ⟨sub_trans h1.1 h2.1, subList_trans h1.2 h2.2⟩
-  termination_by sizeOf ts
-  decreasing_by all_goals simp +arith [*]
-end
-
--- Backward direction: derivable subtyping is decided
-mutual
-  private theorem Typ.Sub_complete (Θ : TypeEnv) {s t : Typ} (p : Typ.Sub Θ s t) : Typ.sub Θ s t = true := by
-    match p with
-    | .refl        => exact sub_refl Θ _
-    | .bot         => cases t <;> simp [Typ.sub]
-    | .top         => cases s <;> simp [Typ.sub]
-    | .trans h1 h2 => exact sub_trans (Sub_complete Θ h1) (Sub_complete Θ h2)
-    | .sum  h      => simp [Typ.sub, SubList_complete Θ h]
-    | .arrow h1 h2 => simp [Typ.sub, Sub_complete Θ h1, Sub_complete Θ h2]
-    | .tuple h     => simp [Typ.sub]; exact SubList_complete Θ h
-
-  private theorem Typ.SubList_complete (Θ : TypeEnv) {ss ts : List Typ}
-      (ps : Typ.SubList Θ ss ts) : Typ.subList Θ ss ts = true := by
-    match ps with
-    | .nil => simp [Typ.subList]
-    | .cons h hs => simp [Typ.subList, Sub_complete Θ h, SubList_complete Θ hs]
-end
-
-theorem Typ.sub_iff {Θ : TypeEnv} {s t : Typ} : Typ.sub Θ s t = true ↔ Typ.Sub Θ s t :=
-  ⟨sub_sound, Sub_complete Θ⟩
-
-/-! ## Operator typing -/
+-- /-! ## Operator typing -/
 
 def BinOp.typeOf : BinOp → Typ → Typ → Option Typ
   | .add,  .int,  .int  => some .int
@@ -320,6 +404,9 @@ mutual
             → ValHasType Θ (.inj tag ts.length payload) (.sum ts)
     | tuple : ValsHaveTypes Θ vs ts
             → ValHasType Θ (Runtime.Val.tuple vs) (Typ.tuple ts)
+    | named : TypeName.unfold Θ T args = some ty
+            → ValHasType Θ v ty
+            → ValHasType Θ v (.named T args)
     -- Any value has type .value
     | any : ValHasType Θ v .value
 
@@ -347,6 +434,15 @@ mutual
     | .tuple hsub =>
       cases h with
       | tuple hvs => exact .tuple (ValsHaveTypes_sub hvs hsub)
+    | .named_left hunfold hsub =>
+      cases h with
+      | named hunfold' hv =>
+        rw [hunfold] at hunfold'
+        injection hunfold' with hty
+        subst hty
+        exact ValHasType_sub hv hsub
+    | .named_right hunfold hsub =>
+        exact .named hunfold (ValHasType_sub h hsub)
 
   theorem ValsHaveTypes_sub {Θ : TypeEnv} {vs : List Runtime.Val} {ts ts' : List Typ}
       (h : ValsHaveTypes Θ vs ts) (hsub : Typ.SubList Θ ts ts') :
@@ -569,15 +665,15 @@ mutual
         let (scrutTy, scrut') ← infer Θ Γ scrutinee
         match scrutTy with
         | .sum ts =>
-            if _h : ts.length = branches.length then
-              let branches' ← inferBranches Θ Γ ts branches
-              let ty := joinAll Θ (branches'.map (fun p => p.2.ty))
-              let branches'' := branches'.map fun
-                | (binder, body) =>
-                    (binder, if body.ty == ty then body else .cast body ty)
-              .ok (ty, .match_ scrut' branches'' ty)
-            else
-              .error (.arityMismatch ts.length branches.length)
+                if _h : ts.length = branches.length then
+                  let branches' ← inferBranches Θ Γ ts branches
+                  let ty := joinAll Θ (branches'.map (fun p => p.2.ty))
+                  let branches'' := branches'.map fun
+                    | (binder, body) =>
+                        (binder, if body.ty == ty then body else .cast body ty)
+                  .ok (ty, .match_ scrut' branches'' ty)
+                else
+                  .error (.arityMismatch ts.length branches.length)
         | _ => .error (.notASum scrutTy)
 
   def check (Θ : TypeEnv) (Γ : TinyML.TyCtx) (e : Untyped.Expr) (expected : Typ) : Except TypeError Typed.Expr := do

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -680,7 +680,7 @@ mutual
     let (actual, e') ← infer Θ Γ e
     if actual == expected then
       .ok e'
-    else if Typ.sub Θ actual expected then
+    else if Typ.sub Θ .left actual expected || Typ.sub Θ .right actual expected then
       .ok (.cast e' expected)
     else
       .error (.subsumptionFailure actual expected)
@@ -705,7 +705,7 @@ mutual
     | [], [] => .ok []
     | ty :: tys, (binder, body) :: rest => do
         let binderTy := Typed.Binder.expectedTy binder ty
-        if Typ.sub Θ ty binderTy then
+        if Typ.sub Θ .left ty binderTy || Typ.sub Θ .right ty binderTy then
           let typedBinder := Typed.Binder.ofUntyped binder binderTy
           let (_bodyTy, body') ← infer Θ (extendTyped Γ typedBinder) body
           let rest' ← inferBranches Θ Γ tys rest
@@ -1011,7 +1011,7 @@ mutual
         · simp [heq] at hcont
           cases hcont
           simpa using infer_runtime Θ Γ e _ hinfer
-        · by_cases hsub : Typ.sub Θ actual expected
+        · by_cases hsub : Typ.sub Θ .left actual expected || Typ.sub Θ .right actual expected
           · simp [heq, hsub] at hcont
             cases hcont
             simp [Expr.runtime, infer_runtime Θ Γ e _ hinfer]
@@ -1080,7 +1080,7 @@ mutual
         | cons ty tys =>
           obtain ⟨binder, body⟩ := br
           let binderTy := Typed.Binder.expectedTy binder ty
-          by_cases hsub : Typ.sub Θ ty binderTy
+          by_cases hsub : Typ.sub Θ .left ty binderTy || Typ.sub Θ .right ty binderTy
           · unfold Typed.inferBranches at h
             simp [binderTy, hsub] at h
             let typedBinder := Typed.Binder.ofUntyped binder binderTy

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -349,7 +349,7 @@ mutual
 end
 
 
--- /-! ## Operator typing -/
+/-! ## Operator typing -/
 
 def BinOp.typeOf : BinOp → Typ → Typ → Option Typ
   | .add,  .int,  .int  => some .int

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -616,8 +616,8 @@ theorem Binder.ofUntyped_runtime (b : Untyped.Binder) (ty : Typ) :
     (Typed.Binder.ofUntyped b ty).runtime = b.runtime := by
   cases b <;> rfl
 
-def Decl.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.Decl S) :
-    Except TypeError (Typed.Decl S) := do
+def ValDecl.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.ValDecl S) :
+    Except TypeError (Typed.ValDecl S) := do
   let (bodyTy, body') ←
     match d.name with
     | .named _ (some ty) => do
@@ -629,13 +629,24 @@ def Decl.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.De
     | _ => bodyTy
   .ok { name := Typed.Binder.ofUntyped d.name nameTy, body := body', spec := d.spec }
 
+def Decl.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.Decl S) :
+    Except TypeError (Typed.Decl S) := do
+  match d with
+  | .val_ d =>
+      return .val_ (← ValDecl.elaborate Θ Γ d)
+  | .type_ d =>
+      return .type_ { name := d.name, body := d.body }
+
 def Program.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) : Untyped.Program S → Except TypeError (Typed.Program S)
   | [] => .ok []
   | d :: ds => do
       let d' ← Decl.elaborate Θ Γ d
-      let Γ' := match d'.name.name with
-        | some x => Γ.extend x d'.name.ty
-        | none => Γ
+      let Γ' := match d' with
+        | .val_ d =>
+            match d.name.name with
+            | some x => Γ.extend x d.name.ty
+            | none => Γ
+        | .type_ _ => Γ
       let ds' ← Program.elaborate Θ Γ' ds
       .ok (d' :: ds')
 
@@ -992,49 +1003,52 @@ theorem Decl.elaborate_runtime {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d 
       Typed.Decl.elaborate Θ Γ d = .ok d' →
       d'.runtime = d.runtime := by
   intro d' h
-  cases hname : d.name with
-  | none =>
-    cases hinfer : Typed.infer Θ Γ d.body with
-    | error err =>
-      simp [Typed.Decl.elaborate, hname] at h
-      have ⟨p, hinfer', _⟩ := Except.bind_ok h
-      rw [hinfer] at hinfer'
-      cases hinfer'
-    | ok p =>
-      cases p with
-      | mk bodyTy body' =>
-        simp [Typed.Decl.elaborate, hname, hinfer] at h
-        cases h
-        simp [Typed.Decl.runtime, Untyped.Decl.runtime, infer_runtime Θ Γ d.body _ hinfer,
-          Binder.ofUntyped_runtime, hname]
-  | named x ann =>
-    cases hann : ann with
+  cases d with
+  | val_ dval =>
+    simp [Decl.elaborate] at h
+    have ⟨dval', helab, hret⟩ := Except.bind_ok h
+    cases hret
+    cases hname : dval.name with
     | none =>
-      cases hinfer : Typed.infer Θ Γ d.body with
+      cases hinfer : Typed.infer Θ Γ dval.body with
       | error err =>
-        simp [Typed.Decl.elaborate, hname, hann] at h
-        have ⟨p, hinfer', _⟩ := Except.bind_ok h
-        rw [hinfer] at hinfer'
-        cases hinfer'
+        simp [ValDecl.elaborate, hname, hinfer] at helab
+        cases helab
       | ok p =>
         cases p with
         | mk bodyTy body' =>
-          simp [Typed.Decl.elaborate, hname, hann, hinfer] at h
-          cases h
-          simp [Typed.Decl.runtime, Untyped.Decl.runtime, infer_runtime Θ Γ d.body _ hinfer,
-            Binder.ofUntyped_runtime, hname, hann]
-    | some ty =>
-      cases hcheck : Typed.check Θ Γ d.body ty with
-      | error err =>
-        simp [Typed.Decl.elaborate, hname, hann] at h
-        have ⟨body', hcheck', _⟩ := Except.bind_ok h
-        rw [hcheck] at hcheck'
-        cases hcheck'
-      | ok body' =>
-        simp [Typed.Decl.elaborate, hname, hann, hcheck] at h
-        cases h
-        simp [Typed.Decl.runtime, Untyped.Decl.runtime, check_runtime Θ Γ d.body ty _ hcheck,
-          Binder.ofUntyped_runtime, hname, hann]
+          simp [ValDecl.elaborate, hname, hinfer] at helab
+          cases helab
+          simp [Typed.Decl.runtime, Untyped.Decl.runtime, Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
+            infer_runtime Θ Γ dval.body _ hinfer, Binder.ofUntyped_runtime, hname]
+    | named x ann =>
+      cases hann : ann with
+      | none =>
+        cases hinfer : Typed.infer Θ Γ dval.body with
+        | error err =>
+          simp [ValDecl.elaborate, hname, hann, hinfer] at helab
+          cases helab
+        | ok p =>
+          cases p with
+          | mk bodyTy body' =>
+            simp [ValDecl.elaborate, hname, hann, hinfer] at helab
+            cases helab
+            simp [Typed.Decl.runtime, Untyped.Decl.runtime, Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
+              infer_runtime Θ Γ dval.body _ hinfer, Binder.ofUntyped_runtime, hname, hann]
+      | some ty =>
+        cases hcheck : Typed.check Θ Γ dval.body ty with
+        | error err =>
+          simp [ValDecl.elaborate, hname, hann, hcheck] at helab
+          cases helab
+        | ok body' =>
+          simp [ValDecl.elaborate, hname, hann, hcheck] at helab
+          cases helab
+          simp [Typed.Decl.runtime, Untyped.Decl.runtime, Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
+            check_runtime Θ Γ dval.body ty _ hcheck, Binder.ofUntyped_runtime, hname, hann]
+  | type_ dty =>
+    simp [Decl.elaborate] at h
+    cases h
+    simp [Typed.Decl.runtime, Untyped.Decl.runtime]
 
 theorem Program.elaborate_runtime {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (prog : Untyped.Program S) :
     ∀ {prog' : Typed.Program S},
@@ -1048,15 +1062,38 @@ theorem Program.elaborate_runtime {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) 
     rfl
   | cons d ds ih =>
     intro prog' h
-    unfold Typed.Program.elaborate at h
-    have ⟨d', hdecl, hcont⟩ := Except.bind_ok h
-    let Γ' := match d'.name.name with
-      | some x => Γ.extend x d'.name.ty
-      | none => Γ
-    have ⟨ds', htail, hcont⟩ := Except.bind_ok hcont
-    simp at hcont
-    cases hcont
-    simp [Typed.Program.runtime, Untyped.Program.runtime, Decl.elaborate_runtime Θ Γ d hdecl]
-    exact ih Γ' htail
+    cases d with
+    | val_ dval =>
+      unfold Typed.Program.elaborate at h
+      have ⟨d', hdecl, hcont⟩ := Except.bind_ok h
+      cases d' with
+      | val_ dval' =>
+        let Γ' := match dval'.name.name with
+          | some x => Γ.extend x dval'.name.ty
+          | none => Γ
+        have ⟨ds', htail, hcont⟩ := Except.bind_ok hcont
+        simp at hcont
+        cases hcont
+        have hdecl_rt : dval'.runtime = dval.runtime := by
+          simpa [Typed.Decl.runtime, Untyped.Decl.runtime] using
+            (Decl.elaborate_runtime Θ Γ (.val_ dval) hdecl)
+        simp [Typed.Program.runtime, Typed.Decl.runtime, Untyped.Program.runtime, Untyped.Decl.runtime]
+        constructor
+        · exact hdecl_rt
+        · exact ih Γ' htail
+      | type_ dty =>
+        cases hval : ValDecl.elaborate Θ Γ dval <;> simp [Decl.elaborate, hval] at hdecl
+    | type_ dty =>
+      unfold Typed.Program.elaborate at h
+      have ⟨d', hdecl, hcont⟩ := Except.bind_ok h
+      cases d' with
+      | val_ dval' =>
+        cases hdecl
+      | type_ dty' =>
+        have ⟨ds', htail, hcont⟩ := Except.bind_ok hcont
+        simp at hcont
+        cases hcont
+        simpa [Typed.Program.runtime, Typed.Decl.runtime, Untyped.Program.runtime, Untyped.Decl.runtime]
+          using ih Γ htail
 
 end Typed

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -68,79 +68,79 @@ theorem TyCtx.foldl_extend_stable
 /-! ## Subtyping -/
 
 mutual
-  inductive Typ.Sub : Typ → Typ → Prop where
-    | refl  : Typ.Sub t t
-    | bot   : Typ.Sub (Typ.empty) t
-    | top   : Typ.Sub t (Typ.value)
-    | trans : Typ.Sub s t → Typ.Sub t u → Typ.Sub s u
-    | sum   : Typ.SubList ss ts
-            → Typ.Sub (Typ.sum ss) (Typ.sum ts)
-    | arrow : Typ.Sub t1 s1 → Typ.Sub s2 t2
-            → Typ.Sub (Typ.arrow s1 s2) (Typ.arrow t1 t2)
-    | tuple : Typ.SubList ss ts
-            → Typ.Sub (Typ.tuple ss) (Typ.tuple ts)
+  inductive Typ.Sub (Θ : TypeEnv) : Typ → Typ → Prop where
+    | refl  : Typ.Sub Θ t t
+    | bot   : Typ.Sub Θ (Typ.empty) t
+    | top   : Typ.Sub Θ t (Typ.value)
+    | trans : Typ.Sub Θ s t → Typ.Sub Θ t u → Typ.Sub Θ s u
+    | sum   : Typ.SubList Θ ss ts
+            → Typ.Sub Θ (Typ.sum ss) (Typ.sum ts)
+    | arrow : Typ.Sub Θ t1 s1 → Typ.Sub Θ s2 t2
+            → Typ.Sub Θ (Typ.arrow s1 s2) (Typ.arrow t1 t2)
+    | tuple : Typ.SubList Θ ss ts
+            → Typ.Sub Θ (Typ.tuple ss) (Typ.tuple ts)
 
-  inductive Typ.SubList : List Typ → List Typ → Prop where
-    | nil  : Typ.SubList [] []
-    | cons : Typ.Sub s t → Typ.SubList ss ts → Typ.SubList (s :: ss) (t :: ts)
+  inductive Typ.SubList (Θ : TypeEnv) : List Typ → List Typ → Prop where
+    | nil  : Typ.SubList Θ [] []
+    | cons : Typ.Sub Θ s t → Typ.SubList Θ ss ts → Typ.SubList Θ (s :: ss) (t :: ts)
 end
 
-theorem Typ.SubList.length_eq : Typ.SubList ss ts → ss.length = ts.length
+theorem Typ.SubList.length_eq : Typ.SubList Θ ss ts → ss.length = ts.length
   | .nil => rfl
   | .cons _ h => by simp [List.length_cons, h.length_eq]
 
 mutual
-  def Typ.join : Typ → Typ → Typ
+  def Typ.join (_Θ : TypeEnv) : Typ → Typ → Typ
     | .empty, t | t, .empty => t
     | .value, _ | _, .value => .value
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
-                                    then .sum (Typ.joinList ss ts)
+                                    then .sum (Typ.joinList _Θ ss ts)
                                     else .value
-    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.meet s1 t1) (Typ.join s2 t2)
+    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.meet _Θ s1 t1) (Typ.join _Θ s2 t2)
     | .ref s,       .ref t       => if s == t then .ref s else .value
     | .tuple ss,    .tuple ts    => if ss.length == ts.length
-                                    then .tuple (Typ.joinList ss ts)
+                                    then .tuple (Typ.joinList _Θ ss ts)
                                     else .value
     | t, t'                      => if t == t' then t else .value
 
-  def Typ.meet : Typ → Typ → Typ
+  def Typ.meet (_Θ : TypeEnv) : Typ → Typ → Typ
     | .value, t | t, .value => t
     | .empty, _ | _, .empty => .empty
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
-                                    then .sum (Typ.meetList ss ts)
+                                    then .sum (Typ.meetList _Θ ss ts)
                                     else .empty
-    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.join s1 t1) (Typ.meet s2 t2)
+    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.join _Θ s1 t1) (Typ.meet _Θ s2 t2)
     | .ref s,       .ref t       => if s == t then .ref s else .empty
     | .tuple ss,    .tuple ts    => if ss.length == ts.length
-                                    then .tuple (Typ.meetList ss ts)
+                                    then .tuple (Typ.meetList _Θ ss ts)
                                     else .empty
     | t, t'                      => if t == t' then t else .empty
 
-  def Typ.joinList : List Typ → List Typ → List Typ
-    | s :: ss, t :: ts => Typ.join s t :: Typ.joinList ss ts
+  def Typ.joinList (_Θ : TypeEnv) : List Typ → List Typ → List Typ
+    | s :: ss, t :: ts => Typ.join _Θ s t :: Typ.joinList _Θ ss ts
     | _, _             => []
 
-  def Typ.meetList : List Typ → List Typ → List Typ
-    | s :: ss, t :: ts => Typ.meet s t :: Typ.meetList ss ts
+  def Typ.meetList (_Θ : TypeEnv) : List Typ → List Typ → List Typ
+    | s :: ss, t :: ts => Typ.meet _Θ s t :: Typ.meetList _Θ ss ts
     | _, _             => []
 end
 
 mutual
-  def Typ.sub (s t : Typ) : Bool :=
+  def Typ.sub (_Θ : TypeEnv) (s t : Typ) : Bool :=
     match s, t with
     | .empty, _      => true
     | _, .value      => true
-    | .sum  ss,     .sum  ts     => Typ.subList ss ts
-    | .arrow s1 s2, .arrow t1 t2 => Typ.sub t1 s1 && Typ.sub s2 t2
-    | .tuple ss,    .tuple ts    => Typ.subList ss ts
+    | .sum  ss,     .sum  ts     => Typ.subList _Θ ss ts
+    | .arrow s1 s2, .arrow t1 t2 => Typ.sub _Θ t1 s1 && Typ.sub _Θ s2 t2
+    | .tuple ss,    .tuple ts    => Typ.subList _Θ ss ts
     | t, t'                      => t == t'
   termination_by sizeOf s + sizeOf t
   decreasing_by all_goals simp +arith [*]
 
-  def Typ.subList (ss ts : List Typ) : Bool :=
+  def Typ.subList (_Θ : TypeEnv) (ss ts : List Typ) : Bool :=
     match ss, ts with
     | [], [] => true
-    | s :: ss, t :: ts => Typ.sub s t && Typ.subList ss ts
+    | s :: ss, t :: ts => Typ.sub _Θ s t && Typ.subList _Θ ss ts
     | _, _ => false
   termination_by sizeOf ss + sizeOf ts
   decreasing_by all_goals simp +arith [*]
@@ -148,7 +148,7 @@ end
 
 -- Forward direction: decision procedure is sound.
 mutual
-  private theorem Typ.sub_sound {s t : Typ} (h : Typ.sub s t = true) : Typ.Sub s t := by
+  private theorem Typ.sub_sound {Θ : TypeEnv} {s t : Typ} (h : Typ.sub Θ s t = true) : Typ.Sub Θ s t := by
     cases s with
     | empty => exact .bot
     | sum ss =>
@@ -179,8 +179,8 @@ mutual
   termination_by sizeOf s + sizeOf t
   decreasing_by all_goals simp +arith [*]
 
-  private theorem Typ.subList_sound {ss ts : List Typ}
-      (h : Typ.subList ss ts = true) : Typ.SubList ss ts := by
+  private theorem Typ.subList_sound {Θ : TypeEnv} {ss ts : List Typ}
+      (h : Typ.subList Θ ss ts = true) : Typ.SubList Θ ss ts := by
     match ss, ts with
     | [], [] => exact .nil
     | [], _ :: _ | _ :: _, [] => simp [Typ.subList] at h
@@ -193,24 +193,24 @@ end
 
 -- Reflexivity of the decision procedure (needed for completeness)
 mutual
-  private theorem Typ.sub_refl : ∀ (t : Typ), Typ.sub t t = true
+  private theorem Typ.sub_refl (Θ : TypeEnv) : ∀ (t : Typ), Typ.sub Θ t t = true
     | .unit | .bool | .int | .empty | .value => by simp [Typ.sub]
-    | .sum  ts     => by simp [Typ.sub, subList_refl ts]
-    | .arrow t1 t2 => by simp [Typ.sub, sub_refl t1, sub_refl t2]
+    | .sum  ts     => by simp [Typ.sub, subList_refl Θ ts]
+    | .arrow t1 t2 => by simp [Typ.sub, sub_refl Θ t1, sub_refl Θ t2]
     | .ref t       => by simp [Typ.sub]
-    | .tuple ts    => by simp [Typ.sub, subList_refl ts]
+    | .tuple ts    => by simp [Typ.sub, subList_refl Θ ts]
 
-  private theorem Typ.subList_refl : ∀ (ts : List Typ), Typ.subList ts ts = true
+  private theorem Typ.subList_refl (Θ : TypeEnv) : ∀ (ts : List Typ), Typ.subList Θ ts ts = true
     | [] => by simp [Typ.subList]
-    | t :: ts => by simp [Typ.subList, sub_refl t, subList_refl ts]
+    | t :: ts => by simp [Typ.subList, sub_refl Θ t, subList_refl Θ ts]
 end
 
 -- Transitivity of the decision procedure (needed for completeness of trans rule).
 -- Proved by recursion on t (the middle type).
 mutual
-  private theorem Typ.sub_trans {s t u : Typ}
-      (h1 : Typ.sub s t = true) (h2 : Typ.sub t u = true) :
-      Typ.sub s u = true := by
+  private theorem Typ.sub_trans {Θ : TypeEnv} {s t u : Typ}
+      (h1 : Typ.sub Θ s t = true) (h2 : Typ.sub Θ t u = true) :
+      Typ.sub Θ s u = true := by
     match t with
     | .empty | .value | .unit | .bool | .int => cases s <;> cases u <;> simp_all [Typ.sub, beq_iff_eq]
     | .ref _ => cases s <;> cases u <;> simp_all [Typ.sub, beq_iff_eq]
@@ -250,9 +250,9 @@ mutual
   termination_by sizeOf t
   decreasing_by all_goals simp +arith [*]
 
-  private theorem Typ.subList_trans {ss ts us : List Typ}
-      (h1 : Typ.subList ss ts = true) (h2 : Typ.subList ts us = true) :
-      Typ.subList ss us = true := by
+  private theorem Typ.subList_trans {Θ : TypeEnv} {ss ts us : List Typ}
+      (h1 : Typ.subList Θ ss ts = true) (h2 : Typ.subList Θ ts us = true) :
+      Typ.subList Θ ss us = true := by
     match ss, ts, us with
     | [], [], [] => simp [Typ.subList]
     | [], [], _ :: _ => simp [Typ.subList] at h2
@@ -267,25 +267,25 @@ end
 
 -- Backward direction: derivable subtyping is decided
 mutual
-  private theorem Typ.Sub_complete {s t : Typ} (p : Typ.Sub s t) : Typ.sub s t = true := by
+  private theorem Typ.Sub_complete (Θ : TypeEnv) {s t : Typ} (p : Typ.Sub Θ s t) : Typ.sub Θ s t = true := by
     match p with
-    | .refl        => exact sub_refl _
+    | .refl        => exact sub_refl Θ _
     | .bot         => cases t <;> simp [Typ.sub]
     | .top         => cases s <;> simp [Typ.sub]
-    | .trans h1 h2 => exact sub_trans (Sub_complete h1) (Sub_complete h2)
-    | .sum  h      => simp [Typ.sub, SubList_complete h]
-    | .arrow h1 h2 => simp [Typ.sub, Sub_complete h1, Sub_complete h2]
-    | .tuple h     => simp [Typ.sub]; exact SubList_complete h
+    | .trans h1 h2 => exact sub_trans (Sub_complete Θ h1) (Sub_complete Θ h2)
+    | .sum  h      => simp [Typ.sub, SubList_complete Θ h]
+    | .arrow h1 h2 => simp [Typ.sub, Sub_complete Θ h1, Sub_complete Θ h2]
+    | .tuple h     => simp [Typ.sub]; exact SubList_complete Θ h
 
-  private theorem Typ.SubList_complete {ss ts : List Typ}
-      (ps : Typ.SubList ss ts) : Typ.subList ss ts = true := by
+  private theorem Typ.SubList_complete (Θ : TypeEnv) {ss ts : List Typ}
+      (ps : Typ.SubList Θ ss ts) : Typ.subList Θ ss ts = true := by
     match ps with
     | .nil => simp [Typ.subList]
-    | .cons h hs => simp [Typ.subList, Sub_complete h, SubList_complete hs]
+    | .cons h hs => simp [Typ.subList, Sub_complete Θ h, SubList_complete Θ hs]
 end
 
-theorem Typ.sub_iff {s t : Typ} : Typ.sub s t = true ↔ Typ.Sub s t :=
-  ⟨sub_sound, Sub_complete⟩
+theorem Typ.sub_iff {Θ : TypeEnv} {s t : Typ} : Typ.sub Θ s t = true ↔ Typ.Sub Θ s t :=
+  ⟨sub_sound, Sub_complete Θ⟩
 
 /-! ## Operator typing -/
 
@@ -311,27 +311,27 @@ def UnOp.typeOf : UnOp → Typ → Option Typ
   | _, _             => none
 
 mutual
-  inductive ValHasType : Runtime.Val → Typ → Prop where
-    | int  (n : Int)  : ValHasType (.int n)  .int
-    | bool (b : Bool) : ValHasType (.bool b) .bool
-    | unit            : ValHasType .unit      .unit
+  inductive ValHasType (Θ : TypeEnv) : Runtime.Val → Typ → Prop where
+    | int  (n : Int)  : ValHasType Θ (.int n)  .int
+    | bool (b : Bool) : ValHasType Θ (.bool b) .bool
+    | unit            : ValHasType Θ .unit      .unit
     | inj  : (ht : ts[tag]? = some t)
-            → ValHasType payload t
-            → ValHasType (.inj tag ts.length payload) (.sum ts)
-    | tuple : ValsHaveTypes vs ts
-            → ValHasType (Runtime.Val.tuple vs) (Typ.tuple ts)
+            → ValHasType Θ payload t
+            → ValHasType Θ (.inj tag ts.length payload) (.sum ts)
+    | tuple : ValsHaveTypes Θ vs ts
+            → ValHasType Θ (Runtime.Val.tuple vs) (Typ.tuple ts)
     -- Any value has type .value
-    | any : ValHasType v .value
+    | any : ValHasType Θ v .value
 
-  inductive ValsHaveTypes : List Runtime.Val → List Typ → Prop where
-    | nil  : ValsHaveTypes [] []
-    | cons : ValHasType v t → ValsHaveTypes vs ts → ValsHaveTypes (v :: vs) (t :: ts)
+  inductive ValsHaveTypes (Θ : TypeEnv) : List Runtime.Val → List Typ → Prop where
+    | nil  : ValsHaveTypes Θ [] []
+    | cons : ValHasType Θ v t → ValsHaveTypes Θ vs ts → ValsHaveTypes Θ (v :: vs) (t :: ts)
 end
 
 
 mutual
-  theorem ValHasType_sub {v : Runtime.Val} {t t' : Typ} (h : ValHasType v t) (hsub : Typ.Sub t t') :
-      ValHasType v t' := by
+  theorem ValHasType_sub {Θ : TypeEnv} {v : Runtime.Val} {t t' : Typ} (h : ValHasType Θ v t) (hsub : Typ.Sub Θ t t') :
+      ValHasType Θ v t' := by
     match hsub with
     | .refl => exact h
     | .bot => cases h
@@ -348,9 +348,9 @@ mutual
       cases h with
       | tuple hvs => exact .tuple (ValsHaveTypes_sub hvs hsub)
 
-  theorem ValsHaveTypes_sub {vs : List Runtime.Val} {ts ts' : List Typ}
-      (h : ValsHaveTypes vs ts) (hsub : Typ.SubList ts ts') :
-      ValsHaveTypes vs ts' := by
+  theorem ValsHaveTypes_sub {Θ : TypeEnv} {vs : List Runtime.Val} {ts ts' : List Typ}
+      (h : ValsHaveTypes Θ vs ts) (hsub : Typ.SubList Θ ts ts') :
+      ValsHaveTypes Θ vs ts' := by
     match hsub with
     | .nil => cases h; exact .nil
     | .cons hs hss =>
@@ -359,17 +359,17 @@ mutual
 
   /-- Lift a payload through a `SubList`: if `ss[tag]? = some s` and `payload : s`,
       find `ts[tag]? = some t` and produce `ValHasType payload t`. -/
-  theorem ValHasType_subList {payload : Runtime.Val} {s : Typ} {ss ts : List Typ}
-      (hpayload : ValHasType payload s) (hlist : Typ.SubList ss ts)
+  theorem ValHasType_subList {Θ : TypeEnv} {payload : Runtime.Val} {s : Typ} {ss ts : List Typ}
+      (hpayload : ValHasType Θ payload s) (hlist : Typ.SubList Θ ss ts)
       {tag : Nat} (hs : ss[tag]? = some s) :
-      ∃ t, ts[tag]? = some t ∧ ValHasType payload t :=
+      ∃ t, ts[tag]? = some t ∧ ValHasType Θ payload t :=
     match hlist, tag with
     | .nil, _ => absurd hs (by simp)
     | .cons hsub _, 0 => by simp at hs; exact ⟨_, rfl, ValHasType_sub (hs ▸ hpayload) hsub⟩
     | .cons _ hss, n + 1 => ValHasType_subList hpayload hss (by simpa using hs)
 end
 
-theorem ValsHaveTypes.length_eq : ValsHaveTypes vs ts → vs.length = ts.length
+theorem ValsHaveTypes.length_eq {Θ : TypeEnv} : ValsHaveTypes Θ vs ts → vs.length = ts.length
   | .nil => rfl
   | .cons _ h => congrArg (· + 1) h.length_eq
 
@@ -379,12 +379,12 @@ end TinyML
 
 /-- Type preservation for `evalBinOp`: if the inputs are well-typed, the operation returns
     `some w` for a well-typed result `w`. -/
-theorem evalBinOp_typed {op : TinyML.BinOp} {v1 v2 : Runtime.Val} {t1 t2 ty : TinyML.Typ}
+theorem evalBinOp_typed {Θ : TinyML.TypeEnv} {op : TinyML.BinOp} {v1 v2 : Runtime.Val} {t1 t2 ty : TinyML.Typ}
     (hndiv : op ≠ .div) (hnmod : op ≠ .mod)
     (hty : TinyML.BinOp.typeOf op t1 t2 = some ty)
-    (ht1 : TinyML.ValHasType v1 t1)
-    (ht2 : TinyML.ValHasType v2 t2) :
-    ∃ w, TinyML.evalBinOp op v1 v2 = some w ∧ TinyML.ValHasType w ty := by
+    (ht1 : TinyML.ValHasType Θ v1 t1)
+    (ht2 : TinyML.ValHasType Θ v2 t2) :
+    ∃ w, TinyML.evalBinOp op v1 v2 = some w ∧ TinyML.ValHasType Θ w ty := by
   cases op
   case div => exact absurd rfl hndiv
   case mod => exact absurd rfl hnmod
@@ -398,9 +398,9 @@ theorem evalBinOp_typed {op : TinyML.BinOp} {v1 v2 : Runtime.Val} {t1 t2 ty : Ti
     simp_all
     first | exact .int _ | exact .bool _
 
-private theorem evalUnOp_proj_typed {n : Nat} {vs : List Runtime.Val} {ts : List TinyML.Typ} {ty : TinyML.Typ}
-    (hty : ts[n]? = some ty) (hvs : TinyML.ValsHaveTypes vs ts) :
-    ∃ w, vs[n]? = some w ∧ TinyML.ValHasType w ty := by
+private theorem evalUnOp_proj_typed {Θ : TinyML.TypeEnv} {n : Nat} {vs : List Runtime.Val} {ts : List TinyML.Typ} {ty : TinyML.Typ}
+    (hty : ts[n]? = some ty) (hvs : TinyML.ValsHaveTypes Θ vs ts) :
+    ∃ w, vs[n]? = some w ∧ TinyML.ValHasType Θ w ty := by
   induction n generalizing vs ts with
   | zero =>
     cases hvs with
@@ -414,8 +414,8 @@ private theorem evalUnOp_proj_typed {n : Nat} {vs : List Runtime.Val} {ts : List
 
 theorem evalUnOp_typed {op : TinyML.UnOp} {v : Runtime.Val} {t ty : TinyML.Typ}
     (hty : TinyML.UnOp.typeOf op t = some ty)
-    (ht : TinyML.ValHasType v t) :
-    ∃ w, TinyML.evalUnOp op v = some w ∧ TinyML.ValHasType w ty := by
+    (ht : TinyML.ValHasType Θ v t) :
+    ∃ w, TinyML.evalUnOp op v = some w ∧ TinyML.ValHasType Θ w ty := by
   cases op
   case proj n =>
     cases ht with
@@ -484,25 +484,25 @@ def extendTyped (Γ : TinyML.TyCtx) (b : Typed.Binder) : TinyML.TyCtx :=
   | none => Γ
   | some x => Γ.extend x b.ty
 
-def joinAll : List Typ → Typ
+def joinAll (Θ : TypeEnv) : List Typ → Typ
   | [] => .value
-  | t :: ts => ts.foldl Typ.join t
+  | t :: ts => ts.foldl (Typ.join Θ) t
 
 mutual
-  def infer (Γ : TinyML.TyCtx) : Untyped.Expr → Except TypeError (Typ × Typed.Expr)
+  def infer (Θ : TypeEnv) (Γ : TinyML.TyCtx) : Untyped.Expr → Except TypeError (Typ × Typed.Expr)
     | .const c => .ok (Typed.Const.ty c, .const c)
     | .var x =>
         match Γ x with
         | some ty => .ok (ty, .var x ty)
         | none => .error (.undefinedVar x)
     | .unop op e => do
-        let (argTy, e') ← infer Γ e
+        let (argTy, e') ← infer Θ Γ e
         match TinyML.UnOp.typeOf op argTy with
         | some ty => .ok (ty, .unop op e' ty)
         | none => .error (.unaryMismatch op argTy)
     | .binop op lhs rhs => do
-        let (lhsTy, lhs') ← infer Γ lhs
-        let (rhsTy, rhs') ← infer Γ rhs
+        let (lhsTy, lhs') ← infer Θ Γ lhs
+        let (rhsTy, rhs') ← infer Θ Γ rhs
         match TinyML.BinOp.typeOf op lhsTy rhsTy with
         | some ty => .ok (ty, .binop op lhs' rhs' ty)
         | none => .error (.operatorMismatch op lhsTy rhsTy)
@@ -512,59 +512,59 @@ mutual
         let selfTy := Typed.arrowOfArgs typedArgs retTy
         let typedSelf := Typed.Binder.ofUntyped self selfTy
         let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
-        let body' ← check Γ' body retTy
+        let body' ← check Θ Γ' body retTy
         .ok (selfTy, .fix typedSelf typedArgs retTy body')
     | .app fn args => do
-        let (fnTy, fn') ← infer Γ fn
-        let (args', retTy) ← checkArgs Γ fnTy args
+        let (fnTy, fn') ← infer Θ Γ fn
+        let (args', retTy) ← checkArgs Θ Γ fnTy args
         .ok (retTy, .app fn' args' retTy)
     | .ifThenElse cond thn els => do
-        let cond' ← check Γ cond .bool
-        let (thnTy, thn') ← infer Γ thn
-        let (elsTy, els') ← infer Γ els
-        let ty := Typ.join thnTy elsTy
+        let cond' ← check Θ Γ cond .bool
+        let (thnTy, thn') ← infer Θ Γ thn
+        let (elsTy, els') ← infer Θ Γ els
+        let ty := Typ.join Θ thnTy elsTy
         let thn'' := if thnTy == ty then thn' else .cast thn' ty
         let els'' := if elsTy == ty then els' else .cast els' ty
         .ok (ty, .ifThenElse cond' thn'' els'' ty)
     | .letIn name bound body => do
         let (boundTy, bound') ←
           match name with
-          | .named _ (some ty) => do let e' ← check Γ bound ty; .ok (ty, e')
-          | _ => infer Γ bound
+          | .named _ (some ty) => do let e' ← check Θ Γ bound ty; .ok (ty, e')
+          | _ => infer Θ Γ bound
         let typedName := Typed.Binder.ofUntyped name (match name with | .named _ (some ty) => ty | _ => boundTy)
-        let (bodyTy, body') ← infer (extendTyped Γ typedName) body
+        let (bodyTy, body') ← infer Θ (extendTyped Γ typedName) body
         .ok (bodyTy, .letIn typedName bound' body')
     | .ref e => do
-        let (ty, e') ← infer Γ e
+        let (ty, e') ← infer Θ Γ e
         .ok (.ref ty, .ref e')
     | .deref e => do
-        let (ty, e') ← infer Γ e
+        let (ty, e') ← infer Θ Γ e
         match ty with
         | .ref inner => .ok (inner, .deref e' inner)
         | _ => .error (.notARef ty)
     | .store loc val => do
-        let (locTy, loc') ← infer Γ loc
+        let (locTy, loc') ← infer Θ Γ loc
         match locTy with
         | .ref inner =>
-            let val' ← check Γ val inner
+            let val' ← check Θ Γ val inner
             .ok (.unit, .store loc' val')
         | _ => .error (.notARef locTy)
     | .assert e => do
-        let e' ← check Γ e .bool
+        let e' ← check Θ Γ e .bool
         .ok (.unit, .assert e')
     | .tuple es => do
-        let pairs ← inferList Γ es
+        let pairs ← inferList Θ Γ es
         .ok (.tuple (pairs.map Prod.fst), .tuple (pairs.map Prod.snd))
     | .inj tag arity payload => do
-        let (ty, payload') ← infer Γ payload
+        let (ty, payload') ← infer Θ Γ payload
         .ok (.sum ((List.replicate arity .empty).set tag ty), .inj tag arity payload')
     | .match_ scrutinee branches => do
-        let (scrutTy, scrut') ← infer Γ scrutinee
+        let (scrutTy, scrut') ← infer Θ Γ scrutinee
         match scrutTy with
         | .sum ts =>
             if _h : ts.length = branches.length then
-              let branches' ← inferBranches Γ ts branches
-              let ty := joinAll (branches'.map (fun p => p.2.ty))
+              let branches' ← inferBranches Θ Γ ts branches
+              let ty := joinAll Θ (branches'.map (fun p => p.2.ty))
               let branches'' := branches'.map fun
                 | (binder, body) =>
                     (binder, if body.ty == ty then body else .cast body ty)
@@ -573,39 +573,39 @@ mutual
               .error (.arityMismatch ts.length branches.length)
         | _ => .error (.notASum scrutTy)
 
-  def check (Γ : TinyML.TyCtx) (e : Untyped.Expr) (expected : Typ) : Except TypeError Typed.Expr := do
-    let (actual, e') ← infer Γ e
+  def check (Θ : TypeEnv) (Γ : TinyML.TyCtx) (e : Untyped.Expr) (expected : Typ) : Except TypeError Typed.Expr := do
+    let (actual, e') ← infer Θ Γ e
     if actual == expected then
       .ok e'
-    else if Typ.sub actual expected then
+    else if Typ.sub Θ actual expected then
       .ok (.cast e' expected)
     else
       .error (.subsumptionFailure actual expected)
 
-  def inferList (Γ : TinyML.TyCtx) : List Untyped.Expr → Except TypeError (List (Typ × Typed.Expr))
+  def inferList (Θ : TypeEnv) (Γ : TinyML.TyCtx) : List Untyped.Expr → Except TypeError (List (Typ × Typed.Expr))
     | [] => .ok []
     | e :: es => do
-        let head ← infer Γ e
-        let tail ← inferList Γ es
+        let head ← infer Θ Γ e
+        let tail ← inferList Θ Γ es
         .ok (head :: tail)
 
-  def checkArgs (Γ : TinyML.TyCtx) : Typ → List Untyped.Expr → Except TypeError (List Typed.Expr × Typ)
+  def checkArgs (Θ : TypeEnv) (Γ : TinyML.TyCtx) : Typ → List Untyped.Expr → Except TypeError (List Typed.Expr × Typ)
     | ty, [] => .ok ([], ty)
     | .arrow dom cod, arg :: args => do
-        let arg' ← check Γ arg dom
-        let (args', retTy) ← checkArgs Γ cod args
+        let arg' ← check Θ Γ arg dom
+        let (args', retTy) ← checkArgs Θ Γ cod args
         .ok (arg' :: args', retTy)
     | _ty, args => .error (.arityMismatch 0 args.length)
 
-  def inferBranches (Γ : TinyML.TyCtx) :
+  def inferBranches (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
       List Typ → List (Untyped.Binder × Untyped.Expr) → Except TypeError (List (Typed.Binder × Typed.Expr))
     | [], [] => .ok []
     | ty :: tys, (binder, body) :: rest => do
         let binderTy := Typed.Binder.expectedTy binder ty
-        if Typ.sub ty binderTy then
+        if Typ.sub Θ ty binderTy then
           let typedBinder := Typed.Binder.ofUntyped binder binderTy
-          let (_bodyTy, body') ← infer (extendTyped Γ typedBinder) body
-          let rest' ← inferBranches Γ tys rest
+          let (_bodyTy, body') ← infer Θ (extendTyped Γ typedBinder) body
+          let rest' ← inferBranches Θ Γ tys rest
           .ok ((typedBinder, body') :: rest')
         else
           .error (.subsumptionFailure ty binderTy)
@@ -616,27 +616,27 @@ theorem Binder.ofUntyped_runtime (b : Untyped.Binder) (ty : Typ) :
     (Typed.Binder.ofUntyped b ty).runtime = b.runtime := by
   cases b <;> rfl
 
-def Decl.elaborate {S : Type} (Γ : TinyML.TyCtx) (d : Untyped.Decl S) :
+def Decl.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.Decl S) :
     Except TypeError (Typed.Decl S) := do
   let (bodyTy, body') ←
     match d.name with
     | .named _ (some ty) => do
-        let body' ← check Γ d.body ty
+        let body' ← check Θ Γ d.body ty
         .ok (ty, body')
-    | _ => infer Γ d.body
+    | _ => infer Θ Γ d.body
   let nameTy := match d.name with
     | .named _ (some ty) => ty
     | _ => bodyTy
   .ok { name := Typed.Binder.ofUntyped d.name nameTy, body := body', spec := d.spec }
 
-def Program.elaborate {S : Type} (Γ : TinyML.TyCtx) : Untyped.Program S → Except TypeError (Typed.Program S)
+def Program.elaborate {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) : Untyped.Program S → Except TypeError (Typed.Program S)
   | [] => .ok []
   | d :: ds => do
-      let d' ← Decl.elaborate Γ d
+      let d' ← Decl.elaborate Θ Γ d
       let Γ' := match d'.name.name with
         | some x => Γ.extend x d'.name.ty
         | none => Γ
-      let ds' ← Program.elaborate Γ' ds
+      let ds' ← Program.elaborate Θ Γ' ds
       .ok (d' :: ds')
 
 -- The main issue in this block is not the mathematical argument, but convincing
@@ -655,8 +655,8 @@ def Program.elaborate {S : Type} (Γ : TinyML.TyCtx) : Untyped.Program S → Exc
 -- over successful elaboration results. Once those recursive implications have
 -- been obtained in the branch, they can be used freely afterward.
 mutual
-  theorem infer_runtime (Γ : TinyML.TyCtx) :
-      (e : Untyped.Expr) → ∀ result, Typed.infer Γ e = .ok result → result.2.runtime = e.runtime
+  theorem infer_runtime (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
+      (e : Untyped.Expr) → ∀ result, Typed.infer Θ Γ e = .ok result → result.2.runtime = e.runtime
     | .const c => by
         intro result h
         simp [Typed.infer] at h
@@ -668,7 +668,7 @@ mutual
         split at h <;> cases h
         simp [Expr.runtime, Untyped.Expr.runtime]
     | .unop op e => by
-        let ih := infer_runtime Γ e
+        let ih := infer_runtime Θ Γ e
         intro result h
         unfold Typed.infer at h
         have ⟨p, hinfer, hcont⟩ := Except.bind_ok h
@@ -681,8 +681,8 @@ mutual
             rcases (by simpa [hty] using hcont) with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ih _ hinfer]
     | .binop op lhs rhs => by
-        let ihL := infer_runtime Γ lhs
-        let ihR := infer_runtime Γ rhs
+        let ihL := infer_runtime Θ Γ lhs
+        let ihR := infer_runtime Θ Γ rhs
         intro result h
         unfold Typed.infer at h
         have ⟨lp, hlhs, hcont⟩ := Except.bind_ok h
@@ -703,15 +703,15 @@ mutual
         let selfTy := Typed.arrowOfArgs typedArgs retTy'
         let typedSelf := Typed.Binder.ofUntyped self selfTy
         let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
-        let ih := check_runtime Γ' body retTy'
+        let ih := check_runtime Θ Γ' body retTy'
         intro result h
         unfold Typed.infer at h
         have ⟨body', hbody, hcont⟩ := Except.bind_ok h
         rcases (by simpa [retTy', typedArgs, selfTy, typedSelf, Γ', hbody] using hcont) with ⟨rfl, rfl⟩
         simp [Expr.runtime, Untyped.Expr.runtime, ih _ hbody, Binder.ofUntyped_runtime]
     | .app fn args => by
-        let ihFn := infer_runtime Γ fn
-        let ihArgs := checkArgs_runtime Γ args
+        let ihFn := infer_runtime Θ Γ fn
+        let ihArgs := checkArgs_runtime Θ Γ args
         intro result h
         unfold Typed.infer at h
         have ⟨fp, hfn, hcont⟩ := Except.bind_ok h
@@ -723,9 +723,9 @@ mutual
             rcases (by simpa [hargs] using hcont) with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ihFn _ hfn, ihArgs fnTy _ hargs]
     | .ifThenElse cond thn els => by
-        let ihCond := check_runtime Γ cond .bool
-        let ihThn := infer_runtime Γ thn
-        let ihEls := infer_runtime Γ els
+        let ihCond := check_runtime Θ Γ cond .bool
+        let ihThn := infer_runtime Θ Γ thn
+        let ihEls := infer_runtime Θ Γ els
         intro result h
         unfold Typed.infer at h
         have ⟨cond', hcond, hcont⟩ := Except.bind_ok h
@@ -738,12 +738,12 @@ mutual
             rcases (by simpa [hels] using hcont) with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ihCond _ hcond]
             constructor
-            · by_cases h : thnTy = thnTy.join elsTy
+            · by_cases h : thnTy = Typ.join Θ thnTy elsTy
               · rw [if_pos h]
                 exact ihThn _ hthn
               · rw [if_neg h]
                 simpa [Typed.Expr.runtime] using ihThn _ hthn
-            · by_cases h : elsTy = thnTy.join elsTy
+            · by_cases h : elsTy = Typ.join Θ thnTy elsTy
               · rw [if_pos h]
                 exact ihEls _ hels
               · rw [if_neg h]
@@ -757,8 +757,8 @@ mutual
           cases p with
           | mk boundTy bound' =>
             let typedName := Typed.Binder.ofUntyped .none boundTy
-            let ihBound := infer_runtime Γ bound
-            let ihBody := infer_runtime (extendTyped Γ typedName) body
+            let ihBound := infer_runtime Θ Γ bound
+            let ihBody := infer_runtime Θ (extendTyped Γ typedName) body
             have ⟨p, hbody, hcont⟩ := Except.bind_ok hcont
             cases p with
             | mk bodyTy body' =>
@@ -773,8 +773,8 @@ mutual
             cases p with
             | mk boundTy bound' =>
               let typedName := Typed.Binder.ofUntyped (.named x .none) boundTy
-              let ihBound := infer_runtime Γ bound
-              let ihBody := infer_runtime (extendTyped Γ typedName) body
+              let ihBound := infer_runtime Θ Γ bound
+              let ihBody := infer_runtime Θ (extendTyped Γ typedName) body
               have ⟨p, hbody, hcont⟩ := Except.bind_ok hcont
               cases p with
               | mk bodyTy body' =>
@@ -785,11 +785,11 @@ mutual
             unfold Typed.infer at h
             have ⟨bound', hbound, hcont⟩ := Except.bind_ok h
             let typedName := Typed.Binder.ofUntyped (.named x (.some ty)) ty
-            let ihBound := check_runtime Γ bound ty
-            let ihBody := infer_runtime (extendTyped Γ typedName) body
+            let ihBound := check_runtime Θ Γ bound ty
+            let ihBody := infer_runtime Θ (extendTyped Γ typedName) body
             have hcont' :
                 (do
-                  let p ← infer (extendTyped Γ typedName) body
+                  let p ← infer Θ (extendTyped Γ typedName) body
                   Except.ok (p.1, Expr.letIn typedName bound' p.2)) = .ok result := by
               simpa [typedName] using hcont
             have ⟨p, hbody, hcont⟩ := Except.bind_ok hcont'
@@ -802,7 +802,7 @@ mutual
               simp [Expr.runtime, Untyped.Expr.runtime, ihBound _ hbound, ihBody _ hbody,
                 hname_rt]
     | .ref e => by
-        let ih := infer_runtime Γ e
+        let ih := infer_runtime Θ Γ e
         intro result h
         unfold Typed.infer at h
         have ⟨p, hinfer, hcont⟩ := Except.bind_ok h
@@ -811,7 +811,7 @@ mutual
           rcases (by simpa using hcont) with ⟨rfl, rfl⟩
           simp [Expr.runtime, Untyped.Expr.runtime, ih _ hinfer]
     | .deref e => by
-        let ih := infer_runtime Γ e
+        let ih := infer_runtime Θ Γ e
         intro result h
         unfold Typed.infer at h
         have ⟨p, hinfer, hcont⟩ := Except.bind_ok h
@@ -822,7 +822,7 @@ mutual
             rcases (by simpa using hcont) with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ih _ hinfer]
     | .store loc val => by
-        let ihLoc := infer_runtime Γ loc
+        let ihLoc := infer_runtime Θ Γ loc
         intro result h
         unfold Typed.infer at h
         have ⟨p, hloc, hcont⟩ := Except.bind_ok h
@@ -830,26 +830,26 @@ mutual
         | mk locTy loc' =>
           cases locTy <;> simp at hcont
           case ref inner =>
-            let ihVal := check_runtime Γ val inner
+            let ihVal := check_runtime Θ Γ val inner
             have ⟨val', hval, hcont⟩ := Except.bind_ok hcont
             rcases (by simpa using hcont) with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ihLoc _ hloc, ihVal _ hval]
     | .assert e => by
-        let ih := check_runtime Γ e .bool
+        let ih := check_runtime Θ Γ e .bool
         intro result h
         unfold Typed.infer at h
         have ⟨e1, he, hcont⟩ := Except.bind_ok h
         rcases (by simpa using hcont) with ⟨rfl, rfl⟩
         simp [Expr.runtime, Untyped.Expr.runtime, ih _ he]
     | .tuple es => by
-        let ih := inferList_runtime Γ es
+        let ih := inferList_runtime Θ Γ es
         intro result h
         unfold Typed.infer at h
         have ⟨pairs, hpairs, hcont⟩ := Except.bind_ok h
         rcases (by simpa [hpairs] using hcont) with ⟨rfl, rfl⟩
         simp [Expr.runtime, Untyped.Expr.runtime, ih _ hpairs]
     | .inj tag arity payload => by
-        let ih := infer_runtime Γ payload
+        let ih := infer_runtime Θ Γ payload
         intro result h
         unfold Typed.infer at h
         have ⟨p, hpayload, hcont⟩ := Except.bind_ok h
@@ -858,8 +858,8 @@ mutual
           rcases (by simpa using hcont) with ⟨rfl, rfl⟩
           simp [Expr.runtime, Untyped.Expr.runtime, ih _ hpayload]
     | .match_ scrutinee branches => by
-        let ihScrut := infer_runtime Γ scrutinee
-        let ihBranches := inferBranches_runtime Γ branches
+        let ihScrut := infer_runtime Θ Γ scrutinee
+        let ihBranches := inferBranches_runtime Θ Γ branches
         intro result h
         unfold Typed.infer at h
         have ⟨p, hscrut, hcont⟩ := Except.bind_ok h
@@ -876,13 +876,13 @@ mutual
                     (List.map
                       (fun x =>
                         (x.1,
-                          if x.2.ty = joinAll (List.map (fun p => p.2.ty) branches') then x.2
-                          else x.2.cast (joinAll (List.map (fun p => p.2.ty) branches'))))
+                          if x.2.ty = joinAll Θ (List.map (fun p => p.2.ty) branches') then x.2
+                          else x.2.cast (joinAll Θ (List.map (fun p => p.2.ty) branches'))))
                       branches') =
                   Expr.runtime.branchListRuntime branches' := by
                 simpa [BEq.beq] using
                   Typed.Expr.branchListRuntime_castBodies
-                    (joinAll (List.map (fun p => p.2.ty) branches')) branches'
+                    (joinAll Θ (List.map (fun p => p.2.ty) branches')) branches'
               simp [Expr.runtime, Untyped.Expr.runtime]
               constructor
               · exact ihScrut _ hscrut
@@ -891,8 +891,8 @@ mutual
           | _ =>
             simp at hcont
 
-  theorem check_runtime (Γ : TinyML.TyCtx) (e : Untyped.Expr) (expected : Typ) :
-      ∀ e', Typed.check Γ e expected = .ok e' → e'.runtime = e.runtime := by
+  theorem check_runtime (Θ : TypeEnv) (Γ : TinyML.TyCtx) (e : Untyped.Expr) (expected : Typ) :
+      ∀ e', Typed.check Θ Γ e expected = .ok e' → e'.runtime = e.runtime := by
       intro e' h
       unfold Typed.check at h
       have ⟨p, hinfer, hcont⟩ := Except.bind_ok h
@@ -901,15 +901,15 @@ mutual
         by_cases heq : actual == expected
         · simp [heq] at hcont
           cases hcont
-          simpa using infer_runtime Γ e _ hinfer
-        · by_cases hsub : Typ.sub actual expected
+          simpa using infer_runtime Θ Γ e _ hinfer
+        · by_cases hsub : Typ.sub Θ actual expected
           · simp [heq, hsub] at hcont
             cases hcont
-            simp [Expr.runtime, infer_runtime Γ e _ hinfer]
+            simp [Expr.runtime, infer_runtime Θ Γ e _ hinfer]
           · simp [heq, hsub] at hcont
 
-  theorem inferList_runtime (Γ : TinyML.TyCtx) :
-      (es : List Untyped.Expr) → ∀ pairs, Typed.inferList Γ es = .ok pairs →
+  theorem inferList_runtime (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
+      (es : List Untyped.Expr) → ∀ pairs, Typed.inferList Θ Γ es = .ok pairs →
         (pairs.map Prod.snd).map Expr.runtime = es.map Untyped.Expr.runtime
     | [] => by
         intro pairs h
@@ -917,8 +917,8 @@ mutual
         cases h
         rfl
     | e :: es => by
-        let ihHead := infer_runtime Γ e
-        let ihTail := inferList_runtime Γ es
+        let ihHead := infer_runtime Θ Γ e
+        let ihTail := inferList_runtime Θ Γ es
         intro pairs h
         unfold Typed.inferList at h
         have ⟨head, hinfer, hcont⟩ := Except.bind_ok h
@@ -929,8 +929,8 @@ mutual
           cases hcont
           simp [ihHead _ hinfer, ihTail _ htail]
 
-  theorem checkArgs_runtime (Γ : TinyML.TyCtx) :
-      (args : List Untyped.Expr) → ∀ ty result, Typed.checkArgs Γ ty args = .ok result →
+  theorem checkArgs_runtime (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
+      (args : List Untyped.Expr) → ∀ ty result, Typed.checkArgs Θ Γ ty args = .ok result →
         result.1.map Expr.runtime = args.map Untyped.Expr.runtime
     | [] => by
         intro ty result h
@@ -938,7 +938,7 @@ mutual
         cases h
         rfl
     | arg :: args => by
-        let ihRest := checkArgs_runtime Γ args
+        let ihRest := checkArgs_runtime Θ Γ args
         intro ty result h
         cases ty <;> simp [Typed.checkArgs] at h
         case arrow dom cod =>
@@ -949,11 +949,11 @@ mutual
             simp at hcont
             cases hcont
             simp only [List.map]
-            rw [check_runtime Γ arg dom _ harg, ihRest cod _ hrest]
+            rw [check_runtime Θ Γ arg dom _ harg, ihRest cod _ hrest]
 
-  theorem inferBranches_runtime (Γ : TinyML.TyCtx) :
+  theorem inferBranches_runtime (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
       (branches : List (Untyped.Binder × Untyped.Expr)) →
-      ∀ tys branches', Typed.inferBranches Γ tys branches = .ok branches' →
+      ∀ tys branches', Typed.inferBranches Θ Γ tys branches = .ok branches' →
         Expr.runtime.branchListRuntime branches' =
           Untyped.Expr.runtime.branchListRuntime branches
     | [] => by
@@ -963,7 +963,7 @@ mutual
           cases h
           simp [Expr.runtime.branchListRuntime, Untyped.Expr.runtime.branchListRuntime]
     | br :: rest => by
-        let ihRest := inferBranches_runtime Γ rest
+        let ihRest := inferBranches_runtime Θ Γ rest
         intro tys branches' h
         cases tys with
         | nil =>
@@ -971,11 +971,11 @@ mutual
         | cons ty tys =>
           obtain ⟨binder, body⟩ := br
           let binderTy := Typed.Binder.expectedTy binder ty
-          by_cases hsub : Typ.sub ty binderTy
+          by_cases hsub : Typ.sub Θ ty binderTy
           · unfold Typed.inferBranches at h
             simp [binderTy, hsub] at h
             let typedBinder := Typed.Binder.ofUntyped binder binderTy
-            let ihBody := infer_runtime (extendTyped Γ typedBinder) body
+            let ihBody := infer_runtime Θ (extendTyped Γ typedBinder) body
             have ⟨p, hbody, hcont⟩ := Except.bind_ok h
             cases p with
             | mk bodyTy body' =>
@@ -987,14 +987,14 @@ mutual
           · simp [Typed.inferBranches, binderTy, hsub] at h
 end
 
-theorem Decl.elaborate_runtime {S : Type} (Γ : TinyML.TyCtx) (d : Untyped.Decl S) :
+theorem Decl.elaborate_runtime {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (d : Untyped.Decl S) :
     ∀ {d' : Typed.Decl S},
-      Typed.Decl.elaborate Γ d = .ok d' →
+      Typed.Decl.elaborate Θ Γ d = .ok d' →
       d'.runtime = d.runtime := by
   intro d' h
   cases hname : d.name with
   | none =>
-    cases hinfer : Typed.infer Γ d.body with
+    cases hinfer : Typed.infer Θ Γ d.body with
     | error err =>
       simp [Typed.Decl.elaborate, hname] at h
       have ⟨p, hinfer', _⟩ := Except.bind_ok h
@@ -1005,12 +1005,12 @@ theorem Decl.elaborate_runtime {S : Type} (Γ : TinyML.TyCtx) (d : Untyped.Decl 
       | mk bodyTy body' =>
         simp [Typed.Decl.elaborate, hname, hinfer] at h
         cases h
-        simp [Typed.Decl.runtime, Untyped.Decl.runtime, infer_runtime Γ d.body _ hinfer,
+        simp [Typed.Decl.runtime, Untyped.Decl.runtime, infer_runtime Θ Γ d.body _ hinfer,
           Binder.ofUntyped_runtime, hname]
   | named x ann =>
     cases hann : ann with
     | none =>
-      cases hinfer : Typed.infer Γ d.body with
+      cases hinfer : Typed.infer Θ Γ d.body with
       | error err =>
         simp [Typed.Decl.elaborate, hname, hann] at h
         have ⟨p, hinfer', _⟩ := Except.bind_ok h
@@ -1021,10 +1021,10 @@ theorem Decl.elaborate_runtime {S : Type} (Γ : TinyML.TyCtx) (d : Untyped.Decl 
         | mk bodyTy body' =>
           simp [Typed.Decl.elaborate, hname, hann, hinfer] at h
           cases h
-          simp [Typed.Decl.runtime, Untyped.Decl.runtime, infer_runtime Γ d.body _ hinfer,
+          simp [Typed.Decl.runtime, Untyped.Decl.runtime, infer_runtime Θ Γ d.body _ hinfer,
             Binder.ofUntyped_runtime, hname, hann]
     | some ty =>
-      cases hcheck : Typed.check Γ d.body ty with
+      cases hcheck : Typed.check Θ Γ d.body ty with
       | error err =>
         simp [Typed.Decl.elaborate, hname, hann] at h
         have ⟨body', hcheck', _⟩ := Except.bind_ok h
@@ -1033,12 +1033,12 @@ theorem Decl.elaborate_runtime {S : Type} (Γ : TinyML.TyCtx) (d : Untyped.Decl 
       | ok body' =>
         simp [Typed.Decl.elaborate, hname, hann, hcheck] at h
         cases h
-        simp [Typed.Decl.runtime, Untyped.Decl.runtime, check_runtime Γ d.body ty _ hcheck,
+        simp [Typed.Decl.runtime, Untyped.Decl.runtime, check_runtime Θ Γ d.body ty _ hcheck,
           Binder.ofUntyped_runtime, hname, hann]
 
-theorem Program.elaborate_runtime {S : Type} (Γ : TinyML.TyCtx) (prog : Untyped.Program S) :
+theorem Program.elaborate_runtime {S : Type} (Θ : TypeEnv) (Γ : TinyML.TyCtx) (prog : Untyped.Program S) :
     ∀ {prog' : Typed.Program S},
-      Typed.Program.elaborate Γ prog = .ok prog' →
+      Typed.Program.elaborate Θ Γ prog = .ok prog' →
       prog'.runtime = prog.runtime := by
   induction prog generalizing Γ with
   | nil =>
@@ -1056,7 +1056,7 @@ theorem Program.elaborate_runtime {S : Type} (Γ : TinyML.TyCtx) (prog : Untyped
     have ⟨ds', htail, hcont⟩ := Except.bind_ok hcont
     simp at hcont
     cases hcont
-    simp [Typed.Program.runtime, Untyped.Program.runtime, Decl.elaborate_runtime Γ d hdecl]
+    simp [Typed.Program.runtime, Untyped.Program.runtime, Decl.elaborate_runtime Θ Γ d hdecl]
     exact ih Γ' htail
 
 end Typed

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -67,15 +67,6 @@ theorem TyCtx.foldl_extend_stable
 
 /-! ## Subtyping -/
 
-inductive UnfoldSide where
-  | left
-  | right
-  deriving Repr, DecidableEq
-
-def UnfoldSide.flip : UnfoldSide → UnfoldSide
-  | .left => .right
-  | .right => .left
-
 mutual
   @[reducible]
   def Typ.weight : Typ → Nat
@@ -142,30 +133,26 @@ theorem Typ.weight_pair_lt_list_tail (s : Typ) (ss : List Typ) (t : Typ) (ts : L
 set_option linter.unnecessarySimpa false in
 mutual
 
-  def Typ.subBody (Θ : TypeEnv) (recur : UnfoldSide → Typ → Typ → Bool) :
-      UnfoldSide → Typ → Typ → Bool :=
-      fun side s t =>
+  def Typ.subBody (Θ : TypeEnv) (recur : Typ → Typ → Bool) : Typ → Typ → Bool :=
+      fun s t =>
         match s, t with
         | .empty, _ => true
         | _, .value => true
-        | .sum ss, .sum ts => Typ.subListBody Θ recur side ss ts
+        | .sum ss, .sum ts => Typ.subListBody Θ recur ss ts
         | .arrow s1 s2, .arrow t1 t2 =>
-            Typ.subBody Θ recur side.flip t1 s1 && Typ.subBody Θ recur side s2 t2
-        | .tuple ss, .tuple ts => Typ.subListBody Θ recur side ss ts
-        | .named T args, t =>
-            if .named T args == t then true
-            else if side ≠ .left then false
-            else match TypeName.unfold Θ T args with
-              | some s => recur .left s t
+            Typ.subBody Θ recur t1 s1 && Typ.subBody Θ recur s2 t2
+        | .tuple ss, .tuple ts => Typ.subListBody Θ recur ss ts
+        | _, _ =>
+            if s == t then true
+            else match s, t with
+              | .named T args, _ => match TypeName.unfold Θ T args with
+                  | some s' => recur s' t
               | none => false
-        | s, .named T args =>
-            if s == .named T args then true
-            else if side ≠ .right then false
-            else match TypeName.unfold Θ T args with
-              | some t => recur .right s t
+              | _, .named T args => match TypeName.unfold Θ T args with
+                  | some t' => recur s t'
               | none => false
-        | s, t => s == t
-  termination_by _ s t => Typ.weight s + Typ.weight t
+              | _, _ => false
+  termination_by s t => Typ.weight s + Typ.weight t
   decreasing_by
     all_goals
       first
@@ -173,12 +160,11 @@ mutual
         | simpa [Typ.weight] using Typ.weight_pair_lt_arrow_dom _ _ _ _
         | simpa [Typ.weight] using Typ.weight_pair_lt_arrow_codom _ _ _ _
 
-  def Typ.subListBody (Θ : TypeEnv) (recur : UnfoldSide → Typ → Typ → Bool) :
-      UnfoldSide → List Typ → List Typ → Bool
-    | _, [], [] => true
-    | side, s :: ss, t :: ts => Typ.subBody Θ recur side s t && Typ.subListBody Θ recur side ss ts
-    | _, _, _ => false
-  termination_by _ ss ts => 1 + Typ.weights ss + Typ.weights ts
+  def Typ.subListBody (Θ : TypeEnv) (recur : Typ → Typ → Bool) : List Typ → List Typ → Bool
+    | [], [] => true
+    | s :: ss, t :: ts => Typ.subBody Θ recur s t && Typ.subListBody Θ recur ss ts
+    | _, _ => false
+  termination_by ss ts => 1 + Typ.weights ss + Typ.weights ts
   decreasing_by
     all_goals
       first
@@ -186,21 +172,21 @@ mutual
         | exact Typ.weight_pair_lt_list_tail _ _ _ _
 end
 
-def Typ.subi (Θ : TypeEnv) (steps : Nat) : UnfoldSide → Typ → Typ → Bool :=
+def Typ.subi (Θ : TypeEnv) (steps : Nat) : Typ → Typ → Bool :=
   match steps with
-  | 0 => fun _ _ _ => false
+  | 0 => fun _ _ => false
   | n + 1 => Typ.subBody Θ (Typ.subi Θ n)
 
-def Typ.subListi (Θ : TypeEnv) (steps : Nat) : UnfoldSide → List Typ → List Typ → Bool :=
+def Typ.subListi (Θ : TypeEnv) (steps : Nat) : List Typ → List Typ → Bool :=
   match steps with
-  | 0 => fun _ _ _ => false
+  | 0 => fun _ _ => false
   | n + 1 => Typ.subListBody Θ (Typ.subi Θ n)
 
-def Typ.sub (Θ : TypeEnv) : UnfoldSide → Typ → Typ → Bool :=
-  fun side s t => Typ.subi Θ (max (Typ.depth s) (Typ.depth t)) side s t
+def Typ.sub (Θ : TypeEnv) : Typ → Typ → Bool :=
+  fun s t => Typ.subi Θ (max (Typ.depth s) (Typ.depth t)) s t
 
-def Typ.subList (Θ : TypeEnv) : UnfoldSide → List Typ → List Typ → Bool :=
-  fun side ss ts => Typ.subListi Θ (max (Typ.depths ss) (Typ.depths ts)) side ss ts
+def Typ.subList (Θ : TypeEnv) : List Typ → List Typ → Bool :=
+  fun ss ts => Typ.subListi Θ (max (Typ.depths ss) (Typ.depths ts)) ss ts
 
 mutual
   inductive Typ.Sub (Θ : TypeEnv) : Typ → Typ → Prop where
@@ -234,9 +220,9 @@ theorem Typ.SubList.length_eq : Typ.SubList Θ ss ts → ss.length = ts.length
 -- Forward direction: decision procedure is sound.
 set_option linter.unnecessarySimpa false in
 mutual
-  private theorem Typ.subBody_sound {Θ : TypeEnv} {recur : UnfoldSide → Typ → Typ → Bool}
-      (hrecur : ∀ {side s t}, recur side s t = true → Typ.Sub Θ s t)
-      {side : UnfoldSide} {s t : Typ} (h : Typ.subBody Θ recur side s t = true) : Typ.Sub Θ s t := by
+  private theorem Typ.subBody_sound {Θ : TypeEnv} {recur : Typ → Typ → Bool}
+      (hrecur : ∀ {s t}, recur s t = true → Typ.Sub Θ s t)
+      {s t : Typ} (h : Typ.subBody Θ recur s t = true) : Typ.Sub Θ s t := by
     unfold Typ.subBody at h
     split at h
     · exact .bot
@@ -245,36 +231,28 @@ mutual
     · simp [Bool.and_eq_true] at h
       exact .arrow (subBody_sound hrecur h.1) (subBody_sound hrecur h.2)
     · exact .tuple (subListBody_sound hrecur h)
-    · split at h
-      · rename_i T args _ hbeq
-        have heq : .named T args = t := by simpa using hbeq
-        cases heq
-        exact .refl
-      · split at h
-        · rename_i T args _ hneq hside
-          simp at h
-        · split at h
-          · rename_i T args _ hneq hside ty hunfold
+    · -- catchall: if s == t then true else match (s, t) for named
+      split at h
+      · -- s == t
+        rename_i hbeq
+        have heq : s = t := by simpa using hbeq
+        subst heq; exact .refl
+      · -- s ≠ t, check if either side is named
+        split at h
+        · -- s = .named T args
+          rename_i T args hneq
+          split at h
+          · rename_i s' hunfold
             exact .named_left hunfold (hrecur h)
-          · rename_i T args _ hneq hside hunfold
-            cases h
-    · split at h
-      · rename_i T args _ _ hbeq
-        have heq : s = .named T args := by simpa using hbeq
-        cases heq
-        exact .refl
-      · split at h
-        · rename_i T args _ _ hneq hside
-          simp at h
-        · split at h
-          · rename_i T args _ _ hneq hside ty hunfold
+          · cases h
+        · -- t = .named T args (s is not named)
+          rename_i T args hneq
+          split at h
+          · rename_i t' hunfold
             exact .named_right hunfold (hrecur h)
-          · rename_i T args _ _ hneq hside hunfold
+          · cases h
+        · -- neither named
             cases h
-    · have hst : s = t := by
-        simpa using h
-      subst hst
-      exact .refl
   termination_by Typ.weight s + Typ.weight t
   decreasing_by
     all_goals
@@ -282,10 +260,10 @@ mutual
       try simp [Typ.weight]
       try omega
 
-  private theorem Typ.subListBody_sound {Θ : TypeEnv} {recur : UnfoldSide → Typ → Typ → Bool}
-      (hrecur : ∀ {side s t}, recur side s t = true → Typ.Sub Θ s t)
-      {side : UnfoldSide} {ss ts : List Typ}
-      (h : Typ.subListBody Θ recur side ss ts = true) : Typ.SubList Θ ss ts := by
+  private theorem Typ.subListBody_sound {Θ : TypeEnv} {recur : Typ → Typ → Bool}
+      (hrecur : ∀ {s t}, recur s t = true → Typ.Sub Θ s t)
+      {ss ts : List Typ}
+      (h : Typ.subListBody Θ recur ss ts = true) : Typ.SubList Θ ss ts := by
     match ss, ts with
     | [], [] =>
         exact .nil
@@ -301,31 +279,31 @@ mutual
         | exact Typ.weight_pair_lt_list_head _ _ _ _
         | exact Typ.weight_pair_lt_list_tail _ _ _ _
 
-  private theorem Typ.subi_sound {Θ : TypeEnv} {steps : Nat} {side : UnfoldSide} {s t : Typ}
-      (h : Typ.subi Θ steps side s t = true) : Typ.Sub Θ s t := by
-    induction steps generalizing side s t with
+  private theorem Typ.subi_sound {Θ : TypeEnv} {steps : Nat} {s t : Typ}
+      (h : Typ.subi Θ steps s t = true) : Typ.Sub Θ s t := by
+    induction steps generalizing s t with
     | zero =>
       simp [Typ.subi] at h
     | succ n ih =>
       simpa [Typ.subi] using
-        (Typ.subBody_sound (Θ := Θ) (recur := Typ.subi Θ n) (hrecur := fun {side s t} h => ih h) h)
+        (Typ.subBody_sound (Θ := Θ) (recur := Typ.subi Θ n) (hrecur := fun {s t} h => ih h) h)
 
-  private theorem Typ.subListi_sound {Θ : TypeEnv} {steps : Nat} {side : UnfoldSide}
-      {ss ts : List Typ} (h : Typ.subListi Θ steps side ss ts = true) : Typ.SubList Θ ss ts := by
-    induction steps generalizing side ss ts with
+  private theorem Typ.subListi_sound {Θ : TypeEnv} {steps : Nat}
+      {ss ts : List Typ} (h : Typ.subListi Θ steps ss ts = true) : Typ.SubList Θ ss ts := by
+    induction steps generalizing ss ts with
     | zero =>
       simp [Typ.subListi] at h
     | succ n ih =>
       simpa [Typ.subListi] using
-        (Typ.subListBody_sound (Θ := Θ) (recur := Typ.subi Θ n) (hrecur := fun {side s t} h => Typ.subi_sound h) h)
+        (Typ.subListBody_sound (Θ := Θ) (recur := Typ.subi Θ n) (hrecur := fun {s t} h => Typ.subi_sound h) h)
 end
 
-theorem Typ.sub_sound {Θ : TypeEnv} {side : UnfoldSide} {s t : Typ}
-    (h : Typ.sub Θ side s t = true) : Typ.Sub Θ s t := by
+theorem Typ.sub_sound {Θ : TypeEnv} {s t : Typ}
+    (h : Typ.sub Θ s t = true) : Typ.Sub Θ s t := by
   exact Typ.subi_sound (Θ := Θ) (steps := max (Typ.depth s) (Typ.depth t)) h
 
-theorem Typ.subList_sound {Θ : TypeEnv} {side : UnfoldSide} {ss ts : List Typ}
-    (h : Typ.subList Θ side ss ts = true) : Typ.SubList Θ ss ts := by
+theorem Typ.subList_sound {Θ : TypeEnv} {ss ts : List Typ}
+    (h : Typ.subList Θ ss ts = true) : Typ.SubList Θ ss ts := by
   exact Typ.subListi_sound (Θ := Θ) (steps := max (Typ.depths ss) (Typ.depths ts)) h
 
 mutual
@@ -341,8 +319,8 @@ mutual
                                     then .tuple (Typ.joinList Θ ss ts)
                                     else .value
     | s, t =>
-        if Typ.sub Θ .left s t || Typ.sub Θ .right s t then t
-        else if Typ.sub Θ .left t s || Typ.sub Θ .right t s then s
+        if Typ.sub Θ s t then t
+        else if Typ.sub Θ t s then s
         else .value
 
   def Typ.meet (Θ : TypeEnv) : Typ → Typ → Typ
@@ -357,8 +335,8 @@ mutual
                                     then .tuple (Typ.meetList Θ ss ts)
                                     else .empty
     | s, t =>
-        if Typ.sub Θ .left s t || Typ.sub Θ .right s t then s
-        else if Typ.sub Θ .left t s || Typ.sub Θ .right t s then t
+        if Typ.sub Θ s t then s
+        else if Typ.sub Θ t s then t
         else .empty
 
   def Typ.joinList (Θ : TypeEnv) : List Typ → List Typ → List Typ
@@ -680,7 +658,7 @@ mutual
     let (actual, e') ← infer Θ Γ e
     if actual == expected then
       .ok e'
-    else if Typ.sub Θ .left actual expected || Typ.sub Θ .right actual expected then
+    else if Typ.sub Θ actual expected then
       .ok (.cast e' expected)
     else
       .error (.subsumptionFailure actual expected)
@@ -705,7 +683,7 @@ mutual
     | [], [] => .ok []
     | ty :: tys, (binder, body) :: rest => do
         let binderTy := Typed.Binder.expectedTy binder ty
-        if Typ.sub Θ .left ty binderTy || Typ.sub Θ .right ty binderTy then
+        if Typ.sub Θ ty binderTy then
           let typedBinder := Typed.Binder.ofUntyped binder binderTy
           let (_bodyTy, body') ← infer Θ (extendTyped Γ typedBinder) body
           let rest' ← inferBranches Θ Γ tys rest
@@ -1011,7 +989,7 @@ mutual
         · simp [heq] at hcont
           cases hcont
           simpa using infer_runtime Θ Γ e _ hinfer
-        · by_cases hsub : Typ.sub Θ .left actual expected || Typ.sub Θ .right actual expected
+        · by_cases hsub : Typ.sub Θ actual expected
           · simp [heq, hsub] at hcont
             cases hcont
             simp [Expr.runtime, infer_runtime Θ Γ e _ hinfer]
@@ -1080,7 +1058,7 @@ mutual
         | cons ty tys =>
           obtain ⟨binder, body⟩ := br
           let binderTy := Typed.Binder.expectedTy binder ty
-          by_cases hsub : Typ.sub Θ .left ty binderTy || Typ.sub Θ .right ty binderTy
+          by_cases hsub : Typ.sub Θ ty binderTy
           · unfold Typed.inferBranches at h
             simp [binderTy, hsub] at h
             let typedBinder := Typed.Binder.ofUntyped binder binderTy

--- a/Mica/TinyML/Untyped.lean
+++ b/Mica/TinyML/Untyped.lean
@@ -157,14 +157,28 @@ abbrev Binders := List Binder
   simp only [BEq.beq, Bool.and_eq_true, Binder.named.injEq, decide_eq_true_iff]
   exact and_congr Iff.rfl beq_iff_eq.symm
 
-structure Decl (S : Type) where
+structure ValDecl (S : Type) where
   name : Binder
   body : Expr
   spec : Option S
   deriving Repr, BEq, Inhabited
 
-def Decl.mapSpec {S T : Type} (f : S → Option T) (d : Decl S) : Decl T :=
+def ValDecl.mapSpec {S T : Type} (f : S → Option T) (d : ValDecl S) : ValDecl T :=
   { name := d.name, body := d.body, spec := d.spec.bind f }
+
+structure TypeDecl where
+  name : TypeName
+  body : DataDecl
+  deriving Repr, BEq, Inhabited
+
+inductive Decl (S : Type) where
+  | val_ (d : ValDecl S)
+  | type_ (d : TypeDecl)
+  deriving Repr, BEq, Inhabited
+
+def Decl.mapSpec {S T : Type} (f : S → Option T) : Decl S → Decl T
+  | .val_ d => .val_ (d.mapSpec f)
+  | .type_ d => .type_ d
 
 abbrev Program (S : Type) := List (Decl S)
 

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -224,7 +224,7 @@ mutual
         | _ => VerifM.fatal "match on non-sum type"
     | .cast e ty => do
         let se ← compile Θ S B Γ e
-        if e.ty.sub Θ ty then pure se
+        if TinyML.Typ.sub Θ .left e.ty ty || TinyML.Typ.sub Θ .right e.ty ty then pure se
         else VerifM.fatal s!"cast type mismatch"
     | .app _ _ _ | .fix _ _ _ _ | .ref _ | .deref _ _ | .store _ _ => VerifM.fatal "unsupported expression"
 
@@ -414,12 +414,20 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
     intro v ρ' st' se hΨ hse_wf heval_se htype_v
     obtain ⟨_, _, hΨ⟩ := hΨ
-    by_cases hsub : e.ty.sub Θ ty
-    · simp [hsub] at hΨ
-      obtain hΨ := VerifM.eval_ret hΨ
-      exact hpost v ρ' st' se hΨ hse_wf heval_se (TinyML.ValHasType_sub htype_v (TinyML.Typ.sub_iff.mp hsub))
+    cases hsub : (TinyML.Typ.sub Θ .left e.ty ty || TinyML.Typ.sub Θ .right e.ty ty)
     · simp [hsub] at hΨ
       exact (VerifM.eval_fatal hΨ).elim
+    · simp [hsub] at hΨ
+      obtain hΨ := VerifM.eval_ret hΨ
+      have hsub' :
+          TinyML.Typ.Sub Θ e.ty ty := by
+        have hsub_prop :
+            TinyML.Typ.sub Θ .left e.ty ty = true ∨ TinyML.Typ.sub Θ .right e.ty ty = true := by
+          simpa [Bool.or_eq_true] using hsub
+        cases hsub_prop with
+        | inl h => exact TinyML.Typ.sub_sound h
+        | inr h => exact TinyML.Typ.sub_sound h
+      exact hpost v ρ' st' se hΨ hse_wf heval_se (TinyML.ValHasType_sub htype_v hsub')
   | assert e =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     apply wp.assert

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -132,7 +132,7 @@ theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : Env}
 /-! ### Compiler and Top-Level Verifier -/
 
 mutual
-  def compile (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
+  def compile (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
     | .const (.int n)  => pure (.unop .ofInt  (.const (.i n)))
     | .const (.bool b) => pure (.unop .ofBool (.const (.b b)))
     | .const .unit     => pure (Term.const .unit)
@@ -141,7 +141,7 @@ mutual
         VerifM.expectEq s!"type annotation mismatch for variable: {x}" (Γ x |>.getD .value) vty
         pure (.const (.uninterpreted x'.name .value))
     | .unop op e uty => do
-        let se ← compile S B Γ e
+        let se ← compile Θ S B Γ e
         let ty ← VerifM.expectSome
           s!"type error: operator {repr op} cannot be applied to {repr e.ty}"
           (TinyML.UnOp.typeOf op e.ty)
@@ -151,12 +151,12 @@ mutual
           (compileUnop op se)
         pure t
     | .assert e => do
-        let sl ← compile S B Γ e
+        let sl ← compile Θ S B Γ e
         VerifM.assert (Formula.eq .bool (Term.unop .toBool sl) (Term.const (.b true)))
         pure (Term.const .unit)
     | .binop op l r bty => do
-        let sl ← compile S B Γ l
-        let sr ← compile S B Γ r
+        let sl ← compile Θ S B Γ l
+        let sr ← compile Θ S B Γ r
         let ty ← VerifM.expectSome
           s!"type error: operator {repr op} cannot be applied to {repr l.ty} and {repr r.ty}"
           (TinyML.BinOp.typeOf op l.ty r.ty)
@@ -172,49 +172,49 @@ mutual
             (compileOp op sl sr)
           pure t
     | .letIn b e body => do
-        let se ← compile S B Γ e
+        let se ← compile Θ S B Γ e
         VerifM.expectEq "let type annotation mismatch" b.ty e.ty
         match b.name with
-        | none => compile S B Γ body
+        | none => compile Θ S B Γ body
         | some x =>
           let x' ← VerifM.decl (some x) .value
           VerifM.assume (Formula.eq .value (.const (.uninterpreted x'.name .value)) se)
-          compile (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
+          compile Θ (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
     | .ifThenElse cond thn els ty => do
-        let sc ← compile S B Γ cond
+        let sc ← compile Θ S B Γ cond
         VerifM.expectEq "if branch type annotation mismatch" thn.ty ty
         VerifM.expectEq "if branch type annotation mismatch" els.ty ty
         let branch ← VerifM.all [true, false]
         if branch then do
           VerifM.assume (.not (.eq .value sc (.unop .ofBool (.const (.b false)))))
-          compile S B Γ thn
+          compile Θ S B Γ thn
         else do
           VerifM.assume (.eq .value sc (.unop .ofBool (.const (.b false))))
-          compile S B Γ els
+          compile Θ S B Γ els
     | .app (.var f fty) args aty => do
         let spec ← VerifM.expectSome s!"no spec for function {f}" (S.lookup f)
-        let sterms ← compileExprs S B Γ args
+        let sterms ← compileExprs Θ S B Γ args
         let sargs := (args.map Expr.ty).zip sterms
         VerifM.expectEq "app type annotation mismatch" spec.retTy aty
         VerifM.expectEq "app type annotation mismatch"
           fty (Typed.arrowOfArgs (spec.args.map fun arg => Binder.named arg.1 arg.2) spec.retTy)
-        let (_, result) ← Spec.call FiniteSubst.id spec sargs
+        let (_, result) ← Spec.call Θ FiniteSubst.id spec sargs
         pure result
     | .tuple es => do
-        let terms ← compileExprs S B Γ es
+        let terms ← compileExprs Θ S B Γ es
         pure (.unop .ofValList (Terms.toValList terms))
     | .inj tag arity payload => do
         if tag ≥ arity then VerifM.fatal "inj tag out of range"
         else
-          let s ← compile S B Γ payload
+          let s ← compile Θ S B Γ payload
           pure (.unop (.mkInj tag arity) s)
     | .match_ scrut branches ty => do
-        let sc ← compile S B Γ scrut
+        let sc ← compile Θ S B Γ scrut
         match scrut.ty with
         | .sum ts =>
           if ts.length ≠ branches.length then VerifM.fatal "match arity mismatch"
           else if ∀ br ∈ branches, br.2.ty = ty then do
-            let actions := compileBranches S B Γ sc ts branches 0
+            let actions := compileBranches Θ S B Γ sc ts branches 0
             let i ← VerifM.all (List.range actions.length)
             match actions[i]? with
             | some m => m
@@ -223,13 +223,13 @@ mutual
             VerifM.fatal "match branch type annotation mismatch"
         | _ => VerifM.fatal "match on non-sum type"
     | .cast e ty => do
-        let se ← compile S B Γ e
-        if e.ty.sub ty then pure se
+        let se ← compile Θ S B Γ e
+        if e.ty.sub Θ ty then pure se
         else VerifM.fatal s!"cast type mismatch"
     | .app _ _ _ | .fix _ _ _ _ | .ref _ | .deref _ _ | .store _ _ => VerifM.fatal "unsupported expression"
 
   /-- Compile a single match branch: assume the scrutinee is `mkInj i n payload`, then compile the body. -/
-  def compileBranch (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  def compileBranch (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
       (sc : Term .value) (n : Nat) (i : Nat) (ty_i : TinyML.Typ)
       : Binder × Expr → VerifM (Term .value)
     | (binder, body) => do
@@ -239,23 +239,23 @@ mutual
         VerifM.assumeAll (typeConstraints ty_i (.const (.uninterpreted xv.name .value)))
         match binder.name with
         | some x =>
-          compile (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body
+          compile Θ (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body
         | none =>
-          compile S B (Γ.extendBinder binder ty_i) body
+          compile Θ S B (Γ.extendBinder binder ty_i) body
 
-  def compileBranches (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  def compileBranches (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
       (sc : Term .value) (ts : List TinyML.Typ) :
       List (Binder × Expr) → Nat → List (VerifM (Term .value))
     | [], _ => []
     | branch :: rest, i =>
-      compileBranch S B Γ sc ts.length i (ts[i]?.getD .value) branch
-        :: compileBranches S B Γ sc ts rest (i + 1)
+      compileBranch Θ S B Γ sc ts.length i (ts[i]?.getD .value) branch
+        :: compileBranches Θ S B Γ sc ts rest (i + 1)
 
-  def compileExprs (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : List Expr → VerifM (List (Term .value))
+  def compileExprs (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : List Expr → VerifM (List (Term .value))
     | [] => pure []
     | e :: es => do
-      let rest ← compileExprs S B Γ es
-      let se ← compile S B Γ e
+      let rest ← compileExprs Θ S B Γ es
+      let se ← compile Θ S B Γ e
       pure (se :: rest)
 end
 
@@ -278,13 +278,13 @@ theorem wp_app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Run
                Runtime.Subst.update']
     exact h)) [v] rfl
 
-theorem compileBranches_spec (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (ts : List TinyML.Typ)
     (branches : List (Binder × Expr)) (idx : Nat) :
-    (compileBranches S B Γ sc ts branches idx).length = branches.length ∧
+    (compileBranches Θ S B Γ sc ts branches idx).length = branches.length ∧
     ∀ j, j < branches.length →
-      (compileBranches S B Γ sc ts branches idx)[j]? =
-        branches[j]?.map (fun branch => compileBranch S B Γ sc ts.length (idx + j) (ts[idx + j]?.getD .value) branch) := by
+      (compileBranches Θ S B Γ sc ts branches idx)[j]? =
+        branches[j]?.map (fun branch => compileBranch Θ S B Γ sc ts.length (idx + j) (ts[idx + j]?.getD .value) branch) := by
   induction branches generalizing idx with
   | nil => exact ⟨rfl, fun j hj => absurd hj (Nat.not_lt_zero _)⟩
   | cons b bs ih =>
@@ -304,16 +304,16 @@ theorem compileBranches_spec (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
 
 mutual
 
-theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
+theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
     (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → Prop) :
-    VerifM.eval (compile S B Γ e) st ρ Ψ →
+    VerifM.eval (compile Θ S B Γ e) st ρ Ψ →
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
-    B.typedSubst Γ γ →
-    S.satisfiedBy γ →
+    B.typedSubst Θ Γ γ →
+    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
-      TinyML.ValHasType v e.ty → Φ v) →
+      TinyML.ValHasType Θ v e.ty → Φ v) →
     wp (e.runtime.subst γ) Φ := by
   intro heval hagree hbwf hts hspec hSwf hpost
   cases e with
@@ -373,7 +373,7 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
           · intro τ' hc'
             exact Signature.wf_unique_const hwfst h hc'
       simp only [Expr.ty] at hpost
-      have htyping : TinyML.ValHasType (ρ.consts .value x'.name) vty := by
+      have htyping : TinyML.ValHasType Θ (ρ.consts .value x'.name) vty := by
         rw [← hcheck]
         cases hΓ : Γ x with
         | none => exact .any
@@ -391,8 +391,8 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     · simp [htag] at heval; exact (VerifM.eval_fatal heval).elim
     · push_neg at htag
       simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
-      have heval_p : (compile S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine compile_correct payload S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hspec hSwf ?_
+      have heval_p : (compile Θ S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+      refine compile_correct Θ payload S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hspec hSwf ?_
       intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p htype_p
       obtain ⟨hdecls_p, hagreeOn_p, hΨ_p⟩ := hΨ_p
       obtain hΨ_p := VerifM.eval_ret hΨ_p
@@ -403,18 +403,18 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
         (by
           let ts := (List.replicate arity TinyML.Typ.empty).set tag payload.ty
           have hlen_ts : ts.length = arity := by simp [ts]
-          have : TinyML.ValHasType (.inj tag ts.length v_p) (.sum ts) :=
+          have : TinyML.ValHasType Θ (.inj tag ts.length v_p) (.sum ts) :=
             .inj (ts := ts) (by simp [ts, htag]) htype_p
           rwa [hlen_ts] at this)
   | cast e ty =>
     simp only [Expr.ty] at hpost
     simp only [compile] at heval
-    have heval_e : (compile S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     simp [Expr.runtime]
-    refine compile_correct e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+    refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
     intro v ρ' st' se hΨ hse_wf heval_se htype_v
     obtain ⟨_, _, hΨ⟩ := hΨ
-    by_cases hsub : e.ty.sub ty
+    by_cases hsub : e.ty.sub Θ ty
     · simp [hsub] at hΨ
       obtain hΨ := VerifM.eval_ret hΨ
       exact hpost v ρ' st' se hΨ hse_wf heval_se (TinyML.ValHasType_sub htype_v (TinyML.Typ.sub_iff.mp hsub))
@@ -424,8 +424,8 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     apply wp.assert
     simp only [compile] at heval
-    have heval_e : (compile S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
@@ -447,8 +447,8 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     apply wp.unop
     simp only [compile] at heval
-    have heval_e : (compile S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se htype_e
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
@@ -465,15 +465,15 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     apply wp.binop
     simp only [compile] at heval
-    have heval_l : (compile S B Γ l).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct l S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_l) hagree hbwf hts hspec hSwf ?_
+    have heval_l : (compile Θ S B Γ l).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine compile_correct Θ l S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_l) hagree hbwf hts hspec hSwf ?_
     intro vl ρ_l st₁ sl hΨ_l hsl_wf heval_l htyl
     obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
     have hagree_l : B.agreeOnLinked ρ_l γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_l hbwf
     have hbwf_l : B.wf st₁.decls := fun p hp => hdecls_l.consts _ (hbwf p hp)
-    have heval_r : (compile S B Γ r).eval st₁ ρ_l _ := VerifM.eval_bind _ _ _ _ hΨ_l
-    refine compile_correct r S B Γ st₁ ρ_l γ _ _ (VerifM.eval.decls_grow ρ_l heval_r) hagree_l hbwf_l hts hspec hSwf ?_
+    have heval_r : (compile Θ S B Γ r).eval st₁ ρ_l _ := VerifM.eval_bind _ _ _ _ hΨ_l
+    refine compile_correct Θ r S B Γ st₁ ρ_l γ _ _ (VerifM.eval.decls_grow ρ_l heval_r) hagree_l hbwf_l hts hspec hSwf ?_
     intro vr ρ_r st₂ sr hΨ_r hsr_wf heval_r htyr
     obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
     obtain ⟨ty, htypeOf, hΨ_r⟩ := VerifM.eval_bind_expectSome hΨ_r
@@ -585,8 +585,8 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     unfold Expr.runtime
     simp only [Runtime.Expr.letIn_subst]
     apply wp.letIn
-    have heval_e_outer : (compile S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hspec hSwf ?_
+    have heval_e_outer : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hspec hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
     have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
@@ -595,7 +595,7 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     cases hname : b.name with
     | none =>
       simp [hname] at hΨ_e
-      have hbody := compile_correct body S B Γ st₁ ρ_e γ _ _
+      have hbody := compile_correct Θ body S B Γ st₁ ρ_e γ _ _
         (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hspec hSwf
         (fun v ρ' st' se hΨ hs hw ht =>
           let ⟨_, _, hΨ'⟩ := hΨ
@@ -636,7 +636,7 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
         simpa [γ_body, base, Runtime.Subst.update', Runtime.Subst.update] using hbody'
       have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e ρ_body :=
         agreeOn_update_fresh_const hfresh
-      have hΨ_body : (compile (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
+      have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
         have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
         have hdecl := VerifM.eval_decl hdecl_eval
         have h := hdecl v_e
@@ -676,9 +676,9 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
       have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body γ_body := by
         have h := Bindings.agreeOnLinked_cons (x := x) (γ := γ) hagree hρ_agree (hvty := (rfl : v.sort = .value))
         rwa [hρ_body_lookup] at h
-      have hts_body : Bindings.typedSubst ((x, v) :: B) (Γ.extend x e.ty) γ_body :=
+      have hts_body : Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body :=
         Bindings.typedSubst_cons hts htyping_e
-      refine compile_correct body (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
+      refine compile_correct Θ body (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
         (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ hts_body
         (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) ?_
       intro v' ρ' st' se' hΨ hs hw ht
@@ -690,8 +690,8 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     simp only [Runtime.Expr.subst]
     apply wp.ifThenElse
     simp only [compile] at heval
-    have heval_cond : (compile S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct cond S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hspec hSwf ?_
+    have heval_cond : (compile Θ S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine compile_correct Θ cond S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hspec hSwf ?_
     intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c _
     obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
     have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
@@ -711,19 +711,19 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     constructor
     · intro hvc_ne
       have heval_ne : sc.eval ρ_c ≠ Runtime.Val.bool false := heval_c ▸ hvc_ne
-      have heval_thn : (compile S B Γ thn).eval _ ρ_c Ψ :=
+      have heval_thn : (compile Θ S B Γ thn).eval _ ρ_c Ψ :=
         htrue_cont hwf_ne (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_ne)
-      exact compile_correct thn S B Γ _ ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hspec hSwf
+      exact compile_correct Θ thn S B Γ _ ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hspec hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hthn_ty ▸ ht))
     · intro hvc_eq
       have heval_eq : sc.eval ρ_c = Runtime.Val.bool false := heval_c ▸ hvc_eq
-      have heval_els : (compile S B Γ els).eval _ ρ_c Ψ :=
+      have heval_els : (compile Θ S B Γ els).eval _ ρ_c Ψ :=
         hfalse_cont hwf_eq (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_eq)
-      exact compile_correct els S B Γ _ ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hspec hSwf
+      exact compile_correct Θ els S B Γ _ ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hspec hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hels_ty ▸ ht))
   | app fn args aty =>
     simp only [Expr.ty] at hpost
@@ -736,8 +736,8 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
       obtain ⟨fval, hγf, hisPrecond⟩ := hspec f spec hlookup
       simp [Expr.runtime, Runtime.Expr.subst, hγf]
       apply wp.app
-      have heval_args : (compileExprs S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine compileExprs_correct args S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hspec hSwf ?_
+      have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+      refine compileExprs_correct Θ args S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hspec hSwf ?_
       intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
       obtain ⟨_, _, hΨ_args⟩ := hΨ_args
       let typedArgs := (args.map Expr.ty).zip sargs
@@ -757,9 +757,9 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
         intro p hp
         have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
         exact hsargs_wf _ hp''
-      have hcall_eval : VerifM.eval (Spec.call FiniteSubst.id spec typedArgs) st_args ρ_args
+      have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
           (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
-      have hcall := Spec.call_correct spec FiniteSubst.id typedArgs st_args ρ_args
+      have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
         (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ
         hwf_pred
         (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
@@ -767,9 +767,9 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
         (fun v st' ρ' t hΨ hwf heval hty =>
           hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval (hret_eq ▸ hty))
       obtain ⟨hsub_ty, happly⟩ := hcall
-      have hsub_ty' : TinyML.Typ.SubList (args.map Expr.ty) (spec.args.map Prod.snd) := by
+      have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
         simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
-      have htyped : TinyML.ValsHaveTypes vs (spec.args.map Prod.snd) :=
+      have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
         TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
       apply hisPrecond vs htyped
       have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
@@ -799,8 +799,8 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     simp only [Runtime.Expr.subst, List.map_map]
     apply wp.tuple
     simp only [compile] at heval
-    have heval_es : (compileExprs S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compileExprs_correct es S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hspec hSwf ?_
+    have heval_es : (compileExprs Θ S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine compileExprs_correct Θ es S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hspec hSwf ?_
     intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
     obtain ⟨_, _, hΨ⟩ := hΨ
     obtain hΨ := VerifM.eval_ret hΨ
@@ -817,8 +817,8 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
     simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
     apply wp.match_
     simp only [compile] at heval
-    have heval_scrut : (compile S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct scrut S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hspec hSwf ?_
+    have heval_scrut : (compile Θ S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine compile_correct Θ scrut S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hspec hSwf ?_
     intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se htype_scrut
     obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
     cases hscrut_ty : scrut.ty with
@@ -831,12 +831,12 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
         by_cases htys : ∀ br ∈ branches, br.2.ty = ty
         · have hΨ_scrut' :
               (do
-                let i ← VerifM.all (List.range (compileBranches S B Γ se_scrut ts branches 0).length)
-                match (compileBranches S B Γ se_scrut ts branches 0)[i]? with
+                let i ← VerifM.all (List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length)
+                match (compileBranches Θ S B Γ se_scrut ts branches 0)[i]? with
                 | some m => m
                 | none => VerifM.fatal "match branch index out of range").eval st_scrut ρ_scrut Ψ := by
             simpa [if_pos hlen, if_pos htys] using hΨ_scrut
-          have hcb := compileBranches_spec S B Γ se_scrut ts branches 0
+          have hcb := compileBranches_spec Θ S B Γ se_scrut ts branches 0
           have hactions_len := hcb.1
           have heval_all := VerifM.eval_bind _ _ _ _ hΨ_scrut'
           have hall := VerifM.eval_all heval_all
@@ -850,7 +850,7 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
             · exact (Runtime.Expr.fix .none [(branches[tag]).1.runtime] (branches[tag]).2.runtime).subst γ
             · simp
             · simp [htag_branches]
-            · have htag_range : tag ∈ List.range (compileBranches S B Γ se_scrut ts branches 0).length := by
+            · have htag_range : tag ∈ List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length := by
                 rw [hactions_len]
                 exact List.mem_range.mpr htag_branches
               have heval_tag := hall tag htag_range
@@ -862,7 +862,7 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
               rw [hty_eq] at heval_tag
               have hagree_scrut := Bindings.agreeOnLinked_env_agree hagree hagreeOn_scrut hbwf
               have hbwf_scrut : B.wf st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
-              have hbranch_wp := compileBranches_correct branches S B Γ se_scrut ts.length ts 0
+              have hbranch_wp := compileBranches_correct Θ branches S B Γ se_scrut ts.length ts 0
                 st_scrut ρ_scrut γ Ψ Φ
                 hagree_scrut hbwf_scrut hts hspec hSwf hse_wf
                 (fun j hj v ρ' st' se hΨ hse_wf hse_eval htyped =>
@@ -878,22 +878,22 @@ theorem compile_correct (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyC
       simp [hscrut_ty] at hΨ_scrut
       exact (VerifM.eval_fatal hΨ_scrut).elim
 
-theorem compileBranch_correct (branch : Binder × Expr) (S : SpecMap) (B : Bindings)
+theorem compileBranch_correct (Θ : TinyML.TypeEnv) (branch : Binder × Expr) (S : SpecMap) (B : Bindings)
     (Γ : TinyML.TyCtx) (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
     (st : TransState) (ρ : Env) (γ : Runtime.Subst)
     (Ψ : Term .value → TransState → Env → Prop)
     (Φ : Runtime.Val → Prop) :
-    VerifM.eval (compileBranch S B Γ sc n i ty_i branch) st ρ Ψ →
+    VerifM.eval (compileBranch Θ S B Γ sc n i ty_i branch) st ρ Ψ →
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
-    B.typedSubst Γ γ →
-    S.satisfiedBy γ →
+    B.typedSubst Θ Γ γ →
+    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType v branch.2.ty → Φ v) →
+      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → Φ v) →
     ∀ payload, sc.eval ρ = Runtime.Val.inj i n payload →
-      TinyML.ValHasType payload ty_i →
+      TinyML.ValHasType Θ payload ty_i →
       wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
   intro heval hagree hbwf hts hspec hSwf hsc_wf hpost payload hsc_eval htype_payload
   obtain ⟨binder, body⟩ := branch
@@ -966,13 +966,13 @@ theorem compileBranch_correct (branch : Binder × Expr) (S : SpecMap) (B : Bindi
       have hagree₁ : B.agreeOnLinked ρ₁ γ :=
         Bindings.agreeOnLinked_env_agree hagree hagreeOn_st hbwf
       have hbwf₁ : B.wf st₂.decls := hst₂_decls ▸ fun p hp => List.Mem.tail _ (hbwf p hp)
-      have hts₁ : B.typedSubst (Γ.extendBinder binder ty_i) γ := by
+      have hts₁ : B.typedSubst Θ (Γ.extendBinder binder ty_i) γ := by
         simpa [TinyML.TyCtx.extendBinder, hname] using hts
-      have heval_body'' : (compile S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+      have heval_body'' : (compile Θ S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, hname] using heval_body'
       rw [Binder.runtime_of_name_none hname]
       simpa [Runtime.Subst.update] using
-        (compile_correct body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
+        (compile_correct Θ body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
           heval_body'' hagree₁ hbwf₁ hts₁ hspec hSwf (by simpa [hty] using hpost))
     | some x =>
       simp [hname, TinyML.TyCtx.extendBinder] at heval_body'
@@ -991,20 +991,20 @@ theorem compileBranch_correct (branch : Binder × Expr) (S : SpecMap) (B : Bindi
       have hagree₁ : Bindings.agreeOnLinked ((x, xv) :: B) ρ₁ (Runtime.Subst.update γ x payload) := by
         have h := Bindings.agreeOnLinked_cons (x := x) (v := xv) (γ := γ) hagree hagreeOn_B (hvty := rfl)
         rwa [hρ₁_lookup] at h
-      have hts₁ : Bindings.typedSubst ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) := by
+      have hts₁ : Bindings.typedSubst Θ ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) := by
         simpa [TinyML.TyCtx.extendBinder, hname, hty] using (Bindings.typedSubst_cons hts htype_payload)
       have heval_body'' :
-          (compile (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+          (compile Θ (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, TinyML.TyCtx.extendBinder, hname] using heval_body'
       rw [Binder.runtime_of_name_some hname]
       simpa [Runtime.Subst.update] using
-        (compile_correct body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
+        (compile_correct Θ body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
           (Runtime.Subst.update γ x payload) Ψ Φ heval_body'' hagree₁ hbwf₂ hts₁
           (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) (by simpa [hty] using hpost))
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
     exact False.elim (hty (VerifM.eval_expectEq hexpect).1)
 
-theorem compileBranches_correct (branches : List (Binder × Expr)) (S : SpecMap) (B : Bindings)
+theorem compileBranches_correct (Θ : TinyML.TypeEnv) (branches : List (Binder × Expr)) (S : SpecMap) (B : Bindings)
     (Γ : TinyML.TyCtx) (sc : Term .value) (n : Nat) (ts : List TinyML.Typ)
     (idx : Nat)
     (st : TransState) (ρ : Env) (γ : Runtime.Subst)
@@ -1012,16 +1012,16 @@ theorem compileBranches_correct (branches : List (Binder × Expr)) (S : SpecMap)
     (Φ : Runtime.Val → Prop) :
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
-    B.typedSubst Γ γ →
-    S.satisfiedBy γ →
+    B.typedSubst Θ Γ γ →
+    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType v (branches[j]).2.ty → Φ v) →
+      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
-      VerifM.eval (compileBranch S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
+      VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ = Runtime.Val.inj (idx + j) n payload →
-        TinyML.ValHasType payload (ts[idx + j]?.getD .value) →
+        TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
         wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
   intro hagree hbwf hts hspec hSwf hsc_wf hpost
   match branches with
@@ -1034,28 +1034,28 @@ theorem compileBranches_correct (branches : List (Binder × Expr)) (S : SpecMap)
     | zero =>
       simp only [Nat.add_zero, List.getElem_cons_zero]
       intro heval
-      exact compileBranch_correct b S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
+      exact compileBranch_correct Θ b S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
         heval hagree hbwf hts hspec hSwf hsc_wf (by simpa using hpost 0 hj)
     | succ k =>
       have hk : k < bs.length := by simp at hj; omega
       have hidx : idx + (k + 1) = (idx + 1) + k := by omega
       simp only [hidx, List.getElem_cons_succ]
-      exact compileBranches_correct bs S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
+      exact compileBranches_correct Θ bs S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
         hagree hbwf hts hspec hSwf hsc_wf
         (by
           intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
           simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
         k hk
 
-theorem compileExprs_correct (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
+theorem compileExprs_correct (Θ : TinyML.TypeEnv) (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
     (Ψ : List (Term .value) → TransState → Env → Prop) (Φ : List Runtime.Val → Prop) :
-    VerifM.eval (compileExprs S B Γ es) st ρ Ψ →
-    B.agreeOnLinked ρ γ → B.wf st.decls → B.typedSubst Γ γ →
-    S.satisfiedBy γ → S.wfIn Signature.empty →
+    VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
+    B.agreeOnLinked ρ γ → B.wf st.decls → B.typedSubst Θ Γ γ →
+    S.satisfiedBy Θ γ → S.wfIn Signature.empty →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ' terms vs →
-      TinyML.ValsHaveTypes vs (es.map Expr.ty) → Φ vs) →
+      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → Φ vs) →
     wps (es.map (fun e => e.runtime.subst γ)) Φ := by
   intro heval hagree hbwf hts hspec hSwf hpost
   match es with
@@ -1067,15 +1067,15 @@ theorem compileExprs_correct (es : List Expr) (S : SpecMap) (B : Bindings) (Γ :
   | e :: rest =>
     simp only [compileExprs] at heval
     simp only [List.map, wps_cons]
-    have heval_rest : (compileExprs S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compileExprs_correct rest S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hspec hSwf ?_
+    have heval_rest : (compileExprs Θ S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine compileExprs_correct Θ rest S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hspec hSwf ?_
     intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
     obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
     have hagree_vs : B.agreeOnLinked ρ_vs γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
     have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
-    have heval_e : (compile S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
-    refine compile_correct e S B Γ st_vs ρ_vs γ _ _ (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hspec hSwf ?_
+    have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
+    refine compile_correct Θ e S B Γ st_vs ρ_vs γ _ _ (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hspec hSwf ?_
     intro v ρ' st' se hΨ_e hse_wf heval_se htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
     have hwfst' : st'.decls.wf := (VerifM.eval.wf hΨ_e).namesDisjoint

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -224,7 +224,7 @@ mutual
         | _ => VerifM.fatal "match on non-sum type"
     | .cast e ty => do
         let se ← compile Θ S B Γ e
-        if TinyML.Typ.sub Θ .left e.ty ty || TinyML.Typ.sub Θ .right e.ty ty then pure se
+        if TinyML.Typ.sub Θ e.ty ty then pure se
         else VerifM.fatal s!"cast type mismatch"
     | .app _ _ _ | .fix _ _ _ _ | .ref _ | .deref _ _ | .store _ _ => VerifM.fatal "unsupported expression"
 
@@ -414,19 +414,12 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
     intro v ρ' st' se hΨ hse_wf heval_se htype_v
     obtain ⟨_, _, hΨ⟩ := hΨ
-    cases hsub : (TinyML.Typ.sub Θ .left e.ty ty || TinyML.Typ.sub Θ .right e.ty ty)
+    cases hsub : TinyML.Typ.sub Θ e.ty ty
     · simp [hsub] at hΨ
       exact (VerifM.eval_fatal hΨ).elim
     · simp [hsub] at hΨ
       obtain hΨ := VerifM.eval_ret hΨ
-      have hsub' :
-          TinyML.Typ.Sub Θ e.ty ty := by
-        have hsub_prop :
-            TinyML.Typ.sub Θ .left e.ty ty = true ∨ TinyML.Typ.sub Θ .right e.ty ty = true := by
-          simpa [Bool.or_eq_true] using hsub
-        cases hsub_prop with
-        | inl h => exact TinyML.Typ.sub_sound h
-        | inr h => exact TinyML.Typ.sub_sound h
+      have hsub' : TinyML.Typ.Sub Θ e.ty ty := TinyML.Typ.sub_sound hsub
       exact hpost v ρ' st' se hΨ hse_wf heval_se (TinyML.ValHasType_sub htype_v hsub')
   | assert e =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -16,7 +16,7 @@ import Mathlib.Data.Finmap
 open Typed
 
 
-def checkSpec (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
+def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
   let (fb, argNames, body) ← match e with
     | .fix fb argBinders _ body => do
       match extractArgNames argBinders s.args with
@@ -27,18 +27,18 @@ def checkSpec (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
   Spec.implement s fun argVars => do
     let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
     let Γ := (argNames.zip (s.args.map Prod.snd)).foldl (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
-    let se ← compile S' B Γ body
-    if body.ty.sub s.retTy then pure ()
+    let se ← compile Θ S' B Γ body
+    if body.ty.sub Θ s.retTy then pure ()
     else VerifM.fatal s!"checkSpec: return type mismatch"
     pure se
 
-theorem checkSpec_correct (S : SpecMap) (e : Expr) (s : Spec)
+theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (hS : S.satisfiedBy γ)
+    (hS : S.satisfiedBy Θ γ)
     (st : TransState) (ρ : Env) :
-    VerifM.eval (checkSpec S e s) st ρ (fun _ _ _ => True) →
-    wp (e.runtime.subst γ) (fun v => s.isPrecondFor v) := by
+    VerifM.eval (checkSpec Θ S e s) st ρ (fun _ _ _ => True) →
+    wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
   intro heval
   cases e with
   | fix fb argBinders retTy body =>
@@ -66,8 +66,8 @@ theorem checkSpec_correct (S : SpecMap) (e : Expr) (s : Spec)
       apply wp.func
       intro vs htyped Φ happly
       set Φ_inv : (Runtime.Val → Prop) → List Runtime.Val → Prop := fun P vs =>
-        TinyML.ValsHaveTypes vs (s.args.map Prod.snd) ∧
-          PredTrans.apply (fun r => TinyML.ValHasType r s.retTy → P r) s.pred
+        TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∧
+          PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy → P r) s.pred
             (Spec.argsEnv Env.empty s.args vs)
       suffices ∀ vs P, Φ_inv P vs → wp (Runtime.Expr.app (.val fval) (vs.map Runtime.Expr.val)) P from
         this vs Φ ⟨htyped, happly⟩
@@ -83,23 +83,23 @@ theorem checkSpec_correct (S : SpecMap) (e : Expr) (s : Spec)
         rw [Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen]
         set γ_body := γ.update' fb.runtime fval |>.updateAll' bs vs
         -- Use implement_correct to get into the body
-        apply Spec.implement_correct s _ _ _ vs _ (wp (body.runtime.subst γ_body) P) hswf htyped_args hbody happly_args
+        apply Spec.implement_correct Θ s _ _ _ vs _ (wp (body.runtime.subst γ_body) P) hswf htyped_args hbody happly_args
         intro argVars st' ρ' hargVars_mem hargVars_sort hargVars_lookup hbody_eval
         -- Key facts about fval and the spec map
-        have isPrecond : s.isPrecondFor fval := by
+        have isPrecond : s.isPrecondFor Θ fval := by
           intro vs' htyped' Φ' happly'
           exact ih_rec vs' Φ' ⟨htyped', happly'⟩
         have hS'wf : S'.wfIn Signature.empty :=
           SpecMap.wfIn_eraseAll (SpecMap.wfIn_insert' hSwf hswf)
-        have hS'_sat : S'.satisfiedBy γ_body := by
+        have hS'_sat : S'.satisfiedBy Θ γ_body := by
           -- Simplified using the new lemma
-          have hS_ext : (S.insert' fb s).satisfiedBy (γ.update' fb.runtime fval) := by
+          have hS_ext : (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) := by
             apply SpecMap.satisfiedBy_insert'_update' hS isPrecond
           have hsat := SpecMap.satisfiedBy_eraseAll_updateAll' hS_ext hlen_nv0
           -- hsat : (eraseAll argNames (insert' S fb s)).satisfiedBy ((γ.update' fb.runtime fval).updateAll' (argNames.map .named) vs)
           -- γ_body : (γ.update' fb.runtime fval).updateAll' bs vs
           -- and bs = argNames.map .named (from hbs_eq)
-          change (SpecMap.eraseAll argNames (S.insert' fb s)).satisfiedBy ((γ.update' fb.runtime fval).updateAll' bs vs)
+          change (SpecMap.eraseAll argNames (S.insert' fb s)).satisfiedBy Θ ((γ.update' fb.runtime fval).updateAll' bs vs)
           rw [hbs_runtime]; exact hsat
         set Γ := (argNames.zip (s.args.map Prod.snd)).foldl (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
         set B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
@@ -126,10 +126,10 @@ theorem checkSpec_correct (S : SpecMap) (e : Expr) (s : Spec)
           apply hargVars_mem v
           have hmem : (n, v) ∈ (argNames.zip argVars) := by simp [B, Bindings.empty] at hp; exact hp
           exact List.of_mem_zip hmem |>.2
-        have hts : Bindings.typedSubst B Γ γ_body := by
+        have hts : Bindings.typedSubst Θ B Γ γ_body := by
           apply Bindings.typedSubst_of_agreeOnLinked hagree
           intro x x' t hmem hΓ
-          show TinyML.ValHasType (ρ'.consts .value x'.name) t
+          show TinyML.ValHasType Θ (ρ'.consts .value x'.name) t
           set args' := argNames.zip (s.args.map Prod.snd)
           have hfst : args'.map Prod.fst = argNames := by
             simp [args']; exact List.map_fst_zip (by simp; omega)
@@ -142,10 +142,10 @@ theorem checkSpec_correct (S : SpecMap) (e : Expr) (s : Spec)
             hΓ hargVars_lookup
             (by rw [hsnd]; exact htyped_args)
         have hcompile := VerifM.eval_bind _ _ _ _ hbody_eval
-        apply compile_correct body S' B Γ st' ρ' γ_body _ P
+        apply compile_correct Θ body S' B Γ st' ρ' γ_body _ P
           hcompile hagree hbwf hts hS'_sat hS'wf
         intro result ρ'' st'' se hΨ hse_wf hse_eval htyped_result
-        by_cases hsub : body.ty.sub s.retTy
+        by_cases hsub : body.ty.sub Θ s.retTy
         · simp [hsub] at hΨ
           have hret := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ hΨ)
           have hret' := VerifM.eval_ret hret

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -28,7 +28,7 @@ def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM
     let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
     let Γ := (argNames.zip (s.args.map Prod.snd)).foldl (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
     let se ← compile Θ S' B Γ body
-    if body.ty.sub Θ s.retTy then pure ()
+    if TinyML.Typ.sub Θ .left body.ty s.retTy || TinyML.Typ.sub Θ .right body.ty s.retTy then pure ()
     else VerifM.fatal s!"checkSpec: return type mismatch"
     pure se
 
@@ -145,14 +145,18 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
         apply compile_correct Θ body S' B Γ st' ρ' γ_body _ P
           hcompile hagree hbwf hts hS'_sat hS'wf
         intro result ρ'' st'' se hΨ hse_wf hse_eval htyped_result
-        by_cases hsub : body.ty.sub Θ s.retTy
-        · simp [hsub] at hΨ
+        split at hΨ
+        · rename_i hsub
           have hret := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ hΨ)
           have hret' := VerifM.eval_ret hret
+          have hsub' : TinyML.Typ.Sub Θ body.ty s.retTy := by
+            cases hsub with
+            | inl h => exact TinyML.Typ.sub_sound h
+            | inr h => exact TinyML.Typ.sub_sound h
           rw [hse_eval] at hret'
-          exact hret' hse_wf (TinyML.ValHasType_sub htyped_result (TinyML.Typ.sub_iff.mp hsub))
-        · simp [hsub] at hΨ
-          exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ hΨ)).elim)
+          exact hret' hse_wf (TinyML.ValHasType_sub htyped_result hsub')
+        · have hcheck := VerifM.eval_bind _ _ _ _ hΨ
+          exact (VerifM.eval_fatal hcheck).elim)
   | _ =>
     simp only [checkSpec] at heval
     exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -28,7 +28,7 @@ def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM
     let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
     let Γ := (argNames.zip (s.args.map Prod.snd)).foldl (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
     let se ← compile Θ S' B Γ body
-    if TinyML.Typ.sub Θ .left body.ty s.retTy || TinyML.Typ.sub Θ .right body.ty s.retTy then pure ()
+    if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
     else VerifM.fatal s!"checkSpec: return type mismatch"
     pure se
 
@@ -149,10 +149,7 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
         · rename_i hsub
           have hret := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ hΨ)
           have hret' := VerifM.eval_ret hret
-          have hsub' : TinyML.Typ.Sub Θ body.ty s.retTy := by
-            cases hsub with
-            | inl h => exact TinyML.Typ.sub_sound h
-            | inr h => exact TinyML.Typ.sub_sound h
+          have hsub' : TinyML.Typ.Sub Θ body.ty s.retTy := TinyML.Typ.sub_sound hsub
           rw [hse_eval] at hret'
           exact hret' hse_wf (TinyML.ValHasType_sub htyped_result hsub')
         · have hcheck := VerifM.eval_bind _ _ _ _ hΨ

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -39,9 +39,10 @@ def Spec.complete (sp : SpecPredicate) (e : Expr) : Except String Spec :=
 Iterates over a list of declarations, verifying each one against its spec
 and accumulating the spec map for use by subsequent declarations. -/
 
-def Program.prepare (Θ : TinyML.TypeEnv) (prog : Untyped.Program Untyped.Expr) : VerifM (Typed.Program Untyped.Expr) :=
-  match Typed.Program.elaborate Θ TinyML.TyCtx.empty prog with
-  | .ok typed => .ret typed
+def Program.prepare (prog : Untyped.Program Untyped.Expr) :
+    VerifM (TinyML.TypeEnv × Typed.Program Untyped.Expr) :=
+  match Typed.Program.elaborate TinyML.TypeEnv.empty TinyML.TyCtx.empty prog with
+  | .ok prepared => .ret prepared
   | .error err => .fatal (toString err)
 
 /-- Check an individual declaration. Each declaration's `checkSpec` runs inside a `seq` bracket so its
@@ -69,49 +70,46 @@ def ValDecl.checkExpr (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Unt
 def Program.check (Θ : TinyML.TypeEnv) : SpecMap → Typed.Program Untyped.Expr → VerifM Unit
   | _, [] => pure ()
   | S, d :: ds => do
-    match d with
-    | .type_ _ =>
+    match d.name.name, d.spec with
+    | none, none =>
+      ValDecl.checkExpr Θ S d
       Program.check Θ S ds
-    | .val_ d =>
-      match d.name.name, d.spec with
-      | none, none =>
+    | some n, none =>
+    -- Named declaration without a spec: skip if it's a function definition
+    -- (no code executes), otherwise check it. Erase any old spec for this
+    -- name since the new binding shadows it.
+      if d.body.isFunc then
+        Program.check Θ (S.erase n) ds
+      else
         ValDecl.checkExpr Θ S d
-        Program.check Θ S ds
-      | some n, none =>
-      -- Named declaration without a spec: skip if it's a function definition
-      -- (no code executes), otherwise check it. Erase any old spec for this
-      -- name since the new binding shadows it.
-        if d.body.isFunc then
-          Program.check Θ (S.erase n) ds
-        else
-          ValDecl.checkExpr Θ S d
-          Program.check Θ (S.erase n) ds
-      | _, _ =>
-        let spec ← ValDecl.check Θ S d
-        let S' := match d.name.name with
-          | some name => S.insert name spec
-          | none => S
-        Program.check Θ S' ds
+        Program.check Θ (S.erase n) ds
+    | _, _ =>
+      let spec ← ValDecl.check Θ S d
+      let S' := match d.name.name with
+        | some name => S.insert name spec
+        | none => S
+      Program.check Θ S' ds
 
 def Program.verify (prog : Untyped.Program Untyped.Expr) : Smt.Strategy Smt.Strategy.Outcome :=
   VerifM.strategy do
-    let typed ← Program.prepare TinyML.TypeEnv.empty prog
-    Program.check TinyML.TypeEnv.empty ∅ typed
+    let (Θ, typed) ← Program.prepare prog
+    Program.check Θ ∅ typed
 
 /-! ## Correctness -/
 
-theorem Program.prepare_correct (Θ : TinyML.TypeEnv) (prog : Untyped.Program Untyped.Expr)
+theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
     (st : TransState) (ρ : Env)
-    {Q : Typed.Program Untyped.Expr → TransState → Env → Prop}
-    (heval : VerifM.eval (Program.prepare Θ prog) st ρ Q) :
-    ∃ typed, Typed.Program.runtime typed = Untyped.Program.runtime prog ∧ Q typed st ρ := by
+    {Q : (TinyML.TypeEnv × Typed.Program Untyped.Expr) → TransState → Env → Prop}
+    (heval : VerifM.eval (Program.prepare prog) st ρ Q) :
+    ∃ Θ typed, Typed.Program.runtime typed = Untyped.Program.runtime prog ∧ Q (Θ, typed) st ρ := by
   unfold Program.prepare at heval
-  cases helab : Typed.Program.elaborate Θ TinyML.TyCtx.empty prog with
+  cases helab : Typed.Program.elaborate TinyML.TypeEnv.empty TinyML.TyCtx.empty prog with
   | error err =>
     simp [helab] at heval
     exact (VerifM.eval_fatal heval).elim
-  | ok typed =>
-    refine ⟨typed, Typed.Program.elaborate_runtime Θ TinyML.TyCtx.empty prog helab, ?_⟩
+  | ok prepared =>
+    rcases prepared with ⟨Θ, typed⟩
+    refine ⟨Θ, typed, Typed.Program.elaborate_runtime TinyML.TypeEnv.empty TinyML.TyCtx.empty prog helab, ?_⟩
     simp [helab] at heval
     exact VerifM.eval_ret heval
 
@@ -187,77 +185,72 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
     simp [Typed.Program.runtime, Runtime.Program.subst, pwp]
   | cons d ds ih =>
     intro heval
-    cases d with
-    | type_ td =>
-      simp [Program.check, Typed.Program.runtime] at heval ⊢
-      exact ih S γ hS hSwf st ρ heval
-    | val_ d =>
-      have hpwp_unfold : pwp ((Typed.Program.runtime (.val_ d :: ds)).subst γ) ↔
-          wp (d.body.runtime.subst γ) (fun v =>
-            pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
-        simp [Typed.Program.runtime, pwp, Typed.Decl.runtime, Typed.ValDecl.runtime,
-          Runtime.Program.subst, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
-      rw [hpwp_unfold]
-      simp only [Program.check] at heval
-      cases hname : d.name.name
-      · cases hspec : d.spec
-        · simp only [hname, hspec] at heval
-          have hbind := VerifM.eval_bind _ _ _ _ heval
+    have hpwp_unfold : pwp ((Typed.Program.runtime (d :: ds)).subst γ) ↔
+        wp (d.body.runtime.subst γ) (fun v =>
+          pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
+      simp [Typed.Program.runtime, pwp, Typed.ValDecl.runtime,
+        Runtime.Program.subst, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
+    rw [hpwp_unfold]
+    simp only [Program.check] at heval
+    cases hname : d.name.name
+    · cases hspec : d.spec
+      · simp only [hname, hspec] at heval
+        have hbind := VerifM.eval_bind _ _ _ _ heval
+        have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
+        have ⟨_, hcont⟩ := VerifM.eval_seq hbind
+        apply wp.mono _ hwp
+        intro v _
+        simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
+        exact ih S γ hS hSwf st ρ (VerifM.eval_ret hcont)
+      · simp only [hname, hspec] at heval
+        obtain ⟨spec, hswf, hwp, hcont⟩ :=
+          ValDecl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
+        apply wp.mono (fun v hprecond => _) hwp
+        intro v hprecond
+        simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
+        exact ih S γ hS hSwf st ρ hcont
+    · rename_i n
+      cases hspec : d.spec
+      · simp only [hname, hspec] at heval
+        split at heval
+        · rename_i hfunc
+          obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
+          have hbody_rt : d.body.runtime.subst γ =
+              Runtime.Expr.fix self.runtime (args.map (·.runtime))
+                (body.runtime.subst ((γ.remove' self.runtime).removeAll'
+                  (args.map (·.runtime)))) := by
+            rw [hbody]
+            conv_lhs => unfold Expr.runtime
+            simp only [Runtime.Expr.subst_fix]
+          rw [hbody_rt]
+          apply wp.func
+          simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
+          simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+            ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime _ γ)
+            (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
+              simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
+        · have hbind := VerifM.eval_bind _ _ _ _ heval
           have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
           apply wp.mono _ hwp
           intro v _
-          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-          exact ih S γ hS hSwf st ρ (VerifM.eval_ret hcont)
-        · simp only [hname, hspec] at heval
-          obtain ⟨spec, hswf, hwp, hcont⟩ :=
-            ValDecl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
-          apply wp.mono (fun v hprecond => _) hwp
-          intro v hprecond
-          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-          exact ih S γ hS hSwf st ρ hcont
-      · rename_i n
-        cases hspec : d.spec
-        · simp only [hname, hspec] at heval
-          split at heval
-          · rename_i hfunc
-            obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
-            have hbody_rt : d.body.runtime.subst γ =
-                Runtime.Expr.fix self.runtime (args.map (·.runtime))
-                  (body.runtime.subst ((γ.remove' self.runtime).removeAll'
-                    (args.map (·.runtime)))) := by
-              rw [hbody]
-              conv_lhs => unfold Expr.runtime
-              simp only [Runtime.Expr.subst_fix]
-            rw [hbody_rt]
-            apply wp.func
-            simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-            simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-              ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime _ γ)
-              (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
-                simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
-          · have hbind := VerifM.eval_bind _ _ _ _ heval
-            have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
-            have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-            apply wp.mono _ hwp
-            intro v _
-            simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-            simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-              ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime v γ)
-              (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
-                simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-                  (VerifM.eval_ret hcont))
-        · simp only [hname, hspec] at heval
-          obtain ⟨spec, hswf, hwp, hcont⟩ :=
-            ValDecl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
-          apply wp.mono (fun v hprecond => _) hwp
-          intro v hprecond
           simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-          simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-            ih (S.insert' d.name spec) (Runtime.Subst.update' d.name.runtime v γ)
-              (SpecMap.satisfiedBy_insert'_update' hS hprecond) (SpecMap.wfIn_insert' hSwf hswf) st ρ
-              (by
-                simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using hcont)
+          simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+            ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime v γ)
+            (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
+              simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+                (VerifM.eval_ret hcont))
+      · simp only [hname, hspec] at heval
+        obtain ⟨spec, hswf, hwp, hcont⟩ :=
+          ValDecl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
+        apply wp.mono (fun v hprecond => _) hwp
+        intro v hprecond
+        simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
+        simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+          ih (S.insert' d.name spec) (Runtime.Subst.update' d.name.runtime v γ)
+            (SpecMap.satisfiedBy_insert'_update' hS hprecond) (SpecMap.wfIn_insert' hSwf hswf) st ρ
+            (by
+              simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using hcont)
 
 theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
   Smt.Strategy.checks (Program.verify p) (pwp (Untyped.Program.runtime p)) := by
@@ -276,12 +269,12 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
        by simp [FlatCtx.empty, Signature.empty, Signature.allNames]⟩
     have hverifM := VerifM.eval_of_translate
                       (do
-                        let typed ← Program.prepare TinyML.TypeEnv.empty p
-                        Program.check TinyML.TypeEnv.empty ∅ typed)
+                        let (Θ, typed) ← Program.prepare p
+                        Program.check Θ ∅ typed)
                       FlatCtx.empty default ctx_mid hverif hholdsFor hwf
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
-    obtain ⟨typed, hrt, hcheck⟩ := Program.prepare_correct TinyML.TypeEnv.empty p FlatCtx.empty default hbind
-    have hcorrect := Program.check_correct TinyML.TypeEnv.empty ∅ typed Runtime.Subst.id
+    obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p FlatCtx.empty default hbind
+    have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
                        (SpecMap.empty_satisfiedBy _) (SpecMap.empty_wfIn _)
                        FlatCtx.empty default hcheck
     rw [Runtime.Program.subst_id] at hcorrect

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -39,14 +39,14 @@ def Spec.complete (sp : SpecPredicate) (e : Expr) : Except String Spec :=
 Iterates over a list of declarations, verifying each one against its spec
 and accumulating the spec map for use by subsequent declarations. -/
 
-def Program.prepare (prog : Untyped.Program Untyped.Expr) : VerifM (Typed.Program Untyped.Expr) :=
-  match Typed.Program.elaborate TinyML.TyCtx.empty prog with
+def Program.prepare (Θ : TinyML.TypeEnv) (prog : Untyped.Program Untyped.Expr) : VerifM (Typed.Program Untyped.Expr) :=
+  match Typed.Program.elaborate Θ TinyML.TyCtx.empty prog with
   | .ok typed => .ret typed
   | .error err => .fatal (toString err)
 
 /-- Check an individual declaration. Each declaration's `checkSpec` runs inside a `seq` bracket so its
     declarations and assertions don't pollute subsequent verifications. -/
-def Decl.check (S : SpecMap) (d : Typed.Decl Untyped.Expr) : VerifM Spec := do
+def Decl.check (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr) : VerifM Spec := do
   let specExpr ← match d.spec with
     | some e => .ret e
     | none => .fatal "declaration has no spec"
@@ -59,68 +59,68 @@ def Decl.check (S : SpecMap) (d : Typed.Decl Untyped.Expr) : VerifM Spec := do
   let () ← match Spec.checkWf spec Signature.empty with
     | .ok () => .ret ()
     | .error msg => .fatal msg
-  VerifM.seq (checkSpec S d.body spec) (pure spec)
+  VerifM.seq (checkSpec Θ S d.body spec) (pure spec)
 
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
-def Decl.checkExpr (S : SpecMap) (d : Typed.Decl Untyped.Expr) : VerifM Unit :=
-  VerifM.seq (do let _ ← compile S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
+def Decl.checkExpr (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr) : VerifM Unit :=
+  VerifM.seq (do let _ ← compile Θ S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
 
 /-- Verify all declarations in a program, accumulating specs as we go. -/
-def Program.check : SpecMap → Typed.Program Untyped.Expr → VerifM Unit
+def Program.check (Θ : TinyML.TypeEnv) : SpecMap → Typed.Program Untyped.Expr → VerifM Unit
   | _, [] => pure ()
   | S, d :: ds => do
     match d.name.name, d.spec with
     | none, none =>
-      Decl.checkExpr S d
-      Program.check S ds
+      Decl.checkExpr Θ S d
+      Program.check Θ S ds
     | some n, none =>
       -- Named declaration without a spec: skip if it's a function definition
       -- (no code executes), otherwise check it. Erase any old spec for this
       -- name since the new binding shadows it.
       if d.body.isFunc then
-        Program.check (S.erase n) ds
+        Program.check Θ (S.erase n) ds
       else
-        Decl.checkExpr S d
-        Program.check (S.erase n) ds
+        Decl.checkExpr Θ S d
+        Program.check Θ (S.erase n) ds
     | _, _ =>
-      let spec ← Decl.check S d
+      let spec ← Decl.check Θ S d
       let S' := match d.name.name with
         | some name => S.insert name spec
         | none => S
-      Program.check S' ds
+      Program.check Θ S' ds
 
 def Program.verify (prog : Untyped.Program Untyped.Expr) : Smt.Strategy Smt.Strategy.Outcome :=
   VerifM.strategy do
-    let typed ← Program.prepare prog
-    Program.check ∅ typed
+    let typed ← Program.prepare TinyML.TypeEnv.empty prog
+    Program.check TinyML.TypeEnv.empty ∅ typed
 
 /-! ## Correctness -/
 
-theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
+theorem Program.prepare_correct (Θ : TinyML.TypeEnv) (prog : Untyped.Program Untyped.Expr)
     (st : TransState) (ρ : Env)
     {Q : Typed.Program Untyped.Expr → TransState → Env → Prop}
-    (heval : VerifM.eval (Program.prepare prog) st ρ Q) :
+    (heval : VerifM.eval (Program.prepare Θ prog) st ρ Q) :
     ∃ typed, Typed.Program.runtime typed = Untyped.Program.runtime prog ∧ Q typed st ρ := by
   unfold Program.prepare at heval
-  cases helab : Typed.Program.elaborate TinyML.TyCtx.empty prog with
+  cases helab : Typed.Program.elaborate Θ TinyML.TyCtx.empty prog with
   | error err =>
     simp [helab] at heval
     exact (VerifM.eval_fatal heval).elim
   | ok typed =>
-    refine ⟨typed, Typed.Program.elaborate_runtime TinyML.TyCtx.empty prog helab, ?_⟩
+    refine ⟨typed, Typed.Program.elaborate_runtime Θ TinyML.TyCtx.empty prog helab, ?_⟩
     simp [helab] at heval
     exact VerifM.eval_ret heval
 
-theorem Decl.checkExpr_correct (S : SpecMap) (d : Typed.Decl Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy γ) (hSwf : S.wfIn Signature.empty)
+theorem Decl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr) (γ : Runtime.Subst)
+    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
     (st : TransState) (ρ : Env)
     {Q : Unit → TransState → Env → Prop}
-    (heval : VerifM.eval (Decl.checkExpr S d) st ρ Q) :
+    (heval : VerifM.eval (Decl.checkExpr Θ S d) st ρ Q) :
     wp (d.body.runtime.subst γ) (fun _ => True) := by
   simp only [Decl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
-  exact compile_correct d.body S [] TinyML.TyCtx.empty st ρ γ
+  exact compile_correct Θ d.body S [] TinyML.TyCtx.empty st ρ γ
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => True)
     hcompile
@@ -130,13 +130,13 @@ theorem Decl.checkExpr_correct (S : SpecMap) (d : Typed.Decl Untyped.Expr) (γ :
     hS hSwf
     (fun _ _ _ _ _ _ _ _ => trivial)
 
-theorem Decl.check_correct (S : SpecMap) (d : Typed.Decl Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy γ) (hSwf : S.wfIn Signature.empty)
+theorem Decl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr) (γ : Runtime.Subst)
+    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
     (st : TransState) (ρ : Env)
     {Q : Spec → TransState → Env → Prop}
-    (heval : VerifM.eval (Decl.check S d) st ρ Q) :
+    (heval : VerifM.eval (Decl.check Θ S d) st ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
-            wp (d.body.runtime.subst γ) (spec.isPrecondFor ·) ∧
+            wp (d.body.runtime.subst γ) (spec.isPrecondFor Θ ·) ∧
             Q spec st ρ := by
   simp only [Decl.check] at heval
   cases hspec : d.spec with
@@ -169,13 +169,13 @@ theorem Decl.check_correct (S : SpecMap) (d : Typed.Decl Untyped.Expr) (γ : Run
           have h4 := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ h3)
           have hswf : spec.wfIn Signature.empty := Spec.checkWf_ok (by cases u; exact hwf)
           have ⟨hcheckSpec, hpure⟩ := VerifM.eval_seq h4
-          exact ⟨spec, hswf, checkSpec_correct S d.body spec γ hswf hSwf hS st ρ hcheckSpec,
+          exact ⟨spec, hswf, checkSpec_correct Θ S d.body spec γ hswf hSwf hS st ρ hcheckSpec,
                  VerifM.eval_ret hpure⟩
 
-theorem Program.check_correct (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy γ) (hSwf : S.wfIn Signature.empty)
+theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
+    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
     (st : TransState) (ρ : Env) :
-    VerifM.eval (Program.check S prog) st ρ (fun _ _ _ => True) →
+    VerifM.eval (Program.check Θ S prog) st ρ (fun _ _ _ => True) →
     pwp ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ st ρ with
   | nil =>
@@ -199,7 +199,7 @@ theorem Program.check_correct (S : SpecMap) (prog : Typed.Program Untyped.Expr) 
     · cases hspec : d.spec
       · simp only [hname, hspec] at heval
         have hbind := VerifM.eval_bind _ _ _ _ heval
-        have hwp := Decl.checkExpr_correct S d γ hS hSwf st ρ hbind
+        have hwp := Decl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
         have ⟨_, hcont⟩ := VerifM.eval_seq hbind
         apply wp.mono _ hwp
         intro v _
@@ -207,7 +207,7 @@ theorem Program.check_correct (S : SpecMap) (prog : Typed.Program Untyped.Expr) 
         exact ih S γ hS hSwf st ρ (VerifM.eval_ret hcont)
       · simp only [hname, hspec] at heval
         obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          Decl.check_correct S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
+          Decl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
         apply wp.mono (fun v hprecond => _) hwp
         intro v hprecond
         simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
@@ -234,7 +234,7 @@ theorem Program.check_correct (S : SpecMap) (prog : Typed.Program Untyped.Expr) 
             (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
               simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
         · have hbind := VerifM.eval_bind _ _ _ _ heval
-          have hwp := Decl.checkExpr_correct S d γ hS hSwf st ρ hbind
+          have hwp := Decl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
           apply wp.mono _ hwp
           intro v _
@@ -246,7 +246,7 @@ theorem Program.check_correct (S : SpecMap) (prog : Typed.Program Untyped.Expr) 
                 (VerifM.eval_ret hcont))
       · simp only [hname, hspec] at heval
         obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          Decl.check_correct S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
+          Decl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
         apply wp.mono (fun v hprecond => _) hwp
         intro v hprecond
         simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
@@ -273,12 +273,12 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
        by simp [FlatCtx.empty, Signature.empty, Signature.allNames]⟩
     have hverifM := VerifM.eval_of_translate
                       (do
-                        let typed ← Program.prepare p
-                        Program.check ∅ typed)
+                        let typed ← Program.prepare TinyML.TypeEnv.empty p
+                        Program.check TinyML.TypeEnv.empty ∅ typed)
                       FlatCtx.empty default ctx_mid hverif hholdsFor hwf
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
-    obtain ⟨typed, hrt, hcheck⟩ := Program.prepare_correct p FlatCtx.empty default hbind
-    have hcorrect := Program.check_correct ∅ typed Runtime.Subst.id
+    obtain ⟨typed, hrt, hcheck⟩ := Program.prepare_correct TinyML.TypeEnv.empty p FlatCtx.empty default hbind
+    have hcorrect := Program.check_correct TinyML.TypeEnv.empty ∅ typed Runtime.Subst.id
                        (SpecMap.empty_satisfiedBy _) (SpecMap.empty_wfIn _)
                        FlatCtx.empty default hcheck
     rw [Runtime.Program.subst_id] at hcorrect

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -46,7 +46,7 @@ def Program.prepare (Θ : TinyML.TypeEnv) (prog : Untyped.Program Untyped.Expr) 
 
 /-- Check an individual declaration. Each declaration's `checkSpec` runs inside a `seq` bracket so its
     declarations and assertions don't pollute subsequent verifications. -/
-def Decl.check (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr) : VerifM Spec := do
+def ValDecl.check (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) : VerifM Spec := do
   let specExpr ← match d.spec with
     | some e => .ret e
     | none => .fatal "declaration has no spec"
@@ -62,32 +62,36 @@ def Decl.check (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr)
   VerifM.seq (checkSpec Θ S d.body spec) (pure spec)
 
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
-def Decl.checkExpr (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr) : VerifM Unit :=
+def ValDecl.checkExpr (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) : VerifM Unit :=
   VerifM.seq (do let _ ← compile Θ S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
 
 /-- Verify all declarations in a program, accumulating specs as we go. -/
 def Program.check (Θ : TinyML.TypeEnv) : SpecMap → Typed.Program Untyped.Expr → VerifM Unit
   | _, [] => pure ()
   | S, d :: ds => do
-    match d.name.name, d.spec with
-    | none, none =>
-      Decl.checkExpr Θ S d
+    match d with
+    | .type_ _ =>
       Program.check Θ S ds
-    | some n, none =>
+    | .val_ d =>
+      match d.name.name, d.spec with
+      | none, none =>
+        ValDecl.checkExpr Θ S d
+        Program.check Θ S ds
+      | some n, none =>
       -- Named declaration without a spec: skip if it's a function definition
       -- (no code executes), otherwise check it. Erase any old spec for this
       -- name since the new binding shadows it.
-      if d.body.isFunc then
-        Program.check Θ (S.erase n) ds
-      else
-        Decl.checkExpr Θ S d
-        Program.check Θ (S.erase n) ds
-    | _, _ =>
-      let spec ← Decl.check Θ S d
-      let S' := match d.name.name with
-        | some name => S.insert name spec
-        | none => S
-      Program.check Θ S' ds
+        if d.body.isFunc then
+          Program.check Θ (S.erase n) ds
+        else
+          ValDecl.checkExpr Θ S d
+          Program.check Θ (S.erase n) ds
+      | _, _ =>
+        let spec ← ValDecl.check Θ S d
+        let S' := match d.name.name with
+          | some name => S.insert name spec
+          | none => S
+        Program.check Θ S' ds
 
 def Program.verify (prog : Untyped.Program Untyped.Expr) : Smt.Strategy Smt.Strategy.Outcome :=
   VerifM.strategy do
@@ -111,13 +115,13 @@ theorem Program.prepare_correct (Θ : TinyML.TypeEnv) (prog : Untyped.Program Un
     simp [helab] at heval
     exact VerifM.eval_ret heval
 
-theorem Decl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr) (γ : Runtime.Subst)
+theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
     (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
     (st : TransState) (ρ : Env)
     {Q : Unit → TransState → Env → Prop}
-    (heval : VerifM.eval (Decl.checkExpr Θ S d) st ρ Q) :
+    (heval : VerifM.eval (ValDecl.checkExpr Θ S d) st ρ Q) :
     wp (d.body.runtime.subst γ) (fun _ => True) := by
-  simp only [Decl.checkExpr] at heval
+  simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
   exact compile_correct Θ d.body S [] TinyML.TyCtx.empty st ρ γ
@@ -130,15 +134,15 @@ theorem Decl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.De
     hS hSwf
     (fun _ _ _ _ _ _ _ _ => trivial)
 
-theorem Decl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Decl Untyped.Expr) (γ : Runtime.Subst)
+theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
     (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
     (st : TransState) (ρ : Env)
     {Q : Spec → TransState → Env → Prop}
-    (heval : VerifM.eval (Decl.check Θ S d) st ρ Q) :
+    (heval : VerifM.eval (ValDecl.check Θ S d) st ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
             wp (d.body.runtime.subst γ) (spec.isPrecondFor Θ ·) ∧
             Q spec st ρ := by
-  simp only [Decl.check] at heval
+  simp only [ValDecl.check] at heval
   cases hspec : d.spec with
   | none =>
     simp only [hspec] at heval
@@ -183,78 +187,77 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
     simp [Typed.Program.runtime, Runtime.Program.subst, pwp]
   | cons d ds ih =>
     intro heval
-    -- Unfold pwp for the cons case
-    have hpwp_unfold : pwp ((Typed.Program.runtime (d :: ds)).subst γ) ↔
-        wp (d.body.runtime.subst γ) (fun v =>
-          pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
-      conv_lhs =>
-        unfold Typed.Program.runtime List.map Runtime.Program.subst pwp
-        simp only [Typed.Decl.runtime, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
-      simp only [Typed.Program.runtime]
-    rw [hpwp_unfold]
-    simp only [Program.check] at heval
-    -- Case-split to match the branching in Program.check
-    cases hname : d.name.name
-    -- Case: d.name = .none
-    · cases hspec : d.spec
-      · simp only [hname, hspec] at heval
-        have hbind := VerifM.eval_bind _ _ _ _ heval
-        have hwp := Decl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
-        have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-        apply wp.mono _ hwp
-        intro v _
-        simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-        exact ih S γ hS hSwf st ρ (VerifM.eval_ret hcont)
-      · simp only [hname, hspec] at heval
-        obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          Decl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
-        apply wp.mono (fun v hprecond => _) hwp
-        intro v hprecond
-        simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-        exact ih S γ hS hSwf st ρ hcont
-    -- Case: d.name = .named n
-    · rename_i n
-      cases hspec : d.spec
-      · simp only [hname, hspec] at heval
-        split at heval
-        · rename_i hfunc
-          obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
-          have hbody_rt : d.body.runtime.subst γ =
-              Runtime.Expr.fix self.runtime (args.map (·.runtime))
-                (body.runtime.subst ((γ.remove' self.runtime).removeAll'
-                  (args.map (·.runtime)))) := by
-            rw [hbody]
-            conv_lhs => unfold Expr.runtime
-            simp only [Runtime.Expr.subst_fix]
-          rw [hbody_rt]
-          apply wp.func
-          simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-          simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-            ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime _ γ)
-            (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
-              simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
-        · have hbind := VerifM.eval_bind _ _ _ _ heval
-          have hwp := Decl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
+    cases d with
+    | type_ td =>
+      simp [Program.check, Typed.Program.runtime] at heval ⊢
+      exact ih S γ hS hSwf st ρ heval
+    | val_ d =>
+      have hpwp_unfold : pwp ((Typed.Program.runtime (.val_ d :: ds)).subst γ) ↔
+          wp (d.body.runtime.subst γ) (fun v =>
+            pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
+        simp [Typed.Program.runtime, pwp, Typed.Decl.runtime, Typed.ValDecl.runtime,
+          Runtime.Program.subst, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
+      rw [hpwp_unfold]
+      simp only [Program.check] at heval
+      cases hname : d.name.name
+      · cases hspec : d.spec
+        · simp only [hname, hspec] at heval
+          have hbind := VerifM.eval_bind _ _ _ _ heval
+          have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
           apply wp.mono _ hwp
           intro v _
+          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
+          exact ih S γ hS hSwf st ρ (VerifM.eval_ret hcont)
+        · simp only [hname, hspec] at heval
+          obtain ⟨spec, hswf, hwp, hcont⟩ :=
+            ValDecl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
+          apply wp.mono (fun v hprecond => _) hwp
+          intro v hprecond
+          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
+          exact ih S γ hS hSwf st ρ hcont
+      · rename_i n
+        cases hspec : d.spec
+        · simp only [hname, hspec] at heval
+          split at heval
+          · rename_i hfunc
+            obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
+            have hbody_rt : d.body.runtime.subst γ =
+                Runtime.Expr.fix self.runtime (args.map (·.runtime))
+                  (body.runtime.subst ((γ.remove' self.runtime).removeAll'
+                    (args.map (·.runtime)))) := by
+              rw [hbody]
+              conv_lhs => unfold Expr.runtime
+              simp only [Runtime.Expr.subst_fix]
+            rw [hbody_rt]
+            apply wp.func
+            simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
+            simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+              ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime _ γ)
+              (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
+                simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
+          · have hbind := VerifM.eval_bind _ _ _ _ heval
+            have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
+            have ⟨_, hcont⟩ := VerifM.eval_seq hbind
+            apply wp.mono _ hwp
+            intro v _
+            simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
+            simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+              ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime v γ)
+              (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
+                simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+                  (VerifM.eval_ret hcont))
+        · simp only [hname, hspec] at heval
+          obtain ⟨spec, hswf, hwp, hcont⟩ :=
+            ValDecl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
+          apply wp.mono (fun v hprecond => _) hwp
+          intro v hprecond
           simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-          simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-            ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime v γ)
-            (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
-              simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-                (VerifM.eval_ret hcont))
-      · simp only [hname, hspec] at heval
-        obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          Decl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
-        apply wp.mono (fun v hprecond => _) hwp
-        intro v hprecond
-        simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-        simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-          ih (S.insert' d.name spec) (Runtime.Subst.update' d.name.runtime v γ)
-            (SpecMap.satisfiedBy_insert'_update' hS hprecond) (SpecMap.wfIn_insert' hSwf hswf) st ρ
-            (by
-              simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using hcont)
+          simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+            ih (S.insert' d.name spec) (Runtime.Subst.update' d.name.runtime v γ)
+              (SpecMap.satisfiedBy_insert'_update' hS hprecond) (SpecMap.wfIn_insert' hSwf hswf) st ρ
+              (by
+                simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using hcont)
 
 theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
   Smt.Strategy.checks (Program.verify p) (pwp (Untyped.Program.runtime p)) := by

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -48,10 +48,10 @@ def Spec.argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val �
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => Spec.argsEnv (ρ.updateConst .value name v) rest vs
 
-def Spec.isPrecondFor (f : Runtime.Val) (s : Spec) : Prop :=
-  ∀ (vs : List Runtime.Val), TinyML.ValsHaveTypes vs (s.args.map Prod.snd) →
+def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : Prop :=
+  ∀ (vs : List Runtime.Val), TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) →
     ∀ (Φ : Runtime.Val → Prop),
-      PredTrans.apply (fun r => TinyML.ValHasType r s.retTy → Φ r) s.pred
+      PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy → Φ r) s.pred
         (Spec.argsEnv Env.empty s.args vs) →
       wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ
 
@@ -134,7 +134,7 @@ end
 mutual
   /-- If `ValHasType v ty` and `t.eval ρ = v`, then all formulas in `typeConstraints ty t` hold. -/
   theorem typeConstraints_hold {ty : TinyML.Typ} {t : Term .value} {ρ : Env}
-      {v : Runtime.Val} (ht : t.eval ρ = v) (hty : TinyML.ValHasType v ty) :
+      {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ = v) (hty : TinyML.ValHasType Θ v ty) :
       ∀ φ ∈ typeConstraints ty t, φ.eval ρ := by
     cases hty with
     | int n =>
@@ -156,7 +156,7 @@ mutual
     | _ => simp [typeConstraints]
 
   theorem typeConstraintsList_hold {ts : List TinyML.Typ} {tl : Term .vallist} {ρ : Env}
-      {vs : List Runtime.Val} (htl : tl.eval ρ = vs) (hty : TinyML.ValsHaveTypes vs ts) :
+      {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} (htl : tl.eval ρ = vs) (hty : TinyML.ValsHaveTypes Θ vs ts) :
       ∀ φ ∈ typeConstraints.typeConstraintsList ts tl, φ.eval ρ := by
     cases hty with
     | nil => simp [typeConstraints.typeConstraintsList]
@@ -176,23 +176,23 @@ end
 
 /-- Declare argument variables, check types, and assume equalities for a spec call.
     Returns the updated substitution. -/
-def Spec.declareArgs (σ : FiniteSubst) :
+def Spec.declareArgs (Θ : TinyML.TypeEnv) (σ : FiniteSubst) :
     List (String × TinyML.Typ) → List (TinyML.Typ × Term .value) → VerifM FiniteSubst
   | [], [] => pure σ
   | (name, ty) :: rest, (targ, sarg) :: sargs => do
-    if targ.sub ty then pure ()
+    if targ.sub Θ ty then pure ()
     else VerifM.fatal s!"type mismatch in call to spec"
     let argVar ← VerifM.decl (some name) .value
     let σ' := σ.rename ⟨name, .value⟩ argVar.name
     VerifM.assume (.eq .value (.const (.uninterpreted argVar.name .value)) sarg)
-    Spec.declareArgs σ' rest sargs
+    Spec.declareArgs Θ σ' rest sargs
   | _, _ => VerifM.fatal "wrong number of arguments"
 
 /-- Full call protocol for a spec: declare argument variables, assume they equal the
     compiled argument terms, check argument types, then invoke `PredTrans.call`. -/
-def Spec.call (σ : FiniteSubst) (s : Spec) (sargs : List (TinyML.Typ × Term .value)) :
+def Spec.call (Θ : TinyML.TypeEnv) (σ : FiniteSubst) (s : Spec) (sargs : List (TinyML.Typ × Term .value)) :
     VerifM (TinyML.Typ × Term .value) := do
-  let σ' ← Spec.declareArgs σ s.args sargs
+  let σ' ← Spec.declareArgs Θ σ s.args sargs
   let result ← PredTrans.call σ' s.pred
   VerifM.assumeAll (typeConstraints s.retTy result)
   pure (s.retTy, result)
@@ -222,9 +222,9 @@ def Spec.implement (s : Spec) (body : List FOL.Const → VerifM (Term .value)) :
 
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
-def SpecMap.satisfiedBy (S : SpecMap) (γ : Runtime.Subst) : Prop :=
+def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) : Prop :=
   ∀ x s, S.lookup x = some s →
-    ∃ f, γ x = some f ∧ s.isPrecondFor f
+    ∃ f, γ x = some f ∧ s.isPrecondFor Θ f
 
 def SpecMap.wfIn (S : SpecMap) (Δ : Signature) : Prop :=
   ∀ f spec, S.lookup f = some spec → spec.wfIn Δ
@@ -296,10 +296,10 @@ def SpecMap.erase' (S : SpecMap) (b : Typed.Binder) : SpecMap :=
   | some x => S.erase x
   | none => S
 
-theorem SpecMap.satisfiedBy_insert {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy γ) (hγ : γ x = some fval) (hf : spec.isPrecondFor fval) :
-    SpecMap.satisfiedBy (Finmap.insert x spec S) γ := by
+    (hS : S.satisfiedBy Θ γ) (hγ : γ x = some fval) (hf : spec.isPrecondFor Θ fval) :
+    SpecMap.satisfiedBy Θ (Finmap.insert x spec S) γ := by
   intro y s' hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup
@@ -307,10 +307,10 @@ theorem SpecMap.satisfiedBy_insert {S : SpecMap} {γ : Runtime.Subst}
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup
     exact hS y s' hlookup
 
-theorem SpecMap.satisfiedBy_insert_update {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy γ) (hf : spec.isPrecondFor v) :
-    SpecMap.satisfiedBy (Finmap.insert x spec S) (γ.update x v) := by
+    (hS : S.satisfiedBy Θ γ) (hf : spec.isPrecondFor Θ v) :
+    SpecMap.satisfiedBy Θ (Finmap.insert x spec S) (γ.update x v) := by
   intro y s' hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup
@@ -326,22 +326,22 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup; exact hs
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup; exact hS y s' hlookup
 
-theorem SpecMap.satisfiedBy_insert' {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy γ)
+    (hS : S.satisfiedBy Θ γ)
     (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval)
-    (hf : spec.isPrecondFor fval) :
-    SpecMap.satisfiedBy (S.insert' b spec) γ := by
+    (hf : spec.isPrecondFor Θ fval) :
+    SpecMap.satisfiedBy Θ (S.insert' b spec) γ := by
   cases b with
   | mk name ty =>
     cases name with
     | none => exact hS
     | some x => exact SpecMap.satisfiedBy_insert hS (hγ x ty rfl) hf
 
-theorem SpecMap.satisfiedBy_insert'_update' {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert'_update' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy γ) (hf : spec.isPrecondFor v) :
-    SpecMap.satisfiedBy (S.insert' b spec) (Runtime.Subst.update' b.runtime v γ) := by
+    (hS : S.satisfiedBy Θ γ) (hf : spec.isPrecondFor Θ v) :
+    SpecMap.satisfiedBy Θ (S.insert' b spec) (Runtime.Subst.update' b.runtime v γ) := by
   cases b with
   | mk name _ =>
     cases name with
@@ -364,9 +364,9 @@ theorem SpecMap.wfIn_erase' {S : SpecMap} {b : Typed.Binder} {Δ : Signature}
     | none => exact hS
     | some _ => exact SpecMap.wfIn_erase hS
 
-theorem SpecMap.satisfiedBy_eraseAll_updateAll' {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
-    {vs : List Runtime.Val} (hS : S.satisfiedBy γ) (hlen : keys.length = vs.length) :
-    (SpecMap.eraseAll keys S).satisfiedBy (γ.updateAll' (keys.map Runtime.Binder.named) vs) := by
+theorem SpecMap.satisfiedBy_eraseAll_updateAll' {Θ : TinyML.TypeEnv} {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
+    {vs : List Runtime.Val} (hS : S.satisfiedBy Θ γ) (hlen : keys.length = vs.length) :
+    (SpecMap.eraseAll keys S).satisfiedBy Θ (γ.updateAll' (keys.map Runtime.Binder.named) vs) := by
   intro y s hlookup
   have hy_notin : y ∉ keys := by
     intro hmem
@@ -380,15 +380,15 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAll' {keys : List String} {S : SpecMa
   rwa [SpecMap.eraseAll_lookup_of_notin hy_notin] at hlookup
 
 theorem SpecMap.empty_satisfiedBy (γ : Runtime.Subst) :
-    SpecMap.satisfiedBy (∅ : SpecMap) γ := by
+    SpecMap.satisfiedBy Θ (∅ : SpecMap) γ := by
   intro x s h; simp [Finmap.lookup_empty] at h
 
 theorem SpecMap.empty_wfIn (Δ : Signature) :
     SpecMap.wfIn (∅ : SpecMap) Δ := by
   intro f spec h; simp [Finmap.lookup_empty] at h
 
-theorem SpecMap.satisfiedBy_erase {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val}
-    (h : S.satisfiedBy γ) : SpecMap.satisfiedBy (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
+theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val}
+    (h : S.satisfiedBy Θ γ) : SpecMap.satisfiedBy Θ (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
   intro y s hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_erase] at hlookup; exact absurd hlookup (by simp)
@@ -396,20 +396,20 @@ theorem SpecMap.satisfiedBy_erase {S : SpecMap} {γ : Runtime.Subst} {x : TinyML
     obtain ⟨fval, hγ, hisPrecond⟩ := h y s hlookup
     exact ⟨fval, by simp [Runtime.Subst.update, hyx, hγ], hisPrecond⟩
 
-theorem SpecMap.satisfiedBy_erase' {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_erase' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val}
-    (hS : S.satisfiedBy γ) :
-    SpecMap.satisfiedBy (S.erase' b) (Runtime.Subst.update' b.runtime v γ) := by
+    (hS : S.satisfiedBy Θ γ) :
+    SpecMap.satisfiedBy Θ (S.erase' b) (Runtime.Subst.update' b.runtime v γ) := by
   cases b with
   | mk name _ =>
     cases name with
     | none => exact hS
     | some _ => exact SpecMap.satisfiedBy_erase hS
 
-theorem SpecMap.satisfiedBy_update_of_not_mem {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val}
-    (h : S.satisfiedBy γ) (hx : S.lookup x = none) :
-    S.satisfiedBy (γ.update x v) := by
+    (h : S.satisfiedBy Θ γ) (hx : S.lookup x = none) :
+    S.satisfiedBy Θ (γ.update x v) := by
   intro y s hlookup
   have hyx : y ≠ x := by intro heq; subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)
   obtain ⟨fval, hγ, hisPrecond⟩ := h y s hlookup
@@ -442,18 +442,18 @@ theorem Spec.argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : Env}
 
 /-- Correctness of `declareArgs`: after processing all arguments, the resulting
     substitution is well-formed, types match, and the env agrees with `argsEnv`. -/
-theorem Spec.declareArgs_correct :
+theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
     ∀ (args : List (String × TinyML.Typ)) (sargs : List (TinyML.Typ × Term .value))
       (σ : FiniteSubst) (st : TransState) (ρ : Env)
       (Ψ : FiniteSubst → TransState → Env → Prop),
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
-    VerifM.eval (Spec.declareArgs σ args sargs) st ρ Ψ →
+    VerifM.eval (Spec.declareArgs Θ σ args sargs) st ρ Ψ →
     ∃ σ' st' ρ', Ψ σ' st' ρ' ∧
       σ'.wf st'.decls ∧
       (Signature.ofVars σ'.dom).wf ∧
-      TinyML.Typ.SubList (sargs.map Prod.fst) (args.map Prod.snd) ∧
+      @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
       (((Signature.ofVars σ.dom).declVars (Spec.argVars args)).vars ⊆ σ'.dom) ∧
       Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args)) (σ'.subst.eval ρ')
         (Spec.argsEnv (σ.subst.eval ρ) args (sargs.map fun p => p.2.eval ρ)) := by
@@ -480,7 +480,7 @@ theorem Spec.declareArgs_correct :
     | cons sarg_hd sargs_rest =>
       obtain ⟨targ, sarg⟩ := sarg_hd
       simp only [Spec.declareArgs] at heval
-      by_cases hsub_ty : targ.sub ty = true
+      by_cases hsub_ty : targ.sub Θ ty = true
       · simp [hsub_ty] at heval
         have hbind := VerifM.eval_bind _ _ _ _ heval
         have hret := VerifM.eval_ret hbind
@@ -553,7 +553,7 @@ theorem Spec.declareArgs_correct :
         have hb := VerifM.eval_bind _ _ _ _ heval
         exact (VerifM.eval_fatal hb).elim
 
-theorem Spec.call_correct (s : Spec) (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
+theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
     (st : TransState) (ρ : Env)
     (Ψ : (TinyML.Typ × Term .value) → TransState → Env → Prop)
     (Φ : Runtime.Val → Prop) :
@@ -561,22 +561,22 @@ theorem Spec.call_correct (s : Spec) (σ : FiniteSubst) (sargs : List (TinyML.Ty
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
-    VerifM.eval (Spec.call σ s sargs) st ρ Ψ →
+    VerifM.eval (Spec.call Θ σ s sargs) st ρ Ψ →
     (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
-      TinyML.ValHasType v s.retTy → Φ v) →
-    TinyML.Typ.SubList (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
-    PredTrans.apply (fun r => TinyML.ValHasType r s.retTy → Φ r) s.pred
+      TinyML.ValHasType Θ v s.retTy → Φ v) →
+    @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
+    PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy → Φ r) s.pred
       (Spec.argsEnv (σ.subst.eval ρ) s.args (sargs.map fun p => p.2.eval ρ)) := by
   intro hwf hσdomwf hσwf hsargs heval hΨ
   simp only [Spec.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   obtain ⟨σ', st', ρ', hΨ', hσ'wf, hσ'domwf, hsublist, hdom_sub, hagree⟩ :=
-    Spec.declareArgs_correct s.args sargs σ st ρ _ hσwf hσdomwf hsargs hb
+    Spec.declareArgs_correct Θ s.args sargs σ st ρ _ hσwf hσdomwf hsargs hb
   constructor
   · exact hsublist
   · have hb2 := VerifM.eval_bind _ _ _ _ hΨ'
     have hcall := PredTrans.call_correct s.pred σ' st' ρ'
-      _ (fun r => TinyML.ValHasType r s.retTy → Φ r)
+      _ (fun r => TinyML.ValHasType Θ r s.retTy → Φ r)
       (PredTrans.wfIn_mono hwf
         ⟨hdom_sub,
           by intro c hc; simp at hc,
@@ -596,13 +596,13 @@ theorem Spec.call_correct (s : Spec) (σ : FiniteSubst) (sargs : List (TinyML.Ty
 /-- Correctness of `declareImplArgs`: after processing all arguments, the resulting
     substitution is well-formed, all argVars are in decls with sort `.value`,
     and the env agrees with `argsEnv`. -/
-theorem Spec.declareImplArgs_correct :
+theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
     ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
       (σ : FiniteSubst) (st : TransState) (ρ : Env)
       (Ψ : (FiniteSubst × List FOL.Const) → TransState → Env → Prop),
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
-    TinyML.ValsHaveTypes vs (args.map Prod.snd) →
+    TinyML.ValsHaveTypes Θ vs (args.map Prod.snd) →
     VerifM.eval (Spec.declareImplArgs σ args) st ρ Ψ →
     ∃ σ' argVars st' ρ', Ψ (σ', argVars) st' ρ' ∧
       σ'.wf st'.decls ∧
@@ -710,10 +710,10 @@ theorem Spec.declareImplArgs_correct :
           exact h1'.trans hvar_eval
         · exact hlookups
 
-theorem Spec.implement_correct (s : Spec) (body : List FOL.Const → VerifM (Term .value))
+theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
     (st : TransState) (ρ : Env) (vs : List Runtime.Val) (Φ : Runtime.Val → Prop) (R : Prop) :
     s.wfIn Signature.empty →
-    TinyML.ValsHaveTypes vs (s.args.map Prod.snd) →
+    TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) →
     VerifM.eval (Spec.implement s body) st ρ (fun _ _ _ => True) →
     PredTrans.apply Φ s.pred (Spec.argsEnv Env.empty s.args vs) →
     (∀ argVars st' ρ',
@@ -728,7 +728,7 @@ theorem Spec.implement_correct (s : Spec) (body : List FOL.Const → VerifM (Ter
   have hb := VerifM.eval_bind _ _ _ _ heval
   obtain ⟨σ', argVars, st', ρ', hΨ, hσ'wf, hσ'domwf, hdsub, hragree, hdom_sub, hagree,
     hmem_decls, hsorts, hlookups⟩ :=
-    Spec.declareImplArgs_correct s.args vs FiniteSubst.id st ρ _ (FiniteSubst.id_wf st.decls)
+    Spec.declareImplArgs_correct Θ s.args vs FiniteSubst.id st ρ _ (FiniteSubst.id_wf st.decls)
       (by simpa [Signature.ofVars] using Signature.wf_empty) hvs hb
   -- Transport apply from argsEnv Env.empty to σ'.subst.eval ρ'
   have hag_empty : Env.agreeOn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars s.args))

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -176,11 +176,11 @@ end
 
 /-- Declare argument variables, check types, and assume equalities for a spec call.
     Returns the updated substitution. -/
-def Spec.declareArgs (Θ : TinyML.TypeEnv) (σ : FiniteSubst) :
-    List (String × TinyML.Typ) → List (TinyML.Typ × Term .value) → VerifM FiniteSubst
+  def Spec.declareArgs (Θ : TinyML.TypeEnv) (σ : FiniteSubst) :
+      List (String × TinyML.Typ) → List (TinyML.Typ × Term .value) → VerifM FiniteSubst
   | [], [] => pure σ
   | (name, ty) :: rest, (targ, sarg) :: sargs => do
-    if targ.sub Θ ty then pure ()
+    if TinyML.Typ.sub Θ .left targ ty || TinyML.Typ.sub Θ .right targ ty then pure ()
     else VerifM.fatal s!"type mismatch in call to spec"
     let argVar ← VerifM.decl (some name) .value
     let σ' := σ.rename ⟨name, .value⟩ argVar.name
@@ -480,12 +480,30 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
     | cons sarg_hd sargs_rest =>
       obtain ⟨targ, sarg⟩ := sarg_hd
       simp only [Spec.declareArgs] at heval
-      by_cases hsub_ty : targ.sub Θ ty = true
-      · simp [hsub_ty] at heval
+      by_cases hsub_ty : TinyML.Typ.sub Θ .left targ ty || TinyML.Typ.sub Θ .right targ ty = true
+      · have hsub_ty_prop :
+            TinyML.Typ.sub Θ .left targ ty = true ∨ TinyML.Typ.sub Θ .right targ ty = true := by
+            simpa [Bool.or_eq_true] using hsub_ty
+        simp [hsub_ty_prop] at heval
         have hbind := VerifM.eval_bind _ _ _ _ heval
         have hret := VerifM.eval_ret hbind
-        have hb2 := VerifM.eval_bind _ _ _ _ hret
-        have hdecl := VerifM.eval_decl hb2
+        have hbind' :
+            (VerifM.decl (some name) .value).eval st ρ
+              (fun argVar st' ρ' =>
+                (do
+                  VerifM.assume
+                    (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg)
+                  Spec.declareArgs Θ (σ.rename ⟨name, .value⟩ argVar.name) rest sargs_rest).eval
+                    st' ρ' Ψ) := by
+          simpa using
+            (VerifM.eval_bind
+              (m := VerifM.decl (some name) .value)
+              (k := fun argVar => do
+                VerifM.assume
+                  (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg)
+                Spec.declareArgs Θ (σ.rename ⟨name, .value⟩ argVar.name) rest sargs_rest)
+              (st := st) (ρ := ρ) hret)
+        have hdecl := VerifM.eval_decl hbind'
         set argVar := st.freshConst (some name) .value
         have hfresh_decls : argVar.name ∉ st.decls.allNames :=
           fresh_not_mem (addNumbers name) st.decls.allNames (addNumbers_injective _)
@@ -514,8 +532,8 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           simp only [Formula.eval, Term.eval, Const.denote]
           simpa [Env.lookupConst, Env.updateConst] using
             (Term.eval_env_agree hsarg_wf (agreeOn_update_fresh_const hfresh_decls))
-        have hb3 := VerifM.eval_bind _ _ _ _ hdecl
-        have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
+        have hbind'' := VerifM.eval_bind _ _ _ _ hdecl
+        have hassume := VerifM.eval_assume hbind'' heq_wf heq_holds
         set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ)
         have hsargs_rest : ∀ p ∈ sargs_rest, (p : TinyML.Typ × Term .value).2.wfIn
             (st.decls.addConst argVar) := by
@@ -534,8 +552,12 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := ⟨name, .value⟩) (name' := argVar.name) hσdomwf)
         obtain ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf, hsublist, hdom_sub, hagree⟩ :=
           ih sargs_rest σ' _ ρ₁ Ψ hσ'wf hσ'domwf hsargs_rest hassume
+        have hsub_ty' : TinyML.Typ.Sub Θ targ ty := by
+          cases hsub_ty_prop with
+          | inl h => exact TinyML.Typ.sub_sound h
+          | inr h => exact TinyML.Typ.sub_sound h
         refine ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf,
-          .cons (TinyML.Typ.sub_iff.mp hsub_ty) hsublist, ?_, ?_⟩
+          .cons hsub_ty' hsublist, ?_, ?_⟩
         · simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
             using hdom_sub
         · have hag_rename := FiniteSubst.rename_agreeOn_declVar
@@ -549,7 +571,10 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           rw [hsargs_eval] at hagree
           simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar] using
             (Env.agreeOn_trans hagree hag_env)
-      · rw [if_neg hsub_ty] at heval
+      · have hsub_ty_prop :
+            ¬(TinyML.Typ.sub Θ .left targ ty = true ∨ TinyML.Typ.sub Θ .right targ ty = true) := by
+            simpa [Bool.or_eq_true] using hsub_ty
+        simp [hsub_ty_prop] at heval
         have hb := VerifM.eval_bind _ _ _ _ heval
         exact (VerifM.eval_fatal hb).elim
 

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -180,7 +180,7 @@ end
       List (String × TinyML.Typ) → List (TinyML.Typ × Term .value) → VerifM FiniteSubst
   | [], [] => pure σ
   | (name, ty) :: rest, (targ, sarg) :: sargs => do
-    if TinyML.Typ.sub Θ .left targ ty || TinyML.Typ.sub Θ .right targ ty then pure ()
+    if TinyML.Typ.sub Θ targ ty then pure ()
     else VerifM.fatal s!"type mismatch in call to spec"
     let argVar ← VerifM.decl (some name) .value
     let σ' := σ.rename ⟨name, .value⟩ argVar.name
@@ -480,11 +480,8 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
     | cons sarg_hd sargs_rest =>
       obtain ⟨targ, sarg⟩ := sarg_hd
       simp only [Spec.declareArgs] at heval
-      by_cases hsub_ty : TinyML.Typ.sub Θ .left targ ty || TinyML.Typ.sub Θ .right targ ty = true
-      · have hsub_ty_prop :
-            TinyML.Typ.sub Θ .left targ ty = true ∨ TinyML.Typ.sub Θ .right targ ty = true := by
-            simpa [Bool.or_eq_true] using hsub_ty
-        simp [hsub_ty_prop] at heval
+      by_cases hsub_ty : TinyML.Typ.sub Θ targ ty = true
+      · simp [hsub_ty] at heval
         have hbind := VerifM.eval_bind _ _ _ _ heval
         have hret := VerifM.eval_ret hbind
         have hbind' :
@@ -552,10 +549,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := ⟨name, .value⟩) (name' := argVar.name) hσdomwf)
         obtain ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf, hsublist, hdom_sub, hagree⟩ :=
           ih sargs_rest σ' _ ρ₁ Ψ hσ'wf hσ'domwf hsargs_rest hassume
-        have hsub_ty' : TinyML.Typ.Sub Θ targ ty := by
-          cases hsub_ty_prop with
-          | inl h => exact TinyML.Typ.sub_sound h
-          | inr h => exact TinyML.Typ.sub_sound h
+        have hsub_ty' : TinyML.Typ.Sub Θ targ ty := TinyML.Typ.sub_sound hsub_ty
         refine ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf,
           .cons hsub_ty' hsublist, ?_, ?_⟩
         · simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
@@ -571,10 +565,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           rw [hsargs_eval] at hagree
           simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar] using
             (Env.agreeOn_trans hagree hag_env)
-      · have hsub_ty_prop :
-            ¬(TinyML.Typ.sub Θ .left targ ty = true ∨ TinyML.Typ.sub Θ .right targ ty = true) := by
-            simpa [Bool.or_eq_true] using hsub_ty
-        simp [hsub_ty_prop] at heval
+      · simp [hsub_ty] at heval
         have hb := VerifM.eval_bind _ _ _ _ heval
         exact (VerifM.eval_fatal hb).elim
 

--- a/Mica/Verifier/Utils.lean
+++ b/Mica/Verifier/Utils.lean
@@ -44,8 +44,8 @@ theorem Bindings.wf_cons {B : Bindings} {decls : Signature} {x : TinyML.Var} {v 
   · exact List.Mem.tail _ (hbwf p hp)
 
 /-- The substitution `γ` maps every binding to a value well-typed by `Γ`. -/
-def Bindings.typedSubst (B : Bindings) (Γ : TinyML.TyCtx) (γ : Runtime.Subst) : Prop :=
-  ∀ x x' t, B.lookup x = some x' → Γ x = some t → ∃ v, γ x = some v ∧ TinyML.ValHasType v t
+def Bindings.typedSubst (Θ : TinyML.TypeEnv) (B : Bindings) (Γ : TinyML.TyCtx) (γ : Runtime.Subst) : Prop :=
+  ∀ x x' t, B.lookup x = some x' → Γ x = some t → ∃ v, γ x = some v ∧ TinyML.ValHasType Θ v t
 
 /-! ### Term List Evaluation -/
 
@@ -151,9 +151,9 @@ theorem Terms.Eval.lookup_const {ρ : Env} {avs : List FOL.Const} {vs : List Run
 
 theorem Bindings.typedSubst_cons {B : Bindings} {Γ : TinyML.TyCtx} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : FOL.Const} {te : TinyML.Typ} {w : Runtime.Val}
-    (hts  : B.typedSubst Γ γ)
-    (hval : TinyML.ValHasType w te) :
-    Bindings.typedSubst ((x, v) :: B) (Γ.extend x te) (Runtime.Subst.update γ x w) := by
+    (hts  : B.typedSubst Θ Γ γ)
+    (hval : TinyML.ValHasType Θ w te) :
+    Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x te) (Runtime.Subst.update γ x w) := by
   intro y y' t hmem hΓ
   by_cases hyx : y == x
   · -- head case: y = x
@@ -190,8 +190,8 @@ theorem Bindings.typedSubst_of_agreeOnLinked
     {B : Bindings} {Γ : TinyML.TyCtx} {γ : Runtime.Subst} {ρ : Env}
     (hagree : B.agreeOnLinked ρ γ)
     (htyped_vals : ∀ x x' t, B.lookup x = some x' → Γ x = some t →
-      TinyML.ValHasType (ρ.consts .value x'.name) t) :
-    B.typedSubst Γ γ := by
+      TinyML.ValHasType Θ (ρ.consts .value x'.name) t) :
+    B.typedSubst Θ Γ γ := by
   intro x x' t hmem hΓ
   obtain ⟨_, hval⟩ := hagree x x' hmem
   exact ⟨_, hval, htyped_vals x x' t hmem hΓ⟩
@@ -371,8 +371,8 @@ theorem val_typed_of_last_wins
     (hlookup : List.lookup x ((args.map Prod.fst).zip vars).reverse = some x')
     (hΓ : (args.foldl (fun ctx a => ctx.extend a.1 a.2) Γ₀) x = some t)
     (hlookups : List.Forall₂ (fun av val => ρ.consts .value av.name = val) vars vals)
-    (htyped : TinyML.ValsHaveTypes vals (args.map Prod.snd))
-    : TinyML.ValHasType (ρ.consts .value x'.name) t := by
+    (htyped : TinyML.ValsHaveTypes Θ vals (args.map Prod.snd))
+    : TinyML.ValHasType Θ (ρ.consts .value x'.name) t := by
   induction args generalizing vars vals Γ₀ with
   | nil => simp at hlookup
   | cons a as ih =>


### PR DESCRIPTION
This PR adds support for nominal types to deal with recursive types. Most of the PR is relatively straightforward plumbing, and cleanup in the frontend. The main work is in the new sub typing judgement (and proving termination of it) plus the extension of the value typing to support named types (and hence recursive types).