### PR TITLE
Persistent separation logic specifications

### DIFF
--- a/Mica/SeparationLogic/Axioms.lean
+++ b/Mica/SeparationLogic/Axioms.lean
@@ -43,12 +43,6 @@ axiom wp.bind {k : TinyML.K} {e : Runtime.Expr} {Q : Runtime.Val → iProp} :
 axiom wp.mono {e : Runtime.Expr} {P Q : Runtime.Val → iProp} :
     (∀ v, P v -∗ Q v) ∗ wp e P ⊢ wp e Q
 
-axiom wp.fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
-    {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp} :
-    ((∀ vs, Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
-      ∀ vs, Φ vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)
-    ⊢ (∀ (vs : List Runtime.Val), Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
-
 axiom wp.app {fn : Runtime.Expr} {args : Runtime.Exprs} {P : Runtime.Val → iProp} :
     wps args (fun vs => wp fn (fun fv =>
       wp (.app (.val fv) (vs.map Runtime.Expr.val)) P)) ⊢
@@ -58,15 +52,18 @@ axiom wp.func {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Exp
     (P : Runtime.Val → iProp) :
     P (.fix f args e) ⊢ wp (.fix f args e) P
 
--- @agent: wp.fix' needs several persistency modalities that are currently missing
+axiom wp.fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
+    {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp} :
+      wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P
+    ⊢ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P
+
 axiom wp.fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp} :
-    ((∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+    □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
         Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
       ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
         Φ P vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)
-    ⊢ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-        Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
+    ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp), Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
 
 axiom wp.unop {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iProp} :
     TinyML.evalUnOp op v = some res →

--- a/Mica/SeparationLogic/Axioms.lean
+++ b/Mica/SeparationLogic/Axioms.lean
@@ -52,7 +52,7 @@ axiom wp.func {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Exp
     (P : Runtime.Val → iProp) :
     P (.fix f args e) ⊢ wp (.fix f args e) P
 
-axiom wp.fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
+axiom wp.fix {vs : List Runtime.Val} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp} :
       wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P
     ⊢ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P

--- a/Mica/SeparationLogic/Axioms.lean
+++ b/Mica/SeparationLogic/Axioms.lean
@@ -163,17 +163,10 @@ theorem wp.letIn {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.V
   isplitl []
   · iintro %v Hv
     iapply wp.func
-    iapply (@wp.fix .none [b] body Q
-      (fun vs => ∃ v', ⌜vs = [v']⌝ ∗ wp (body.subst (Runtime.Subst.id.update' b v')) Q))
-    · iintro _IH %vs ⟨%v', %Heq, Hwp⟩
-      subst Heq
-      simp only [Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left,
-                  Runtime.Subst.update']
-      iexact Hwp
-    · iexists v
-      isplitr
-      · ipure_intro; rfl
-      · iexact Hv
+    iapply (wp.fix (Φ := fun _ => emp) (vs := [v]))
+    simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons,
+               Runtime.Subst.updateAll'_nil_left]
+    iexact Hv
   · iexact Hbound
 
 /-- Applying a single-argument lambda `(fun b -> body)` to a value reduces to substituting. -/
@@ -187,14 +180,7 @@ theorem wp.app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Run
   simp only [wps_cons, wps_nil]
   iapply wp.val
   iapply wp.func
-  iapply (@wp.fix .none [b] body Φ
-    (fun vs => ∃ v', ⌜vs = [v']⌝ ∗ wp (body.subst (Runtime.Subst.id.update' b v')) Φ))
-  · iintro _IH %vs ⟨%v', %Heq, Hwp'⟩
-    subst Heq
-    simp only [Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left,
-               Runtime.Subst.update']
-    iexact Hwp'
-  · iexists v
-    isplitr
-    · ipure_intro; rfl
-    · iexact Hwp
+  iapply (wp.fix (Φ := fun _ => emp) (vs := [v]))
+  simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons,
+             Runtime.Subst.updateAll'_nil_left]
+  iexact Hwp

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -342,10 +342,9 @@ theorem wp_fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Ex
     {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp}
     R
     (h : R ⊢
-      ((∀ vs, Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
-        ∀ vs, Φ vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
+      (wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
     R ⊢
-      (∀ vs, Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
+      (wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
   h.trans wp.fix
 
 /-- Fixpoint unfolding with a continuation-indexed invariant. -/
@@ -353,12 +352,11 @@ theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.E
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢
-      ((∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
         ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
-    R ⊢
-      (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+    R ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
   h.trans wp.fix'
 

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -375,4 +375,21 @@ theorem wp_app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Run
     R ⊢ wp (.app (.fix .none [b] body) [.val v]) Φ :=
   h.trans wp.app_lambda_single
 
+
+/-- Strengthen the postcondition of a `wp` using a persistent resource:
+    if `R` (persistent) entails `wp e P`, and `R` together with `P v` entails `Q v`,
+    then `R` entails `wp e Q`. -/
+theorem wp_strengthen_persistent
+    {R : iProp} [Iris.BI.Persistent R] {e : Runtime.Expr}
+    {P Q : Runtime.Val → iProp}
+    (hwp : R ⊢ wp e P) (hpost : ∀ v, R ⊢ P v -∗ Q v) :
+    R ⊢ wp e Q := by
+  iintro □HR
+  iapply wp.mono
+  isplitr
+  · iintro %v
+    iapply (hpost v)
+    iexact HR
+  · iapply hwp; iexact HR
+
 end SpatialContext

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -345,7 +345,7 @@ theorem wp_fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Ex
       (wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
     R ⊢
       (wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
-  h.trans wp.fix
+  h.trans (wp.fix (Φ := Φ))
 
 /-- Fixpoint unfolding with a continuation-indexed invariant. -/
 theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
@@ -358,7 +358,7 @@ theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.E
           Φ P vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
     R ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
-  h.trans wp.fix'
+  h.trans (wp.fix' (Φ := Φ))
 
 /-- Let-bindings: evaluate the bound expression, then continue in the body with
     the resulting value substituted. -/

--- a/Mica/SeparationLogic/ProofModePatterns.lean
+++ b/Mica/SeparationLogic/ProofModePatterns.lean
@@ -218,8 +218,18 @@ example (P : Nat → iProp) : (∀ n, P n) ⊢ P 42 := by
   ispecialize Hall $$ %42
   iexact Hall
 
+/-! ## 10. Persistency -/
 
-/-! ## 10. Hypothesis management -/
+/-- Introduce a persistent assertion, cross a persistency modality, and use it twice. -/
+example (R Q : iProp): R ∗ □ Q ⊢ □ (Q ∗ Q) := by
+  iintro ⟨HR, □HQ⟩
+  imodintro
+  isplitl
+  . iexact HQ
+  . iexact HQ
+
+
+/-! ## 11. Hypothesis management -/
 
 /-- `irevert` moves a hypothesis back into the goal as a wand. -/
 example (P Q : iProp) : P ∗ Q ⊢ Q ∗ P := by
@@ -233,7 +243,7 @@ example (P Q : iProp) : P ∗ Q ⊢ Q ∗ P := by
   · iexact HP
 
 
-/-! ## 11. Combining Iris and Lean reasoning
+/-! ## 12. Combining Iris and Lean reasoning
 
 Often the best approach is to use Lean term mode for simple entailment chains
 and only enter proof mode for the parts that need hypothesis management.

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -286,6 +286,34 @@ theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) 
         have : idx + 1 + k = idx + (k + 1) := by omega
         rw [ih_get k hk, this]
 
+theorem SpecMap.project (P : iProp) (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) :
+  (P ⊢ S.satisfiedBy Θ γ) →
+  S.lookup x = some s →
+  (∀ fval, γ x = some fval → s.isPrecondFor Θ fval ∗ P ⊢ Q) →
+  (P ⊢ Q) := by
+  intro hsat hlook hcont
+  simp only [SpecMap.satisfiedBy] at hsat
+  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor Θ fval) ∗ P := by
+    refine (persistent_entails_r hsat).trans ?_
+    istart
+    iintro ⟨□Hall, HP⟩
+    ispecialize Hall $$ %x
+    ispecialize Hall $$ %s
+    isplitl []
+    · iapply Hall
+      ipure_intro
+      exact hlook
+    · iexact HP
+  refine hstep.trans ?_
+  istart
+  iintro ⟨⟨%fval, Hγ, Hpre⟩, HP⟩
+  ipure Hγ
+  iapply (hcont fval Hγ)
+  isplitl [Hpre]
+  · iexact Hpre
+  · iexact HP
+
+
 /-! ### Correctness -/
 
 mutual
@@ -298,9 +326,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
-      TinyML.ValHasType Θ v e.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+      TinyML.ValHasType Θ v e.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
     st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ := by
-  intro heval hagree hbwf hts hspec hSwf hpost
+  intro heval hagree hbwf hts hSwf hpost
   cases e with
   | const c =>
     cases c with
@@ -309,7 +337,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| hpost (.int n) ρ st _ heval
+      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost (.int n) ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
         (by simp [Term.eval, UnOp.eval, Const.denote])
         (.int n)
@@ -318,7 +346,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| hpost (.bool b) ρ st _ heval
+      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost (.bool b) ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
         (by simp [Term.eval, UnOp.eval, Const.denote])
         (.bool b)
@@ -327,7 +355,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| hpost .unit ρ st _ heval
+      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost .unit ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn])
         (by simp [Term.eval])
         .unit
@@ -365,7 +393,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           obtain ⟨w, hw, hwt⟩ := hts x x' t hbind hΓ
           rw [hγ] at hw
           exact (Option.some.inj hw) ▸ hwt
-      exact SpatialContext.wp_val <|
+      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <|
         hpost _ ρ st _ heval hwfv (by simp [Term.eval, Const.denote]) htyping
     · exact False.elim (hcheck (VerifM.eval_bind_expectEq heval).1)
   | inj tag arity payload =>
@@ -377,7 +405,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
       have heval_p : (compile Θ S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
       refine SpatialContext.wp_bind_inj <| compile_correct Θ R payload S B Γ st ρ γ _ _
-        (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hspec hSwf ?_
+        (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hSwf ?_
       intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p htype_p
       obtain ⟨hdecls_p, hagreeOn_p, hΨ_p⟩ := hΨ_p
       obtain hΨ_p := VerifM.eval_ret hΨ_p
@@ -396,7 +424,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     simp [Expr.runtime]
-    refine compile_correct Θ R e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+    refine compile_correct Θ R e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v ρ' st' se hΨ hse_wf heval_se htype_v
     obtain ⟨_, _, hΨ⟩ := hΨ
     cases hsub : TinyML.Typ.sub Θ e.ty ty
@@ -411,7 +439,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_assert <| compile_correct Θ R e S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
@@ -438,7 +466,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_unop <| compile_correct Θ R e S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se htype_e
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
@@ -458,8 +486,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     -- compile processes r first (matching runtime r-first evaluation order)
     have heval_r : (compile Θ S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_binop <| compile_correct Θ R r S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_binop <| (SpecMap.satisfiedBy_dup).trans <|
+      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) r S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hSwf ?_
     intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr htyr
     obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
     have hagree_r : B.agreeOnLinked ρ_r γ :=
@@ -467,7 +496,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     have hbwf_r : B.wf st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
     have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
     refine compile_correct Θ R l S B Γ st₁ ρ_r γ _ _
-      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hts hspec hSwf ?_
+      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hts hSwf ?_
     intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
     obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
     obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
@@ -584,8 +613,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     unfold Expr.runtime
     simp only [Runtime.Expr.letIn_subst]
     have heval_e_outer : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine (compile_correct Θ R e S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hspec hSwf ?_).trans wp.letIn
+    refine (SpecMap.satisfiedBy_dup.trans <| compile_correct Θ (S.satisfiedBy Θ γ ∗ R) e S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hSwf ?_).trans wp.letIn
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
     have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
@@ -595,12 +624,12 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     | none =>
       simp [hname] at hΨ_e
       have hbody := compile_correct Θ R body S B Γ st₁ ρ_e γ _ _
-        (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hspec hSwf
+        (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hSwf
         (fun v ρ' st' se hΨ hs hw ht =>
           let ⟨_, _, hΨ'⟩ := hΨ
           hpost v ρ' st' se hΨ' hs hw ht)
       have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ Runtime.Binder.none v_e
-      have hbody' : st₁.owns.interp ρ_e ∗ R ⊢ wp
+      have hbody' : st₁.owns.interp ρ_e ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp
             (Runtime.Expr.subst
               (Runtime.Subst.update' Runtime.Binder.none v_e Runtime.Subst.id)
               (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
@@ -622,9 +651,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           owns := st₁.owns }
       set ρ_body := ρ_e.updateConst .value v.name v_e
       set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
-      suffices st₂.owns.interp ρ_body ∗ R ⊢ wp (body.runtime.subst γ_body) Φ by
+      suffices st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp (body.runtime.subst γ_body) Φ by
         have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ (.named x) v_e
-        have hbody' : st₂.owns.interp ρ_body ∗ R ⊢ wp
+        have hbody' : st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp
               (Runtime.Expr.subst
                 (Runtime.Subst.update' (.named x) v_e Runtime.Subst.id)
                 (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
@@ -634,7 +663,14 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           (SpatialContext.interp_env_agree (VerifM.eval.wf hΨ_e).ownsWf
             (agreeOn_update_fresh_const hfresh)).1
         rw [Binder.runtime_of_name_some hname]
-        exact (sep_mono_l hinterp_eq).trans (by simpa [γ_body, base, Runtime.Subst.update', Runtime.Subst.update] using hbody')
+        have hsat :
+            st₂.owns.interp ρ_body ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+              st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) := by
+          exact SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase
+        exact (sep_mono_l hinterp_eq).trans <|
+          hsat.trans <|
+          by simpa [st₂, γ_body, base, Runtime.Subst.update', Runtime.Subst.update, Runtime.Subst.id]
+            using hbody'
       have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e ρ_body :=
         agreeOn_update_fresh_const hfresh
       have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
@@ -681,7 +717,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         Bindings.typedSubst_cons hts htyping_e
       refine compile_correct Θ R body (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
         (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ hts_body
-        (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) ?_
+        (SpecMap.wfIn_erase hSwf) ?_
       intro v' ρ' st' se' hΨ hs hw ht
       obtain ⟨_, _, hΨ'⟩ := hΨ
       exact hpost v' ρ' st' se' hΨ' hs hw ht
@@ -691,8 +727,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [Runtime.Expr.subst]
     simp only [compile] at heval
     have heval_cond : (compile Θ S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_if <| compile_correct Θ R cond S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_if <| SpecMap.satisfiedBy_dup.trans <|
+      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) cond S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hSwf ?_
     intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c htypc
     obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
     have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
@@ -719,7 +756,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         hfalse_cont hwf_eq (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_c)
-      exact SpatialContext.wp_if_false <| compile_correct Θ R els S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hspec hSwf
+      exact SpatialContext.wp_if_false <| compile_correct Θ R els S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hels_ty ▸ ht))
     · have hvc_true : v_c = .bool true := by
         rw [hcond_bool] at htypc
@@ -733,7 +770,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         htrue_cont hwf_ne (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_ne)
-      exact SpatialContext.wp_if_true <| compile_correct Θ R thn S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hspec hSwf
+      exact SpatialContext.wp_if_true <| compile_correct Θ R thn S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hthn_ty ▸ ht))
   | app fn args aty =>
     simp only [Expr.ty] at hpost
@@ -743,63 +780,112 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     | var f fty =>
       simp only [compile] at heval
       obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
-      obtain ⟨fval, hγf, hisPrecond⟩ := hspec f spec hlookup
-      simp [Expr.runtime, Runtime.Expr.subst, hγf]
-      refine SpatialContext.wp_bind_app ?_
       have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine compileExprs_correct Θ R args S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hspec hSwf ?_
-      intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
-      obtain ⟨_, _, hΨ_args⟩ := hΨ_args
-      let typedArgs := (args.map Expr.ty).zip sargs
-      have hlen_sargs : sargs.length = vs.length := by
-        simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
-      have hlen_typed : (args.map Expr.ty).length = sargs.length := by
-        calc
-          (args.map Expr.ty).length = vs.length := by simpa using htyping_args.length_eq.symm
-          _ = sargs.length := hlen_sargs.symm
-      obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-      obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-      have hwf_pred : spec.pred.wfIn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars spec.args)) := by
-        simpa [Spec.wfIn, FiniteSubst.id, Signature.empty, Signature.ofVars] using hSwf f spec hlookup
-      have hid_wf : FiniteSubst.id.wf st_args.decls := FiniteSubst.id_wf st_args.decls
-      have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
-        intro p hp
-        have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
-        exact hsargs_wf _ hp''
-      have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
-          (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
-      have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
-        (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
-        hwf_pred
-        (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
-        hid_wf htypedArgs_wf hcall_eval
-        (fun v st' ρ' t hΨ hwf heval hty =>
-          hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval (hret_eq ▸ hty))
-      obtain ⟨hsub_ty, happly⟩ := hcall
-      have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
-        simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
-      have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
-        TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
-      refine SpatialContext.wp_val ?_
-      apply BIBase.Entails.trans _ (hisPrecond vs htyped Φ)
-      have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
-        have hsnd :
-            List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
-          simpa using
-            (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
-              (Nat.le_of_eq hlen_typed.symm))
-        calc
-          typedArgs.map (fun p => p.2.eval ρ_args)
-              = sargs.map (fun t => t.eval ρ_args) := by
-                  simpa [typedArgs, List.map_map] using
-                    congrArg (List.map (fun t => t.eval ρ_args)) hsnd
-          _ = vs := Terms.Eval.map_eval heval_sargs
-      rw [heval_sargs_map] at happly
-      exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
-        Spec.argsEnv_agreeOn (Δ := Signature.empty)
-          (ρ₁ := FiniteSubst.id.subst.eval ρ_args) (ρ₂ := Env.empty)
-          ⟨nofun, nofun, nofun, nofun⟩ spec.args vs
-          (by have := htyped.length_eq; simp [List.length_map] at this; omega)
+      refine SpecMap.project (P := st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R)) Θ S γ ?_ hlookup ?_
+      · istart
+        iintro ⟨_, □HS, _⟩
+        iexact HS
+      · intro fval hγf
+        simp [Expr.runtime, Runtime.Expr.subst, hγf]
+        refine SpatialContext.wp_bind_app ?_
+        have hctx :
+            spec.isPrecondFor Θ fval ∗ (st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
+              st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
+          istart
+          iintro ⟨□Hspec, Howns, □HS, HR⟩
+          isplitl [Howns]
+          · iexact Howns
+          · isplitl []
+            · iexact HS
+            · isplitl []
+              · iexact Hspec
+              · iexact HR
+        refine hctx.trans <| compileExprs_correct Θ (spec.isPrecondFor Θ fval ∗ R) args S B Γ st ρ γ _ _
+          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hSwf ?_
+        intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
+        obtain ⟨_, _, hΨ_args⟩ := hΨ_args
+        let typedArgs := (args.map Expr.ty).zip sargs
+        have hlen_sargs : sargs.length = vs.length := by
+          simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
+        have hlen_typed : (args.map Expr.ty).length = sargs.length := by
+          calc
+            (args.map Expr.ty).length = vs.length := by simpa using htyping_args.length_eq.symm
+            _ = sargs.length := hlen_sargs.symm
+        obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
+        obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
+        have hwf_pred : spec.pred.wfIn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars spec.args)) := by
+          simpa [Spec.wfIn, FiniteSubst.id, Signature.empty, Signature.ofVars] using hSwf f spec hlookup
+        have hid_wf : FiniteSubst.id.wf st_args.decls := FiniteSubst.id_wf st_args.decls
+        have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
+          intro p hp
+          have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
+          exact hsargs_wf _ hp''
+        have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
+            (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
+        have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
+          (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
+          hwf_pred
+          (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
+          hid_wf htypedArgs_wf hcall_eval
+          (fun v st' ρ' t hΨ hwf heval hty =>
+            hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval (hret_eq ▸ hty))
+        obtain ⟨hsub_ty, happly⟩ := hcall
+        have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
+          simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
+        have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
+          TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
+        have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
+          have hsnd :
+              List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
+            simpa using
+              (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
+                (Nat.le_of_eq hlen_typed.symm))
+          calc
+            typedArgs.map (fun p => p.2.eval ρ_args)
+                = sargs.map (fun t => t.eval ρ_args) := by
+                    simpa [typedArgs, List.map_map] using
+                      congrArg (List.map (fun t => t.eval ρ_args)) hsnd
+            _ = vs := Terms.Eval.map_eval heval_sargs
+        have happly' :
+            st_args.owns.interp ρ_args ∗ R ⊢
+              PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
+                (Spec.argsEnv Env.empty spec.args vs) := by
+          rw [heval_sargs_map] at happly
+          exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
+            Spec.argsEnv_agreeOn (Δ := Signature.empty)
+              (ρ₁ := FiniteSubst.id.subst.eval ρ_args) (ρ₂ := Env.empty)
+              ⟨nofun, nofun, nofun, nofun⟩ spec.args vs
+              (by have := htyped.length_eq; simp [List.length_map] at this; omega)
+        have happly'' :
+            st_args.owns.interp ρ_args ∗
+                (S.satisfiedBy Θ γ ∗ R) ⊢
+              PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
+                (Spec.argsEnv Env.empty spec.args vs) := by
+          have hdrop :
+              st_args.owns.interp ρ_args ∗
+                  (S.satisfiedBy Θ γ ∗ R) ⊢
+                st_args.owns.interp ρ_args ∗ R := by
+            simpa [sep_assoc] using
+              (SpecMap.satisfiedBy_drop
+                (A := st_args.owns.interp ρ_args)
+                (Θ := Θ) (S := S) (γ := γ)
+                (R := R))
+          exact hdrop.trans happly'
+        refine SpatialContext.wp_val ?_
+        unfold Spec.isPrecondFor
+        istart
+        iintro ⟨Howns, □HS, □Hspec, HR⟩
+        ispecialize Hspec $$ %Φ
+        ispecialize Hspec $$ %vs
+        iapply Hspec
+        · ipure_intro
+          exact htyped
+        · iapply happly''
+          isplitl [Howns]
+          · iexact Howns
+          · isplitl []
+            · iexact HS
+            · iexact HR
     | _ =>
       simp only [compile] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -810,7 +896,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_es : (compileExprs Θ S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_tuple <| compileExprs_correct Θ R es S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hspec hSwf ?_
+      (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hSwf ?_
     intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
     obtain ⟨_, _, hΨ⟩ := hΨ
     obtain hΨ := VerifM.eval_ret hΨ
@@ -819,7 +905,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     have hwf_tuple : (Term.unop UnOp.ofValList (Terms.toValList terms)).wfIn st'.decls := by
       simp only [Term.wfIn]
       exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
-    exact SpatialContext.wp_tuple <|
+    exact SpecMap.satisfiedBy_drop.trans <| SpatialContext.wp_tuple <|
       hpost (Runtime.Val.tuple vs) ρ' st' (.unop .ofValList (Terms.toValList terms))
         hΨ hwf_tuple heval_tuple (.tuple htyping)
   | match_ scrut branches ty =>
@@ -828,8 +914,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
     simp only [compile] at heval
     have heval_scrut : (compile Θ S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_match <| compile_correct Θ R scrut S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_match <| SpecMap.satisfiedBy_dup.trans <|
+      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) scrut S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hSwf ?_
     intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se htype_scrut
     obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
     cases hscrut_ty : scrut.ty with
@@ -874,9 +961,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             have hbwf_scrut : B.wf st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
             have hbranch_wp := compileBranches_correct Θ R branches S B Γ se_scrut ts.length ts 0
               st_scrut ρ_scrut γ Ψ Φ
-              hagree_scrut hbwf_scrut hts hspec hSwf hse_wf
+              hagree_scrut hbwf_scrut hts hSwf hse_wf
               (fun j hj v ρ' st' se hΨ hse_wf hse_eval htyped =>
-                hpost v ρ' st' se hΨ hse_wf hse_eval
+                SpecMap.satisfiedBy_drop.trans <| hpost v ρ' st' se hΨ hse_wf hse_eval
                   ((htys (branches[j]) (List.getElem_mem _)) ▸ htyped))
               tag htag_branches (by simpa [Nat.zero_add, hty_eq] using heval_tag)
             have hsc_eval : se_scrut.eval ρ_scrut = Runtime.Val.inj tag ts.length v_payload :=
@@ -908,7 +995,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
     ∀ payload, sc.eval ρ = Runtime.Val.inj i n payload →
       TinyML.ValHasType Θ payload ty_i →
       st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
-  intro heval hagree hbwf hts hspec hSwf hsc_wf hpost payload hsc_eval htype_payload
+  intro heval hagree hbwf hts hSwf hsc_wf hpost payload hsc_eval htype_payload
   obtain ⟨binder, body⟩ := branch
   simp only [compileBranch] at heval
   by_cases hty : binder.ty = ty_i
@@ -983,17 +1070,19 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       rw [Binder.runtime_of_name_none hname]
       simp only [Runtime.Expr.subst_fix]
       apply BIBase.Entails.trans _ wp.app_lambda_single
-      change SpatialContext.interp ρ st.owns ∗ R ⊢
+      change SpatialContext.interp ρ st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
         wp
           ((body.runtime.subst ((γ.remove' .none).removeAll' [.none])).subst
             ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.none] [payload]))
           Φ
       rw [Runtime.Expr.subst_fix_comp body.runtime .none [.none] γ Runtime.Val.unit [payload] rfl]
       simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left]
-      exact (sep_mono_l hinterp_eq).trans (hst₂_owns_eq ▸
+      exact (sep_mono_l hinterp_eq).trans <| SpecMap.satisfiedBy_dup.trans <| (hst₂_owns_eq ▸
         by simpa [Runtime.Subst.update] using
-          compile_correct Θ R body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
-            heval_body'' hagree₁ hbwf₁ hts₁ hspec hSwf (by simpa [hty] using hpost))
+          compile_correct Θ (S.satisfiedBy Θ γ ∗ R) body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
+            heval_body'' hagree₁ hbwf₁ hts₁ hSwf
+            (fun v ρ' st' se hΨ hs hw ht =>
+              by simpa [hty] using hpost v ρ' st' se hΨ hs hw ht))
     | some x =>
       simp [hname, TinyML.TyCtx.extendBinder] at heval_body'
       have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁ ρ := by
@@ -1019,18 +1108,21 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       rw [Binder.runtime_of_name_some hname]
       simp only [Runtime.Expr.subst_fix]
       apply BIBase.Entails.trans _ wp.app_lambda_single
-      change SpatialContext.interp ρ st.owns ∗ R ⊢
+      change SpatialContext.interp ρ st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
         wp
           ((body.runtime.subst ((γ.remove' .none).removeAll' [.named x])).subst
             ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.named x] [payload]))
           Φ
       rw [Runtime.Expr.subst_fix_comp body.runtime .none [.named x] γ Runtime.Val.unit [payload] rfl]
       simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left]
-      exact (sep_mono_l hinterp_eq).trans (hst₂_owns_eq ▸
-        by simpa [Runtime.Subst.update] using
-          compile_correct Θ R body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
+      exact (sep_mono_l hinterp_eq).trans <| SpecMap.satisfiedBy_dup.trans <|
+        (SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase).trans <| by
+          simpa [hst₂_owns_eq, Runtime.Subst.update] using
+          compile_correct Θ (S.satisfiedBy Θ γ ∗ R) body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
             (Runtime.Subst.update γ x payload) Ψ Φ heval_body'' hagree₁ hbwf₂ hts₁
-            (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) (by simpa [hty] using hpost))
+            (SpecMap.wfIn_erase hSwf)
+            (fun v ρ' st' se hΨ hs hw ht =>
+              by simpa [hty] using hpost v ρ' st' se hΨ hs hw ht)
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
     exact False.elim (hty (VerifM.eval_expectEq hexpect).1)
 
@@ -1052,7 +1144,7 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : Li
       ∀ payload, sc.eval ρ = Runtime.Val.inj (idx + j) n payload →
         TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
         st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
-  intro hagree hbwf hts hspec hSwf hsc_wf hpost
+  intro hagree hbwf hts hSwf hsc_wf hpost
   match branches with
   | [] =>
     intro j hj
@@ -1064,13 +1156,13 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : Li
       simp only [Nat.add_zero, List.getElem_cons_zero]
       intro heval
       exact compileBranch_correct Θ R b S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
-        heval hagree hbwf hts hspec hSwf hsc_wf (by simpa using hpost 0 hj)
+        heval hagree hbwf hts hSwf hsc_wf (by simpa using hpost 0 hj)
     | succ k =>
       have hk : k < bs.length := by simp at hj; omega
       have hidx : idx + (k + 1) = (idx + 1) + k := by omega
       simp only [hidx, List.getElem_cons_succ]
       exact compileBranches_correct Θ R bs S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
-        hagree hbwf hts hspec hSwf hsc_wf
+        hagree hbwf hts hSwf hsc_wf
         (by
           intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
           simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
@@ -1086,7 +1178,7 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
       Terms.Eval ρ' terms vs →
       TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
     st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
-  intro heval hagree hbwf hts hspec hSwf hpost
+  intro heval hagree hbwf hts hSwf hpost
   match es with
   | [] =>
     simp only [compileExprs] at heval
@@ -1097,14 +1189,17 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
     simp only [compileExprs] at heval
     simp only [List.map, wps_cons]
     have heval_rest : (compileExprs Θ S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compileExprs_correct Θ R rest S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hspec hSwf ?_
+    refine SpecMap.satisfiedBy_dup.trans <|
+      compileExprs_correct Θ (S.satisfiedBy Θ γ ∗ R) rest S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hSwf ?_
     intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
     obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
     have hagree_vs : B.agreeOnLinked ρ_vs γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
     have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
     have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
-    refine compile_correct Θ R e S B Γ st_vs ρ_vs γ _ _ (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hspec hSwf ?_
+    refine compile_correct Θ (S.satisfiedBy Θ γ ∗ R) e S B Γ st_vs ρ_vs γ _ _
+      (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hSwf ?_
     intro v ρ' st' se hΨ_e hse_wf heval_se htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
     have hwfst' : st'.decls.wf := (VerifM.eval.wf hΨ_e).namesDisjoint

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -296,11 +296,10 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
-    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
-      TinyML.ValHasType Θ v e.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
-    st.owns.interp ρ ∗ R ⊢ wp (e.runtime.subst γ) Φ := by
+      TinyML.ValHasType Θ v e.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+    st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ := by
   intro heval hagree hbwf hts hspec hSwf hpost
   cases e with
   | const c =>
@@ -902,14 +901,13 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
-    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
+      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
     ∀ payload, sc.eval ρ = Runtime.Val.inj i n payload →
       TinyML.ValHasType Θ payload ty_i →
-      st.owns.interp ρ ∗ R ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
+      st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
   intro heval hagree hbwf hts hspec hSwf hsc_wf hpost payload hsc_eval htype_payload
   obtain ⟨binder, body⟩ := branch
   simp only [compileBranch] at heval
@@ -1045,16 +1043,15 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : Li
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
-    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
+      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
       VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ = Runtime.Val.inj (idx + j) n payload →
         TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
-        st.owns.interp ρ ∗ R ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
+        st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
   intro hagree hbwf hts hspec hSwf hsc_wf hpost
   match branches with
   | [] =>
@@ -1083,12 +1080,12 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
     (Ψ : List (Term .value) → TransState → Env → Prop) (Φ : List Runtime.Val → iProp) :
     VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
     B.agreeOnLinked ρ γ → B.wf st.decls → B.typedSubst Θ Γ γ →
-    S.satisfiedBy Θ γ → S.wfIn Signature.empty →
+    S.wfIn Signature.empty →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ' terms vs →
-      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.owns.interp ρ' ∗ R ⊢ Φ vs) →
-    st.owns.interp ρ ∗ R ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
+      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
+    st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
   intro heval hagree hbwf hts hspec hSwf hpost
   match es with
   | [] =>

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -262,7 +262,7 @@ end
 
 
 
-/-! ### Helper lemma for match compilation -/
+/-! ### Helper lemmas -/
 
 theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (ts : List TinyML.Typ)
@@ -286,33 +286,30 @@ theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) 
         have : idx + 1 + k = idx + (k + 1) := by omega
         rw [ih_get k hk, this]
 
-theorem SpecMap.project (P : iProp) (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) :
-  (P ⊢ S.satisfiedBy Θ γ) →
-  S.lookup x = some s →
-  (∀ fval, γ x = some fval → s.isPrecondFor Θ fval ∗ P ⊢ Q) →
-  (P ⊢ Q) := by
-  intro hsat hlook hcont
-  simp only [SpecMap.satisfiedBy] at hsat
-  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor Θ fval) ∗ P := by
-    refine (persistent_entails_r hsat).trans ?_
-    istart
-    iintro ⟨□Hall, HP⟩
-    ispecialize Hall $$ %x
-    ispecialize Hall $$ %s
-    isplitl []
-    · iapply Hall
-      ipure_intro
-      exact hlook
-    · iexact HP
-  refine hstep.trans ?_
-  istart
-  iintro ⟨⟨%fval, Hγ, Hpre⟩, HP⟩
-  ipure Hγ
-  iapply (hcont fval Hγ)
-  isplitl [Hpre]
-  · iexact Hpre
-  · iexact HP
 
+/-- Drop `satisfiedBy` from the resource. -/
+theorem SpecMap.satisfiedBy_drop {A R : iProp} {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ R :=
+  sep_mono_r sep_elim_r
+
+/-- Duplicate `satisfiedBy` (persistent) in the resource. -/
+theorem SpecMap.satisfiedBy_dup {A R : iProp} {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ (SpecMap.satisfiedBy Θ S γ ∗ (SpecMap.satisfiedBy Θ S γ ∗ R)) :=
+  by
+    iintro ⟨HA, □HS, HR⟩
+    isplitl [HA]
+    · iexact HA
+    · isplitl []
+      · iexact HS
+      · isplitl []
+        · iexact HS
+        · iexact HR
+
+/-- Weaken `satisfiedBy` in the resource via an entailment. -/
+theorem SpecMap.satisfiedBy_weaken {A R : iProp}
+    (h : SpecMap.satisfiedBy Θ S γ ⊢ SpecMap.satisfiedBy Θ' S' γ') :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ (SpecMap.satisfiedBy Θ' S' γ' ∗ R) :=
+  sep_mono_r (sep_mono_l h)
 
 /-! ### Correctness -/
 

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -11,6 +11,7 @@ import Mica.Engine.Driver
 import Mica.Base.Fresh
 import Mathlib.Data.Finmap
 
+open Iris Iris.BI
 open Typed
 
 
@@ -33,7 +34,6 @@ def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM
 theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (hS : S.satisfiedBy Θ γ)
     (st : TransState) (ρ : Env)
     (fb : Binder) (argBinders : List Binder) (body : Expr)
     (argNames : List String)
@@ -50,12 +50,11 @@ theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
         else VerifM.fatal s!"checkSpec: return type mismatch"
         pure se).eval st ρ (fun _ _ _ => True))
     (vs : List Runtime.Val) (P : Runtime.Val → iProp)
-    (htyped_args : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd))
-    (isPrecond_rec : s.isPrecondFor Θ fval) :
+    (htyped_args : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd))  :
     st.owns.interp ρ ∗
       PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
         (Spec.argsEnv Env.empty s.args vs) ⊢
-      wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
+      (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗ wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
   obtain ⟨hlen1, hlen2, hbs_eq⟩ := extractArgNames_spec hext
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := by rw [hbs_def]; exact hbs_eq
   have hlen_nv : argNames.length = vs.length := by
@@ -65,19 +64,12 @@ theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
   set S' : SpecMap := SpecMap.eraseAll argNames (S.insert' fb s)
   -- Use implement_correct
   apply Spec.implement_correct Θ s _ st ρ vs P
-    (wp (body.runtime.subst γ_body) P)
+    ((S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗ wp (body.runtime.subst γ_body) P)
     hswf htyped_args hbody
   intro argVars st' ρ' Q hargVars_mem hargVars_sort hargVars_lookup hbody_eval
   -- Establish spec map satisfaction
   have hS'wf : S'.wfIn Signature.empty :=
     SpecMap.wfIn_eraseAll (SpecMap.wfIn_insert' hSwf hswf)
-  have hS'_sat : S'.satisfiedBy Θ γ_body := by
-    have hS_ext : (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) :=
-      SpecMap.satisfiedBy_insert'_update' hS isPrecond_rec
-    have hsat := SpecMap.satisfiedBy_eraseAll_updateAll' hS_ext hlen_nv
-    change (SpecMap.eraseAll argNames (S.insert' fb s)).satisfiedBy Θ
-      ((γ.update' fb.runtime fval).updateAll' bs vs)
-    rw [hbs_runtime]; exact hsat
   -- Set up bindings, agreement, well-formedness, typed substitution
   set Γ := (argNames.zip (s.args.map Prod.snd)).foldl
     (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
@@ -120,58 +112,82 @@ theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
       (by rw [hsnd]; exact htyped_args)
   -- Use compile_correct
   have hcompile := VerifM.eval_bind _ _ _ _ hbody_eval
-  exact compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
-    (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'_sat hS'wf
-    (fun v ρ'' st'' se hΨ hse_wf heval_se htyped => by
-      obtain ⟨hdecls, hagreeOn, hΨ⟩ := hΨ
-      by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
-      · simp [hsub] at hΨ
-        have hΨ' := VerifM.eval_ret hΨ
-        dsimp only at hΨ'
-        subst heval_se
-        have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
-          TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
-        refine (show st''.owns.interp ρ'' ∗ Q ⊢
-            st''.owns.interp ρ'' ∗ Q ∗
-              ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
-                P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
-        istart
-        iintro ⟨Howns, HQ⟩
-        isplitl [Howns]
-        · iexact Howns
-        · isplitl [HQ]
-          · iexact HQ
-          · iintro Hwand
-            iapply Hwand
-            ipure_intro
-            exact hret
-      · simp [hsub] at hΨ
-        exact (VerifM.eval_fatal hΨ).elim)
+  have hS'_sat :
+      S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval ⊢ S'.satisfiedBy Θ γ_body := by
+    have hinsert :
+        S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval ⊢
+          (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) :=
+      SpecMap.satisfiedBy_insert'_update'
+    have herase :
+        (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) ⊢
+          S'.satisfiedBy Θ ((γ.update' fb.runtime fval).updateAll' (argNames.map Runtime.Binder.named) vs) :=
+      SpecMap.satisfiedBy_eraseAll_updateAll' hlen_nv
+    exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
+  have hbody_wp :
+      st'.owns.interp ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Q) ⊢
+        wp (body.runtime.subst γ_body) P :=
+    compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
+      (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'wf
+      (fun v ρ'' st'' se hΨ hse_wf heval_se htyped => by
+        obtain ⟨hdecls, hagreeOn, hΨ⟩ := hΨ
+        by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
+        · simp [hsub] at hΨ
+          have hΨ' := VerifM.eval_ret hΨ
+          dsimp only at hΨ'
+          subst heval_se
+          have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
+            TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
+          refine (show st''.owns.interp ρ'' ∗ Q ⊢
+              st''.owns.interp ρ'' ∗ Q ∗
+                ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
+                  P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
+          istart
+          iintro ⟨Howns, HQ⟩
+          isplitl [Howns]
+          · iexact Howns
+          · isplitl [HQ]
+            · iexact HQ
+            · iintro Hwand
+              iapply Hwand
+              ipure_intro
+              exact hret
+        · simp [hsub] at hΨ
+          exact (VerifM.eval_fatal hΨ).elim)
+  iintro ⟨Howns, HQ⟩
+  iintro HSat
+  iapply hbody_wp
+  isplitl [Howns]
+  · iexact Howns
+  · isplitl [HSat]
+    · iapply hS'_sat
+      iexact HSat
+    · iexact HQ
 
-/-- Sorry'd helper: extract `isPrecondFor` (a `Prop`) from an iProp wand.
-
-The hypothesis is a universally quantified wand asserting that the spec's predicate
-transformer entails `wp` of calling `f`. The conclusion `isPrecondFor` says the same
-at the `Prop` level. The only gap is the wand-to-entailment and `⌜ValsHaveTypes⌝`-to-Prop
-conversions.
-
-Once `isPrecondFor` is migrated to a persistent separation logic assertion, this becomes
-a direct consequence of the hypothesis. -/
+/-- The recursive obligation produced by `wp_fix'` is definitionally the spec precondition. -/
 theorem isPrecondFor_of_wp_rec (Θ : TinyML.TypeEnv) (s : Spec)
     (f : Runtime.Val) :
-    iprop(□(∀ (P : Runtime.Val → iProp),(∀ (vs : List Runtime.Val),
-      ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
+    iprop(□ ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      (⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-          (Spec.argsEnv Env.empty s.args vs) -∗
-        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P))) ⊢ s.isPrecondFor Θ f := by
-  sorry
+          (Spec.argsEnv Env.empty s.args vs)) -∗
+        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ f := by
+    unfold Spec.isPrecondFor
+    iintro □H
+    imodintro
+    iintro %Φ %vs Htyped Hpred
+    ispecialize H $$ %vs
+    ispecialize H $$ %Φ
+    iapply H
+    isplitl [Htyped]
+    · iexact Htyped
+    · iexact Hpred
 
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (st : TransState) (ρ : Env) :
-    VerifM.eval (checkSpec Θ S e s) st ρ (fun _ _ _ => True) →
-    st.owns.interp ρ ∗ S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
+    (ρ : Env) :
+    VerifM.eval (checkSpec Θ S e s) TransState.empty ρ (fun _ _ _ => True) →
+    S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
   intro heval
   cases e
   case fix fb argBinders retTy body =>
@@ -197,44 +213,72 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       set fval := Runtime.Val.fix fb.runtime (argBinders.map (·.runtime))
         (body.runtime.subst γ') with hfval_def
       -- Use the extracted body correctness lemma
-      have body_correct := fun vs P htyped_args isPrecond_rec =>
-        checkSpec_body_correct Θ S s γ hswf hSwf hS st ρ fb argBinders body argNames
-          hext bs rfl fval hbody vs P htyped_args isPrecond_rec
-      -- Step 1: Apply wp.func to reduce wp (Expr.fix ...) to the value case
-      -- Goal: owns ⊢ wp (Expr.fix fb bs body') (fun v => ⌜isPrecondFor Θ v s⌝)
-      -- wp.func: P fval ⊢ wp (Expr.fix fb bs body') P, where fval = Val.fix fb bs body'
-      change st.owns.interp ρ ⊢ wp (Runtime.Expr.fix fb.runtime bs (body.runtime.subst γ'))
-        (fun v => ⌜s.isPrecondFor Θ v⌝)
+      have body_correct := fun vs P htyped_args =>
+        checkSpec_body_correct Θ S s γ hswf hSwf TransState.empty ρ fb argBinders body argNames
+          hext bs rfl fval hbody vs P htyped_args
       -- Set up Φ for wp_fix': Φ P vs = ⌜ValsHaveTypes⌝ ∗ PredTrans.apply (... -∗ P) s.pred ...
       set Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp :=
         fun P vs => ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
           PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
             (Spec.argsEnv Env.empty s.args vs)
-      -- Apply wp_fix' to get the recursive spec, then isPrecondFor_of_wp_rec to extract Prop
-      suffices hwp : st.owns.interp ρ ⊢
-          ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-            Φ P vs -∗ wp (Runtime.Expr.app (.val fval) (vs.map Runtime.Expr.val)) P by
-        -- Extract the Prop-level recursive spec, then lift it through `wp_func`.
-        have hgoal2 := hwp.trans (isPrecondFor_of_wp_rec Θ s fval)
-        exact SpatialContext.wp_func hgoal2
       -- Prove the wp_fix' obligation
       obtain ⟨_, _, hbs_eq⟩ := extractArgNames_spec hext
       have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_eq
-      apply SpatialContext.wp_fix'
+      have Hrec := (SpatialContext.wp_fix' (R := iprop(SpecMap.satisfiedBy Θ S γ)) (f := fb.runtime) (args := bs)
+        (e := body.runtime.subst γ') (Φ := fun P vs => Φ P vs) (by
+          istart
+          iintro □Hspec
+          imodintro
+          iintro IH %vs %P
+          iintro ⟨%htyped, Hpred⟩
+          -- Use body_correct: needs owns ∗ PredTrans ⊢ wp (body.subst (γ.update'...))
+          -- wp_fix' gives body.subst (id.update'...) — bridge via subst_fix_comp
+          have hlen_vs : bs.length = vs.length := by
+            simp [hbs_runtime]; have := htyped.length_eq; simp at this; omega
+          have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
+          simp only [] at hsub; rw [hsub]
+          have hbody := body_correct vs P htyped
+          have hisPre : iprop(□ ∀ vs P, Φ P vs -∗ wp (Runtime.Expr.app (.val fval) (vs.map .val)) P) ⊢
+              Spec.isPrecondFor Θ fval s :=
+            isPrecondFor_of_wp_rec _ _ _
+          have hbody' : PredTrans.apply (fun r => iprop(⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r)) s.pred
+              (Spec.argsEnv Env.empty s.args vs) ⊢
+              SpecMap.satisfiedBy Θ S γ ∗ Spec.isPrecondFor Θ fval s -∗
+                wp (Runtime.Expr.subst ((Runtime.Subst.update' fb.runtime fval γ).updateAll' bs vs) body.runtime) P := by
+            change SpatialContext.interp ρ TransState.empty.owns ∗ _ ⊢ _ at hbody
+            simp only [TransState.empty, SpatialContext.interp] at hbody
+            exact emp_sep.2.trans hbody
+          iapply hbody' $$ [Hpred] [IH]
+          · iexact Hpred
+          · isplitl []
+            · iexact Hspec
+            · iapply hisPre
+              iexact IH
+          ))
+      apply SpatialContext.wp_func
+      refine (BIBase.Entails.trans ?_ (isPrecondFor_of_wp_rec _ _ _))
       istart
-      iintro Howns IH %vs %P ⟨%htyped, Hpred⟩
-      -- Extract the Prop-level recursive spec from the recursive wp hypothesis.
-      ihave ⌜hipc⌝ := isPrecondFor_of_wp_rec Θ s fval $$ IH
-      -- Use body_correct: needs owns ∗ PredTrans ⊢ wp (body.subst (γ.update'...))
-      -- wp_fix' gives body.subst (id.update'...) — bridge via subst_fix_comp
-      have hlen_vs : bs.length = vs.length := by
-        simp [hbs_runtime]; have := htyped.length_eq; simp at this; omega
-      have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
-      simp only [] at hsub; rw [hsub]
-      iapply (body_correct vs _ htyped hipc)
-      isplitl [Howns]
-      · iexact Howns
-      · iexact Hpred
+      iintro □Hspec
+      imodintro
+      iintro %ws %P
+      iintro ⟨%hty, Hd⟩
+      -- Combine Hrec with Φ to get the final wp
+      have Hwp : SpecMap.satisfiedBy Θ S γ ∗ Φ P ws ⊢
+          wp ((Runtime.Expr.val fval).app (ws.map .val)) P := by
+        refine (sep_mono_l (persistent_entails_l Hrec)).trans ?_
+        simp only [Φ]
+        istart
+        iintro ⟨⟨□_, □Hsat⟩, Harg⟩
+        ispecialize Hsat $$ %ws
+        ispecialize Hsat $$ %P
+        iapply Hsat
+        iexact Harg
+      iapply Hwp
+      isplitl []
+      · iexact Hspec
+      · isplitl []
+        · ipure_intro; exact hty
+        · iexact Hd
   all_goals
     simp only [checkSpec] at heval
     exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -159,21 +159,19 @@ Once `isPrecondFor` is migrated to a persistent separation logic assertion, this
 a direct consequence of the hypothesis. -/
 theorem isPrecondFor_of_wp_rec (Θ : TinyML.TypeEnv) (s : Spec)
     (f : Runtime.Val) :
-    (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+    iprop(□(∀ (P : Runtime.Val → iProp),(∀ (vs : List Runtime.Val),
       ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
           (Spec.argsEnv Env.empty s.args vs) -∗
-        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢
-    ⌜s.isPrecondFor Θ f⌝ := by
+        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P))) ⊢ s.isPrecondFor Θ f := by
   sorry
 
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (hS : S.satisfiedBy Θ γ)
     (st : TransState) (ρ : Env) :
     VerifM.eval (checkSpec Θ S e s) st ρ (fun _ _ _ => True) →
-    st.owns.interp ρ ⊢ wp (e.runtime.subst γ) (fun v => ⌜s.isPrecondFor Θ v⌝) := by
+    st.owns.interp ρ ∗ S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
   intro heval
   cases e
   case fix fb argBinders retTy body =>

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -15,6 +15,19 @@ open Iris Iris.BI
 open Typed
 
 
+/-- Compile the body of a specification under its argument context and
+    check that the inferred return type is a subtype of the declared one. -/
+def checkBody (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
+    (argNames : List String) (body : Expr)
+    (argVars : List FOL.Const) : VerifM (Term .value) := do
+  let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
+  let Γ := (argNames.zip (s.args.map Prod.snd)).foldl
+    (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
+  let se ← compile Θ S B Γ body
+  if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
+  else VerifM.fatal s!"checkSpec: return type mismatch"
+  pure se
+
 def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
   let (fb, argNames, body) ← match e with
     | .fix fb argBinders _ body => do
@@ -23,54 +36,44 @@ def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM
       | .error msg => VerifM.fatal msg
     | _ => VerifM.fatal "checkSpec: expected function"
   let S' := SpecMap.eraseAll argNames (S.insert' fb s)
-  Spec.implement s fun argVars => do
-    let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
-    let Γ := (argNames.zip (s.args.map Prod.snd)).foldl (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
-    let se ← compile Θ S' B Γ body
-    if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
-    else VerifM.fatal s!"checkSpec: return type mismatch"
-    pure se
+  Spec.implement s (checkBody Θ S' s argNames body)
 
-theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
+/-- Soundness of `checkBody`: given argument variables supplied by
+    `Spec.implement_correct` and a successful `checkBody` evaluation, the
+    compiled body's `wp` holds. -/
+theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (st : TransState) (ρ : Env)
     (fb : Binder) (argBinders : List Binder) (body : Expr)
     (argNames : List String)
     (hext : extractArgNames argBinders s.args = Except.ok argNames)
     (bs : List Runtime.Binder) (hbs_def : bs = argBinders.map (·.runtime))
     (fval : Runtime.Val)
-    (hbody : (Spec.implement s fun argVars => do
-        let S' := SpecMap.eraseAll argNames (S.insert' fb s)
-        let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
-        let Γ := (argNames.zip (s.args.map Prod.snd)).foldl
-          (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
-        let se ← compile Θ S' B Γ body
-        if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
-        else VerifM.fatal s!"checkSpec: return type mismatch"
-        pure se).eval st ρ (fun _ _ _ => True))
-    (vs : List Runtime.Val) (P : Runtime.Val → iProp)
-    (htyped_args : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd))  :
-    st.owns.interp ρ ∗
-      PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-        (Spec.argsEnv Env.empty s.args vs) ⊢
-      (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗ wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
-  obtain ⟨hlen1, hlen2, hbs_eq⟩ := extractArgNames_spec hext
-  have hbs_runtime : bs = argNames.map Runtime.Binder.named := by rw [hbs_def]; exact hbs_eq
+    (vs : List Runtime.Val)
+    (htyped_args : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd))
+    (P : Runtime.Val → iProp)
+    {argVars : List FOL.Const} {st' : TransState} {ρ' : Env} {Q : iProp}
+    (hargVars_mem : ∀ v ∈ argVars, v ∈ st'.decls.consts)
+    (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
+    (hargVars_lookup : List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs)
+    (hbody_eval : VerifM.eval
+        (checkBody Θ (SpecMap.eraseAll argNames (S.insert' fb s)) s argNames body argVars)
+        st' ρ'
+        (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
+          st''.owns.interp ρ'' ∗ Q ∗
+            ((⌜TinyML.ValHasType Θ (result.eval ρ'') s.retTy⌝ -∗ P (result.eval ρ'')) -∗ S) ⊢ S)) :
+    st'.owns.interp ρ' ∗ Q ⊢
+      (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
+        wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
+  simp only [checkBody] at hbody_eval
+  obtain ⟨_, _, hbs_eq⟩ := extractArgNames_spec hext
+  have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_def ▸ hbs_eq
   have hlen_nv : argNames.length = vs.length := by
     have := htyped_args.length_eq; simp at this; omega
-  have hlen : bs.length = vs.length := by simp [hbs_runtime]; omega
   set γ_body := γ.update' fb.runtime fval |>.updateAll' bs vs
   set S' : SpecMap := SpecMap.eraseAll argNames (S.insert' fb s)
-  -- Use implement_correct
-  apply Spec.implement_correct Θ s _ st ρ vs P
-    ((S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗ wp (body.runtime.subst γ_body) P)
-    hswf htyped_args hbody
-  intro argVars st' ρ' Q hargVars_mem hargVars_sort hargVars_lookup hbody_eval
-  -- Establish spec map satisfaction
   have hS'wf : S'.wfIn Signature.empty :=
     SpecMap.wfIn_eraseAll (SpecMap.wfIn_insert' hSwf hswf)
-  -- Set up bindings, agreement, well-formedness, typed substitution
   set Γ := (argNames.zip (s.args.map Prod.snd)).foldl
     (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
   set B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
@@ -125,34 +128,35 @@ theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
       st'.owns.interp ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Q) ⊢
-        wp (body.runtime.subst γ_body) P :=
-    compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
-      (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'wf
-      (fun v ρ'' st'' se hΨ hse_wf heval_se htyped => by
-        obtain ⟨hdecls, hagreeOn, hΨ⟩ := hΨ
-        by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
-        · simp [hsub] at hΨ
-          have hΨ' := VerifM.eval_ret hΨ
-          dsimp only at hΨ'
-          subst heval_se
-          have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
-            TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
-          refine (show st''.owns.interp ρ'' ∗ Q ⊢
-              st''.owns.interp ρ'' ∗ Q ∗
-                ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
-                  P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
-          istart
-          iintro ⟨Howns, HQ⟩
-          isplitl [Howns]
-          · iexact Howns
-          · isplitl [HQ]
-            · iexact HQ
-            · iintro Hwand
-              iapply Hwand
-              ipure_intro
-              exact hret
-        · simp [hsub] at hΨ
-          exact (VerifM.eval_fatal hΨ).elim)
+        wp (body.runtime.subst γ_body) P := by
+    refine compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
+      (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'wf ?_
+    intro v ρ'' st'' se hΨ hse_wf heval_se htyped
+    obtain ⟨_, _, hΨ⟩ := hΨ
+    by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
+    case neg =>
+      simp [hsub] at hΨ
+      exact (VerifM.eval_fatal hΨ).elim
+    simp [hsub] at hΨ
+    have hΨ' := VerifM.eval_ret hΨ
+    dsimp only at hΨ'
+    subst heval_se
+    have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
+      TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
+    refine (show st''.owns.interp ρ'' ∗ Q ⊢
+        st''.owns.interp ρ'' ∗ Q ∗
+          ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
+            P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
+    istart
+    iintro ⟨Howns, HQ⟩
+    isplitl [Howns]
+    · iexact Howns
+    · isplitl [HQ]
+      · iexact HQ
+      · iintro Hwand
+        iapply Hwand
+        ipure_intro
+        exact hret
   iintro ⟨Howns, HQ⟩
   iintro HSat
   iapply hbody_wp
@@ -163,25 +167,6 @@ theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
       iexact HSat
     · iexact HQ
 
-/-- The recursive obligation produced by `wp_fix'` is definitionally the spec precondition. -/
-theorem isPrecondFor_of_wp_rec (Θ : TinyML.TypeEnv) (s : Spec)
-    (f : Runtime.Val) :
-    iprop(□ ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-      (⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
-        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-          (Spec.argsEnv Env.empty s.args vs)) -∗
-        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ f := by
-    unfold Spec.isPrecondFor
-    iintro □H
-    imodintro
-    iintro %Φ %vs Htyped Hpred
-    ispecialize H $$ %vs
-    ispecialize H $$ %Φ
-    iapply H
-    isplitl [Htyped]
-    · iexact Htyped
-    · iexact Hpred
-
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
@@ -189,6 +174,10 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
     VerifM.eval (checkSpec Θ S e s) TransState.empty ρ (fun _ _ _ => True) →
     S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
   intro heval
+  -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
+  have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
+      VerifM.eval (VerifM.fatal msg >>= k) st ρ Ψ → False :=
+    fun h => VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ h)
   cases e
   case fix fb argBinders retTy body =>
     simp only [checkSpec] at heval
@@ -196,11 +185,11 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
     cases hext : extractArgNames argBinders s.args with
     | error msg =>
       simp [hext] at heval
-      exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim
+      exact (elim_bind_fatal heval).elim
     | ok argNames =>
       simp [hext] at heval
-      have hbody := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
-      dsimp only at hbody
+      have himpl := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
+      dsimp only at himpl
       set bs := argBinders.map (·.runtime)
       set γ' := (γ.remove' fb.runtime).removeAll' bs with hγ'_def
       set S' : SpecMap := SpecMap.eraseAll argNames (S.insert' fb s)
@@ -212,73 +201,37 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       rw [hgoal]
       set fval := Runtime.Val.fix fb.runtime (argBinders.map (·.runtime))
         (body.runtime.subst γ') with hfval_def
-      -- Use the extracted body correctness lemma
-      have body_correct := fun vs P htyped_args =>
-        checkSpec_body_correct Θ S s γ hswf hSwf TransState.empty ρ fb argBinders body argNames
-          hext bs rfl fval hbody vs P htyped_args
-      -- Set up Φ for wp_fix': Φ P vs = ⌜ValsHaveTypes⌝ ∗ PredTrans.apply (... -∗ P) s.pred ...
-      set Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp :=
-        fun P vs => ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
-          PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-            (Spec.argsEnv Env.empty s.args vs)
-      -- Prove the wp_fix' obligation
       obtain ⟨_, _, hbs_eq⟩ := extractArgNames_spec hext
       have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_eq
-      have Hrec := (SpatialContext.wp_fix' (R := iprop(SpecMap.satisfiedBy Θ S γ)) (f := fb.runtime) (args := bs)
-        (e := body.runtime.subst γ') (Φ := fun P vs => Φ P vs) (by
-          istart
-          iintro □Hspec
-          imodintro
-          iintro IH %vs %P
-          iintro ⟨%htyped, Hpred⟩
-          -- Use body_correct: needs owns ∗ PredTrans ⊢ wp (body.subst (γ.update'...))
-          -- wp_fix' gives body.subst (id.update'...) — bridge via subst_fix_comp
-          have hlen_vs : bs.length = vs.length := by
-            simp [hbs_runtime]; have := htyped.length_eq; simp at this; omega
-          have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
-          simp only [] at hsub; rw [hsub]
-          have hbody := body_correct vs P htyped
-          have hisPre : iprop(□ ∀ vs P, Φ P vs -∗ wp (Runtime.Expr.app (.val fval) (vs.map .val)) P) ⊢
-              Spec.isPrecondFor Θ fval s :=
-            isPrecondFor_of_wp_rec _ _ _
-          have hbody' : PredTrans.apply (fun r => iprop(⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r)) s.pred
-              (Spec.argsEnv Env.empty s.args vs) ⊢
-              SpecMap.satisfiedBy Θ S γ ∗ Spec.isPrecondFor Θ fval s -∗
-                wp (Runtime.Expr.subst ((Runtime.Subst.update' fb.runtime fval γ).updateAll' bs vs) body.runtime) P := by
-            change SpatialContext.interp ρ TransState.empty.owns ∗ _ ⊢ _ at hbody
-            simp only [TransState.empty, SpatialContext.interp] at hbody
-            exact emp_sep.2.trans hbody
-          iapply hbody' $$ [Hpred] [IH]
-          · iexact Hpred
-          · isplitl []
-            · iexact Hspec
-            · iapply hisPre
-              iexact IH
-          ))
       apply SpatialContext.wp_func
-      refine (BIBase.Entails.trans ?_ (isPrecondFor_of_wp_rec _ _ _))
+      apply Spec.isPrecondFor_fix
       istart
       iintro □Hspec
       imodintro
-      iintro %ws %P
-      iintro ⟨%hty, Hd⟩
-      -- Combine Hrec with Φ to get the final wp
-      have Hwp : SpecMap.satisfiedBy Θ S γ ∗ Φ P ws ⊢
-          wp ((Runtime.Expr.val fval).app (ws.map .val)) P := by
-        refine (sep_mono_l (persistent_entails_l Hrec)).trans ?_
-        simp only [Φ]
-        istart
-        iintro ⟨⟨□_, □Hsat⟩, Harg⟩
-        ispecialize Hsat $$ %ws
-        ispecialize Hsat $$ %P
-        iapply Hsat
-        iexact Harg
-      iapply Hwp
-      isplitl []
-      · iexact Hspec
+      iintro Hrec %vs %P %htyped Hpred
+      -- `isPrecondFor_fix` hands us the body's subst as `id.update' ... |>.updateAll' ...`;
+      -- fuse it with γ via `subst_fix_comp` so it matches `body_correct`.
+      have hlen_vs : bs.length = vs.length := by
+        simp [hbs_runtime]; have := htyped.length_eq; simp at this; omega
+      have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
+      simp only [] at hsub; rw [hsub]
+      have hbody' : PredTrans.apply (fun r => iprop(⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r)) s.pred
+          (Spec.argsEnv Env.empty s.args vs) ⊢
+          SpecMap.satisfiedBy Θ S γ ∗ s.isPrecondFor Θ fval -∗
+            wp (Runtime.Expr.subst ((Runtime.Subst.update' fb.runtime fval γ).updateAll' bs vs) body.runtime) P := by
+        refine emp_sep.2.trans ?_
+        apply Spec.implement_correct Θ s _ TransState.empty ρ vs P
+          ((S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
+            wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P)
+          hswf htyped himpl
+        intro argVars st' ρ' Q hargVars_mem hargVars_sort hargVars_lookup hbody_eval
+        exact checkBody_correct Θ S s γ hswf hSwf fb argBinders body argNames
+          hext bs rfl fval vs htyped P hargVars_mem hargVars_sort hargVars_lookup hbody_eval
+      iapply hbody' $$ [Hpred] [Hrec]
+      · iexact Hpred
       · isplitl []
-        · ipure_intro; exact hty
-        · iexact Hd
+        · iexact Hspec
+        · iexact Hrec
   all_goals
     simp only [checkSpec] at heval
-    exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim
+    exact (elim_bind_fatal heval).elim

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -113,42 +113,46 @@ theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
     exact VerifM.eval_ret heval
 
 theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty)
-    (st : TransState) (ρ : Env)
+    (hSwf : S.wfIn Signature.empty) (ρ : Env)
     {Q : Unit → TransState → Env → Prop}
-    (heval : VerifM.eval (ValDecl.checkExpr Θ S d) st ρ Q) :
-    st.owns.interp ρ ∗ S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => iprop(True)) := by
+    (heval : VerifM.eval (ValDecl.checkExpr Θ S d) TransState.empty ρ Q) :
+    (S.satisfiedBy Θ γ ⊢ Φ) →
+    S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
+  intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
-  have hemp : st.owns.interp ρ ⊢ st.owns.interp ρ ∗ emp := by
-    istart
-    iintro Howns
-    isplitl [Howns]
-    · iexact Howns
-    · iemp_intro
-  exact hemp.trans <|
-    compile_correct Θ iprop(emp) d.body S [] TinyML.TyCtx.empty st ρ γ
+  have hcomp :=
+    compile_correct Θ iprop(S.satisfiedBy Θ γ) d.body S [] TinyML.TyCtx.empty TransState.empty ρ γ
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
-    (fun _ => iprop(True))
+    (fun _ => Φ)
     hcompile
     (fun _ _ h => by simp at h)
     (fun _ h => by simp at h)
     (fun _ _ _ h _ => by simp at h)
-    hS hSwf
+    hSwf
     (fun _ _ _ _ _ _ _ _ => by
       istart
-      iintro _
-      ipure_intro
-      trivial)
+      iintro ⟨_, Hsat⟩
+      iapply Hent
+      iexact Hsat)
+  refine (BIBase.Entails.trans ?_ hcomp)
+  istart
+  iintro □Hspec
+  isplitl []
+  . simp [TransState.empty]
+    iemp_intro
+  . isplitl []
+    . iexact Hspec
+    . iexact Hspec
 
 theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (st : TransState) (ρ : Env)
+    (hSwf : S.wfIn Signature.empty) (ρ : Env)
     {Q : Spec → TransState → Env → Prop}
-    (heval : VerifM.eval (ValDecl.check Θ S d) st ρ Q) :
+    (heval : VerifM.eval (ValDecl.check Θ S d) TransState.empty ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
-            (st.owns.interp ρ ∗ S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
-            Q spec st ρ := by
+            (S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
+            Q spec TransState.empty ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.spec with
   | none =>
@@ -180,8 +184,24 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
           have h4 := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ h3)
           have hswf : spec.wfIn Signature.empty := Spec.checkWf_ok (by cases u; exact hwf)
           have ⟨hcheckSpec, hpure⟩ := VerifM.eval_seq h4
-          exact ⟨spec, hswf, checkSpec_correct Θ S d.body spec γ hswf hSwf hS st ρ hcheckSpec,
+          exact ⟨spec, hswf, checkSpec_correct Θ S d.body spec γ hswf hSwf ρ hcheckSpec,
                  VerifM.eval_ret hpure⟩
+
+/-- Strengthen the postcondition of a `wp` using a persistent resource:
+    if `R` (persistent) entails `wp e P`, and `R` together with `P v` entails `Q v`,
+    then `R` entails `wp e Q`. -/
+private theorem wp_strengthen_persistent
+    {R : iProp} [Iris.BI.Persistent R] {e : Runtime.Expr}
+    {P Q : Runtime.Val → iProp}
+    (hwp : R ⊢ wp e P) (hpost : ∀ v, R ⊢ P v -∗ Q v) :
+    R ⊢ wp e Q := by
+  iintro □HR
+  iapply wp.mono
+  isplitr
+  · iintro %v
+    iapply (hpost v)
+    iexact HR
+  · iapply hwp; iexact HR
 
 theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
     (hSwf : S.wfIn Signature.empty) (ρ : Env) :
@@ -190,7 +210,8 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
   induction prog generalizing S γ ρ with
   | nil =>
     intro _
-    simp [Typed.Program.runtime, Runtime.Program.subst]
+    simp only [Typed.Program.runtime, List.map_nil, Runtime.Program.subst, pwp]
+    exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | cons d ds ih =>
     intro heval
     have hpwp_unfold : pwp ((Typed.Program.runtime (d :: ds)).subst γ) ⊣⊢
@@ -198,74 +219,90 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
           pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
       simp [Typed.Program.runtime, Typed.ValDecl.runtime,
         Runtime.Program.subst, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
-    have hmain : emp ⊢
-        wp (d.body.runtime.subst γ) (fun v =>
-          pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
-      simp only [Program.check] at heval
-      cases hname : d.name.name
-      · cases hspec : d.spec
-        · simp only [hname, hspec] at heval
+    refine BIBase.Entails.trans ?_ hpwp_unfold.2
+    simp only [Program.check] at heval
+    cases hname : d.name.name with
+    | none =>
+      -- unnamed: pwp continuation does not depend on `v`
+      have hupd : ∀ v, Runtime.Subst.update' d.name.runtime v γ = γ := by
+        intro v; simp [Binder.runtime_of_name_none hname, Runtime.Subst.update']
+      cases hspec : d.spec with
+      | none =>
+        -- unnamed, no spec
+        simp only [hname, hspec] at heval
+        have hbind := VerifM.eval_bind _ _ _ _ heval
+        have ⟨_, hcont⟩ := VerifM.eval_seq hbind
+        have hih := ih S γ hSwf ρ (VerifM.eval_ret hcont)
+        have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf ρ hbind hih
+        refine hwp.trans (wp.mono' ?_)
+        intro v; rw [hupd v]; exact .rfl
+      | some _ =>
+        -- unnamed, with spec
+        simp only [hname, hspec] at heval
+        obtain ⟨spec, _, hwp, hcont⟩ :=
+          ValDecl.check_correct Θ S d γ hSwf ρ (VerifM.eval_bind _ _ _ _ heval)
+        have hih := ih S γ hSwf ρ hcont
+        refine wp_strengthen_persistent hwp ?_
+        intro v
+        rw [hupd v]
+        exact wand_intro (sep_elim_l.trans hih)
+    | some n =>
+      have hname_rt : d.name.runtime = .named n := Binder.runtime_of_name_some hname
+      have herase : S.erase' d.name = S.erase n := by simp [SpecMap.erase', hname]
+      have hinsert : ∀ s, S.insert' d.name s = S.insert n s := by
+        intro s; simp [SpecMap.insert', hname]
+      have hupd : ∀ v, Runtime.Subst.update' d.name.runtime v γ = γ.update n v := by
+        intro v; simp [hname_rt, Runtime.Subst.update']
+      cases hspec : d.spec with
+      | none =>
+        simp only [hname, hspec] at heval
+        split at heval
+        · -- named, no spec, function value
+          rename_i hfunc
+          obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
+          have hbody_rt : d.body.runtime.subst γ =
+              Runtime.Expr.fix self.runtime (args.map (·.runtime))
+                (body.runtime.subst ((γ.remove' self.runtime).removeAll'
+                  (args.map (·.runtime)))) := by
+            rw [hbody]; conv_lhs => unfold Expr.runtime
+            simp only [Runtime.Expr.subst_fix]
+          rw [hbody_rt]
+          set fval := Runtime.Val.fix self.runtime (args.map (·.runtime))
+            (body.runtime.subst ((γ.remove' self.runtime).removeAll'
+              (args.map (·.runtime))))
+          apply SpatialContext.wp_func
+          rw [hupd fval]
+          have heval' : VerifM.eval (Program.check Θ (S.erase n) ds) TransState.empty ρ (fun _ _ _ => True) := by
+            convert heval
+          have hih := ih (S.erase n) (γ.update n fval)
+            (SpecMap.wfIn_erase hSwf) ρ heval'
+          exact (SpecMap.satisfiedBy_erase (x := n) (v := fval)).trans hih
+        · -- named, no spec, not a function
           have hbind := VerifM.eval_bind _ _ _ _ heval
-          have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf TransState.empty ρ hbind
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          refine hwp.trans (wp.mono' ?_)
+          have hcont' : VerifM.eval (Program.check Θ (S.erase n) ds) TransState.empty ρ (fun _ _ _ => True) :=
+            VerifM.eval_ret hcont
+          have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf ρ hbind
+            (Φ := iprop(emp)) (by istart; iintro _; iemp_intro)
+          refine wp_strengthen_persistent hwp ?_
           intro v
-          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-          exact ih S γ hS hSwf ρ (VerifM.eval_ret hcont)
-        · simp only [hname, hspec] at heval
-          obtain ⟨spec, hswf, hwp, hcont⟩ :=
-            ValDecl.check_correct Θ S d γ hS hSwf TransState.empty ρ (VerifM.eval_bind _ _ _ _ heval)
-          refine hwp.trans (wp.mono' ?_)
-          intro v
-          apply pure_elim'
-          intro _
-          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-          exact ih S γ hS hSwf ρ hcont
-      · rename_i n
-        cases hspec : d.spec
-        · simp only [hname, hspec] at heval
-          split at heval
-          · rename_i hfunc
-            obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
-            have hbody_rt : d.body.runtime.subst γ =
-                Runtime.Expr.fix self.runtime (args.map (·.runtime))
-                  (body.runtime.subst ((γ.remove' self.runtime).removeAll'
-                    (args.map (·.runtime)))) := by
-              rw [hbody]
-              conv_lhs => unfold Expr.runtime
-              simp only [Runtime.Expr.subst_fix]
-            rw [hbody_rt]
-            exact SpatialContext.wp_func <| by
-              simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-              simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-                ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime _ γ)
-                (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) ρ (by
-                  simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
-          · have hbind := VerifM.eval_bind _ _ _ _ heval
-            have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf TransState.empty ρ hbind
-            have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-            refine hwp.trans (wp.mono' ?_)
-            intro v
-            simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-            simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-              ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime v γ)
-              (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) ρ (by
-                simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-                  (VerifM.eval_ret hcont))
-        · simp only [hname, hspec] at heval
-          obtain ⟨spec, hswf, hwp, hcont⟩ :=
-            ValDecl.check_correct Θ S d γ hS hSwf TransState.empty ρ (VerifM.eval_bind _ _ _ _ heval)
-          refine hwp.trans (wp.mono' ?_)
-          intro v
-          apply pure_elim'
-          intro hprecond
-          simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-          simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-            ih (S.insert' d.name spec) (Runtime.Subst.update' d.name.runtime v γ)
-              (SpecMap.satisfiedBy_insert'_update' hS hprecond) (SpecMap.wfIn_insert' hSwf hswf) ρ
-              (by
-                simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using hcont)
-    exact hmain.trans hpwp_unfold.2
+          rw [hupd v]
+          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) ρ hcont'
+          exact wand_intro (sep_elim_l.trans <|
+            (SpecMap.satisfiedBy_erase (x := n) (v := v)).trans hih)
+      | some _ =>
+        simp only [hname, hspec] at heval
+        obtain ⟨spec, hswf, hwp, hcont⟩ :=
+          ValDecl.check_correct Θ S d γ hSwf ρ (VerifM.eval_bind _ _ _ _ heval)
+        have hcont' : VerifM.eval (Program.check Θ (S.insert n spec) ds) TransState.empty ρ (fun _ _ _ => True) := by
+          convert hcont
+        refine wp_strengthen_persistent hwp ?_
+        intro v
+        rw [hupd v]
+        have hih := ih (S.insert n spec) (γ.update n v)
+          (SpecMap.wfIn_insert hSwf hswf) ρ hcont'
+        exact wand_intro
+          ((SpecMap.satisfiedBy_insert_update (x := n) (v := v) (spec := spec)).trans hih)
 
 theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
   Smt.Strategy.checks (Program.verify p) (⊢ pwp (Untyped.Program.runtime p)) := by
@@ -291,7 +328,8 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
     obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty default hbind
     have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
-                       (SpecMap.empty_satisfiedBy _) (SpecMap.empty_wfIn _)
-                        default hcheck
+                       (SpecMap.empty_wfIn _) default hcheck
     rw [Runtime.Program.subst_id] at hcorrect
-    simpa [hrt] using hcorrect
+    have hsat : (⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) Runtime.Subst.id) :=
+      SpecMap.empty_satisfiedBy _
+    simpa [hrt] using hsat.trans hcorrect

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -113,11 +113,11 @@ theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
     exact VerifM.eval_ret heval
 
 theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
+    (hSwf : S.wfIn Signature.empty)
     (st : TransState) (ρ : Env)
     {Q : Unit → TransState → Env → Prop}
     (heval : VerifM.eval (ValDecl.checkExpr Θ S d) st ρ Q) :
-    st.owns.interp ρ ⊢ wp (d.body.runtime.subst γ) (fun _ => iprop(True)) := by
+    st.owns.interp ρ ∗ S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => iprop(True)) := by
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
@@ -143,12 +143,11 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed
       trivial)
 
 theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
-    (st : TransState) (ρ : Env)
+    (hSwf : S.wfIn Signature.empty) (st : TransState) (ρ : Env)
     {Q : Spec → TransState → Env → Prop}
     (heval : VerifM.eval (ValDecl.check Θ S d) st ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
-            (st.owns.interp ρ ⊢ wp (d.body.runtime.subst γ) (fun v => ⌜spec.isPrecondFor Θ v⌝)) ∧
+            (st.owns.interp ρ ∗ S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.spec with
@@ -185,9 +184,9 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
                  VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty) (ρ : Env) :
+    (hSwf : S.wfIn Signature.empty) (ρ : Env) :
     VerifM.eval (Program.check Θ S prog) TransState.empty ρ (fun _ _ _ => True) →
-    emp ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
+    S.satisfiedBy Θ γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ ρ with
   | nil =>
     intro _

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -1,6 +1,7 @@
 import Mica.TinyML.Typed
 import Mica.TinyML.Untyped
 import Mica.TinyML.Typing
+import Mica.SeparationLogic.PrimitiveLaws
 import Mica.Verifier.Functions
 import Mica.Frontend.SpecParser
 import Mica.Verifier.SpecTranslation
@@ -187,22 +188,6 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
           exact ⟨spec, hswf, checkSpec_correct Θ S d.body spec γ hswf hSwf ρ hcheckSpec,
                  VerifM.eval_ret hpure⟩
 
-/-- Strengthen the postcondition of a `wp` using a persistent resource:
-    if `R` (persistent) entails `wp e P`, and `R` together with `P v` entails `Q v`,
-    then `R` entails `wp e Q`. -/
-private theorem wp_strengthen_persistent
-    {R : iProp} [Iris.BI.Persistent R] {e : Runtime.Expr}
-    {P Q : Runtime.Val → iProp}
-    (hwp : R ⊢ wp e P) (hpost : ∀ v, R ⊢ P v -∗ Q v) :
-    R ⊢ wp e Q := by
-  iintro □HR
-  iapply wp.mono
-  isplitr
-  · iintro %v
-    iapply (hpost v)
-    iexact HR
-  · iapply hwp; iexact HR
-
 theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
     (hSwf : S.wfIn Signature.empty) (ρ : Env) :
     VerifM.eval (Program.check Θ S prog) TransState.empty ρ (fun _ _ _ => True) →
@@ -242,7 +227,7 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
         obtain ⟨spec, _, hwp, hcont⟩ :=
           ValDecl.check_correct Θ S d γ hSwf ρ (VerifM.eval_bind _ _ _ _ heval)
         have hih := ih S γ hSwf ρ hcont
-        refine wp_strengthen_persistent hwp ?_
+        refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
         exact wand_intro (sep_elim_l.trans hih)
@@ -284,7 +269,7 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
             VerifM.eval_ret hcont
           have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf ρ hbind
             (Φ := iprop(emp)) (by istart; iintro _; iemp_intro)
-          refine wp_strengthen_persistent hwp ?_
+          refine SpatialContext.wp_strengthen_persistent hwp ?_
           intro v
           rw [hupd v]
           have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) ρ hcont'
@@ -296,7 +281,7 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
           ValDecl.check_correct Θ S d γ hSwf ρ (VerifM.eval_bind _ _ _ _ heval)
         have hcont' : VerifM.eval (Program.check Θ (S.insert n spec) ds) TransState.empty ρ (fun _ _ _ => True) := by
           convert hcont
-        refine wp_strengthen_persistent hwp ?_
+        refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
         have hih := ih (S.insert n spec) (γ.update n v)

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -58,6 +58,56 @@ def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : iProp
 instance : Iris.BI.Persistent (Spec.isPrecondFor Θ f s) := by
   unfold Spec.isPrecondFor; infer_instance
 
+
+/-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
+    the two differ only by currying the typing hypothesis and the predicate transformer. -/
+theorem Spec.isPrecondFor_fold (Θ : TinyML.TypeEnv) (s : Spec)
+    (f : Runtime.Val) :
+    iprop(□ ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      (⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
+          (Spec.argsEnv Env.empty s.args vs)) -∗
+        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ f := by
+  unfold Spec.isPrecondFor
+  iintro □H
+  imodintro
+  iintro %Φ %vs Htyped Hpred
+  ispecialize H $$ %vs
+  ispecialize H $$ %Φ
+  iapply H
+  isplitl [Htyped]
+  · iexact Htyped
+  · iexact Hpred
+
+/-- Löb-style rule for spec preconditions on `fix`: to prove
+    `s.isPrecondFor Θ (.fix f args e)`, assume it as the recursive hypothesis and
+    prove the `wp` of the body (after the usual fix-substitution). -/
+theorem Spec.isPrecondFor_fix {Θ : TinyML.TypeEnv} {s : Spec}
+    {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
+    {R : iProp}
+    (h : R ⊢ □ (s.isPrecondFor Θ (.fix f args e) -∗
+        ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+          ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
+          PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
+              (Spec.argsEnv Env.empty s.args vs) -∗
+          wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
+    R ⊢ s.isPrecondFor Θ (.fix f args e) := by
+  refine (SpatialContext.wp_fix' (Φ := fun P vs =>
+      iprop(⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
+            (Spec.argsEnv Env.empty s.args vs))) (h.trans ?_)).trans
+    (Spec.isPrecondFor_fold Θ s _)
+  istart
+  iintro □HR
+  imodintro
+  iintro IH %vs %P ⟨%htyped, Hpred⟩
+  ispecialize HR $$ [IH]
+  · iapply (Spec.isPrecondFor_fold Θ s (.fix f args e)); iexact IH
+  ispecialize HR $$ %vs %P
+  iapply HR
+  · ipure_intro; exact htyped
+  · iexact Hpred
+
 /-- A spec is well-formed when its predicate transformer is well-formed in the
     context extended with all argument variables. -/
 def Spec.wfIn (spec : Spec) (Δ : Signature) : Prop :=
@@ -231,29 +281,33 @@ def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst)
 instance : Iris.BI.Persistent (SpecMap.satisfiedBy Θ S γ) := by
   unfold SpecMap.satisfiedBy; infer_instance
 
-/-- Drop `satisfiedBy` from the resource. -/
-theorem SpecMap.satisfiedBy_drop {A R : iProp} {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} :
-    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ R :=
-  sep_mono_r sep_elim_r
+theorem SpecMap.project (P : iProp) (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) :
+  (P ⊢ S.satisfiedBy Θ γ) →
+  S.lookup x = some s →
+  (∀ fval, γ x = some fval → s.isPrecondFor Θ fval ∗ P ⊢ Q) →
+  (P ⊢ Q) := by
+  intro hsat hlook hcont
+  simp only [SpecMap.satisfiedBy] at hsat
+  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor Θ fval) ∗ P := by
+    refine (persistent_entails_r hsat).trans ?_
+    istart
+    iintro ⟨□Hall, HP⟩
+    ispecialize Hall $$ %x
+    ispecialize Hall $$ %s
+    isplitl []
+    · iapply Hall
+      ipure_intro
+      exact hlook
+    · iexact HP
+  refine hstep.trans ?_
+  istart
+  iintro ⟨⟨%fval, Hγ, Hpre⟩, HP⟩
+  ipure Hγ
+  iapply (hcont fval Hγ)
+  isplitl [Hpre]
+  · iexact Hpre
+  · iexact HP
 
-/-- Duplicate `satisfiedBy` (persistent) in the resource. -/
-theorem SpecMap.satisfiedBy_dup {A R : iProp} {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} :
-    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ (SpecMap.satisfiedBy Θ S γ ∗ (SpecMap.satisfiedBy Θ S γ ∗ R)) :=
-  by
-    iintro ⟨HA, □HS, HR⟩
-    isplitl [HA]
-    · iexact HA
-    · isplitl []
-      · iexact HS
-      · isplitl []
-        · iexact HS
-        · iexact HR
-
-/-- Weaken `satisfiedBy` in the resource via an entailment. -/
-theorem SpecMap.satisfiedBy_weaken {A R : iProp}
-    (h : SpecMap.satisfiedBy Θ S γ ⊢ SpecMap.satisfiedBy Θ' S' γ') :
-    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ (SpecMap.satisfiedBy Θ' S' γ' ∗ R) :=
-  sep_mono_r (sep_mono_l h)
 
 def SpecMap.wfIn (S : SpecMap) (Δ : Signature) : Prop :=
   ∀ f spec, S.lookup f = some spec → spec.wfIn Δ

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -281,7 +281,7 @@ def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst)
 instance : Iris.BI.Persistent (SpecMap.satisfiedBy Θ S γ) := by
   unfold SpecMap.satisfiedBy; infer_instance
 
-theorem SpecMap.project (P : iProp) (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) :
+theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp) (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) :
   (P ⊢ S.satisfiedBy Θ γ) →
   S.lookup x = some s →
   (∀ fval, γ x = some fval → s.isPrecondFor Θ fval ∗ P ⊢ Q) →

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -49,11 +49,14 @@ def Spec.argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val �
   | (name, _) :: rest, v :: vs => Spec.argsEnv (ρ.updateConst .value name v) rest vs
 
 def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : iProp :=
-  iprop (□ ∀ (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
+  iprop(□ ∀ (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
           (Spec.argsEnv Env.empty s.args vs) -∗
         wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
+
+instance : Iris.BI.Persistent (Spec.isPrecondFor Θ f s) := by
+  unfold Spec.isPrecondFor; infer_instance
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
     context extended with all argument variables. -/
@@ -223,7 +226,34 @@ def Spec.implement (s : Spec) (body : List FOL.Const → VerifM (Term .value)) :
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
 def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) : iProp :=
-  iprop(∀ x s, ⌜S.lookup x = some s⌝ -∗ ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor Θ f)
+  iprop(□ (∀ x s, ⌜S.lookup x = some s⌝ -∗ ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor Θ f))
+
+instance : Iris.BI.Persistent (SpecMap.satisfiedBy Θ S γ) := by
+  unfold SpecMap.satisfiedBy; infer_instance
+
+/-- Drop `satisfiedBy` from the resource. -/
+theorem SpecMap.satisfiedBy_drop {A R : iProp} {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ R :=
+  sep_mono_r sep_elim_r
+
+/-- Duplicate `satisfiedBy` (persistent) in the resource. -/
+theorem SpecMap.satisfiedBy_dup {A R : iProp} {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ (SpecMap.satisfiedBy Θ S γ ∗ (SpecMap.satisfiedBy Θ S γ ∗ R)) :=
+  by
+    iintro ⟨HA, □HS, HR⟩
+    isplitl [HA]
+    · iexact HA
+    · isplitl []
+      · iexact HS
+      · isplitl []
+        · iexact HS
+        · iexact HR
+
+/-- Weaken `satisfiedBy` in the resource via an entailment. -/
+theorem SpecMap.satisfiedBy_weaken {A R : iProp}
+    (h : SpecMap.satisfiedBy Θ S γ ⊢ SpecMap.satisfiedBy Θ' S' γ') :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ (SpecMap.satisfiedBy Θ' S' γ' ∗ R) :=
+  sep_mono_r (sep_mono_l h)
 
 def SpecMap.wfIn (S : SpecMap) (Δ : Signature) : Prop :=
   ∀ f spec, S.lookup f = some spec → spec.wfIn Δ
@@ -298,23 +328,44 @@ def SpecMap.erase' (S : SpecMap) (b : Typed.Binder) : SpecMap :=
 theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
     S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ fval ⊢ SpecMap.satisfiedBy Θ (Finmap.insert x spec S) γ := by
-  intro y s' hlookup
+  simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
+  iintro ⟨□HS, □Hf⟩
+  imodintro
+  iintro %y %s' %hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup
-    exact ⟨fval, hγ, hf⟩
+    iexists fval
+    isplitr
+    · ipure_intro; exact hγ
+    · iexact Hf
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup
-    exact hS y s' hlookup
+    ispecialize HS $$ %y
+    ispecialize HS $$ %s'
+    ispecialize HS $$ %hlookup
+    iexact HS
 
 theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
     S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ v ⊢ SpecMap.satisfiedBy Θ (Finmap.insert x spec S) (γ.update x v) := by
-  intro y s' hlookup
+  simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
+  iintro ⟨□HS, □Hf⟩
+  imodintro
+  iintro %y %s' %hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup
-    exact ⟨v, by simp [Runtime.Subst.update], hf⟩
+    iexists v
+    isplitr
+    · ipure_intro; simp [Runtime.Subst.update]
+    · iexact Hf
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup
-    obtain ⟨f, hγf, hprecond⟩ := hS y s' hlookup
-    exact ⟨f, by simp [Runtime.Subst.update, beq_false_of_ne hyx, hγf], hprecond⟩
+    ispecialize HS $$ %y
+    ispecialize HS $$ %s'
+    ispecialize HS $$ %hlookup
+    icases HS with ⟨%f, %hγf, Hprecond⟩
+    iexists f
+    isplitl [Hprecond]
+    · ipure_intro; simp [Runtime.Subst.update, beq_false_of_ne hyx, hγf]
+    · iexact Hprecond
 
 theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : Signature}
     (hS : S.wfIn Δ) (hs : spec.wfIn Δ) : SpecMap.wfIn (Finmap.insert x spec S) Δ := by
@@ -330,8 +381,8 @@ theorem SpecMap.satisfiedBy_insert' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Ru
   cases b with
   | mk name ty =>
     cases name with
-    | none => exact hS
-    | some x => exact SpecMap.satisfiedBy_insert hS (hγ x ty rfl) hf
+    | none => simp [SpecMap.insert']; iintro ⟨HS, _⟩; iexact HS
+    | some x => exact SpecMap.satisfiedBy_insert (hγ x ty rfl)
 
 theorem SpecMap.satisfiedBy_insert'_update' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
@@ -339,8 +390,8 @@ theorem SpecMap.satisfiedBy_insert'_update' {Θ : TinyML.TypeEnv} {S : SpecMap} 
   cases b with
   | mk name _ =>
     cases name with
-    | none => exact hS
-    | some _ => exact SpecMap.satisfiedBy_insert_update hS hf
+    | none => simp [SpecMap.insert', Runtime.Subst.update']; iintro ⟨HS, _⟩; iexact HS
+    | some _ => exact SpecMap.satisfiedBy_insert_update
 
 theorem SpecMap.wfIn_insert' {S : SpecMap} {b : Typed.Binder} {spec : Spec} {Δ : Signature}
     (hS : S.wfIn Δ) (hs : spec.wfIn Δ) : SpecMap.wfIn (S.insert' b spec) Δ := by
@@ -361,7 +412,10 @@ theorem SpecMap.wfIn_erase' {S : SpecMap} {b : Typed.Binder} {Δ : Signature}
 theorem SpecMap.satisfiedBy_eraseAll_updateAll' {Θ : TinyML.TypeEnv} {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
     {vs : List Runtime.Val} (hlen : keys.length = vs.length) :
     S.satisfiedBy Θ γ ⊢ (SpecMap.eraseAll keys S).satisfiedBy Θ (γ.updateAll' (keys.map Runtime.Binder.named) vs) := by
-  intro y s hlookup
+  simp only [SpecMap.satisfiedBy]
+  iintro □HS
+  imodintro
+  iintro %y %s %hlookup
   have hy_notin : y ∉ keys := by
     intro hmem
     have := SpecMap.eraseAll_lookup_none hmem (S := S)
@@ -369,13 +423,22 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAll' {Θ : TinyML.TypeEnv} {keys : Li
   have hγ_eq : (γ.updateAll' (keys.map Runtime.Binder.named) vs) y = γ y := by
     rw [Runtime.Subst.updateAll'_eq _ _ _ _ (by simp; omega)]
     rw [findVal_none_of_not_mem keys vs y (by omega) hy_notin]
-  rw [hγ_eq]
-  apply hS
-  rwa [SpecMap.eraseAll_lookup_of_notin hy_notin] at hlookup
+  have hlookup' : S.lookup y = some s := by rwa [SpecMap.eraseAll_lookup_of_notin hy_notin] at hlookup
+  ispecialize HS $$ %y
+  ispecialize HS $$ %s
+  ispecialize HS $$ %hlookup'
+  icases HS with ⟨%f, %hγf, Hprecond⟩
+  iexists f
+  isplitl [Hprecond]
+  · ipure_intro; rw [hγ_eq]; exact hγf
+  · iexact Hprecond
 
 theorem SpecMap.empty_satisfiedBy (γ : Runtime.Subst) :
     ⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) γ := by
-  intro x s h; simp [Finmap.lookup_empty] at h
+  simp only [SpecMap.satisfiedBy]
+  imodintro
+  iintro %x %s %h
+  simp [Finmap.lookup_empty] at h
 
 theorem SpecMap.empty_wfIn (Δ : Signature) :
     SpecMap.wfIn (∅ : SpecMap) Δ := by
@@ -383,12 +446,21 @@ theorem SpecMap.empty_wfIn (Δ : Signature) :
 
 theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
     S.satisfiedBy Θ γ ⊢ SpecMap.satisfiedBy Θ (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
-  intro y s hlookup
+  simp only [SpecMap.satisfiedBy]
+  iintro □HS
+  imodintro
+  iintro %y %s %hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_erase] at hlookup; exact absurd hlookup (by simp)
   · rw [Finmap.lookup_erase_ne hyx] at hlookup
-    obtain ⟨fval, hγ, hisPrecond⟩ := h y s hlookup
-    exact ⟨fval, by simp [Runtime.Subst.update, hyx, hγ], hisPrecond⟩
+    ispecialize HS $$ %y
+    ispecialize HS $$ %s
+    ispecialize HS $$ %hlookup
+    icases HS with ⟨%fval, %hγ, Hprecond⟩
+    iexists fval
+    isplitl [Hprecond]
+    · ipure_intro; simp [Runtime.Subst.update, hyx, hγ]
+    · iexact Hprecond
 
 theorem SpecMap.satisfiedBy_erase' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} :
@@ -396,16 +468,25 @@ theorem SpecMap.satisfiedBy_erase' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Run
   cases b with
   | mk name _ =>
     cases name with
-    | none => exact hS
-    | some _ => exact SpecMap.satisfiedBy_erase hS
+    | none => simp [SpecMap.erase', Runtime.Subst.update']
+    | some _ => exact SpecMap.satisfiedBy_erase
 
 theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} (hx : S.lookup x = none) :
     S.satisfiedBy Θ γ ⊢ S.satisfiedBy Θ (γ.update x v) := by
-  intro y s hlookup
+  simp only [SpecMap.satisfiedBy]
+  iintro □HS
+  imodintro
+  iintro %y %s %hlookup
   have hyx : y ≠ x := by intro heq; subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)
-  obtain ⟨fval, hγ, hisPrecond⟩ := h y s hlookup
-  exact ⟨fval, by simp [Runtime.Subst.update, hyx, hγ], hisPrecond⟩
+  ispecialize HS $$ %y
+  ispecialize HS $$ %s
+  ispecialize HS $$ %hlookup
+  icases HS with ⟨%fval, %hγ, Hprecond⟩
+  iexists fval
+  isplitl [Hprecond]
+  · ipure_intro; simp [Runtime.Subst.update, hyx, hγ]
+  · iexact Hprecond
 
 -- ---------------------------------------------------------------------------
 -- Spec correctness
@@ -614,7 +695,7 @@ theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (s
         have hret := VerifM.eval_ret heval_pure
         iapply (hΨ v st₃ ρ'' t hret (hst₃_decls ▸ htwf) hteval hty)
         isplitl [Howns]
-        · simpa [hst₃_owns] using Howns
+        · simp [hst₃_owns]
         · iexact HR)
     have hcall' : st.owns.interp ρ' ∗ R ⊢
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
@@ -832,7 +913,7 @@ theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL
       iintro H
       icases H with ⟨Howns, Happ⟩
       isplitr [Happ]
-      · iapply (show st.owns.interp ρ' ⊢ st'.owns.interp ρ' by simpa [howns])
+      · iapply (show st.owns.interp ρ' ⊢ st'.owns.interp ρ' by simp [howns])
         iapply (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1
         iexact Howns
       · iapply (PredTrans.apply_env_agree hswf (Env.agreeOn_trans hag_empty (Env.agreeOn_symm hagree)))

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -48,12 +48,12 @@ def Spec.argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val �
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => Spec.argsEnv (ρ.updateConst .value name v) rest vs
 
-def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : Prop :=
-  ∀ (vs : List Runtime.Val), TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) →
-    ∀ (Φ : Runtime.Val → iProp),
-      PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-        (Spec.argsEnv Env.empty s.args vs) ⊢
-      wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ
+def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : iProp :=
+  iprop (□ ∀ (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
+      ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+          (Spec.argsEnv Env.empty s.args vs) -∗
+        wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
     context extended with all argument variables. -/
@@ -222,9 +222,8 @@ def Spec.implement (s : Spec) (body : List FOL.Const → VerifM (Term .value)) :
 
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
-def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) : Prop :=
-  ∀ x s, S.lookup x = some s →
-    ∃ f, γ x = some f ∧ s.isPrecondFor Θ f
+def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) : iProp :=
+  iprop(∀ x s, ⌜S.lookup x = some s⌝ -∗ ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor Θ f)
 
 def SpecMap.wfIn (S : SpecMap) (Δ : Signature) : Prop :=
   ∀ f spec, S.lookup f = some spec → spec.wfIn Δ
@@ -297,9 +296,8 @@ def SpecMap.erase' (S : SpecMap) (b : Typed.Binder) : SpecMap :=
   | none => S
 
 theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy Θ γ) (hγ : γ x = some fval) (hf : spec.isPrecondFor Θ fval) :
-    SpecMap.satisfiedBy Θ (Finmap.insert x spec S) γ := by
+    {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
+    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ fval ⊢ SpecMap.satisfiedBy Θ (Finmap.insert x spec S) γ := by
   intro y s' hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup
@@ -308,9 +306,8 @@ theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Run
     exact hS y s' hlookup
 
 theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {x : TinyML.Var} {v : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy Θ γ) (hf : spec.isPrecondFor Θ v) :
-    SpecMap.satisfiedBy Θ (Finmap.insert x spec S) (γ.update x v) := by
+    {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
+    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ v ⊢ SpecMap.satisfiedBy Θ (Finmap.insert x spec S) (γ.update x v) := by
   intro y s' hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup
@@ -328,10 +325,8 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
 
 theorem SpecMap.satisfiedBy_insert' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy Θ γ)
-    (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval)
-    (hf : spec.isPrecondFor Θ fval) :
-    SpecMap.satisfiedBy Θ (S.insert' b spec) γ := by
+    (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval) :
+    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ fval ⊢ SpecMap.satisfiedBy Θ (S.insert' b spec) γ := by
   cases b with
   | mk name ty =>
     cases name with
@@ -339,9 +334,8 @@ theorem SpecMap.satisfiedBy_insert' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Ru
     | some x => exact SpecMap.satisfiedBy_insert hS (hγ x ty rfl) hf
 
 theorem SpecMap.satisfiedBy_insert'_update' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {b : Typed.Binder} {v : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy Θ γ) (hf : spec.isPrecondFor Θ v) :
-    SpecMap.satisfiedBy Θ (S.insert' b spec) (Runtime.Subst.update' b.runtime v γ) := by
+    {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
+    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ v ⊢ SpecMap.satisfiedBy Θ (S.insert' b spec) (Runtime.Subst.update' b.runtime v γ) := by
   cases b with
   | mk name _ =>
     cases name with
@@ -365,8 +359,8 @@ theorem SpecMap.wfIn_erase' {S : SpecMap} {b : Typed.Binder} {Δ : Signature}
     | some _ => exact SpecMap.wfIn_erase hS
 
 theorem SpecMap.satisfiedBy_eraseAll_updateAll' {Θ : TinyML.TypeEnv} {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
-    {vs : List Runtime.Val} (hS : S.satisfiedBy Θ γ) (hlen : keys.length = vs.length) :
-    (SpecMap.eraseAll keys S).satisfiedBy Θ (γ.updateAll' (keys.map Runtime.Binder.named) vs) := by
+    {vs : List Runtime.Val} (hlen : keys.length = vs.length) :
+    S.satisfiedBy Θ γ ⊢ (SpecMap.eraseAll keys S).satisfiedBy Θ (γ.updateAll' (keys.map Runtime.Binder.named) vs) := by
   intro y s hlookup
   have hy_notin : y ∉ keys := by
     intro hmem
@@ -380,15 +374,15 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAll' {Θ : TinyML.TypeEnv} {keys : Li
   rwa [SpecMap.eraseAll_lookup_of_notin hy_notin] at hlookup
 
 theorem SpecMap.empty_satisfiedBy (γ : Runtime.Subst) :
-    SpecMap.satisfiedBy Θ (∅ : SpecMap) γ := by
+    ⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) γ := by
   intro x s h; simp [Finmap.lookup_empty] at h
 
 theorem SpecMap.empty_wfIn (Δ : Signature) :
     SpecMap.wfIn (∅ : SpecMap) Δ := by
   intro f spec h; simp [Finmap.lookup_empty] at h
 
-theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val}
-    (h : S.satisfiedBy Θ γ) : SpecMap.satisfiedBy Θ (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
+theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
+    S.satisfiedBy Θ γ ⊢ SpecMap.satisfiedBy Θ (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
   intro y s hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_erase] at hlookup; exact absurd hlookup (by simp)
@@ -397,9 +391,8 @@ theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runt
     exact ⟨fval, by simp [Runtime.Subst.update, hyx, hγ], hisPrecond⟩
 
 theorem SpecMap.satisfiedBy_erase' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {b : Typed.Binder} {v : Runtime.Val}
-    (hS : S.satisfiedBy Θ γ) :
-    SpecMap.satisfiedBy Θ (S.erase' b) (Runtime.Subst.update' b.runtime v γ) := by
+    {b : Typed.Binder} {v : Runtime.Val} :
+    S.satisfiedBy Θ γ ⊢ SpecMap.satisfiedBy Θ (S.erase' b) (Runtime.Subst.update' b.runtime v γ) := by
   cases b with
   | mk name _ =>
     cases name with
@@ -407,9 +400,8 @@ theorem SpecMap.satisfiedBy_erase' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Run
     | some _ => exact SpecMap.satisfiedBy_erase hS
 
 theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {x : TinyML.Var} {v : Runtime.Val}
-    (h : S.satisfiedBy Θ γ) (hx : S.lookup x = none) :
-    S.satisfiedBy Θ (γ.update x v) := by
+    {x : TinyML.Var} {v : Runtime.Val} (hx : S.lookup x = none) :
+    S.satisfiedBy Θ γ ⊢ S.satisfiedBy Θ (γ.update x v) := by
   intro y s hlookup
   have hyx : y ≠ x := by intro heq; subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)
   obtain ⟨fval, hγ, hisPrecond⟩ := h y s hlookup


### PR DESCRIPTION
This PR adds proper persistency support for specifications. That is, like in #48, this PR doesn't actually introduce any separation logic contexts or the like, but it moves the specification predicate `isPrecondFor` inside the Iris logic as a persistent assertion. This requires refactoring quite a few theorem statements and proofs.