### PR TITLE
Prepare atoms for separation logic

### DIFF
--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -676,78 +676,86 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
         hσwf.2.2
     have hpwf_decls : (p.subst σ.subst).wfIn st.decls :=
       Atom.wfIn_mono hpwf_range hσwf.2.1 hwfst
-    obtain ⟨result, hq, hresult_eval, hresult_wf⟩ := VerifM.eval_resolve hb hpwf_decls
-    cases hr : result with
-    | none =>
-      simp [hr] at hq
-      exact (VerifM.eval_fatal hq).elim
-    | some t =>
-      simp only [hr] at hq hresult_eval hresult_wf
-      specialize hresult_eval t rfl
-      specialize hresult_wf t rfl
-      simp only [Assertion.pre]
-      -- The witness is t.eval ρ
-      have hpu : ⊢ p.eval (σ.subst.eval ρ) (t.eval ρ) := by
-        rw [← Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
-        iapply Atom.toFormula_eval_2
-        ipure_intro
-        exact hresult_eval
-      istart
-      iintro Howns
-      iexists (t.eval ρ)
-      isplitr
-      · iapply hpu
-      · have hb2 := VerifM.eval_bind _ _ _ _ hq
-        have hdecl := VerifM.eval_decl hb2
-        set v' := st.freshConst (some v.name) v.sort
-        have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
-          fresh_not_mem (addNumbers (v.name)) (st.decls.allNames) (addNumbers_injective _)
-        have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
-          fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-        specialize hdecl (t.eval ρ)
-        have hb3 := VerifM.eval_bind _ _ _ _ hdecl
-        have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
-            (st.decls.addConst v') := by
-          refine ⟨?_, ?_⟩
-          · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
-            have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
-            refine ⟨List.Mem.head _, ?_, ?_⟩
-            · intro τ' hvar
-              exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
-            · intro τ' hc'
-              exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-          · exact Term.wfIn_mono _ hresult_wf (Signature.Subset.subset_addConst _ _)
-              (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-        have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
-            (ρ.updateConst v.sort v'.name (t.eval ρ)) := by
-          simp only [Formula.eval, Term.eval, Const.denote]
-          simpa [Env.lookupConst, Env.updateConst] using
-            (Term.eval_env_agree hresult_wf (agreeOn_update_fresh_const hv'_fresh_decls))
-        have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
-        set σ' := σ.rename v v'.name
-        have hσ'wf : σ'.wf (st.decls.addConst v') :=
-          by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
-        have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
-          simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
-        have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
-          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-        have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
-          (ρ.updateConst v.sort v'.name (t.eval ρ)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-            (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-        have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
-            SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st.owns :=
-          SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
-            (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-        have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
-            SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st.owns ∗ R := by
-          exact sep_mono hinterp_bi.1 (by
-            iintro HR
-            iexact HR)
-        exact hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
-          (by
-            simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-              (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-          hΦ
+    exact VerifM.eval_resolve hb hpwf_decls
+      (fun st' hq hdecls => by
+        simp at hq
+        exact (VerifM.eval_fatal hq).elim)
+      (fun t st' hq hdecls htwf => by
+        simp only [Assertion.pre]
+        have hwfst' : st'.decls.wf := by simpa [hdecls] using hwfst
+        have htwf' : t.wfIn st'.decls := by simpa [hdecls] using htwf
+        istart
+        iintro H
+        icases H with ⟨Hpred, Howns, HR⟩
+        iexists (t.eval ρ)
+        isplitr [Howns HR]
+        · rw [← Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
+          iexact Hpred
+        · have hb2 := VerifM.eval_bind _ _ _ _ hq
+          have hdecl := VerifM.eval_decl hb2
+          set v' := st'.freshConst (some v.name) v.sort
+          have hv'_fresh_decls : v'.name ∉ st'.decls.allNames :=
+            fresh_not_mem (addNumbers (v.name)) (st'.decls.allNames) (addNumbers_injective _)
+          have hv'_fresh_range : v'.name ∉ σ.range.allNames := by
+            intro h
+            apply hv'_fresh_decls
+            rw [hdecls]
+            exact Signature.allNames_subset hσwf.2.1 _ h
+          specialize hdecl (t.eval ρ)
+          have hb3 := VerifM.eval_bind _ _ _ _ hdecl
+          have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
+              (st'.decls.addConst v') := by
+            refine ⟨?_, ?_⟩
+            · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+              have hwf_add : (st'.decls.addConst v').wf := Signature.wf_addConst hwfst' hv'_fresh_decls
+              refine ⟨List.Mem.head _, ?_, ?_⟩
+              · intro τ' hvar
+                exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
+              · intro τ' hc'
+                exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
+            · exact Term.wfIn_mono _ htwf' (Signature.Subset.subset_addConst _ _)
+                (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
+          have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
+              (ρ.updateConst v.sort v'.name (t.eval ρ)) := by
+            simp only [Formula.eval, Term.eval, Const.denote]
+            simpa [Env.lookupConst, Env.updateConst] using
+              (Term.eval_env_agree htwf' (agreeOn_update_fresh_const hv'_fresh_decls))
+          have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
+          set σ' := σ.rename v v'.name
+          have hσ'wf : σ'.wf (st'.decls.addConst v') := by
+            rw [hdecls]
+            simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
+          have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
+            simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
+          have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
+            simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
+          have hih := ih σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
+            (ρ.updateConst v.sort v'.name (t.eval ρ)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
+              (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
+          have hinterp_bi : SpatialContext.interp ρ st'.owns ⊣⊢
+              SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st'.owns :=
+            SpatialContext.interp_env_agree (VerifM.eval.wf hq).ownsWf
+              (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+          have hframe : SpatialContext.interp ρ st'.owns ∗ R ⊢
+              SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st'.owns ∗ R := by
+            exact sep_mono hinterp_bi.1 (by
+              iintro HR
+              iexact HR)
+          have hdrop : Atom.eval (p.subst σ.subst) ρ (t.eval ρ) ∗
+              SpatialContext.interp ρ st'.owns ∗ R ⊢ SpatialContext.interp ρ st'.owns ∗ R := by
+            istart
+            iintro ⟨_Hpred, Howns, HR⟩
+            isplitl [Howns]
+            · iexact Howns
+            · iexact HR
+          iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
+            (by
+              simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
+                (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
+            hΦ)
+          isplitl [Howns]
+          · iexact Howns
+          · iexact HR)
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
     simp only [Assertion.prove] at heval

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -313,25 +313,25 @@ theorem Assertion.pre_post_combine {α : Type}
 def Assertion.assume (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst × α)
   | .ret a => pure (σ, a)
   | .assert φ k => do
-    VerifM.assume (φ.subst σ.subst σ.range.allNames)
+    VerifM.assume (.pure (φ.subst σ.subst σ.range.allNames))
     Assertion.assume σ k
   | .let_ v t k => do
     let v' ← VerifM.decl (some v.name) v.sort
     let σ' := σ.rename v v'.name
-    VerifM.assume (.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst))
+    VerifM.assume (.pure (.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)))
     Assertion.assume σ' k
   | .pred v p k => do
     let v' ← VerifM.decl (some v.name) v.sort
     let σ' := σ.rename v v'.name
-    VerifM.assume ((p.subst σ.subst).toFormula (.const (.uninterpreted v'.name v.sort)))
+    VerifM.assume ((p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort)))
     Assertion.assume σ' k
   | .ite φ kt ke => do
     let branch ← VerifM.all [true, false]
     if branch then do
-      VerifM.assume (φ.subst σ.subst σ.range.allNames)
+      VerifM.assume (.pure (φ.subst σ.subst σ.range.allNames))
       Assertion.assume σ kt
     else do
-      VerifM.assume (.not (φ.subst σ.subst σ.range.allNames))
+      VerifM.assume (.pure (.not (φ.subst σ.subst σ.range.allNames)))
       Assertion.assume σ ke
 
 /-- Assert postconditions: assert formulas, declare and bind let-variables.
@@ -344,23 +344,23 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
   | .let_ v t k => do
     let v' ← VerifM.decl (some v.name) v.sort
     let σ' := σ.rename v v'.name
-    VerifM.assume (.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst))
+    VerifM.assume (.pure (.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)))
     Assertion.prove σ' k
   | .pred v p k => do
     match ← VerifM.resolve (p.subst σ.subst) with
     | some t =>
       let v' ← VerifM.decl (some v.name) v.sort
       let σ' := σ.rename v v'.name
-      VerifM.assume (.eq v.sort (.const (.uninterpreted v'.name v.sort)) t)
+      VerifM.assume (.pure (.eq v.sort (.const (.uninterpreted v'.name v.sort)) t))
       Assertion.prove σ' k
     | none => VerifM.fatal s!"could not resolve type predicate for {v.name}"
   | .ite φ kt ke => do
     let branch ← VerifM.all [true, false]
     if branch then do
-      VerifM.assume (φ.subst σ.subst σ.range.allNames)
+      VerifM.assume (.pure (φ.subst σ.subst σ.range.allNames))
       Assertion.prove σ kt
     else do
-      VerifM.assume (.not (φ.subst σ.subst σ.range.allNames))
+      VerifM.assume (.pure (.not (φ.subst σ.subst σ.range.allNames)))
       Assertion.prove σ ke
 
 
@@ -394,7 +394,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
       FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
     have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-    have hassume := VerifM.eval_assume hb hsubst_wf hsubst_eval
+    have hassume := VerifM.eval_assumePure hb hsubst_wf hsubst_eval
     iapply (ih σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkwf hassume hpost hwfst)
     iexact Howns
   | let_ v t k ih =>
@@ -435,7 +435,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
       simpa [u, Env.lookupConst, Env.updateConst] using
         (Term.eval_env_agree htwf (FiniteSubst.eval_update_fresh hσwf.1 hv'_fresh_range))
-    have hassume := VerifM.eval_assume hb2 heq_wf heq_holds
+    have hassume := VerifM.eval_assumePure hb2 heq_wf heq_holds
     -- Apply IH with σ' = σ.rename v v'.name
     set σ' := σ.rename v v'.name
     have hσ'wf : σ'.wf (st.decls.addConst v') :=
@@ -472,7 +472,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
         FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
       iexact Howns
     · iintro Howns %hnφ
@@ -484,7 +484,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
         FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
       iexact Howns
   | pred v p k ih =>
@@ -545,7 +545,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       iapply hpu'
       iexact Hpu
     icases Hformula with %hformula_holds
-    have hassume := VerifM.eval_assume hb2 hformula_wf hformula_holds
+    have hassume := VerifM.eval_assumePure hb2 hformula_wf hformula_holds
     set σ' := σ.rename v v'.name
     have hσ'wf : σ'.wf (st.decls.addConst v') :=
       by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
@@ -644,7 +644,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
       simpa [u, Env.lookupConst, Env.updateConst] using
         (Term.eval_env_agree htwf (FiniteSubst.eval_update_fresh hσwf.1 hv'_fresh_range))
-    have hassume := VerifM.eval_assume hb2 heq_wf heq_holds
+    have hassume := VerifM.eval_assumePure hb2 heq_wf heq_holds
     set σ' := σ.rename v v'.name
     have hσ'wf : σ'.wf (st.decls.addConst v') :=
       by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
@@ -723,7 +723,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
           simp only [Formula.eval, Term.eval, Const.denote]
           simpa [Env.lookupConst, Env.updateConst] using
             (Term.eval_env_agree hresult_wf (agreeOn_update_fresh_const hv'_fresh_decls))
-        have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
+        have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
         set σ' := σ.rename v v'.name
         have hσ'wf : σ'.wf (st.decls.addConst v') :=
           by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
@@ -765,7 +765,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
         FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
       iexact Howns
     · apply wand_intro
@@ -779,6 +779,6 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
         FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
       iexact Howns

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -518,9 +518,9 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
         exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
       · intro τ' hc'
         exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-    have hformula_wf : ((p.subst σ.subst).toFormula (.const (.uninterpreted v'.name v.sort))).wfIn
+    have hitem_wf : ((p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))).wfIn
         (st.decls.addConst v') :=
-      Atom.toFormula_wfIn
+      Atom.toItem_wfIn
         (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint) hvar_wf
     have hpu' : p.eval (σ.subst.eval ρ) u ⊢ (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
@@ -539,13 +539,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
           (Δ := Signature.ofVars σ.dom) hpwf hagree
       rw [heval_agree]
       exact .rfl
-    ihave Hformula : (⌜((p.subst σ.subst).toFormula (.const (.uninterpreted v'.name v.sort))).eval
-        (ρ.updateConst v.sort v'.name u)⌝ : iProp) $$ [Hpu]
-    · iapply Atom.toFormula_eval_1
-      iapply hpu'
-      iexact Hpu
-    icases Hformula with %hformula_holds
-    have hassume := VerifM.eval_assumePure hb2 hformula_wf hformula_holds
+    set item := (p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))
     set σ' := σ.rename v v'.name
     have hσ'wf : σ'.wf (st.decls.addConst v') :=
       by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
@@ -553,23 +547,85 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
     have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
       simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-    have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
-      (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-        (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
-        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
-      SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
-        (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-    have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
-        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns ∗ R := by
-      exact sep_mono hinterp_bi.1 (by
-        iintro HR
-        iexact HR)
-    exact hframe.trans <| hih.trans <| Assertion.post_env_agree hkwf'
-      (by
-        simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-          (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-      hΦ
+    cases hitem : item with
+    | pure φ =>
+      have hφ_entail : p.eval (σ.subst.eval ρ) u ⊢ ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ := by
+        simpa [item, hitem] using
+          (hpu'.trans (Atom.eval_purePart (p := p.subst σ.subst)
+            (t := .const (.uninterpreted v'.name v.sort))
+            (ρ := ρ.updateConst v.sort v'.name u)))
+      ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ $$ [Hpu]
+      · iapply hφ_entail
+        iexact Hpu
+      icases Hφ with %hφ
+      have hb2' : (VerifM.assume (.pure φ)).eval
+          { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
+          (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
+        simpa [item, hitem] using hb2
+      have hitem_wf' : (.pure φ : CtxItem).wfIn (st.decls.addConst v') := by
+        simpa [item, hitem] using hitem_wf
+      have hassume := VerifM.eval_assume hb2' hitem_wf' hφ
+      have hih := ih σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ))
+        (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
+          (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
+      have hframe :
+          st.owns.interp ρ ∗ R ⊢
+            (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).owns.interp
+              (ρ.updateConst v.sort v'.name u) ∗ R := by
+        simp [TransState.addItem]
+        exact sep_mono
+          (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+            (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
+          (by
+            iintro HR
+            iexact HR)
+      iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree hkwf'
+        (by
+          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
+            (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
+        hΦ)
+      iexact Howns
+    | spatial a =>
+      have hb2' : (VerifM.assume (.spatial a)).eval
+          { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
+          (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
+        simpa [item, hitem] using hb2
+      have hitem_wf' : (.spatial a : CtxItem).wfIn (st.decls.addConst v') := by
+        simpa [item, hitem] using hitem_wf
+      have hassume := VerifM.eval_assume hb2' hitem_wf' trivial
+      have hih := ih σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.spatial a))
+        (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
+          (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
+      have hitem_interp :
+          p.eval (σ.subst.eval ρ) u ⊢
+            CtxItem.interp (ρ.updateConst v.sort v'.name u) item := by
+        simpa [item] using
+          (hpu'.trans (Atom.eval_toItem (p := p.subst σ.subst)
+            (t := .const (.uninterpreted v'.name v.sort))
+            (ρ := ρ.updateConst v.sort v'.name u)))
+      have hspatial_interp :
+          p.eval (σ.subst.eval ρ) u ⊢
+            SpatialAtom.interp (ρ.updateConst v.sort v'.name u) a := by
+        simpa [item, hitem, CtxItem.interp] using hitem_interp
+      have howns_agree :
+          SpatialContext.interp ρ st.owns ⊢
+            SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+        (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+          (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
+      iapply (hih.trans <| Assertion.post_env_agree hkwf'
+        (by
+          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
+            (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
+        hΦ)
+      simp [TransState.addItem]
+      icases Howns with ⟨HS, HR⟩
+      isplitr [HR]
+      · isplitr [HS]
+        · iapply hspatial_interp
+          iexact Hpu
+        · iapply howns_agree
+          iexact HS
+      · iexact HR
 
 theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -797,13 +797,6 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
             exact sep_mono hinterp_bi.1 (by
               iintro HR
               iexact HR)
-          have hdrop : Atom.eval (p.subst σ.subst) ρ (t.eval ρ) ∗
-              SpatialContext.interp ρ st'.owns ∗ R ⊢ SpatialContext.interp ρ st'.owns ∗ R := by
-            istart
-            iintro ⟨_Hpred, Howns, HR⟩
-            isplitl [Howns]
-            · iexact Howns
-            · iexact HR
           iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
             (by
               simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -59,6 +59,11 @@ def interp (ρ : Env) : CtxItem → iProp
   | .pure φ => ⌜φ.eval ρ⌝
   | .spatial a => a.interp ρ
 
+def purePart (i : CtxItem) (ρ : Env) : Prop :=
+  match i with
+  | .pure φ => φ.eval ρ
+  | .spatial _ => True
+
 end CtxItem
 
 /-- Convert an instantiated atom into the corresponding verifier context item. -/
@@ -242,6 +247,16 @@ theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : Env} :
   | isint v  => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isinj tag arity v => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+
+theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
+    p.eval ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
+  cases p with
+  | isint v =>
+    simp [Atom.eval, CtxItem.purePart, Atom.toFormula, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+  | isbool v =>
+    simp [Atom.eval, CtxItem.purePart, Atom.toFormula, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+  | isinj tag arity v =>
+    simp [Atom.eval, CtxItem.purePart, Atom.toFormula, Atom.toItem, Formula.eval, Term.eval, eq_comm]
 
 
 -- ---------------------------------------------------------------------------

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -36,7 +36,7 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
 
 
 -- ---------------------------------------------------------------------------
--- Conversion to formula
+-- Conversion to context items
 -- ---------------------------------------------------------------------------
 
 /-- Convert an atom applied to a typed term into a formula. -/
@@ -44,6 +44,10 @@ def Atom.toFormula : Atom τ → Term τ → Formula
   | .isint  v, t => .eq .value v (.unop .ofInt t)
   | .isbool v, t => .eq .value v (.unop .ofBool t)
   | .isinj tag arity v, t => .eq .value v (.unop (.mkInj tag arity) t)
+
+/-- Convert an instantiated atom into the corresponding verifier context item. -/
+def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
+  .pure (a.toFormula t)
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
 def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -42,16 +42,6 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
   | .isinj tag arity t => .isinj tag arity (t.subst σ)
 
 
--- ---------------------------------------------------------------------------
--- Conversion to context items
--- ---------------------------------------------------------------------------
-
-/-- Convert an atom applied to a typed term into a formula. -/
-def Atom.toFormula : Atom τ → Term τ → Formula
-  | .isint  v, t => .eq .value v (.unop .ofInt t)
-  | .isbool v, t => .eq .value v (.unop .ofBool t)
-  | .isinj tag arity v, t => .eq .value v (.unop (.mkInj tag arity) t)
-
 namespace CtxItem
 
 /-- Semantic interpretation of a verifier context item. -/
@@ -68,7 +58,10 @@ end CtxItem
 
 /-- Convert an instantiated atom into the corresponding verifier context item. -/
 def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
-  .pure (a.toFormula t)
+  match a with
+  | .isint v => .pure (.eq .value v (.unop .ofInt t))
+  | .isbool v => .pure (.eq .value v (.unop .ofBool t))
+  | .isinj tag arity v => .pure (.eq .value v (.unop (.mkInj tag arity) t))
 
 -- ---------------------------------------------------------------------------
 -- Semantics
@@ -113,7 +106,7 @@ theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : 
 
 
 theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
-    (h : φ.matchAtom a = some t) : φ = a.toFormula t := by
+    (h : φ.matchAtom a = some t) : a.toItem t = .pure φ := by
   cases a with
   | isint v =>
     simp only [Formula.matchAtom] at h
@@ -137,11 +130,11 @@ def Atom.resolve (a : Atom τ) (C : List Formula) : Option (Term τ) :=
 
 theorem Atom.resolve_correct {a : Atom τ} {C : List Formula} {t : Term τ}
     (h : a.resolve C = some t) (ρ : Env) (hC : ∀ φ ∈ C, φ.eval ρ) :
-    (a.toFormula t).eval ρ := by
+    ⊢ (a.toItem t).interp ρ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
-  have heq := Formula.matchAtom_correct hφ_match
-  subst heq
-  exact hC _ hφ_mem
+  rw [Formula.matchAtom_correct hφ_match]
+  simp [CtxItem.interp, hC _ hφ_mem]
+  exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
 
 theorem Atom.resolve_wfIn {a : Atom τ} {C : List Formula} {t : Term τ} {Δ : Signature}
     (h : a.resolve C = some t) (hwf : ∀ φ ∈ C, φ.wfIn Δ) :
@@ -210,33 +203,33 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     exact ⟨hp, trivial, ht⟩
 
 theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
-    p.eval ρ (t.eval ρ) ⊣⊢ ⌜(p.toFormula t).eval ρ⌝ := by
+    p.eval ρ (t.eval ρ) ⊣⊢ CtxItem.interp ρ (p.toItem t) := by
   cases p with
-  | isint v  => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
-  | isbool v => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
-  | isinj tag arity v => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
+  | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
 
-/-- If `(p.toFormula t).eval ρ` holds, then `p.eval ρ (t.eval ρ)`. -/
-theorem Atom.toFormula_eval_2 {p : Atom τ} {t : Term τ} {ρ : Env}
-    : ⌜(p.toFormula t).eval ρ⌝ ⊢ p.eval ρ (t.eval ρ) := by
+/-- If `p.toItem t` holds semantically, then `p.eval ρ (t.eval ρ)`. -/
+theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : Env}
+    : CtxItem.interp ρ (p.toItem t) ⊢ p.eval ρ (t.eval ρ) := by
   exact Atom.eval_pure.2
 
 theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊢ CtxItem.interp ρ (p.toItem t) := by
   cases p with
-  | isint v  => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
-  | isbool v => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
-  | isinj tag arity v => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
 
 theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
   cases p with
   | isint v =>
-    simp [Atom.eval, CtxItem.purePart, Atom.toFormula, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+    simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
   | isbool v =>
-    simp [Atom.eval, CtxItem.purePart, Atom.toFormula, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+    simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
   | isinj tag arity v =>
-    simp [Atom.eval, CtxItem.purePart, Atom.toFormula, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+    simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
 
 
 -- ---------------------------------------------------------------------------
@@ -284,23 +277,26 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .isinj tag arity v => [(.unpred (.isInj tag arity) v, .unop .payloadOf v)]
 
 theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : Env}
-    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : (a.toFormula t).eval ρ := by
+    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : ⊢ (a.toItem t).interp ρ := by
   cases a with
   | isint v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
-    simp [toFormula, Formula.eval, Term.eval, UnOp.eval]
+    simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ <;> simp_all
+    · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isbool v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
-    simp [toFormula, Formula.eval, Term.eval, UnOp.eval]
+    simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ <;> simp_all
+    · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isinj tag arity v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
-    simp [toFormula, Formula.eval, Term.eval, UnOp.eval]
+    simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ <;> simp_all
+    · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
 
 theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Signature}
     (hmem : (φ, t) ∈ a.candidates) (h : a.wfIn Δ) : φ.wfIn Δ ∧ t.wfIn Δ := by
@@ -329,7 +325,7 @@ private theorem VerifM.eval_tryCandidates
     (hpwf : a.wfIn st.decls) :
     ∃ result : Option (Term τ),
       Q result st ρ
-      ∧ (∀ t, result = some t → (a.toFormula t).eval ρ)
+      ∧ (∀ t, result = some t → ⊢ (a.toItem t).interp ρ)
       ∧ (∀ t, result = some t → t.wfIn st.decls) := by
   induction candidates with
   | nil =>
@@ -570,9 +566,7 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
       have hq := VerifM.eval_ret hctx_q
       have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
       have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
-        iapply Atom.toFormula_eval_2
-        ipure_intro
-        exact Atom.resolve_correct hres ρ hholds
+        exact (Atom.resolve_correct hres ρ hholds).trans Atom.toItem_eval
       have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
           Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
         istart
@@ -593,9 +587,7 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
         have htwf : t.wfIn st.decls := hresult_wf t hr
         have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
         have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
-          iapply Atom.toFormula_eval_2
-          ipure_intro
-          exact hresult_eval t hr
+          exact (hresult_eval t hr).trans Atom.toItem_eval
         have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
             Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
           istart

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -25,6 +25,13 @@ inductive Atom : Srt → Type where
   | isinj  (tag : Nat) (arity : Nat) : Term .value → Atom .value
 
 
+def Atom.pure {τ: Srt} (a : Atom τ) : Bool :=
+  match a with
+  | isint _ => true
+  | isbool _ => true
+  | isinj _ _ _ => true
+
+
 -- ---------------------------------------------------------------------------
 -- Substitution
 -- ---------------------------------------------------------------------------
@@ -45,9 +52,29 @@ def Atom.toFormula : Atom τ → Term τ → Formula
   | .isbool v, t => .eq .value v (.unop .ofBool t)
   | .isinj tag arity v, t => .eq .value v (.unop (.mkInj tag arity) t)
 
+namespace CtxItem
+
+/-- Semantic interpretation of a verifier context item. -/
+def interp (ρ : Env) : CtxItem → iProp
+  | .pure φ => ⌜φ.eval ρ⌝
+  | .spatial a => a.interp ρ
+
+end CtxItem
+
 /-- Convert an instantiated atom into the corresponding verifier context item. -/
 def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
   .pure (a.toFormula t)
+
+-- ---------------------------------------------------------------------------
+-- Semantics
+-- ---------------------------------------------------------------------------
+
+def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
+  match p with
+  | isint t  => λ v => ⌜.int v = t.eval ρ⌝
+  | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
+  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
+
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
 def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
@@ -65,6 +92,20 @@ def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
     | .eq .value v' (.unop (.mkInj tag' arity') t) =>
       if v' = v ∧ tag = tag' ∧ arity = arity' then some t else none
     | _ => none
+
+theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : Signature}
+    (h : φ.matchAtom a = some t) (hφ : φ.wfIn Δ) : t.wfIn Δ := by
+  cases a with
+  | isint v =>
+    simp only [Formula.matchAtom] at h
+    split at h <;> simp_all [Formula.wfIn, Term.wfIn]
+  | isbool v =>
+    simp only [Formula.matchAtom] at h
+    split at h <;> simp_all [Formula.wfIn, Term.wfIn]
+  | isinj tag arity v =>
+    simp only [Formula.matchAtom] at h
+    split at h <;> simp_all [Formula.wfIn, Term.wfIn]
+
 
 theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
     (h : φ.matchAtom a = some t) : φ = a.toFormula t := by
@@ -101,19 +142,7 @@ theorem Atom.resolve_wfIn {a : Atom τ} {C : List Formula} {t : Term τ} {Δ : S
     (h : a.resolve C = some t) (hwf : ∀ φ ∈ C, φ.wfIn Δ) :
     t.wfIn Δ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
-  have heq := Formula.matchAtom_correct hφ_match
-  subst heq
-  have hφwf := hwf _ hφ_mem
-  cases a with
-  | isint u =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn] at hφwf
-    exact hφwf.2.2
-  | isbool u =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn] at hφwf
-    exact hφwf.2.2
-  | isinj tag arity u =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn] at hφwf
-    exact hφwf.2.2
+  exact Formula.matchAtom_wfIn hφ_match (hwf _ hφ_mem)
 
 
 -- ---------------------------------------------------------------------------
@@ -124,18 +153,6 @@ def Atom.toStringHum : {τ : Srt} → Atom τ → String
   | _, .isint  t => s!"isint {t.toStringHum}"
   | _, .isbool t => s!"isbool {t.toStringHum}"
   | _, .isinj tag arity t => s!"isinj {tag}/{arity} {t.toStringHum}"
-
-
--- ---------------------------------------------------------------------------
--- Semantics
--- ---------------------------------------------------------------------------
-
-def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
-  match p with
-  | isint t  => λ v => ⌜.int v = t.eval ρ⌝
-  | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
-  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
-
 
 -- ---------------------------------------------------------------------------
 -- Well-formedness
@@ -173,6 +190,20 @@ theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isinj tag arity t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
 
+theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
+    (hp : p.wfIn Δ) (ht : t.wfIn Δ) :
+    (p.toItem t).wfIn Δ := by
+  cases p with
+  | isint v =>
+    simp only [Atom.toItem, CtxItem.wfIn]
+    exact ⟨hp, trivial, ht⟩
+  | isbool v =>
+    simp only [Atom.toItem, CtxItem.wfIn]
+    exact ⟨hp, trivial, ht⟩
+  | isinj tag arity v =>
+    simp only [Atom.toItem, CtxItem.wfIn]
+    exact ⟨hp, trivial, ht⟩
+
 theorem Atom.toFormula_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     (hp : p.wfIn Δ) (ht : t.wfIn Δ) :
     (p.toFormula t).wfIn Δ := by
@@ -204,6 +235,13 @@ theorem Atom.toFormula_eval_1 {p : Atom τ} {t : Term τ} {ρ : Env} :
 theorem Atom.toFormula_eval_2 {p : Atom τ} {t : Term τ} {ρ : Env}
     : ⌜(p.toFormula t).eval ρ⌝ ⊢ p.eval ρ (t.eval ρ) := by
   exact Atom.eval_pure.2
+
+theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : Env} :
+    p.eval ρ (t.eval ρ) ⊢ CtxItem.interp ρ (p.toItem t) := by
+  cases p with
+  | isint v  => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isbool v => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isinj tag arity v => simp [Atom.eval, Atom.toFormula, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
 
 
 -- ---------------------------------------------------------------------------
@@ -319,35 +357,6 @@ private theorem VerifM.eval_tryCandidates
     | false =>
       simp at hq
       exact ih hq (fun p hp => hcands p (List.mem_cons_of_mem _ hp))
-
-/-- Look up an atom in the assertion context.
-    Tier 1: syntactic search through the context.
-    Tier 2: try candidate resolutions via the SMT solver. -/
-def VerifM.resolve (a : Atom τ) : VerifM (Option (Term τ)) := do
-  match ← VerifM.ctxPure (a.resolve ·) with
-  | some t => pure (some t)
-  | none => VerifM.tryCandidates a.candidates
-
-theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
-    {Q : Option (Term τ) → TransState → Env → Prop}
-    (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
-    (hpwf : pred.wfIn st.decls) :
-    ∃ result : Option (Term τ),
-      Q result st ρ
-      ∧ (∀ t, result = some t → (pred.toFormula t).eval ρ)
-      ∧ (∀ t, result = some t → t.wfIn st.decls) := by
-  unfold VerifM.resolve at h
-  have hb1 := VerifM.eval_bind _ _ _ _ h
-  have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
-  cases hres : pred.resolve st.asserts with
-  | some t =>
-    simp [hres] at hctx_q
-    exact ⟨some t, VerifM.eval_ret hctx_q,
-           fun t' ht' => by cases ht'; exact Atom.resolve_correct hres ρ hholds,
-           fun t' ht' => by cases ht'; exact Atom.resolve_wfIn hres hwfAsserts⟩
-  | none =>
-    simp [hres] at hctx_q
-    exact eval_tryCandidates hctx_q (fun p hp => hp) hpwf
 
 
 -- ---------------------------------------------------------------------------
@@ -529,3 +538,47 @@ theorem VerifM.eval_findMatchForce {lq : Term .value}
   · intro hQ
     simp at hQ
     exact (VerifM.eval_fatal hQ).elim
+
+
+/-- Look up an atom in the assertion context.
+    Tier 1: syntactic search through the context.
+    Tier 2: try candidate resolutions via the SMT solver. -/
+def VerifM.resolve (a : Atom τ) : VerifM (Option (Term τ)) := do
+  if a.pure then
+    match ← VerifM.ctxPure (a.resolve ·) with
+    | some t => pure (some t)
+    | none => VerifM.tryCandidates a.candidates
+  else
+    VerifM.fatal "here will be the points-to case"
+
+-- theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
+--     {Q : Option (Term τ) → TransState → Env → Prop}
+--     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
+--     (hpwf : pred.wfIn st.decls) :
+--     ∃ result : Option (Term τ),
+--       Q result st ρ
+--       ∧ (∀ t, result = some t → (pred.toFormula t).eval ρ)
+--       ∧ (∀ t, result = some t → t.wfIn st.decls) := by
+--   unfold VerifM.resolve at h
+--   have hb1 := VerifM.eval_bind _ _ _ _ h
+--   have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
+--   cases hres : pred.resolve st.asserts with
+--   | some t =>
+--     simp [hres] at hctx_q
+--     exact ⟨some t, VerifM.eval_ret hctx_q,
+--            fun t' ht' => by cases ht'; exact Atom.resolve_correct hres ρ hholds,
+--            fun t' ht' => by cases ht'; exact Atom.resolve_wfIn hres hwfAsserts⟩
+--   | none =>
+--     simp [hres] at hctx_q
+--     exact eval_tryCandidates hctx_q (fun p hp => hp) hpwf
+
+
+theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
+    {Q : Option (Term τ) → TransState → Env → Prop}
+    {R Φ : iProp}
+    (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
+    (hwf : pred.wfIn st.decls)
+    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls → Atom.eval p ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ  := by
+  sorry

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -551,34 +551,61 @@ def VerifM.resolve (a : Atom τ) : VerifM (Option (Term τ)) := do
   else
     VerifM.fatal "here will be the points-to case"
 
--- theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
---     {Q : Option (Term τ) → TransState → Env → Prop}
---     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
---     (hpwf : pred.wfIn st.decls) :
---     ∃ result : Option (Term τ),
---       Q result st ρ
---       ∧ (∀ t, result = some t → (pred.toFormula t).eval ρ)
---       ∧ (∀ t, result = some t → t.wfIn st.decls) := by
---   unfold VerifM.resolve at h
---   have hb1 := VerifM.eval_bind _ _ _ _ h
---   have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
---   cases hres : pred.resolve st.asserts with
---   | some t =>
---     simp [hres] at hctx_q
---     exact ⟨some t, VerifM.eval_ret hctx_q,
---            fun t' ht' => by cases ht'; exact Atom.resolve_correct hres ρ hholds,
---            fun t' ht' => by cases ht'; exact Atom.resolve_wfIn hres hwfAsserts⟩
---   | none =>
---     simp [hres] at hctx_q
---     exact eval_tryCandidates hctx_q (fun p hp => hp) hpwf
-
-
 theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
     {Q : Option (Term τ) → TransState → Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
-    (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls → Atom.eval p ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ  := by
-  sorry
+    (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
+      Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+  unfold VerifM.resolve at h
+  cases hpure : pred.pure with
+  | false =>
+    simp [hpure] at h
+    exact (VerifM.eval_fatal h).elim
+  | true =>
+    simp [hpure] at h
+    have hb1 := VerifM.eval_bind _ _ _ _ h
+    have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
+    cases hres : pred.resolve st.asserts with
+    | some t =>
+      simp [hres] at hctx_q
+      have hq := VerifM.eval_ret hctx_q
+      have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
+      have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
+        iapply Atom.toFormula_eval_2
+        ipure_intro
+        exact Atom.resolve_correct hres ρ hholds
+      have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
+          Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
+        istart
+        iintro H
+        isplitr [H]
+        · iapply hpred
+        · iexact H
+      exact hframe.trans (hsome t st hq rfl htwf)
+    | none =>
+      simp [hres] at hctx_q
+      obtain ⟨result, hq, hresult_eval, hresult_wf⟩ :=
+        eval_tryCandidates hctx_q (fun p hp => hp) hwf
+      cases hr : result with
+      | none =>
+        have hqnone : Q .none st ρ := by simpa [hr] using hq
+        exact hnone st hqnone rfl
+      | some t =>
+        have htwf : t.wfIn st.decls := hresult_wf t hr
+        have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
+        have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
+          iapply Atom.toFormula_eval_2
+          ipure_intro
+          exact hresult_eval t hr
+        have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
+            Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
+          istart
+          iintro H
+          isplitr [H]
+          · iapply hpred
+          · iexact H
+        exact hframe.trans (hsome t st hqsome rfl htwf)

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -209,32 +209,12 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     simp only [Atom.toItem, CtxItem.wfIn]
     exact ⟨hp, trivial, ht⟩
 
-theorem Atom.toFormula_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
-    (hp : p.wfIn Δ) (ht : t.wfIn Δ) :
-    (p.toFormula t).wfIn Δ := by
-  cases p with
-  | isint v =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn]
-    exact ⟨hp, trivial, ht⟩
-  | isbool v =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn]
-    exact ⟨hp, trivial, ht⟩
-  | isinj tag arity v =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn]
-    exact ⟨hp, trivial, ht⟩
-
 theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊣⊢ ⌜(p.toFormula t).eval ρ⌝ := by
   cases p with
   | isint v  => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
   | isinj tag arity v => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
-
-/-- If `p.eval ρ u` holds and `p` is wfIn fresh decls, then `p.toFormula (.var τ x)` holds
-    after updating `ρ` with `x ↦ u`. -/
-theorem Atom.toFormula_eval_1 {p : Atom τ} {t : Term τ} {ρ : Env} :
-     p.eval ρ (t.eval ρ) ⊢ ⌜(p.toFormula t).eval ρ⌝ := by
-  exact Atom.eval_pure.1
 
 /-- If `(p.toFormula t).eval ρ` holds, then `p.eval ρ (t.eval ρ)`. -/
 theorem Atom.toFormula_eval_2 {p : Atom τ} {t : Term τ} {ρ : Env}

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -344,3 +344,184 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
   | none =>
     simp [hres] at hctx_q
     exact eval_tryCandidates hctx_q (fun p hp => hp) hpwf
+
+
+-- ---------------------------------------------------------------------------
+-- Spatial resolution (linear search over st.owns)
+-- ---------------------------------------------------------------------------
+
+namespace SpatialAtom
+
+/-- Two points-to atoms with semantically equal locations have equal Iris
+    interpretations. -/
+theorem interp_pointsTo_loc_congr {ρ : Env} {l l' v : Term .value}
+    (h : Term.eval ρ l = Term.eval ρ l') :
+    interp ρ (.pointsTo l v) ⊣⊢ interp ρ (.pointsTo l' v) := by
+  simp only [interp, h]
+  exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
+
+end SpatialAtom
+
+/-- Walk a spatial context and return the index and stored value at the first
+    `pointsTo` whose location the SMT solver can prove equal to `lq`. The
+    returned index is into the input list; consumption is the caller's job. -/
+def VerifM.findMatchIn (lq : Term .value) :
+    SpatialContext → VerifM (Option (Nat × Term .value))
+  | [] => pure none
+  | .pointsTo l v :: rest => do
+      if ← VerifM.check (.eq .value lq l) then
+        pure (some (0, v))
+      else
+        return (← VerifM.findMatchIn lq rest).map fun (n, v') => (n + 1, v')
+
+/-- Search the current ownership context for a `pointsTo` at location `lq`,
+    returning the stored value and consuming the matched entry from `st.owns`. -/
+def VerifM.findMatch (lq : Term .value) : VerifM (Option (Term .value)) := do
+  let owns ← VerifM.ctx (fun st => (st.owns, st.owns))
+  match ← VerifM.findMatchIn lq owns with
+  | none => pure none
+  | some (n, v) =>
+      match SpatialContext.remove owns n with
+      | none => VerifM.fatal "findMatch: returned index out of range"
+      | some (_, rest) => do
+          let _ ← VerifM.ctx (fun _ => ((), rest))
+          pure (some v)
+
+/-- Correctness of `findMatchIn`: on a `some (n, v)` result, `remove ctx n`
+    extracts a points-to whose location the solver has proved equal to `lq`. -/
+theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
+    {st : TransState} {ρ : Env}
+    {Q : Option (Nat × Term .value) → TransState → Env → Prop}
+    (h : VerifM.eval (VerifM.findMatchIn lq ctx) st ρ Q)
+    (hlq : lq.wfIn st.decls) (hctx : ctx.wfIn st.decls) :
+    ∃ result,
+      Q result st ρ ∧
+      (∀ n v, result = some (n, v) →
+        ∃ l rest,
+          SpatialContext.remove ctx n = some (.pointsTo l v, rest) ∧
+          Term.eval ρ lq = Term.eval ρ l) := by
+  induction ctx generalizing Q with
+  | nil =>
+    simp only [VerifM.findMatchIn] at h
+    refine ⟨none, VerifM.eval_ret h, ?_⟩
+    intros n v hvr; simp at hvr
+  | cons a ctx ih =>
+    cases a with
+    | pointsTo l v =>
+      simp only [VerifM.findMatchIn] at h
+      have hb := VerifM.eval_bind _ _ _ _ h
+      have hcons := (SpatialContext.wfIn_cons _ _ _).1 hctx
+      have hatom := hcons.1
+      have hrest := hcons.2
+      have hwfeq : (Formula.eq .value lq l).wfIn st.decls := ⟨hlq, hatom.1⟩
+      obtain ⟨b, hb_sound, hq⟩ := VerifM.eval_check hb hwfeq
+      cases b with
+      | true =>
+        simp at hq
+        refine ⟨some (0, v), VerifM.eval_ret hq, ?_⟩
+        intros n' v' hnv
+        simp at hnv
+        obtain ⟨rfl, rfl⟩ := hnv
+        have heq : Term.eval ρ lq = Term.eval ρ l := by
+          have := hb_sound rfl
+          simpa [Formula.eval] using this
+        exact ⟨l, ctx, rfl, heq⟩
+      | false =>
+        simp at hq
+        have hb' := VerifM.eval_bind _ _ _ _ hq
+        obtain ⟨result', hres', hsome'⟩ := ih hb' hrest
+        cases result' with
+        | none =>
+          simp at hres'
+          refine ⟨none, VerifM.eval_ret hres', ?_⟩
+          intros n' v' hnv; simp at hnv
+        | some pair =>
+          obtain ⟨n₀, v₀⟩ := pair
+          simp at hres'
+          refine ⟨some (n₀ + 1, v₀), VerifM.eval_ret hres', ?_⟩
+          intros n' v' hnv
+          simp at hnv
+          obtain ⟨rfl, rfl⟩ := hnv
+          obtain ⟨l', rest', hrem, heq⟩ := hsome' n₀ v₀ rfl
+          refine ⟨l', .pointsTo l v :: rest', ?_, heq⟩
+          simp [SpatialContext.remove, hrem]
+
+/-- Correctness of `findMatch` in CPS style: the caller supplies Iris-level
+    continuations for the `some` and `none` branches. On `some v`, the
+    postcondition state has the matched points-to consumed from `st.owns`, and
+    the caller receives separate ownership of `lq ↦ v`. -/
+theorem VerifM.eval_findMatch {lq : Term .value}
+    {st : TransState} {ρ : Env}
+    {Q : Option (Term .value) → TransState → Env → Prop}
+    {R Φ : iProp}
+    (h : VerifM.eval (VerifM.findMatch lq) st ρ Q)
+    (hlq : lq.wfIn st.decls)
+    (hsome : ∀ v st', Q (some v) st' ρ →
+        st'.decls = st.decls → v.wfIn st.decls →
+        SpatialAtom.interp ρ (.pointsTo lq v) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hnone : Q none st ρ → SpatialContext.interp ρ st.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+  unfold VerifM.findMatch at h
+  have hb := VerifM.eval_bind _ _ _ _ h
+  have ⟨hk, howns, _, _⟩ := VerifM.eval_ctx hb
+  have hst_eq : ({ st with owns := st.owns } : TransState) = st := rfl
+  rw [hst_eq] at hk
+  have hk' := hk howns
+  have hb2 := VerifM.eval_bind _ _ _ _ hk'
+  obtain ⟨result, hres, hprop⟩ := eval_findMatchIn hb2 hlq howns
+  cases result with
+  | none =>
+    simp at hres
+    exact hnone (VerifM.eval_ret hres)
+  | some pair =>
+    obtain ⟨n, v⟩ := pair
+    obtain ⟨l, rest, hrem, heq⟩ := hprop n v rfl
+    have hrest_wf : SpatialContext.wfIn rest st.decls :=
+      (SpatialContext.wfIn_remove howns hrem).2
+    have hatom_wf : SpatialAtom.wfIn (.pointsTo l v) st.decls :=
+      (SpatialContext.wfIn_remove howns hrem).1
+    have hv_wf : v.wfIn st.decls := hatom_wf.2
+    simp [hrem] at hres
+    -- hres : (VerifM.ctx (fun _ => ((), rest)) >>= fun _ => pure (some v)).eval st ρ Q
+    have hb3 := VerifM.eval_bind _ _ _ _ hres
+    have ⟨hk3, _, _, _⟩ := VerifM.eval_ctx hb3
+    have hk3' := hk3 hrest_wf
+    have hQ : Q (some v) { st with owns := rest } ρ := VerifM.eval_ret hk3'
+    have hsplit := SpatialContext.interp_remove ρ st.owns n _ _ hrem
+    have hcong := SpatialAtom.interp_pointsTo_loc_congr (v := v) heq.symm
+    -- goal: st.owns.interp ρ ∗ R ⊢ Φ
+    -- st.owns.interp ρ ⊣⊢ (pointsTo l v).interp ρ ∗ rest.interp ρ
+    --                ⊣⊢ (pointsTo lq v).interp ρ ∗ rest.interp ρ
+    refine (Iris.BI.sep_mono hsplit.1 BIBase.Entails.rfl).trans ?_
+    refine (Iris.BI.sep_mono (Iris.BI.sep_mono hcong.1 BIBase.Entails.rfl) BIBase.Entails.rfl).trans ?_
+    refine Iris.BI.sep_assoc.1.trans ?_
+    exact hsome v { st with owns := rest } hQ rfl hv_wf
+
+/-- Like `findMatch`, but aborts with a fatal error if no matching points-to
+    is found in the current ownership context. -/
+def VerifM.findMatchForce (lq : Term .value) : VerifM (Term .value) := do
+  match ← VerifM.findMatch lq with
+  | some v => pure v
+  | none => VerifM.fatal s!"no matching points-to for location"
+
+/-- CPS correctness for `findMatchForce`: only a `some`-style continuation is
+    required, since the `none` branch is discharged by the fatal error. -/
+theorem VerifM.eval_findMatchForce {lq : Term .value}
+    {st : TransState} {ρ : Env}
+    {Q : Term .value → TransState → Env → Prop}
+    {R Φ : iProp}
+    (h : VerifM.eval (VerifM.findMatchForce lq) st ρ Q)
+    (hlq : lq.wfIn st.decls)
+    (hsome : ∀ v st', Q v st' ρ →
+        st'.decls = st.decls → v.wfIn st.decls →
+        SpatialAtom.interp ρ (.pointsTo lq v) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+  unfold VerifM.findMatchForce at h
+  have hb := VerifM.eval_bind _ _ _ _ h
+  refine eval_findMatch (R := R) (Φ := Φ) hb hlq ?_ ?_
+  · intros v st' hQ hdecls hv
+    simp at hQ
+    exact hsome v st' (VerifM.eval_ret hQ) hdecls hv
+  · intro hQ
+    simp at hQ
+    exact (VerifM.eval_fatal hQ).elim

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -178,7 +178,7 @@ mutual
         | none => compile Θ S B Γ body
         | some x =>
           let x' ← VerifM.decl (some x) .value
-          VerifM.assume (Formula.eq .value (.const (.uninterpreted x'.name .value)) se)
+          VerifM.assume (.pure (Formula.eq .value (.const (.uninterpreted x'.name .value)) se))
           compile Θ (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
     | .ifThenElse cond thn els ty => do
         let sc ← compile Θ S B Γ cond
@@ -187,10 +187,10 @@ mutual
         VerifM.expectEq "if branch type annotation mismatch" els.ty ty
         let branch ← VerifM.all [true, false]
         if branch then do
-          VerifM.assume (.not (.eq .value sc (.unop .ofBool (.const (.b false)))))
+          VerifM.assume (.pure (.not (.eq .value sc (.unop .ofBool (.const (.b false))))))
           compile Θ S B Γ thn
         else do
-          VerifM.assume (.eq .value sc (.unop .ofBool (.const (.b false))))
+          VerifM.assume (.pure (.eq .value sc (.unop .ofBool (.const (.b false)))))
           compile Θ S B Γ els
     | .app (.var f fty) args aty => do
         let spec ← VerifM.expectSome s!"no spec for function {f}" (S.lookup f)
@@ -236,7 +236,7 @@ mutual
     | (binder, body) => do
         VerifM.expectEq "match binder type annotation mismatch" binder.ty ty_i
         let xv ← VerifM.decl binder.name .value
-        VerifM.assume (.eq .value sc (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value))))
+        VerifM.assume (.pure (.eq .value sc (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value)))))
         VerifM.assumeAll (typeConstraints ty_i (.const (.uninterpreted xv.name .value)))
         match binder.name with
         | some x =>
@@ -675,7 +675,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         have hdecl := VerifM.eval_decl hdecl_eval
         have h := hdecl v_e
         obtain h := VerifM.eval_bind _ _ _ _ h
-        obtain h := VerifM.eval_assume h
+        obtain h := VerifM.eval_assumePure h
         apply h
         · simp only [Formula.wfIn, Term.wfIn, Const.wfIn]
           refine ⟨?_, Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _)
@@ -742,8 +742,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
     have hwf_eq : (Formula.eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))).wfIn st₁.decls := by
       simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
-    have htrue_cont := VerifM.eval_assume (VerifM.eval_bind _ _ _ _ htrue)
-    have hfalse_cont := VerifM.eval_assume (VerifM.eval_bind _ _ _ _ hfalse)
+    have htrue_cont := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ htrue)
+    have hfalse_cont := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ hfalse)
     let φ_eq : Formula := .eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))
     let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
     let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
@@ -1004,7 +1004,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
     let xv := TransState.freshConst hint .value st
     have heval_inst := hdecl payload
     have heval_assume := VerifM.eval_bind _ _ _ _ heval_inst
-    have hassume := VerifM.eval_assume heval_assume
+    have hassume := VerifM.eval_assumePure heval_assume
     let st₁ : TransState := { decls := st.decls.addConst xv, asserts := st.asserts, owns := st.owns }
     let ρ₁ := ρ.updateConst .value xv.name payload
     have hxv_fresh : xv.name ∉ st.decls.allNames :=

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -23,13 +23,25 @@ structure TransState where
   asserts : Context
   owns    : SpatialContext
 
+inductive CtxItem where
+  | pure : Formula → CtxItem
+  | spatial : SpatialAtom → CtxItem
+
+namespace CtxItem
+
+def wfIn : CtxItem → Signature → Prop
+  | .pure φ, Δ => φ.wfIn Δ
+  | .spatial a, Δ => a.wfIn Δ
+
+end CtxItem
+
 inductive VerifM : Type → Type 1 where
   | ret : α → VerifM α
   | bind : VerifM α → (α → VerifM β) → VerifM β
   /-- Declare a fresh SMT constant. -/
   | decl : Option String → Srt → VerifM FOL.Const
-  /-- Add a formula to the assertion context (permanent, no check). -/
-  | assume : Formula → VerifM Unit
+  /-- Add a context item to the verifier state (permanent, no check). -/
+  | assume : CtxItem → VerifM Unit
   /-- Check whether φ is provable from the current context.
       Returns `true` if UNSAT (provable), `false` otherwise. Never fails. -/
   | check : Formula → VerifM Bool
@@ -74,7 +86,7 @@ def VerifM.expectSome (msg : String) (x : Option α) : VerifM α := do
 /-- Assume all formulas in a list via `VerifM.assume`. -/
 def VerifM.assumeAll : List Formula → VerifM Unit
   | [] => pure ()
-  | φ :: φs => do VerifM.assume φ; VerifM.assumeAll φs
+  | φ :: φs => do VerifM.assume (.pure φ); VerifM.assumeAll φs
 
 /-! ### Translation to ScopedM -/
 
@@ -141,6 +153,16 @@ theorem TransState.addAssert.wf (st : TransState) :
   · exact hwf.namesDisjoint
   · exact hwf.ownsWf
 
+theorem TransState.addSpatial.wf (st : TransState) :
+  TransState.wf st →
+  a.wfIn st.decls →
+  TransState.wf { st with owns := a :: st.owns } := by
+  intro hwf ha
+  constructor
+  · exact hwf.assertsWf
+  · exact hwf.namesDisjoint
+  · simpa [SpatialContext.wfIn_cons] using And.intro ha hwf.ownsWf
+
 
 def TransCont α := α → TransState → ScopedM (Except VerifError Unit)
 
@@ -175,9 +197,13 @@ def VerifM.translate :
       let c := st.freshConst hint t
       .declareConst c.name t (fun () =>
         k (.ok c) { st with decls := st.decls.addConst c })
-  | .assume φ, st, k =>
-      ScopedM.assert φ (fun () =>
-        k (.ok ()) { st with asserts := φ :: st.asserts })
+  | .assume item, st, k =>
+      match item with
+      | .pure φ =>
+          ScopedM.assert φ (fun () =>
+            k (.ok ()) { st with asserts := φ :: st.asserts })
+      | .spatial a =>
+          k (.ok ()) { st with owns := a :: st.owns }
   | .check φ, st, k =>
       .bracket
         (ScopedM.assert (.not φ) (fun () =>
@@ -207,7 +233,10 @@ def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState �
   | .decl hint t, st, ρ, P =>
       let c := st.freshConst hint t
       ∀ u, P c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u)
-  | .assume φ, st, ρ, P => φ.wfIn st.decls → φ.eval ρ → P () { st with asserts := φ :: st.asserts } ρ
+  | .assume item, st, ρ, P =>
+      match item with
+      | .pure φ => φ.wfIn st.decls → φ.eval ρ → P () { st with asserts := φ :: st.asserts } ρ
+      | .spatial a => a.wfIn st.decls → P () { st with owns := a :: st.owns } ρ
   | .check φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ) ∧ P b st ρ
   | .fatal _, _, _, _ => False
   | .failed _, _, _, _ => False
@@ -234,9 +263,14 @@ theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : 
     exact agreeOn_update_fresh_const
       (c := ⟨fresh (addNumbers (hint.getD "_v")) st.decls.allNames, t⟩)
       (fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _))
-  | assume =>
-    intro hwf hφ
-    exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf hφ)
+  | assume item =>
+    cases item with
+    | pure φ =>
+      intro hwf hφ
+      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf hφ)
+    | spatial a =>
+      intro hwf
+      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf)
   | check =>
     intro hwf
     obtain ⟨b, hb, hp⟩ := h hwf
@@ -290,14 +324,20 @@ theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
     · intro φ hφ
       exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
     · exact ⟨TransState.freshConst.wf _ hwf, h⟩
-  | assume φ =>
-    simp only [VerifM.eval_rec] at h ⊢
-    intro hwf' hφ
-    refine ⟨?_, TransState.addAssert.wf _ hwf hwf', h hwf' hφ⟩
-    intro ψ hψ
-    cases hψ with
-    | head => exact hφ
-    | tail _ hψ => exact g ψ hψ
+  | assume item =>
+    cases item with
+    | pure φ =>
+      simp only [VerifM.eval_rec] at h ⊢
+      intro hwf' hφ
+      refine ⟨?_, TransState.addAssert.wf _ hwf hwf', h hwf' hφ⟩
+      intro ψ hψ
+      cases hψ with
+      | head => exact hφ
+      | tail _ hψ => exact g ψ hψ
+    | spatial a =>
+      simp only [VerifM.eval_rec] at h ⊢
+      intro hwf'
+      exact ⟨g, TransState.addSpatial.wf _ hwf hwf', h hwf'⟩
   | check φ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro hwf'
@@ -393,11 +433,17 @@ theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
     simp only [VerifM.eval_rec]
     intro u
     exact ⟨_, h⟩
-  | assume φ =>
-    simp only [VerifM.translate] at h
-    have h := ScopedM.eval_assert h
-    intro hwf' hφ
-    exact ⟨_, h⟩
+  | assume item =>
+    cases item with
+    | pure φ =>
+      simp only [VerifM.translate] at h
+      have h := ScopedM.eval_assert h
+      intro hwf' hφ
+      exact ⟨_, h⟩
+    | spatial a =>
+      simp only [VerifM.translate] at h
+      intro hwf'
+      exact ⟨_, h⟩
   | check φ =>
     simp only [VerifM.translate] at h
     obtain ⟨b, _, hxx, hk⟩ := ScopedM.eval_bracket h
@@ -518,11 +564,17 @@ theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ 
     ∀ u, Q c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u) :=
   fun u => (h.2.2 u).2.2
 
-theorem VerifM.eval_assume {φ : Formula} {st : TransState} {ρ : Env}
+theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : Env}
     {Q : Unit → TransState → Env → Prop}
-    (h : VerifM.eval (.assume φ) st ρ Q) :
+    (h : VerifM.eval (.assume (.pure φ)) st ρ Q) :
     φ.wfIn st.decls → φ.eval ρ → Q () { st with asserts := φ :: st.asserts } ρ :=
   fun hwf hφ => (h.2.2 hwf hφ).2.2
+
+theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
+    (h : VerifM.eval (.assume (.spatial a)) st ρ Q) :
+    a.wfIn st.decls → Q () { st with owns := a :: st.owns } ρ :=
+  fun hwf => (h.2.2 hwf).2.2
 
 theorem VerifM.eval_check {φ : Formula} {st : TransState} {ρ : Env}
     {Q : Bool → TransState → Env → Prop}
@@ -649,7 +701,7 @@ theorem VerifM.eval_assumeAll {φs : List Formula}
     intro hwf heval
     simp only [VerifM.assumeAll] at h
     have hb := VerifM.eval_bind _ _ _ _ h
-    have hassume := VerifM.eval_assume hb
+    have hassume := VerifM.eval_assumePure hb
     have hcont := hassume
       (hwf φ (List.mem_cons_self ..))
       (heval φ (List.mem_cons_self ..))

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -127,6 +127,11 @@ def TransState.freshConst (hint : Option String) (t : Srt) (st : TransState) : F
   let x' := fresh (addNumbers base) st.decls.allNames
   ⟨x', t⟩
 
+def TransState.addItem (st: TransState) (item: CtxItem) :=
+  match item with
+  | .pure φ =>  { st with asserts := φ :: st.asserts }
+  | .spatial p => { st with owns := p :: st.owns }
+
 theorem TransState.freshConst.wf {hint t} (st : TransState) :
   TransState.wf st →
   TransState.wf { st with decls := st.decls.addConst (st.freshConst hint t) } := by
@@ -575,6 +580,19 @@ theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : Env}
     (h : VerifM.eval (.assume (.spatial a)) st ρ Q) :
     a.wfIn st.decls → Q () { st with owns := a :: st.owns } ρ :=
   fun hwf => (h.2.2 hwf).2.2
+
+theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
+    (h : VerifM.eval (.assume item) st ρ Q) :
+    item.wfIn st.decls → (match item with | .pure φ => φ.eval ρ | .spatial _ => True) → Q () (st.addItem item) ρ :=
+  by
+    cases item with
+    | pure φ =>
+      simp [TransState.addItem]
+      exact VerifM.eval_assumePure h
+    | spatial a =>
+      simp [TransState.addItem]
+      exact VerifM.eval_assumeSpatial h
 
 theorem VerifM.eval_check {φ : Formula} {st : TransState} {ρ : Env}
     {Q : Bool → TransState → Env → Prop}

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -79,7 +79,7 @@ def PredTrans.implement (σ : FiniteSubst) (pt : PredTrans) (body : VerifM (Term
   let result ← body
   let resVar ← VerifM.decl (some postName) .value
   let σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
-  VerifM.assume (.eq .value (.const (.uninterpreted resVar.name .value)) result)
+  VerifM.assume (.pure (.eq .value (.const (.uninterpreted resVar.name .value)) result))
   let (_, ()) ← Assertion.prove σ₂ postBody
   pure ()
 
@@ -288,7 +288,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         simp only [Formula.eval, Term.eval, Const.denote]
         simpa [Env.lookupConst, Env.updateConst] using
           (Term.eval_env_agree hwf_result (agreeOn_update_fresh_const hfresh_decls))
-      have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
+      have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
       set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
       have hσ₂wf : σ₂.wf (st₂.decls.addConst resVar) := by
         simpa [σ₂] using

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -237,7 +237,7 @@ end
     else VerifM.fatal s!"type mismatch in call to spec"
     let argVar ← VerifM.decl (some name) .value
     let σ' := σ.rename ⟨name, .value⟩ argVar.name
-    VerifM.assume (.eq .value (.const (.uninterpreted argVar.name .value)) sarg)
+    VerifM.assume (.pure (.eq .value (.const (.uninterpreted argVar.name .value)) sarg))
     Spec.declareArgs Θ σ' rest sargs
   | _, _ => VerifM.fatal "wrong number of arguments"
 
@@ -617,7 +617,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
               (fun argVar st' ρ' =>
                 (do
                   VerifM.assume
-                    (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg)
+                    (.pure (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg))
                   Spec.declareArgs Θ (σ.rename ⟨name, .value⟩ argVar.name) rest sargs_rest).eval
                     st' ρ' Ψ) := by
           simpa using
@@ -625,7 +625,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
               (m := VerifM.decl (some name) .value)
               (k := fun argVar => do
                 VerifM.assume
-                  (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg)
+                  (.pure (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg))
                 Spec.declareArgs Θ (σ.rename ⟨name, .value⟩ argVar.name) rest sargs_rest)
               (st := st) (ρ := ρ) hret)
         have hdecl := VerifM.eval_decl hbind'
@@ -658,7 +658,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           simpa [Env.lookupConst, Env.updateConst] using
             (Term.eval_env_agree hsarg_wf (agreeOn_update_fresh_const hfresh_decls))
         have hbind'' := VerifM.eval_bind _ _ _ _ hdecl
-        have hassume := VerifM.eval_assume hbind'' heq_wf heq_holds
+        have hassume := VerifM.eval_assumePure hbind'' heq_wf heq_holds
         set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ)
         have hsargs_rest : ∀ p ∈ sargs_rest, (p : TinyML.Typ × Term .value).2.wfIn
             (st.decls.addConst argVar) := by


### PR DESCRIPTION
This PR prepares the foundation of Mica for proper separation logic atoms. It removes the assumption that atoms can be converted to formulas and that they are always pure.