### PR TITLE
Ownership assertions and stateful operations

### DIFF
--- a/Examples/references.ml
+++ b/Examples/references.ml
@@ -1,0 +1,96 @@
+(* Examples that exercise allocation, dereference, assignment, and sequencing. *)
+
+(* Swap the contents of two integer references. *)
+let swap (x : int ref) (y : int ref) : unit =
+  let tmp = !x in
+  x := !y;
+  y := tmp
+[@@spec fun x y ->
+  bind (own x) @@ fun vx ->
+  bind (isint vx) @@ fun a ->
+  bind (own y) @@ fun vy ->
+  bind (isint vy) @@ fun b ->
+  ret (fun r ->
+    assert (r = ());
+    bind (own x) @@ fun vx2 ->
+    bind (isint vx2) @@ fun a2 ->
+    bind (own y) @@ fun vy2 ->
+    bind (isint vy2) @@ fun b2 ->
+    assert (a2 = b);
+    assert (b2 = a))];;
+
+(* Swap two local cells and return the observed pair. *)
+let swap_pair_via_refs (a : int) (b : int) : int * int =
+  let x = ref a in
+  let y = ref b in
+  swap x y;
+  (!x, !y)
+[@@spec fun a b ->
+  bind (isint a) @@ fun n ->
+  bind (isint b) @@ fun m ->
+  ret (fun v ->
+    bind (isint v.0) @@ fun fst ->
+    bind (isint v.1) @@ fun snd ->
+    assert (fst = m);
+    assert (snd = n))];;
+
+(* Reuse swap twice; the state returns to the start. *)
+let id_by_swapping_twice (a : int) (b : int) : int * int =
+  let x = ref a in
+  let y = ref b in
+  swap x y;
+  swap x y;
+  (!x, !y)
+[@@spec fun a b ->
+  bind (isint a) @@ fun n ->
+  bind (isint b) @@ fun m ->
+  ret (fun v ->
+    bind (isint v.0) @@ fun fst ->
+    bind (isint v.1) @@ fun snd ->
+    assert (fst = n);
+    assert (snd = m))];;
+
+(* Sum into the left cell while keeping the right one unchanged. *)
+let sum_into_left_local (a : int) (b : int) : int * int =
+  let x = ref a in
+  let y = ref b in
+  x := !x + !y;
+  (!x, !y)
+[@@spec fun a b ->
+  bind (isint a) @@ fun n ->
+  bind (isint b) @@ fun m ->
+  ret (fun v ->
+    bind (isint v.0) @@ fun left ->
+    bind (isint v.1) @@ fun right ->
+    assert (left = n + m);
+    assert (right = m))];;
+
+(* A slightly more creative reference program: conditionally normalize order by swapping. *)
+let sort2_via_swap (a : int) (b : int) : int * int =
+  let x = ref a in
+  let y = ref b in
+  if !x > !y then swap x y else ();
+  (!x, !y)
+[@@spec fun a b ->
+  bind (isint a) @@ fun n ->
+  bind (isint b) @@ fun m ->
+  ret (fun v ->
+    bind (isint v.0) @@ fun fst ->
+    bind (isint v.1) @@ fun snd ->
+    assert (fst <= snd);
+    if n > m then
+      assert (fst = m && snd = n)
+    else
+      assert (fst = n && snd = m))];;
+
+(* Two increments through the same local cell. *)
+let bump_twice (n : int) : int =
+  let x = ref n in
+  x := !x + 1;
+  x := !x + 1;
+  !x
+[@@spec fun n ->
+  bind (isint n) @@ fun m ->
+  ret (fun v ->
+    bind (isint v) @@ fun r ->
+    assert (r = m + 2))];;

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -84,6 +84,10 @@ def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyM
     | "int"  => if args'.isEmpty then .ok .int  else err loc (.arityMismatch 0 args'.length)
     | "bool" => if args'.isEmpty then .ok .bool else err loc (.arityMismatch 0 args'.length)
     | "unit" => if args'.isEmpty then .ok .unit else err loc (.arityMismatch 0 args'.length)
+    | "ref" =>
+      match args' with
+      | [arg] => .ok (.ref arg)
+      | _ => err loc (.arityMismatch 1 args'.length)
     | _ =>
       if env.types.elem name then .ok (.named name args')
       else err loc (.unknownType name)

--- a/Mica/Frontend/Spec.lean
+++ b/Mica/Frontend/Spec.lean
@@ -40,6 +40,7 @@ inductive Pred where
   | isint (arg : Term)
   | isbool (arg : Term)
   | isinj (tag arity : Nat) (arg : Term)
+  | own (loc : Term)
   deriving Repr, BEq, Inhabited
 
 inductive Assert (α : Type) where

--- a/Mica/Frontend/SpecParser.lean
+++ b/Mica/Frontend/SpecParser.lean
@@ -43,7 +43,8 @@ private def parsePred : Untyped.Expr → M Pred
   | .app (.var "isbool") [e] => do .ok (.isbool (← parseTerm e))
   | .app (.var "isinj") [.const (.int tag), .const (.int arity), e] => do
     .ok (.isinj tag.toNat arity.toNat (← parseTerm e))
-  | e => .error s!"expected type predicate (isint, isbool, isinj), got {repr e}"
+  | .app (.var "own") [e] => do .ok (.own (← parseTerm e))
+  | e => .error s!"expected type predicate (isint, isbool, isinj, own), got {repr e}"
 
 private def parseAssert (inner : Untyped.Expr → M α)
     (bareAssert : Untyped.Expr → M (Assert α)) : Untyped.Expr → M (Assert α)

--- a/Mica/TinyML/LogicalRelation.lean
+++ b/Mica/TinyML/LogicalRelation.lean
@@ -10,6 +10,7 @@ mutual
     | int  (n : Int)  : ValHasType Θ (.int n)  .int
     | bool (b : Bool) : ValHasType Θ (.bool b) .bool
     | unit            : ValHasType Θ .unit      .unit
+    | ref τ       : ValHasType Θ (.loc l)   (.ref τ)
     | inj  : (ht : ts[tag]? = some t)
             → ValHasType Θ payload t
             → ValHasType Θ (.inj tag ts.length payload) (.sum ts)

--- a/Mica/TinyML/LogicalRelation.lean
+++ b/Mica/TinyML/LogicalRelation.lean
@@ -10,7 +10,7 @@ mutual
     | int  (n : Int)  : ValHasType Θ (.int n)  .int
     | bool (b : Bool) : ValHasType Θ (.bool b) .bool
     | unit            : ValHasType Θ .unit      .unit
-    | ref τ       : ValHasType Θ (.loc l)   (.ref τ)
+    | ref l τ         : ValHasType Θ (.loc l)   (.ref τ)
     | inj  : (ht : ts[tag]? = some t)
             → ValHasType Θ payload t
             → ValHasType Θ (.inj tag ts.length payload) (.sum ts)

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -23,6 +23,7 @@ inductive Atom : Srt → Type where
   | isint  : Term .value → Atom .int
   | isbool : Term .value → Atom .bool
   | isinj  (tag : Nat) (arity : Nat) : Term .value → Atom .value
+  | own    : Term .value → Atom .value
 
 
 def Atom.pure {τ: Srt} (a : Atom τ) : Bool :=
@@ -30,6 +31,7 @@ def Atom.pure {τ: Srt} (a : Atom τ) : Bool :=
   | isint _ => true
   | isbool _ => true
   | isinj _ _ _ => true
+  | own _ => false
 
 
 -- ---------------------------------------------------------------------------
@@ -40,6 +42,7 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
   | .isint t  => .isint (t.subst σ)
   | .isbool t => .isbool (t.subst σ)
   | .isinj tag arity t => .isinj tag arity (t.subst σ)
+  | .own t    => .own (t.subst σ)
 
 
 namespace CtxItem
@@ -62,6 +65,7 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
   | .isint v => .pure (.eq .value v (.unop .ofInt t))
   | .isbool v => .pure (.eq .value v (.unop .ofBool t))
   | .isinj tag arity v => .pure (.eq .value v (.unop (.mkInj tag arity) t))
+  | .own l => .spatial (.pointsTo l t)
 
 -- ---------------------------------------------------------------------------
 -- Semantics
@@ -72,6 +76,7 @@ def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
   | isint t  => λ v => ⌜.int v = t.eval ρ⌝
   | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
   | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
+  | own l => λ v => ∃ loc : Runtime.Location, ⌜l.eval ρ = .loc loc⌝ ∗ loc ↦ v
 
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
@@ -90,6 +95,7 @@ def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
     | .eq .value v' (.unop (.mkInj tag' arity') t) =>
       if v' = v ∧ tag = tag' ∧ arity = arity' then some t else none
     | _ => none
+  | .own _ => none
 
 theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : Signature}
     (h : φ.matchAtom a = some t) (hφ : φ.wfIn Δ) : t.wfIn Δ := by
@@ -103,6 +109,7 @@ theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : 
   | isinj tag arity v =>
     simp only [Formula.matchAtom] at h
     split at h <;> simp_all [Formula.wfIn, Term.wfIn]
+  | own l => simp only [Formula.matchAtom] at h; cases h
 
 
 theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
@@ -118,6 +125,7 @@ theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
     simp only [Formula.matchAtom] at h
     split at h <;> simp_all
     obtain ⟨⟨rfl, rfl, rfl⟩, rfl⟩ := h; rfl
+  | own l => simp only [Formula.matchAtom] at h; cases h
 
 
 -- ---------------------------------------------------------------------------
@@ -151,6 +159,7 @@ def Atom.toStringHum : {τ : Srt} → Atom τ → String
   | _, .isint  t => s!"isint {t.toStringHum}"
   | _, .isbool t => s!"isbool {t.toStringHum}"
   | _, .isinj tag arity t => s!"isinj {tag}/{arity} {t.toStringHum}"
+  | _, .own t => s!"own {t.toStringHum}"
 
 -- ---------------------------------------------------------------------------
 -- Well-formedness
@@ -161,18 +170,21 @@ def Atom.wfIn (Δ : Signature) : Atom τ → Prop
   | .isint t  => t.wfIn Δ
   | .isbool t => t.wfIn Δ
   | .isinj _ _ t => t.wfIn Δ
+  | .own t    => t.wfIn Δ
 
 def Atom.checkWf (p : Atom τ) (Δ : Signature) : Except String Unit :=
   match p with
   | .isint t  => t.checkWf Δ
   | .isbool t => t.checkWf Δ
   | .isinj _ _ t => t.checkWf Δ
+  | .own t    => t.checkWf Δ
 
 theorem Atom.checkWf_ok {p : Atom τ} {Δ : Signature} (h : p.checkWf Δ = .ok ()) : p.wfIn Δ := by
   cases p with
   | isint t  => exact Term.checkWf_ok h
   | isbool t => exact Term.checkWf_ok h
   | isinj tag arity t => exact Term.checkWf_ok h
+  | own t => exact Term.checkWf_ok h
 
 theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
     (h : p.wfIn Δ) (hmono : Δ.Subset Δ') (hwf : Δ'.wf) : p.wfIn Δ' := by
@@ -180,6 +192,7 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | isint t  => exact Term.wfIn_mono t h hmono hwf
   | isbool t => exact Term.wfIn_mono t h hmono hwf
   | isinj tag arity t => exact Term.wfIn_mono t h hmono hwf
+  | own t => exact Term.wfIn_mono t h hmono hwf
 
 theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
     (hwf : p.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') : p.eval ρ = p.eval ρ' := by
@@ -187,6 +200,7 @@ theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isinj tag arity t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
+  | own l => simp [Atom.eval, Term.eval_env_agree hwf hagree]
 
 theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     (hp : p.wfIn Δ) (ht : t.wfIn Δ) :
@@ -201,6 +215,9 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
   | isinj tag arity v =>
     simp only [Atom.toItem, CtxItem.wfIn]
     exact ⟨hp, trivial, ht⟩
+  | own l =>
+    simp only [Atom.toItem, CtxItem.wfIn, SpatialAtom.wfIn]
+    exact ⟨hp, ht⟩
 
 theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊣⊢ CtxItem.interp ρ (p.toItem t) := by
@@ -208,6 +225,9 @@ theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | own l =>
+    simp only [Atom.eval, Atom.toItem, CtxItem.interp, SpatialAtom.interp]
+    exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 
 /-- If `p.toItem t` holds semantically, then `p.eval ρ (t.eval ρ)`. -/
 theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : Env}
@@ -216,10 +236,7 @@ theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : Env}
 
 theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊢ CtxItem.interp ρ (p.toItem t) := by
-  cases p with
-  | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
-  | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
-  | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  exact Atom.eval_pure.1
 
 theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
@@ -230,6 +247,9 @@ theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
   | isinj tag arity v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+  | own l =>
+    simp only [Atom.toItem, CtxItem.purePart]
+    exact pure_intro trivial
 
 
 -- ---------------------------------------------------------------------------
@@ -253,6 +273,10 @@ theorem Atom.eval_subst {p : Atom τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signatur
     funext v
     simp only [Atom.subst, Atom.eval]
     rw [Term.eval_subst hp hσ hwfΔ']
+  | own l =>
+    funext v
+    simp only [Atom.subst, Atom.eval]
+    rw [Term.eval_subst hp hσ hwfΔ']
 
 theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn dom Δ') (hdom : Δ.vars ⊆ dom)
@@ -263,6 +287,7 @@ theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Sign
   | isint t  => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
   | isbool t => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
   | isinj tag arity t => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
+  | own t => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
 
 
 -- ---------------------------------------------------------------------------
@@ -275,6 +300,7 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .isint  v => [(.unpred .isInt v, .unop .toInt v)]
   | .isbool v => [(.unpred .isBool v, .unop .toBool v)]
   | .isinj tag arity v => [(.unpred (.isInj tag arity) v, .unop .payloadOf v)]
+  | .own _ => []
 
 theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : Env}
     (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : ⊢ (a.toItem t).interp ρ := by
@@ -297,6 +323,7 @@ theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ :
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
+  | own l => simp [candidates] at hmem
 
 theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Signature}
     (hmem : (φ, t) ∈ a.candidates) (h : a.wfIn Δ) : φ.wfIn Δ ∧ t.wfIn Δ := by
@@ -304,6 +331,7 @@ theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Si
   | isint v  => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
   | isbool v => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
   | isinj tag arity v => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
+  | own l => simp [candidates] at hmem
 
 
 -- ---------------------------------------------------------------------------
@@ -534,30 +562,28 @@ theorem VerifM.eval_findMatchForce {lq : Term .value}
 /-- Look up an atom in the assertion context.
     Tier 1: syntactic search through the context.
     Tier 2: try candidate resolutions via the SMT solver. -/
-def VerifM.resolve (a : Atom τ) : VerifM (Option (Term τ)) := do
-  if a.pure then
-    match ← VerifM.ctxPure (a.resolve ·) with
-    | some t => pure (some t)
-    | none => VerifM.tryCandidates a.candidates
-  else
-    VerifM.fatal "here will be the points-to case"
+def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
+  | _, .own l => do
+      let v ← VerifM.findMatchForce l
+      pure (some v)
+  | _, a => do
+      match ← VerifM.ctxPure (a.resolve ·) with
+      | some t => pure (some t)
+      | none => VerifM.tryCandidates a.candidates
 
-theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
+/-- Helper: resolution of a pure atom via formula matching or SMT candidates. -/
+private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ : Env}
     {Q : Option (Term τ) → TransState → Env → Prop}
     {R Φ : iProp}
-    (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
+    (h : VerifM.eval (do
+      match ← VerifM.ctxPure (pred.resolve ·) with
+      | some t => pure (some t)
+      | none => VerifM.tryCandidates pred.candidates) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
     (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
       Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
     SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
-  unfold VerifM.resolve at h
-  cases hpure : pred.pure with
-  | false =>
-    simp [hpure] at h
-    exact (VerifM.eval_fatal h).elim
-  | true =>
-    simp [hpure] at h
     have hb1 := VerifM.eval_bind _ _ _ _ h
     have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
     cases hres : pred.resolve st.asserts with
@@ -596,3 +622,34 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
           · iapply hpred
           · iexact H
         exact hframe.trans (hsome t st hqsome rfl htwf)
+
+theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
+    {Q : Option (Term τ) → TransState → Env → Prop}
+    {R Φ : iProp}
+    (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
+    (hwf : pred.wfIn st.decls)
+    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
+      Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+  match pred, hwf, hsome, h with
+  | .own l, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    have hb := VerifM.eval_bind _ _ _ _ h
+    refine VerifM.eval_findMatchForce (R := R) (Φ := Φ) hb hwf ?_
+    intros v st' hQv hdecls hvwf
+    have hqsome : Q (.some v) st' ρ := VerifM.eval_ret hQv
+    have hsome' := hsome v st' hqsome hdecls hvwf
+    have heq : SpatialAtom.interp ρ (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ) := by
+      simp only [Atom.eval, SpatialAtom.interp]
+      exact BIBase.Entails.rfl
+    exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
+  | .isint t, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    exact VerifM.eval_resolve_pure (pred := .isint t) h hwf hnone hsome
+  | .isbool t, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    exact VerifM.eval_resolve_pure (pred := .isbool t) h hwf hnone hsome
+  | .isinj tag arity t, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    exact VerifM.eval_resolve_pure (pred := .isinj tag arity t) h hwf hnone hsome

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -564,8 +564,7 @@ theorem VerifM.eval_findMatchForce {lq : Term .value}
     Tier 2: try candidate resolutions via the SMT solver. -/
 def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
   | _, .own l => do
-      let v ← VerifM.findMatchForce l
-      pure (some v)
+      VerifM.findMatch l
   | _, a => do
       match ← VerifM.ctxPure (a.resolve ·) with
       | some t => pure (some t)
@@ -635,15 +634,15 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
   match pred, hwf, hsome, h with
   | .own l, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    have hb := VerifM.eval_bind _ _ _ _ h
-    refine VerifM.eval_findMatchForce (R := R) (Φ := Φ) hb hwf ?_
-    intros v st' hQv hdecls hvwf
-    have hqsome : Q (.some v) st' ρ := VerifM.eval_ret hQv
-    have hsome' := hsome v st' hqsome hdecls hvwf
-    have heq : SpatialAtom.interp ρ (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ) := by
-      simp only [Atom.eval, SpatialAtom.interp]
-      exact BIBase.Entails.rfl
-    exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
+    refine VerifM.eval_findMatch (R := R) (Φ := Φ) h hwf ?_ ?_
+    · intros v st' hqsome hdecls hvwf
+      have hsome' := hsome v st' hqsome hdecls hvwf
+      have heq : SpatialAtom.interp ρ (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ) := by
+        simp only [Atom.eval, SpatialAtom.interp]
+        exact BIBase.Entails.rfl
+      exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
+    · intros hqnone
+      exact hnone st hqnone rfl
   | .isint t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
     exact VerifM.eval_resolve_pure (pred := .isint t) h hwf hnone hsome

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -227,7 +227,29 @@ mutual
         let se ← compile Θ S B Γ e
         if TinyML.Typ.sub Θ e.ty ty then pure se
         else VerifM.fatal s!"cast type mismatch"
-    | .app _ _ _ | .fix _ _ _ _ | .ref _ | .deref _ _ | .store _ _ => VerifM.fatal "unsupported expression"
+    | .ref e => do
+        let sv ← compile Θ S B Γ e
+        let l ← VerifM.decl none .value
+        VerifM.assume (.spatial (.pointsTo (.const (.uninterpreted l.name .value)) sv))
+        pure (.const (.uninterpreted l.name .value))
+    | .deref e ty => do
+        VerifM.expectEq "deref type annotation mismatch" e.ty (.ref ty)
+        let sl ← compile Θ S B Γ e
+        match ← VerifM.resolve (.own sl) with
+        | some sv =>
+          VerifM.assume (.spatial (.pointsTo sl sv))
+          pure sv
+        | none => VerifM.failed "could not resolve points-to assertion"
+    | .store loc val => do
+        VerifM.expectEq "store location type mismatch" loc.ty (.ref val.ty)
+        let sv ← compile Θ S B Γ val
+        let sl ← compile Θ S B Γ loc
+        match ← VerifM.resolve (.own sl) with
+        | some _ =>
+          VerifM.assume (.spatial (.pointsTo sl sv))
+          pure (Term.const .unit)
+        | none => VerifM.failed "could not resolve points-to assertion"
+    | .app _ _ _ | .fix _ _ _ _ => VerifM.fatal "unsupported expression"
 
   /-- Compile a single match branch: assume the scrutinee is `mkInj i n payload`, then compile the body. -/
   def compileBranch (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -455,9 +477,179 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       trivial
       (by simp [Term.eval])
       .unit
-  | fix _ _ _ _ | ref _ | deref _ _ | store _ _ =>
+  | fix _ _ _ _ =>
     simp only [compile] at heval
     exact (VerifM.eval_fatal heval).elim
+  | ref e =>
+    unfold Expr.runtime; simp only [Runtime.Expr.subst]
+    simp only [compile] at heval
+    simp only [Expr.ty] at hpost
+    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_ref <| compile_correct Θ R e S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+    intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
+    obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
+    have hwf_st₁ := VerifM.eval.wf hΨ_e
+    set c : FOL.Const := st₁.freshConst none .value
+    have hfresh : c.name ∉ st₁.decls.allNames :=
+      fresh_not_mem _ _ (addNumbers_injective _)
+    have hwf_addConst : TransState.wf { st₁ with decls := st₁.decls.addConst c } :=
+      TransState.freshConst.wf _ hwf_st₁
+    refine SpatialContext.wp_ref (ctx := st₁.owns) (Δ := st₁.decls) (vt := se)
+      (name := c.name)
+      (newctx := .pointsTo (.const (.uninterpreted c.name .value)) se :: st₁.owns)
+      hwf_st₁.ownsWf hse_wf heval_se hfresh rfl ?_
+    intro loc
+    have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
+    have hdecl := VerifM.eval_decl hdecl_eval (.loc loc)
+    have hassume_eval := VerifM.eval_bind _ _ _ _ hdecl
+    set ρ_e' : Env := ρ_e.updateConst .value c.name (.loc loc)
+    set st₂ : TransState := { st₁ with decls := st₁.decls.addConst c }
+    have hc_wf : (Term.const (.uninterpreted c.name .value)).wfIn st₂.decls := by
+      simp only [Term.wfIn, Const.wfIn]
+      refine ⟨List.Mem.head _, ?_, ?_⟩
+      · intro τ' hvar
+        exact Signature.wf_no_var_of_const hwf_addConst.namesDisjoint
+          (List.Mem.head _) hvar
+      · intro τ' hc'
+        exact Signature.wf_unique_const hwf_addConst.namesDisjoint (List.Mem.head _) hc'
+    have hse_wf_st₂ : se.wfIn st₂.decls :=
+      Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _) hwf_addConst.namesDisjoint
+    have hatom_wf : SpatialAtom.wfIn
+        (.pointsTo (.const (.uninterpreted c.name .value)) se) st₂.decls :=
+      ⟨hc_wf, hse_wf_st₂⟩
+    have hassume_res := VerifM.eval_assumeSpatial hassume_eval hatom_wf
+    have hret := VerifM.eval_ret hassume_res
+    have hval_eval : Term.eval ρ_e' (Term.const (.uninterpreted c.name .value)) = .loc loc := by
+      simp [ρ_e', Term.eval, Const.denote, Env.updateConst]
+    have hty : TinyML.ValHasType Θ (Runtime.Val.loc loc) (TinyML.Typ.ref e.ty) := by
+      exact TinyML.ValHasType.ref e.ty
+    exact hpost (.loc loc) ρ_e' _ _ hret hc_wf hval_eval hty
+  | deref e ty =>
+    unfold Expr.runtime; simp only [Runtime.Expr.subst]
+    simp only [compile] at heval
+    simp only [Expr.ty] at hpost
+    obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
+    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_deref <| compile_correct Θ R e S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+    intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
+    obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
+    have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_e
+    refine VerifM.eval_resolve (pred := .own se) (R := R)
+      (Φ := wp (.deref (.val v_e)) Φ) hres_bind hse_wf ?_ ?_
+    · intro st' hQ _
+      exact (VerifM.eval_failed hQ).elim
+    · intro v st' hQ hdecls hvwf
+      have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
+      have hse_wf_st' : se.wfIn st'.decls := hdecls ▸ hse_wf
+      have hv_wf_st' : v.wfIn st'.decls := hdecls ▸ hvwf
+      have hatom_wf : SpatialAtom.wfIn (.pointsTo se v) st'.decls :=
+        ⟨hse_wf_st', hv_wf_st'⟩
+      have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
+      have hret := VerifM.eval_ret hassume_res
+      have hv_wf_final : v.wfIn (TransState.addItem st' (.spatial (.pointsTo se v))).decls := by
+        simpa [TransState.addItem] using hv_wf_st'
+      have htype : TinyML.ValHasType Θ (v.eval ρ_e) ty := by
+        -- The value read from the heap has type `ty` by the deref annotation;
+        -- we do not track this in the spatial context, so sorry for now.
+        sorry
+      let st'' := TransState.addItem st' (.spatial (.pointsTo se v))
+      have hgoal : st''.owns.interp ρ_e ∗ R ⊢ Φ (v.eval ρ_e) :=
+        hpost (v.eval ρ_e) ρ_e st'' _ hret hv_wf_final rfl htype
+      simp only [Atom.eval]
+      istart
+      iintro H
+      icases H with ⟨Hex, Hrest, HR⟩
+      icases Hex with ⟨%loc, Hpt'⟩
+      icases Hpt' with ⟨%Hloc, Hpt⟩
+      have hv_e : v_e = .loc loc := heval_se.symm.trans Hloc
+      subst hv_e
+      have hptIntro : loc ↦ v.eval ρ_e ⊢ SpatialAtom.interp ρ_e (.pointsTo se v) := by
+        simpa [Hloc] using
+          (SpatialAtom.interp_pointsTo (ρ := ρ_e) (lt := se) (vt := v) (loc := loc) Hloc).2
+      have hctx : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ∗ R ⊢ Φ (v.eval ρ_e) := by
+        have hcons : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ⊢ st''.owns.interp ρ_e := by
+          simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hptIntro)
+        exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
+      iapply (wp.deref (l := loc) (v := v.eval ρ_e))
+      isplitl [Hpt]
+      · iexact Hpt
+      · iintro Hpt
+        iapply hctx
+        isplitl [Hpt]
+        · iexact Hpt
+        · isplitl [Hrest]
+          · iexact Hrest
+          · iexact HR
+  | store loc val =>
+    unfold Expr.runtime; simp only [Runtime.Expr.subst]
+    simp only [compile] at heval
+    simp only [Expr.ty] at hpost
+    obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
+    have heval_v : (compile Θ S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_store <| (SpecMap.satisfiedBy_dup.trans <|
+      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) val S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hts hSwf ?_)
+    intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv htyv
+    obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
+    have hagree_v : B.agreeOnLinked ρ_v γ :=
+      Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
+    have hbwf_v : B.wf st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
+    have heval_l : (compile Θ S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
+    refine compile_correct Θ R loc S B Γ st₁ ρ_v γ _ _
+      (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hts hSwf ?_
+    intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
+    obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
+    have hsv_ρ_l : sv.eval ρ_l = v_v := by
+      rw [Term.eval_env_agree hsv_wf (Env.agreeOn_symm hagreeOn_l)]
+      exact heval_sv
+    have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_l
+    refine VerifM.eval_resolve (pred := .own sl) (R := R)
+      (Φ := wp (.store (.val v_l) (.val v_v)) Φ) hres_bind hsl_wf ?_ ?_
+    · intro st' hQ _
+      exact (VerifM.eval_failed hQ).elim
+    · intro old st' hQ hdecls hold_wf
+      have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
+      have hsl_wf_st' : sl.wfIn st'.decls := hdecls ▸ hsl_wf
+      have hsv_wf_st₂ : sv.wfIn st₂.decls :=
+        Term.wfIn_mono sv hsv_wf hdecls_l (VerifM.eval.wf hΨ_l).namesDisjoint
+      have hsv_wf_st' : sv.wfIn st'.decls := hdecls ▸ hsv_wf_st₂
+      have hatom_wf : SpatialAtom.wfIn (.pointsTo sl sv) st'.decls :=
+        ⟨hsl_wf_st', hsv_wf_st'⟩
+      have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
+      have hret := VerifM.eval_ret hassume_res
+      have hunit_wf : (Term.const .unit).wfIn
+          (TransState.addItem st' (.spatial (.pointsTo sl sv))).decls := by
+        simp [Term.wfIn, Const.wfIn]
+      let st'' := TransState.addItem st' (.spatial (.pointsTo sl sv))
+      have hgoal : st''.owns.interp ρ_l ∗ R ⊢ Φ .unit :=
+        hpost .unit ρ_l st'' _ hret hunit_wf (by simp [Term.eval]) (.unit)
+      simp only [Atom.eval]
+      istart
+      iintro H
+      icases H with ⟨Hex, Hrest, HR⟩
+      icases Hex with ⟨%loc, Hold'⟩
+      icases Hold' with ⟨%Hloc, Hold⟩
+      have hv_l : v_l = .loc loc := heval_sl.symm.trans Hloc
+      subst hv_l
+      have hnewIntro : loc ↦ v_v ⊢ SpatialAtom.interp ρ_l (.pointsTo sl sv) := by
+        simpa [Hloc, hsv_ρ_l] using
+          (SpatialAtom.interp_pointsTo (ρ := ρ_l) (lt := sl) (vt := sv) (loc := loc) Hloc).2
+      have hctx : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l st'.owns ∗ R ⊢ Φ .unit := by
+        have hcons : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l st'.owns ⊢ st''.owns.interp ρ_l := by
+          simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hnewIntro)
+        exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
+      iapply (wp.store (l := loc) (old := old.eval ρ_l) (v := v_v))
+      isplitl [Hold]
+      · iexact Hold
+      · iintro Hnew
+        iapply hctx
+        isplitl [Hnew]
+        · iexact Hnew
+        · isplitl [Hrest]
+          · iexact Hrest
+          · iexact HR
   | unop op e uty =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     simp only [compile] at heval
@@ -524,8 +716,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           cases htyr with
           | int b =>
             have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
-              simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]
-              exact Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
+              simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
+                (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
             have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
             have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
             simp [Formula.eval, Term.eval, Const.denote] at hne_zero
@@ -539,8 +731,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             have hwf_sr_l : sr.wfIn st₂.decls :=
               Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
             have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
-              simp only [Term.wfIn, BinOp.wfIn, UnOp.wfIn, true_and]
-              exact ⟨hsl_wf, hwf_sr_l⟩
+              simpa [Term.wfIn, BinOp.wfIn, UnOp.wfIn] using And.intro hsl_wf hwf_sr_l
             have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
               simpa using hΨ_post
             exact SpatialContext.wp_binop
@@ -559,8 +750,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           cases htyr with
           | int b =>
             have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
-              simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]
-              exact Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
+              simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
+                (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
             have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
             have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
             simp [Formula.eval, Term.eval, Const.denote] at hne_zero
@@ -574,8 +765,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             have hwf_sr_l : sr.wfIn st₂.decls :=
               Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
             have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
-              simp only [Term.wfIn, BinOp.wfIn, UnOp.wfIn, true_and]
-              exact ⟨hsl_wf, hwf_sr_l⟩
+              simpa [Term.wfIn, BinOp.wfIn, UnOp.wfIn] using And.intro hsl_wf hwf_sr_l
             have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
               simpa using hΨ_post
             exact SpatialContext.wp_binop

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -523,7 +523,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     have hval_eval : Term.eval ρ_e' (Term.const (.uninterpreted c.name .value)) = .loc loc := by
       simp [ρ_e', Term.eval, Const.denote, Env.updateConst]
     have hty : TinyML.ValHasType Θ (Runtime.Val.loc loc) (TinyML.Typ.ref e.ty) := by
-      exact TinyML.ValHasType.ref e.ty
+      exact TinyML.ValHasType.ref loc e.ty
     exact hpost (.loc loc) ρ_e' _ _ hret hc_wf hval_eval hty
   | deref e ty =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -234,12 +234,16 @@ mutual
         pure (.const (.uninterpreted l.name .value))
     | .deref e ty => do
         VerifM.expectEq "deref type annotation mismatch" e.ty (.ref ty)
-        let sl ← compile Θ S B Γ e
-        match ← VerifM.resolve (.own sl) with
-        | some sv =>
-          VerifM.assume (.spatial (.pointsTo sl sv))
-          pure sv
-        | none => VerifM.failed "could not resolve points-to assertion"
+        match ty with
+        | .int =>
+          let sl ← compile Θ S B Γ e
+          match ← VerifM.resolve (.own sl) with
+          | some sv =>
+            VerifM.assert (.unpred .isInt sv)
+            VerifM.assume (.spatial (.pointsTo sl sv))
+            pure sv
+          | none => VerifM.failed "could not resolve points-to assertion"
+        | _ => VerifM.fatal "only int references are supported"
     | .store loc val => do
         VerifM.expectEq "store location type mismatch" loc.ty (.ref val.ty)
         let sv ← compile Θ S B Γ val
@@ -530,58 +534,68 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     simp only [Expr.ty] at hpost
     obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
-    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_deref <| compile_correct Θ R e S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
-    intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
-    obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
-    have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_e
-    refine VerifM.eval_resolve (pred := .own se) (R := R)
-      (Φ := wp (.deref (.val v_e)) Φ) hres_bind hse_wf ?_ ?_
-    · intro st' hQ _
-      exact (VerifM.eval_failed hQ).elim
-    · intro v st' hQ hdecls hvwf
-      have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
-      have hse_wf_st' : se.wfIn st'.decls := hdecls ▸ hse_wf
-      have hv_wf_st' : v.wfIn st'.decls := hdecls ▸ hvwf
-      have hatom_wf : SpatialAtom.wfIn (.pointsTo se v) st'.decls :=
-        ⟨hse_wf_st', hv_wf_st'⟩
-      have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
-      have hret := VerifM.eval_ret hassume_res
-      have hv_wf_final : v.wfIn (TransState.addItem st' (.spatial (.pointsTo se v))).decls := by
-        simpa [TransState.addItem] using hv_wf_st'
-      have htype : TinyML.ValHasType Θ (v.eval ρ_e) ty := by
-        -- The value read from the heap has type `ty` by the deref annotation;
-        -- we do not track this in the spatial context, so sorry for now.
-        sorry
-      let st'' := TransState.addItem st' (.spatial (.pointsTo se v))
-      have hgoal : st''.owns.interp ρ_e ∗ R ⊢ Φ (v.eval ρ_e) :=
-        hpost (v.eval ρ_e) ρ_e st'' _ hret hv_wf_final rfl htype
-      simp only [Atom.eval]
-      istart
-      iintro H
-      icases H with ⟨Hex, Hrest, HR⟩
-      icases Hex with ⟨%loc, Hpt'⟩
-      icases Hpt' with ⟨%Hloc, Hpt⟩
-      have hv_e : v_e = .loc loc := heval_se.symm.trans Hloc
-      subst hv_e
-      have hptIntro : loc ↦ v.eval ρ_e ⊢ SpatialAtom.interp ρ_e (.pointsTo se v) := by
-        simpa [Hloc] using
-          (SpatialAtom.interp_pointsTo (ρ := ρ_e) (lt := se) (vt := v) (loc := loc) Hloc).2
-      have hctx : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ∗ R ⊢ Φ (v.eval ρ_e) := by
-        have hcons : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ⊢ st''.owns.interp ρ_e := by
-          simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hptIntro)
-        exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
-      iapply (wp.deref (l := loc) (v := v.eval ρ_e))
-      isplitl [Hpt]
-      · iexact Hpt
-      · iintro Hpt
-        iapply hctx
+    cases hty : ty with
+    | int =>
+      simp [hty] at heval hpost
+      have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+      refine SpatialContext.wp_bind_deref <| compile_correct Θ R e S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+      intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
+      obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
+      have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_e
+      refine VerifM.eval_resolve (pred := .own se) (R := R)
+        (Φ := wp (.deref (.val v_e)) Φ) hres_bind hse_wf ?_ ?_
+      · intro st' hQ _
+        exact (VerifM.eval_failed hQ).elim
+      · intro v st' hQ hdecls hvwf
+        have hassert_bind := VerifM.eval_bind _ _ _ _ hQ
+        have hse_wf_st' : se.wfIn st'.decls := hdecls ▸ hse_wf
+        have hv_wf_st' : v.wfIn st'.decls := hdecls ▸ hvwf
+        have hassert_wf : (Formula.unpred .isInt v).wfIn st'.decls := hv_wf_st'
+        have ⟨hv_int, hQ⟩ := VerifM.eval_assert hassert_bind hassert_wf
+        have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
+        have hatom_wf : SpatialAtom.wfIn (.pointsTo se v) st'.decls :=
+          ⟨hse_wf_st', hv_wf_st'⟩
+        have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
+        have hret := VerifM.eval_ret hassume_res
+        have hv_wf_final : v.wfIn (TransState.addItem st' (.spatial (.pointsTo se v))).decls := by
+          simpa [TransState.addItem] using hv_wf_st'
+        have htype : TinyML.ValHasType Θ (v.eval ρ_e) .int := by
+          cases hv : v.eval ρ_e with
+          | int n => exact TinyML.ValHasType.int n
+          | bool _ | unit | inj _ _ _ | loc _ | fix _ _ _ | tuple _ =>
+              simp [Formula.eval, hv] at hv_int
+        let st'' := TransState.addItem st' (.spatial (.pointsTo se v))
+        have hgoal : st''.owns.interp ρ_e ∗ R ⊢ Φ (v.eval ρ_e) :=
+          hpost (v.eval ρ_e) ρ_e st'' _ hret hv_wf_final rfl htype
+        simp only [Atom.eval]
+        istart
+        iintro H
+        icases H with ⟨Hex, Hrest, HR⟩
+        icases Hex with ⟨%loc, Hpt'⟩
+        icases Hpt' with ⟨%Hloc, Hpt⟩
+        have hv_e : v_e = .loc loc := heval_se.symm.trans Hloc
+        subst hv_e
+        have hptIntro : loc ↦ v.eval ρ_e ⊢ SpatialAtom.interp ρ_e (.pointsTo se v) := by
+          simpa [Hloc] using
+            (SpatialAtom.interp_pointsTo (ρ := ρ_e) (lt := se) (vt := v) (loc := loc) Hloc).2
+        have hctx : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ∗ R ⊢ Φ (v.eval ρ_e) := by
+          have hcons : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ⊢ st''.owns.interp ρ_e := by
+            simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hptIntro)
+          exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
+        iapply (wp.deref (l := loc) (v := v.eval ρ_e))
         isplitl [Hpt]
         · iexact Hpt
-        · isplitl [Hrest]
-          · iexact Hrest
-          · iexact HR
+        · iintro Hpt
+          iapply hctx
+          isplitl [Hpt]
+          · iexact Hpt
+          · isplitl [Hrest]
+            · iexact Hrest
+            · iexact HR
+    | bool | unit | arrow _ _ | ref _ | sum _ | empty | value | tuple _ | tvar _ | named _ _ =>
+      simp [hty] at heval
+      exact (VerifM.eval_fatal heval).elim
   | store loc val =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     simp only [compile] at heval

--- a/Mica/Verifier/SpecTranslation.lean
+++ b/Mica/Verifier/SpecTranslation.lean
@@ -144,6 +144,7 @@ def translatePred (env : Env) : Spec.Pred → M (Σ t, Atom t)
   | .isbool e => do .ok ⟨.bool, .isbool (← checkTerm env .value e)⟩
   | .isinj tag arity e => do
     .ok ⟨.value, .isinj tag arity (← checkTerm env .value e)⟩
+  | .own e => do .ok ⟨.value, .own (← checkTerm env .value e)⟩
 
 -- ---------------------------------------------------------------------------
 -- Assertions


### PR DESCRIPTION
This PR adds support for an `own` predicate in assertions and for the operations that manipulate references (i.e., allocating a reference with `ref`, reading a value with `!`, and storing a value with `:=`).

**Restriction** It currently only supports reading from integer references (`int ref`), because the dereference case does not yet have enough information available locally to ensure that the result of `! e` when `e: ref A` is actually of type `A`.