### PR TITLE
Introduce separate verifier environment

### DIFF
--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -47,26 +47,26 @@ def Assertion.toStringHum {α : Type} (showA : α → String) : Assertion α →
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Assertion.pre (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
+def Assertion.pre (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   (match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ⌝ ∗ Assertion.pre Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ; Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ.env⌝ ∗ Assertion.pre Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ.env; Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => ∃ (v : x.sort.denote), p.eval ρ v ∗ Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ⌝ -∗ Assertion.pre Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ⌝ -∗ Assertion.pre Φ ke ρ)))
+      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.pre Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.pre Φ ke ρ)))
 
-def Assertion.post {α} (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
+def Assertion.post {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ⌝ -∗ Assertion.post Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ; Assertion.post Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ.env⌝ -∗ Assertion.post Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ.env; Assertion.post Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => iprop(∀ (v : x.sort.denote),
       p.eval ρ v -∗ Assertion.post Φ k (ρ.updateConst x.sort x.name v))
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ⌝ -∗ Assertion.post Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ⌝ -∗ Assertion.post Φ ke ρ))
+      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.post Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.post Φ ke ρ))
 
 
 -- ---------------------------------------------------------------------------
@@ -134,9 +134,9 @@ theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Pro
 -- ---------------------------------------------------------------------------
 
 theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature → Prop}
-    {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
-    (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     Assertion.pre Φ m ρ ⊢ Assertion.pre Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
@@ -154,7 +154,7 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.pre]
     rw [← Term.eval_env_agree htwf hagree]
-    exact ih hkwf (Env.agreeOn_declVar hagree)
+    exact ih hkwf (VerifM.Env.agreeOn_declVar hagree)
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.pre]
@@ -164,7 +164,7 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     iapply (sep_mono
       (show p.eval ρ w ⊢ p.eval ρ' w by
         simp [(Atom.eval_env_agree hpwf hagree)])
-      (ih hkwf (Env.agreeOn_declVar hagree)))
+      (ih hkwf (VerifM.Env.agreeOn_declVar hagree)))
     iexact Hsep
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
@@ -173,7 +173,7 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     · apply BI.and_elim_l.trans
       iintro Hkt
       iintro Hφ
-      have hφ : BIBase.Entails (⌜φ.eval ρ'⌝ : iProp) ⌜φ.eval ρ⌝ := by
+      have hφ : BIBase.Entails (⌜φ.eval ρ'.env⌝ : iProp) ⌜φ.eval ρ.env⌝ := by
         iintro %hφ
         ipure_intro
         exact (Formula.eval_env_agree hφwf hagree).mpr hφ
@@ -184,7 +184,7 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     · apply BI.and_elim_r.trans
       iintro Hke
       iintro Hnφ
-      have hnφ : BIBase.Entails (⌜¬ φ.eval ρ'⌝ : iProp) ⌜¬ φ.eval ρ⌝ := by
+      have hnφ : BIBase.Entails (⌜¬ φ.eval ρ'.env⌝ : iProp) ⌜¬ φ.eval ρ.env⌝ := by
         iintro %hnφ
         ipure_intro
         exact mt (Formula.eval_env_agree hφwf hagree).mp hnφ
@@ -194,9 +194,9 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
       iapply Hnφ
 
 theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature → Prop}
-    {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
-    (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     Assertion.post Φ m ρ ⊢ Assertion.post Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
@@ -205,7 +205,7 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     simp only [Assertion.post]
     iintro H
     iintro %hφ
-    have hφ' : φ.eval ρ := (Formula.eval_env_agree hφwf hagree).mpr hφ
+    have hφ' : φ.eval ρ.env := (Formula.eval_env_agree hφwf hagree).mpr hφ
     iapply (ih hkwf hagree)
     iapply H
     ipure_intro
@@ -214,13 +214,13 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.post]
     rw [← Term.eval_env_agree htwf hagree]
-    exact ih hkwf (Env.agreeOn_declVar hagree)
+    exact ih hkwf (VerifM.Env.agreeOn_declVar hagree)
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.post]
     iintro H
     iintro %w Hw
-    iapply (ih hkwf (Env.agreeOn_declVar hagree))
+    iapply (ih hkwf (VerifM.Env.agreeOn_declVar hagree))
     iapply H
     iapply (show p.eval ρ' w ⊢ p.eval ρ w by simp [(Atom.eval_env_agree hpwf hagree)])
     iexact Hw
@@ -231,7 +231,7 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     · apply BI.and_elim_l.trans
       iintro Hkt
       iintro %hφ
-      have hφ' : φ.eval ρ := (Formula.eval_env_agree hφwf hagree).mpr hφ
+      have hφ' : φ.eval ρ.env := (Formula.eval_env_agree hφwf hagree).mpr hφ
       iapply (iht hktwf hagree)
       iapply Hkt
       ipure_intro
@@ -239,7 +239,7 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     · apply BI.and_elim_r.trans
       iintro Hke
       iintro %hnφ
-      have hnφ' : ¬ φ.eval ρ := mt (Formula.eval_env_agree hφwf hagree).mp hnφ
+      have hnφ' : ¬ φ.eval ρ.env := mt (Formula.eval_env_agree hφwf hagree).mp hnφ
       iapply (ihe hkewf hagree)
       iapply Hke
       ipure_intro
@@ -248,10 +248,10 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
 /-- Combining caller-side `pre` with verifier-side `post`. -/
 theorem Assertion.pre_post_combine {α : Type}
     {m : Assertion α}
-    {Φ Ψ : α → Env → iProp}
-    {ρ : Env}
+    {Φ : α → VerifM.Env → iProp} {Ψ : α → VerifM.Env → iProp}
+    {ρ : VerifM.Env}
     {R : iProp}
-    (hR : ∀ (a : α) (ρ0 : Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
+    (hR : ∀ (a : α) (ρ0 : VerifM.Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
     : (Assertion.pre Φ m ρ ∗ Assertion.post Ψ m ρ) ⊢ R := by
   induction m generalizing ρ R with
   | ret a =>
@@ -269,7 +269,7 @@ theorem Assertion.pre_post_combine {α : Type}
       exact hφ
   | let_ v t k ih =>
     simp only [Assertion.pre, Assertion.post]
-    simpa using ih (ρ := ρ.updateConst v.sort v.name (t.eval ρ)) (R := R) hR
+    simpa using ih (ρ := ρ.updateConst v.sort v.name (t.eval ρ.env)) (R := R) hR
   | pred v p k ih =>
     simp only [Assertion.pre, Assertion.post]
     istart
@@ -282,7 +282,7 @@ theorem Assertion.pre_post_combine {α : Type}
       iexact Hpre1
   | ite φ kt ke iht ihe =>
     simp only [Assertion.pre, Assertion.post]
-    by_cases hφ : φ.eval ρ
+    by_cases hφ : φ.eval ρ.env
     · istart
       iintro ⟨Hpre, Hpost⟩
       iapply (iht (ρ := ρ) (R := R) hR)
@@ -370,16 +370,17 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
 
 theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
-    (st : TransState) (ρ : Env)
-    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    (st : TransState) (ρ : VerifM.Env)
+    (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     m.wfIn retWf (Signature.ofVars σ.dom) →
     VerifM.eval (Assertion.assume σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wf st'.decls → (Signature.ofVars σ'.dom).wf →
-      retWf a (Signature.ofVars σ'.dom) → st'.owns.interp ρ' ∗ R ⊢ Φ a (σ'.subst.eval ρ')) →
-    st.owns.interp ρ ∗ R ⊢ Assertion.post Φ m (σ.subst.eval ρ) := by
+      retWf a (Signature.ofVars σ'.dom) →
+      st'.sl ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
+    st.sl ρ ∗ R ⊢ Assertion.post Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
   intro hσwf hdomwf hwf heval hpost
   have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
   induction m generalizing σ st ρ Ψ with
@@ -396,7 +397,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
     have hassume := VerifM.eval_assumePure hb hsubst_wf hsubst_eval
     iapply (ih σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkwf hassume hpost hwfst)
-    iexact Howns
+    simp [TransState.sl]
   | let_ v t k ih =>
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.assume] at heval
@@ -408,7 +409,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       fresh_not_mem (addNumbers (v.name)) (st.decls.allNames) (addNumbers_injective _)
     have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
       fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-    set u := t.eval (σ.subst.eval ρ)
+    set u := t.eval (σ.subst.eval ρ.env)
     specialize hdecl u
     have hb2 := VerifM.eval_bind _ _ _ _ hdecl
     -- Show the equality formula is well-formed and holds
@@ -430,7 +431,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
           exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
       · exact Term.wfIn_mono _ ht_subst_wf (Signature.Subset.subset_addConst _ _) (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
     have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).eval
-        (ρ.updateConst v.sort v'.name u) := by
+        (ρ.updateConst v.sort v'.name u).env := by
       rw [Formula.eval, Term.eval, Const.denote]
       rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
       simpa [u, Env.lookupConst, Env.updateConst] using
@@ -447,8 +448,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
       (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
         (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
-        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+    have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
       SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
         (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
     exact (sep_mono hinterp_bi.1 (by
@@ -474,7 +474,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
       have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
-      iexact Howns
+      simp [TransState.sl]
     · iintro Howns %hnφ
       have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
       simp at hfalse
@@ -486,7 +486,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
       have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
-      iexact Howns
+      simp [TransState.sl]
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.post]
@@ -523,20 +523,25 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       Atom.toItem_wfIn
         (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint) hvar_wf
-    have hpu' : p.eval (σ.subst.eval ρ) u ⊢ (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
-        ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval (ρ.updateConst v.sort v'.name u)) := by
+    have hpu' : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢ (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
+        ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval (ρ.updateConst v.sort v'.name u).env) := by
       have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
-          (ρ.updateConst v.sort v'.name u)) = u := by
+          (ρ.updateConst v.sort v'.name u).env) = u := by
         simp [Term.eval, Const.denote, Env.updateConst]
       rw [hconst]
       rw [Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
-      have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ)
+      have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
         (τ := v.sort) (name' := v'.name) (u := u) hσwf.1 hv'_fresh_range
       have heval_agree :
-          p.eval (σ.subst.eval ρ) = p.eval (σ.subst.eval (ρ.updateConst v.sort v'.name u)) :=
-        Atom.eval_env_agree (p := p) (ρ := σ.subst.eval ρ)
-          (ρ' := σ.subst.eval (ρ.updateConst v.sort v'.name u))
-          (Δ := Signature.ofVars σ.dom) hpwf hagree
+          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) =
+            p.eval ((ρ.updateConst v.sort v'.name u).withEnv
+              (σ.subst.eval (ρ.updateConst v.sort v'.name u).env)) :=
+        Atom.eval_env_agree (p := p)
+          (ρ := ρ.withEnv (σ.subst.eval ρ.env))
+          (ρ' := (ρ.updateConst v.sort v'.name u).withEnv
+            (σ.subst.eval (ρ.updateConst v.sort v'.name u).env))
+          (Δ := Signature.ofVars σ.dom) hpwf (by
+            simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv_env] using hagree)
       rw [heval_agree]
       exact .rfl
     set item := (p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))
@@ -549,14 +554,15 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
     cases hitem : item with
     | pure φ =>
-      have hφ_entail : p.eval (σ.subst.eval ρ) u ⊢ ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ := by
+      have hφ_entail : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+          ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ := by
         simpa [item, hitem] using
           (hpu'.trans (Atom.eval_purePart (p := p.subst σ.subst)
             (t := .const (.uninterpreted v'.name v.sort))
-            (ρ := ρ.updateConst v.sort v'.name u)))
-      ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ $$ [Hpu]
+            (ρ := (ρ.updateConst v.sort v'.name u))))
+      ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ $$ [Hpu]
       · iapply hφ_entail
-        iexact Hpu
+        simp [VerifM.Env.withEnv]
       icases Hφ with %hφ
       have hb2' : (VerifM.assume (.pure φ)).eval
           { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
@@ -569,8 +575,8 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
         (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
       have hframe :
-          st.owns.interp ρ ∗ R ⊢
-            (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).owns.interp
+          st.sl ρ ∗ R ⊢
+            (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).sl
               (ρ.updateConst v.sort v'.name u) ∗ R := by
         simp [TransState.addItem]
         exact sep_mono
@@ -597,19 +603,19 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
         (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
       have hitem_interp :
-          p.eval (σ.subst.eval ρ) u ⊢
+          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
             CtxItem.interp (ρ.updateConst v.sort v'.name u) item := by
         simpa [item] using
           (hpu'.trans (Atom.eval_toItem (p := p.subst σ.subst)
             (t := .const (.uninterpreted v'.name v.sort))
-            (ρ := ρ.updateConst v.sort v'.name u)))
+            (ρ := (ρ.updateConst v.sort v'.name u))))
       have hspatial_interp :
-          p.eval (σ.subst.eval ρ) u ⊢
-            SpatialAtom.interp (ρ.updateConst v.sort v'.name u) a := by
+          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+            SpatialAtom.interp (ρ.updateConst v.sort v'.name u).env a := by
         simpa [item, hitem, CtxItem.interp] using hitem_interp
       have howns_agree :
-          SpatialContext.interp ρ st.owns ⊢
-            SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+          st.sl ρ ⊢
+            st.sl (ρ.updateConst v.sort v'.name u) :=
         (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
           (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
       iapply (hih.trans <| Assertion.post_env_agree hkwf'
@@ -621,24 +627,32 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       icases Howns with ⟨HS, HR⟩
       isplitr [HR]
       · isplitr [HS]
-        · iapply hspatial_interp
-          iexact Hpu
-        · iapply howns_agree
-          iexact HS
+        · have hspatial_interp' :
+            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+              SpatialAtom.interp (Env.updateConst ρ.env v.sort v'.name u) a := by
+            simpa [VerifM.Env.updateConst] using hspatial_interp
+          iapply hspatial_interp'
+          simp [VerifM.Env.withEnv]
+        · have howns_agree' :
+            st.sl ρ ⊢ SpatialContext.interp (Env.updateConst ρ.env v.sort v'.name u) st.owns := by
+            simpa [TransState.sl, VerifM.Env.updateConst] using howns_agree
+          iapply howns_agree'
+          simp [TransState.sl]
       · iexact HR
 
 theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
-    (st : TransState) (ρ : Env)
-    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    (st : TransState) (ρ : VerifM.Env)
+    (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     m.wfIn retWf (Signature.ofVars σ.dom) →
     VerifM.eval (Assertion.prove σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wf st'.decls → (Signature.ofVars σ'.dom).wf →
-      retWf a (Signature.ofVars σ'.dom) → st'.owns.interp ρ' ∗ R ⊢ Φ a (σ'.subst.eval ρ')) →
-    st.owns.interp ρ ∗ R ⊢ Assertion.pre Φ m (σ.subst.eval ρ) := by
+      retWf a (Signature.ofVars σ'.dom) →
+      st'.sl ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
+    st.sl ρ ∗ R ⊢ Assertion.pre Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
   intro hσwf hdomwf hwf heval hpost
   have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
   induction m generalizing σ st ρ Ψ with
@@ -652,8 +666,8 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
     have hassert := VerifM.eval_assert hb hsubst_wf
     have hφ_holds := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mp hassert.1
-    show SpatialContext.interp ρ st.owns ∗ R ⊢
-      (⌜φ.eval (σ.subst.eval ρ)⌝ ∗ Assertion.pre Φ k (σ.subst.eval ρ) : iProp)
+    show st.sl ρ ∗ R ⊢
+      (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
     istart
     iintro ⟨Howns, HR⟩
     isplitr [Howns HR]
@@ -674,7 +688,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       fresh_not_mem (addNumbers (v.name)) (st.decls.allNames) (addNumbers_injective _)
     have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
       fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-    set u := t.eval (σ.subst.eval ρ)
+    set u := t.eval (σ.subst.eval ρ.env)
     specialize hdecl u
     have hb2 := VerifM.eval_bind _ _ _ _ hdecl
     have ht_subst_wf_range : (t.subst σ.subst).wfIn σ.range :=
@@ -695,7 +709,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
           exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
       · exact Term.wfIn_mono _ ht_subst_wf (Signature.Subset.subset_addConst _ _) (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
     have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).eval
-        (ρ.updateConst v.sort v'.name u) := by
+        (ρ.updateConst v.sort v'.name u).env := by
       rw [Formula.eval, Term.eval, Const.denote]
       rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
       simpa [u, Env.lookupConst, Env.updateConst] using
@@ -711,8 +725,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
     have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
       (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
         (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
-        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+    have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
       SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
         (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
     exact (sep_mono hinterp_bi.1 (by
@@ -737,15 +750,23 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
         simp at hq
         exact (VerifM.eval_fatal hq).elim)
       (fun t st' hq hdecls htwf => by
-        simp only [Assertion.pre]
+        simp [Assertion.pre]
         have hwfst' : st'.decls.wf := by simpa [hdecls] using hwfst
         have htwf' : t.wfIn st'.decls := by simpa [hdecls] using htwf
         istart
         iintro H
         icases H with ⟨Hpred, Howns, HR⟩
-        iexists (t.eval ρ)
+        iexists (t.eval ρ.env)
         isplitr [Howns HR]
-        · rw [← Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
+        · have hpred_subst :
+              (p.subst σ.subst).eval ρ (t.eval ρ.env) ⊢
+                p.eval (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ.env) := by
+              simpa [VerifM.Env.withEnv] using
+                (show (p.subst σ.subst).eval ρ (t.eval ρ.env) ⊢
+                    p.eval (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ.env) by
+                  rw [Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
+                  exact BIBase.Entails.rfl)
+          iapply hpred_subst
           iexact Hpred
         · have hb2 := VerifM.eval_bind _ _ _ _ hq
           have hdecl := VerifM.eval_decl hb2
@@ -757,7 +778,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
             apply hv'_fresh_decls
             rw [hdecls]
             exact Signature.allNames_subset hσwf.2.1 _ h
-          specialize hdecl (t.eval ρ)
+          specialize hdecl (t.eval ρ.env)
           have hb3 := VerifM.eval_bind _ _ _ _ hdecl
           have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
               (st'.decls.addConst v') := by
@@ -772,7 +793,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
             · exact Term.wfIn_mono _ htwf' (Signature.Subset.subset_addConst _ _)
                 (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
           have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
-              (ρ.updateConst v.sort v'.name (t.eval ρ)) := by
+              (ρ.updateConst v.sort v'.name (t.eval ρ.env)).env := by
             simp only [Formula.eval, Term.eval, Const.denote]
             simpa [Env.lookupConst, Env.updateConst] using
               (Term.eval_env_agree htwf' (agreeOn_update_fresh_const hv'_fresh_decls))
@@ -786,14 +807,13 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
           have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
             simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
           have hih := ih σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
-            (ρ.updateConst v.sort v'.name (t.eval ρ)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-              (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
-          have hinterp_bi : SpatialContext.interp ρ st'.owns ⊣⊢
-              SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st'.owns :=
+            (ρ.updateConst v.sort v'.name (t.eval ρ.env)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
+            (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
+          have hinterp_bi : st'.sl ρ ⊣⊢ st'.sl (ρ.updateConst v.sort v'.name (t.eval ρ.env)) :=
             SpatialContext.interp_env_agree (VerifM.eval.wf hq).ownsWf
               (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-          have hframe : SpatialContext.interp ρ st'.owns ∗ R ⊢
-              SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st'.owns ∗ R := by
+          have hframe : st'.sl ρ ∗ R ⊢
+              st'.sl (ρ.updateConst v.sort v'.name (t.eval ρ.env)) ∗ R := by
             exact sep_mono hinterp_bi.1 (by
               iintro HR
               iexact HR)
@@ -803,7 +823,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
                 (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
             hΦ)
           isplitl [Howns]
-          · iexact Howns
+          · simp [TransState.sl]
           · iexact HR)
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
@@ -824,7 +844,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
       have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
-      iexact Howns
+      simp [TransState.sl]
     · apply wand_intro
       iintro H
       icases H with ⟨Howns, %hnφ⟩
@@ -838,4 +858,4 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
       have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
-      iexact Howns
+      simp [TransState.sl]

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -48,16 +48,26 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
 namespace CtxItem
 
 /-- Semantic interpretation of a verifier context item. -/
-def interp (ρ : Env) : CtxItem → iProp
-  | .pure φ => ⌜φ.eval ρ⌝
-  | .spatial a => a.interp ρ
+def interp (ρ : VerifM.Env) : CtxItem → iProp
+  | .pure φ => ⌜φ.eval ρ.env⌝
+  | .spatial a => a.interp ρ.env
 
-def purePart (i : CtxItem) (ρ : Env) : Prop :=
+def purePart (i : CtxItem) (ρ : VerifM.Env) : Prop :=
   match i with
-  | .pure φ => φ.eval ρ
+  | .pure φ => φ.eval ρ.env
   | .spatial _ => True
 
 end CtxItem
+
+namespace TransState
+
+def sl (st : TransState) (ρ : VerifM.Env) : iProp :=
+  SpatialContext.interp ρ.env st.owns
+
+@[simp] theorem sl_eq (st : TransState) (ρ : VerifM.Env) :
+    st.sl ρ = SpatialContext.interp ρ.env st.owns := rfl
+
+end TransState
 
 /-- Convert an instantiated atom into the corresponding verifier context item. -/
 def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
@@ -71,12 +81,12 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
+def Atom.eval {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
   match p with
-  | isint t  => λ v => ⌜.int v = t.eval ρ⌝
-  | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
-  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
-  | own l => λ v => ∃ loc : Runtime.Location, ⌜l.eval ρ = .loc loc⌝ ∗ loc ↦ v
+  | isint t  => λ v => ⌜.int v = t.eval ρ.env⌝
+  | isbool t => λ v => ⌜.bool v = t.eval ρ.env⌝
+  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ.env⌝
+  | own l => λ v => ∃ loc : Runtime.Location, ⌜l.eval ρ.env = .loc loc⌝ ∗ loc ↦ v
 
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
@@ -137,12 +147,11 @@ def Atom.resolve (a : Atom τ) (C : List Formula) : Option (Term τ) :=
   C.findSome? (·.matchAtom a)
 
 theorem Atom.resolve_correct {a : Atom τ} {C : List Formula} {t : Term τ}
-    (h : a.resolve C = some t) (ρ : Env) (hC : ∀ φ ∈ C, φ.eval ρ) :
+    (h : a.resolve C = some t) (ρ : VerifM.Env) (hC : ∀ φ ∈ C, φ.eval ρ.env) :
     ⊢ (a.toItem t).interp ρ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
   rw [Formula.matchAtom_correct hφ_match]
-  simp [CtxItem.interp, hC _ hφ_mem]
-  exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
+  simpa [CtxItem.interp, hC _ hφ_mem] using (pure_intro (PROP := iProp) trivial)
 
 theorem Atom.resolve_wfIn {a : Atom τ} {C : List Formula} {t : Term τ} {Δ : Signature}
     (h : a.resolve C = some t) (hwf : ∀ φ ∈ C, φ.wfIn Δ) :
@@ -194,8 +203,8 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | isinj tag arity t => exact Term.wfIn_mono t h hmono hwf
   | own t => exact Term.wfIn_mono t h hmono hwf
 
-theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
-    (hwf : p.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') : p.eval ρ = p.eval ρ' := by
+theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : p.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') : p.eval ρ = p.eval ρ' := by
   cases p with
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
@@ -219,8 +228,8 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     simp only [Atom.toItem, CtxItem.wfIn, SpatialAtom.wfIn]
     exact ⟨hp, ht⟩
 
-theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
-    p.eval ρ (t.eval ρ) ⊣⊢ CtxItem.interp ρ (p.toItem t) := by
+theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    p.eval ρ (t.eval ρ.env) ⊣⊢ CtxItem.interp ρ (p.toItem t) := by
   cases p with
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
@@ -230,16 +239,16 @@ theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
     exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 
 /-- If `p.toItem t` holds semantically, then `p.eval ρ (t.eval ρ)`. -/
-theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : Env}
-    : CtxItem.interp ρ (p.toItem t) ⊢ p.eval ρ (t.eval ρ) := by
+theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : VerifM.Env}
+    : CtxItem.interp ρ (p.toItem t) ⊢ p.eval ρ (t.eval ρ.env) := by
   exact Atom.eval_pure.2
 
-theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : Env} :
-    p.eval ρ (t.eval ρ) ⊢ CtxItem.interp ρ (p.toItem t) := by
+theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    p.eval ρ (t.eval ρ.env) ⊢ CtxItem.interp ρ (p.toItem t) := by
   exact Atom.eval_pure.1
 
-theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
-    p.eval ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
+theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    p.eval ρ (t.eval ρ.env) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
   cases p with
   | isint v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
@@ -257,25 +266,25 @@ theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
 -- ---------------------------------------------------------------------------
 
 -- @agent: change eval_subst to a bi-entailment in the future.
-theorem Atom.eval_subst {p : Atom τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signature}
+theorem Atom.eval_subst {p : Atom τ} {σ : Subst} {ρ : VerifM.Env} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hwfΔ' : Δ'.wf) :
-    (p.subst σ).eval ρ = p.eval (σ.eval ρ) := by
+    (p.subst σ).eval ρ = p.eval (ρ.withEnv (σ.eval ρ.env)) := by
   cases p with
   | isint t =>
     funext v
-    simp only [Atom.subst, Atom.eval]
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
   | isbool t =>
     funext v
-    simp only [Atom.subst, Atom.eval]
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
   | isinj tag arity t =>
     funext v
-    simp only [Atom.subst, Atom.eval]
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
   | own l =>
     funext v
-    simp only [Atom.subst, Atom.eval]
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
 
 theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Signature}
@@ -302,26 +311,26 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .isinj tag arity v => [(.unpred (.isInj tag arity) v, .unop .payloadOf v)]
   | .own _ => []
 
-theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : Env}
-    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : ⊢ (a.toItem t).interp ρ := by
+theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : VerifM.Env}
+    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ.env) : ⊢ (a.toItem t).interp ρ := by
   cases a with
   | isint v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ <;> simp_all
+    cases hv : v.eval ρ.env <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isbool v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ <;> simp_all
+    cases hv : v.eval ρ.env <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isinj tag arity v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ <;> simp_all
+    cases hv : v.eval ρ.env <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | own l => simp [candidates] at hmem
 
@@ -347,7 +356,7 @@ def VerifM.tryCandidates : List (Formula × Term τ) → VerifM (Option (Term τ
 
 private theorem VerifM.eval_tryCandidates
     {candidates : List (Formula × Term τ)} {a : Atom τ}
-    {st : TransState} {ρ : Env} {Q : Option (Term τ) → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.tryCandidates candidates) st ρ Q)
     (hcands : ∀ p ∈ candidates, p ∈ a.candidates)
     (hpwf : a.wfIn st.decls) :
@@ -422,8 +431,8 @@ def VerifM.findMatch (lq : Term .value) : VerifM (Option (Term .value)) := do
 /-- Correctness of `findMatchIn`: on a `some (n, v)` result, `remove ctx n`
     extracts a points-to whose location the solver has proved equal to `lq`. -/
 theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
-    {st : TransState} {ρ : Env}
-    {Q : Option (Nat × Term .value) → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Option (Nat × Term .value) → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.findMatchIn lq ctx) st ρ Q)
     (hlq : lq.wfIn st.decls) (hctx : ctx.wfIn st.decls) :
     ∃ result,
@@ -431,7 +440,7 @@ theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
       (∀ n v, result = some (n, v) →
         ∃ l rest,
           SpatialContext.remove ctx n = some (.pointsTo l v, rest) ∧
-          Term.eval ρ lq = Term.eval ρ l) := by
+          Term.eval ρ.env lq = Term.eval ρ.env l) := by
   induction ctx generalizing Q with
   | nil =>
     simp only [VerifM.findMatchIn] at h
@@ -454,7 +463,7 @@ theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
         intros n' v' hnv
         simp at hnv
         obtain ⟨rfl, rfl⟩ := hnv
-        have heq : Term.eval ρ lq = Term.eval ρ l := by
+        have heq : Term.eval ρ.env lq = Term.eval ρ.env l := by
           have := hb_sound rfl
           simpa [Formula.eval] using this
         exact ⟨l, ctx, rfl, heq⟩
@@ -483,16 +492,16 @@ theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
     postcondition state has the matched points-to consumed from `st.owns`, and
     the caller receives separate ownership of `lq ↦ v`. -/
 theorem VerifM.eval_findMatch {lq : Term .value}
-    {st : TransState} {ρ : Env}
-    {Q : Option (Term .value) → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Option (Term .value) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.findMatch lq) st ρ Q)
     (hlq : lq.wfIn st.decls)
     (hsome : ∀ v st', Q (some v) st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp ρ (.pointsTo lq v) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
-    (hnone : Q none st ρ → SpatialContext.interp ρ st.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+        SpatialAtom.interp ρ.env (.pointsTo lq v) ∗ st'.sl ρ ∗ R ⊢ Φ)
+    (hnone : Q none st ρ → st.sl ρ ∗ R ⊢ Φ) :
+    st.sl ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatch at h
   have hb := VerifM.eval_bind _ _ _ _ h
   have ⟨hk, howns, _, _⟩ := VerifM.eval_ctx hb
@@ -519,7 +528,7 @@ theorem VerifM.eval_findMatch {lq : Term .value}
     have ⟨hk3, _, _, _⟩ := VerifM.eval_ctx hb3
     have hk3' := hk3 hrest_wf
     have hQ : Q (some v) { st with owns := rest } ρ := VerifM.eval_ret hk3'
-    have hsplit := SpatialContext.interp_remove ρ st.owns n _ _ hrem
+    have hsplit := SpatialContext.interp_remove ρ.env st.owns n _ _ hrem
     have hcong := SpatialAtom.interp_pointsTo_loc_congr (v := v) heq.symm
     -- goal: st.owns.interp ρ ∗ R ⊢ Φ
     -- st.owns.interp ρ ⊣⊢ (pointsTo l v).interp ρ ∗ rest.interp ρ
@@ -539,15 +548,15 @@ def VerifM.findMatchForce (lq : Term .value) : VerifM (Term .value) := do
 /-- CPS correctness for `findMatchForce`: only a `some`-style continuation is
     required, since the `none` branch is discharged by the fatal error. -/
 theorem VerifM.eval_findMatchForce {lq : Term .value}
-    {st : TransState} {ρ : Env}
-    {Q : Term .value → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Term .value → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.findMatchForce lq) st ρ Q)
     (hlq : lq.wfIn st.decls)
     (hsome : ∀ v st', Q v st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp ρ (.pointsTo lq v) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+        SpatialAtom.interp ρ.env (.pointsTo lq v) ∗ st'.sl ρ ∗ R ⊢ Φ) :
+    st.sl ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatchForce at h
   have hb := VerifM.eval_bind _ _ _ _ h
   refine eval_findMatch (R := R) (Φ := Φ) hb hlq ?_ ?_
@@ -571,18 +580,18 @@ def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
       | none => VerifM.tryCandidates a.candidates
 
 /-- Helper: resolution of a pure atom via formula matching or SMT candidates. -/
-private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ : Env}
-    {Q : Option (Term τ) → TransState → Env → Prop}
+private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
+    {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (do
       match ← VerifM.ctxPure (pred.resolve ·) with
       | some t => pure (some t)
       | none => VerifM.tryCandidates pred.candidates) st ρ Q)
     (hwf : pred.wfIn st.decls)
-    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → st'.sl ρ ∗ R ⊢ Φ)
     (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
-      Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+      Atom.eval pred ρ (v.eval ρ.env) ∗ st'.sl ρ ∗ R ⊢ Φ) :
+    st.sl ρ ∗ R ⊢ Φ := by
     have hb1 := VerifM.eval_bind _ _ _ _ h
     have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
     cases hres : pred.resolve st.asserts with
@@ -590,10 +599,10 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
       simp [hres] at hctx_q
       have hq := VerifM.eval_ret hctx_q
       have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
-      have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
+      have hpred : ⊢ Atom.eval pred ρ (t.eval ρ.env) := by
         exact (Atom.resolve_correct hres ρ hholds).trans Atom.toItem_eval
-      have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
-          Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
+      have hframe : st.sl ρ ∗ R ⊢
+          Atom.eval pred ρ (t.eval ρ.env) ∗ st.sl ρ ∗ R := by
         istart
         iintro H
         isplitr [H]
@@ -611,10 +620,10 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
       | some t =>
         have htwf : t.wfIn st.decls := hresult_wf t hr
         have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
-        have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
+        have hpred : ⊢ Atom.eval pred ρ (t.eval ρ.env) := by
           exact (hresult_eval t hr).trans Atom.toItem_eval
-        have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
-            Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
+        have hframe : st.sl ρ ∗ R ⊢
+            Atom.eval pred ρ (t.eval ρ.env) ∗ st.sl ρ ∗ R := by
           istart
           iintro H
           isplitr [H]
@@ -622,22 +631,22 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
           · iexact H
         exact hframe.trans (hsome t st hqsome rfl htwf)
 
-theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
-    {Q : Option (Term τ) → TransState → Env → Prop}
+theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
+    {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
     (hwf : pred.wfIn st.decls)
-    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → st'.sl ρ ∗ R ⊢ Φ)
     (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
-      Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+      Atom.eval pred ρ (v.eval ρ.env) ∗ st'.sl ρ ∗ R ⊢ Φ) :
+    st.sl ρ ∗ R ⊢ Φ := by
   match pred, hwf, hsome, h with
   | .own l, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
     refine VerifM.eval_findMatch (R := R) (Φ := Φ) h hwf ?_ ?_
     · intros v st' hqsome hdecls hvwf
       have hsome' := hsome v st' hqsome hdecls hvwf
-      have heq : SpatialAtom.interp ρ (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ) := by
+      have heq : SpatialAtom.interp ρ.env (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ.env) := by
         simp only [Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -59,16 +59,16 @@ theorem vtailN_wfIn {t : Term .vallist} {Δ : Signature} (ht : t.wfIn Δ) (n : N
   | zero => simpa [vtailN]
   | succ n ih => simp only [vtailN, Term.wfIn]; exact ⟨trivial, ih⟩
 
-@[simp] theorem vtailN_eval (t : Term .vallist) (ρ : Env) :
-    ∀ n, (vtailN t n).eval ρ = List.drop n (t.eval ρ)
+@[simp] theorem vtailN_eval (t : Term .vallist) (ρ : VerifM.Env) :
+    ∀ n, (vtailN t n).eval ρ.env = List.drop n (t.eval ρ.env)
   | 0 => by simp [vtailN]
   | n + 1 => by
     simp only [vtailN, Term.eval, UnOp.eval, vtailN_eval t ρ n]
     rw [List.tail_drop]
 
 theorem vhead_vtailN_eval {vs : List Runtime.Val} {w : Runtime.Val} {n : Nat}
-    (h : vs[n]? = some w) (t : Term .vallist) (ρ : Env) (ht : t.eval ρ = vs) :
-    (Term.unop .vhead (vtailN t n)).eval ρ = w := by
+    (h : vs[n]? = some w) (t : Term .vallist) (ρ : VerifM.Env) (ht : t.eval ρ.env = vs) :
+    (Term.unop .vhead (vtailN t n)).eval ρ.env = w := by
   simp [Term.eval, UnOp.eval, ht, h]
 
 def compileUnop (op : TinyML.UnOp) (s : Term .value) : Option (Term .value) :=
@@ -86,21 +86,21 @@ theorem compileUnop_wfIn {op : TinyML.UnOp} {s : Term .value} {Δ : Signature}
     simp only [Term.wfIn, UnOp.wfIn, true_and]
   all_goals first | exact hs | (have : (Term.unop UnOp.toValList s).wfIn _ := ⟨trivial, hs⟩; exact vtailN_wfIn this _)
 
-theorem compileUnop_eval {op : TinyML.UnOp} {s : Term .value} {ρ : Env}
+theorem compileUnop_eval {op : TinyML.UnOp} {s : Term .value} {ρ : VerifM.Env}
     {v w : Runtime.Val} {t : Term .value}
-    (hs : s.eval ρ = v) (heval : TinyML.evalUnOp op v = some w)
+    (hs : s.eval ρ.env = v) (heval : TinyML.evalUnOp op v = some w)
     (hcomp : compileUnop op s = some t) :
-    t.eval ρ = w := by
+    t.eval ρ.env = w := by
   subst hs
   cases op with
   | proj n =>
     simp only [compileUnop, Option.some.injEq] at hcomp; subst hcomp
-    cases h : s.eval ρ <;> simp_all [TinyML.evalUnOp]
+    cases h : s.eval ρ.env <;> simp_all [TinyML.evalUnOp]
     exact vhead_vtailN_eval heval _ ρ (by simp [Term.eval, UnOp.eval, h])
   | neg | not =>
     simp only [compileUnop, Option.some.injEq] at hcomp
     subst hcomp
-    cases h : s.eval ρ <;>
+    cases h : s.eval ρ.env <;>
     simp_all [TinyML.evalUnOp, Term.eval, UnOp.eval]
 
 theorem compileOp_wfIn {op : TinyML.BinOp} {sl sr : Term .value} {Δ : Signature}
@@ -113,18 +113,18 @@ theorem compileOp_wfIn {op : TinyML.BinOp} {sl sr : Term .value} {Δ : Signature
 /-- If `evalBinOp op v1 v2 = some w` and the input terms evaluate to `v1`, `v2`,
     then the compiled SMT term evaluates to `w`.
     Pair/store return `none` from `compileOp` so those cases are vacuous via `hcomp`. -/
-theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : Env}
+theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : VerifM.Env}
     {v1 v2 w : Runtime.Val} {t : Term .value}
-    (hsl : sl.eval ρ = v1) (hsr : sr.eval ρ = v2)
+    (hsl : sl.eval ρ.env = v1) (hsr : sr.eval ρ.env = v2)
     (heval : TinyML.evalBinOp op v1 v2 = some w)
     (hcomp : compileOp op sl sr = some t) :
-    t.eval ρ = w := by
+    t.eval ρ.env = w := by
   subst hsl hsr
   cases op <;>
     simp only [compileOp, Option.some.injEq] at hcomp <;>
     (try simp at hcomp) <;>
     subst hcomp <;>
-    (cases h1 : sl.eval ρ <;> cases h2 : sr.eval ρ) <;>
+    (cases h1 : sl.eval ρ.env <;> cases h2 : sr.eval ρ.env) <;>
     simp_all [TinyML.evalBinOp, Term.eval, UnOp.eval, BinOp.eval, Const.denote,
               Bool.cond_eq_ite, ge_iff_le, Bool.beq_eq_decide_eq]
 
@@ -341,16 +341,16 @@ theorem SpecMap.satisfiedBy_weaken {A R : iProp}
 
 mutual
 
-theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp) :
+theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) :
     VerifM.eval (compile Θ S B Γ e) st ρ Ψ →
-    B.agreeOnLinked ρ γ →
+    B.agreeOnLinked ρ.env γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
-    (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
-      TinyML.ValHasType Θ v e.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
-    st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ := by
+    (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
+      TinyML.ValHasType Θ v e.ty → st'.sl ρ' ∗ R ⊢ Φ v) →
+    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ := by
   intro heval hagree hbwf hts hSwf hpost
   cases e with
   | const c =>
@@ -408,7 +408,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           · intro τ' hc'
             exact Signature.wf_unique_const hwfst h hc'
       simp only [Expr.ty] at hpost
-      have htyping : TinyML.ValHasType Θ (ρ.consts .value x'.name) vty := by
+      have htyping : TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty := by
         rw [← hcheck]
         cases hΓ : Γ x with
         | none => exact .any
@@ -467,7 +467,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
     have hwf_φ : φ.wfIn st₁.decls := by
-      simp only [φ, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]; exact hse_wf
+      simpa [φ, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using hse_wf
     have heval_assert : (VerifM.assert φ).eval st₁ ρ_e _ := VerifM.eval_bind _ _ _ _ hΨ_e
     obtain ⟨hφ, hcont⟩ := VerifM.eval_assert heval_assert hwf_φ
     have hΨ_pure := VerifM.eval_ret hcont
@@ -507,7 +507,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
     have hdecl := VerifM.eval_decl hdecl_eval (.loc loc)
     have hassume_eval := VerifM.eval_bind _ _ _ _ hdecl
-    set ρ_e' : Env := ρ_e.updateConst .value c.name (.loc loc)
+    set ρ_e' : VerifM.Env := ρ_e.updateConst .value c.name (.loc loc)
     set st₂ : TransState := { st₁ with decls := st₁.decls.addConst c }
     have hc_wf : (Term.const (.uninterpreted c.name .value)).wfIn st₂.decls := by
       simp only [Term.wfIn, Const.wfIn]
@@ -524,8 +524,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       ⟨hc_wf, hse_wf_st₂⟩
     have hassume_res := VerifM.eval_assumeSpatial hassume_eval hatom_wf
     have hret := VerifM.eval_ret hassume_res
-    have hval_eval : Term.eval ρ_e' (Term.const (.uninterpreted c.name .value)) = .loc loc := by
-      simp [ρ_e', Term.eval, Const.denote, Env.updateConst]
+    have hval_eval : Term.eval ρ_e'.env (Term.const (.uninterpreted c.name .value)) = .loc loc := by
+      simp [Term.eval, Const.denote, ρ_e', VerifM.Env.updateConst, Env.updateConst]
     have hty : TinyML.ValHasType Θ (Runtime.Val.loc loc) (TinyML.Typ.ref e.ty) := by
       exact TinyML.ValHasType.ref loc e.ty
     exact hpost (.loc loc) ρ_e' _ _ hret hc_wf hval_eval hty
@@ -560,14 +560,14 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         have hret := VerifM.eval_ret hassume_res
         have hv_wf_final : v.wfIn (TransState.addItem st' (.spatial (.pointsTo se v))).decls := by
           simpa [TransState.addItem] using hv_wf_st'
-        have htype : TinyML.ValHasType Θ (v.eval ρ_e) .int := by
-          cases hv : v.eval ρ_e with
+        have htype : TinyML.ValHasType Θ (v.eval ρ_e.env) .int := by
+          cases hv : v.eval ρ_e.env with
           | int n => exact TinyML.ValHasType.int n
           | bool _ | unit | inj _ _ _ | loc _ | fix _ _ _ | tuple _ =>
               simp [Formula.eval, hv] at hv_int
         let st'' := TransState.addItem st' (.spatial (.pointsTo se v))
-        have hgoal : st''.owns.interp ρ_e ∗ R ⊢ Φ (v.eval ρ_e) :=
-          hpost (v.eval ρ_e) ρ_e st'' _ hret hv_wf_final rfl htype
+        have hgoal : st''.sl ρ_e ∗ R ⊢ Φ (v.eval ρ_e.env) :=
+          hpost (v.eval ρ_e.env) ρ_e st'' _ hret hv_wf_final rfl htype
         simp only [Atom.eval]
         istart
         iintro H
@@ -576,14 +576,14 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         icases Hpt' with ⟨%Hloc, Hpt⟩
         have hv_e : v_e = .loc loc := heval_se.symm.trans Hloc
         subst hv_e
-        have hptIntro : loc ↦ v.eval ρ_e ⊢ SpatialAtom.interp ρ_e (.pointsTo se v) := by
+        have hptIntro : loc ↦ v.eval ρ_e.env ⊢ SpatialAtom.interp ρ_e.env (.pointsTo se v) := by
           simpa [Hloc] using
-            (SpatialAtom.interp_pointsTo (ρ := ρ_e) (lt := se) (vt := v) (loc := loc) Hloc).2
-        have hctx : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ∗ R ⊢ Φ (v.eval ρ_e) := by
-          have hcons : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ⊢ st''.owns.interp ρ_e := by
+            (SpatialAtom.interp_pointsTo (ρ := ρ_e.env) (lt := se) (vt := v) (loc := loc) Hloc).2
+        have hctx : (loc ↦ v.eval ρ_e.env) ∗ SpatialContext.interp ρ_e.env st'.owns ∗ R ⊢ Φ (v.eval ρ_e.env) := by
+          have hcons : (loc ↦ v.eval ρ_e.env) ∗ SpatialContext.interp ρ_e.env st'.owns ⊢ st''.sl ρ_e := by
             simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hptIntro)
           exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
-        iapply (wp.deref (l := loc) (v := v.eval ρ_e))
+        iapply (wp.deref (l := loc) (v := v.eval ρ_e.env))
         isplitl [Hpt]
         · iexact Hpt
         · iintro Hpt
@@ -591,7 +591,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           isplitl [Hpt]
           · iexact Hpt
           · isplitl [Hrest]
-            · iexact Hrest
+            · simp [TransState.sl]
             · iexact HR
     | bool | unit | arrow _ _ | ref _ | sum _ | empty | value | tuple _ | tvar _ | named _ _ =>
       simp [hty] at heval
@@ -607,7 +607,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hts hSwf ?_)
     intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv htyv
     obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
-    have hagree_v : B.agreeOnLinked ρ_v γ :=
+    have hagree_v : B.agreeOnLinked ρ_v.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
     have hbwf_v : B.wf st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
     have heval_l : (compile Θ S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
@@ -615,7 +615,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hts hSwf ?_
     intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
     obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
-    have hsv_ρ_l : sv.eval ρ_l = v_v := by
+    have hsv_ρ_l : sv.eval ρ_l.env = v_v := by
       rw [Term.eval_env_agree hsv_wf (Env.agreeOn_symm hagreeOn_l)]
       exact heval_sv
     have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_l
@@ -637,7 +637,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           (TransState.addItem st' (.spatial (.pointsTo sl sv))).decls := by
         simp [Term.wfIn, Const.wfIn]
       let st'' := TransState.addItem st' (.spatial (.pointsTo sl sv))
-      have hgoal : st''.owns.interp ρ_l ∗ R ⊢ Φ .unit :=
+      have hgoal : st''.sl ρ_l ∗ R ⊢ Φ .unit :=
         hpost .unit ρ_l st'' _ hret hunit_wf (by simp [Term.eval]) (.unit)
       simp only [Atom.eval]
       istart
@@ -647,14 +647,14 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       icases Hold' with ⟨%Hloc, Hold⟩
       have hv_l : v_l = .loc loc := heval_sl.symm.trans Hloc
       subst hv_l
-      have hnewIntro : loc ↦ v_v ⊢ SpatialAtom.interp ρ_l (.pointsTo sl sv) := by
+      have hnewIntro : loc ↦ v_v ⊢ SpatialAtom.interp ρ_l.env (.pointsTo sl sv) := by
         simpa [Hloc, hsv_ρ_l] using
-          (SpatialAtom.interp_pointsTo (ρ := ρ_l) (lt := sl) (vt := sv) (loc := loc) Hloc).2
-      have hctx : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l st'.owns ∗ R ⊢ Φ .unit := by
-        have hcons : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l st'.owns ⊢ st''.owns.interp ρ_l := by
+          (SpatialAtom.interp_pointsTo (ρ := ρ_l.env) (lt := sl) (vt := sv) (loc := loc) Hloc).2
+      have hctx : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l.env st'.owns ∗ R ⊢ Φ .unit := by
+        have hcons : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l.env st'.owns ⊢ st''.sl ρ_l := by
           simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hnewIntro)
         exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
-      iapply (wp.store (l := loc) (old := old.eval ρ_l) (v := v_v))
+      iapply (wp.store (l := loc) (old := old.eval ρ_l.env) (v := v_v))
       isplitl [Hold]
       · iexact Hold
       · iintro Hnew
@@ -662,7 +662,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         isplitl [Hnew]
         · iexact Hnew
         · isplitl [Hrest]
-          · iexact Hrest
+          · simp [TransState.sl]
           · iexact HR
   | unop op e uty =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
@@ -677,7 +677,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     obtain ⟨t, hcompUnop, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
     obtain hΨ_e := VerifM.eval_ret hΨ_e
     obtain ⟨w, heval_op, hwt⟩ := evalUnOp_typed htypeOf htype_e
-    have ht_eval : t.eval ρ_e = w :=
+    have ht_eval : t.eval ρ_e.env = w :=
       compileUnop_eval heval_se heval_op hcompUnop
     simp only [Expr.ty] at hpost
     exact SpatialContext.wp_unop
@@ -694,7 +694,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hSwf ?_
     intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr htyr
     obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
-    have hagree_r : B.agreeOnLinked ρ_r γ :=
+    have hagree_r : B.agreeOnLinked ρ_r.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
     have hbwf_r : B.wf st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
     have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
@@ -706,7 +706,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     obtain ⟨hty_eq, hΨ_l'⟩ := VerifM.eval_bind_expectEq hΨ_l
     simp only [Expr.ty] at hpost
     -- transport sr's eval to the final env ρ_l
-    have hsr_ρ_l : sr.eval ρ_l = vr := by
+    have hsr_ρ_l : sr.eval ρ_l.env = vr := by
       rw [Term.eval_env_agree hsr_wf (Env.agreeOn_symm hagreeOn_l)]; exact heval_sr
     /- Split on whether op is division -/
     by_cases hdivmod : op = .div ∨ op = .mod
@@ -803,7 +803,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       obtain ⟨w, heval_op, hwt⟩ := evalBinOp_typed hdiv hmod htypeOf htyl htyr
       have hwf_sr_l : sr.wfIn st₂.decls :=
         Term.wfIn_mono sr hsr_wf hdecls_l hwfst₂
-      have ht_eval : t.eval ρ_l = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
+      have ht_eval : t.eval ρ_l.env = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
       exact SpatialContext.wp_binop
         (hpost w ρ_l st₂ t hΨ_ndiv
           (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval (hty_eq ▸ hwt))
@@ -830,7 +830,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           let ⟨_, _, hΨ'⟩ := hΨ
           hpost v ρ' st' se hΨ' hs hw ht)
       have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ Runtime.Binder.none v_e
-      have hbody' : st₁.owns.interp ρ_e ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp
+      have hbody' : st₁.sl ρ_e ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp
             (Runtime.Expr.subst
               (Runtime.Subst.update' Runtime.Binder.none v_e Runtime.Subst.id)
               (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
@@ -852,27 +852,27 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           owns := st₁.owns }
       set ρ_body := ρ_e.updateConst .value v.name v_e
       set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
-      suffices st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp (body.runtime.subst γ_body) Φ by
+      suffices st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp (body.runtime.subst γ_body) Φ by
         have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ (.named x) v_e
-        have hbody' : st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp
+        have hbody' : st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp
               (Runtime.Expr.subst
                 (Runtime.Subst.update' (.named x) v_e Runtime.Subst.id)
                 (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
               Φ :=
           hsubst.symm ▸ this
-        have hinterp_eq : SpatialContext.interp ρ_e st₁.owns ⊢ SpatialContext.interp ρ_body st₁.owns :=
+        have hinterp_eq : SpatialContext.interp ρ_e.env st₁.owns ⊢ SpatialContext.interp ρ_body.env st₁.owns :=
           (SpatialContext.interp_env_agree (VerifM.eval.wf hΨ_e).ownsWf
             (agreeOn_update_fresh_const hfresh)).1
         rw [Binder.runtime_of_name_some hname]
         have hsat :
-            st₂.owns.interp ρ_body ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
-              st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) := by
+            st₂.sl ρ_body ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+              st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) := by
           exact SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase
         exact (sep_mono_l hinterp_eq).trans <|
           hsat.trans <|
           by simpa [st₂, γ_body, base, Runtime.Subst.update', Runtime.Subst.update, Runtime.Subst.id]
             using hbody'
-      have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e ρ_body :=
+      have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
         agreeOn_update_fresh_const hfresh
       have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
         have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
@@ -894,12 +894,12 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
               (TransState.freshConst.wf _ (VerifM.eval.wf hdecl_eval)).namesDisjoint
               (List.mem_cons_self ..) hc'
         · simp only [Formula.eval, Term.eval, Const.denote]
-          have : v_e = Term.eval ρ_body se := by
+          have : v_e = Term.eval ρ_body.env se := by
             rw [Term.eval_env_agree hse_wf (Env.agreeOn_symm hagreeOn_body_e)]
             exact heval_e.symm
           simpa [ρ_body, Env.updateConst] using this
       have hbwf₂ : Bindings.wf ((x, v) :: B) st₂.decls := Bindings.wf_cons hbwf_e
-      have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ_body ρ := by
+      have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ_body.env ρ.env := by
         constructor
         · intro y hy
           cases hy
@@ -909,9 +909,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             exact ((hagreeOn_e.2.1 p.2 (hbwf p hp)).trans
               (hagreeOn_body_e.2.1 p.2 (hbwf_e p hp))).symm
           · constructor <;> intro z hz <;> cases hz
-      have hρ_body_lookup : ρ_body.consts .value v.name = v_e := by
-        simp [ρ_body, Env.updateConst]
-      have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body γ_body := by
+      have hρ_body_lookup : ρ_body.env.consts .value v.name = v_e := by
+        simp [ρ_body, VerifM.Env.updateConst, Env.updateConst]
+      have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body.env γ_body := by
         have h := Bindings.agreeOnLinked_cons (x := x) (γ := γ) hagree hρ_agree (hvty := (rfl : v.sort = .value))
         rwa [hρ_body_lookup] at h
       have hts_body : Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body :=
@@ -966,7 +966,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           | false => exact absurd rfl hvc_false
           | true  => rfl
       subst hvc_true
-      have heval_ne : sc.eval ρ_c ≠ Runtime.Val.bool false := by rw [heval_c]; simp
+      have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by rw [heval_c]; simp
       have heval_thn : (compile Θ S B Γ thn).eval st_thn ρ_c Ψ :=
         htrue_cont hwf_ne (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
@@ -982,7 +982,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [compile] at heval
       obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
       have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine SpecMap.project (P := st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R)) Θ S γ ?_ hlookup ?_
+      refine SpecMap.project (P := st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R)) Θ S γ ?_ hlookup ?_
       · istart
         iintro ⟨_, □HS, _⟩
         iexact HS
@@ -990,8 +990,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         simp [Expr.runtime, Runtime.Expr.subst, hγf]
         refine SpatialContext.wp_bind_app ?_
         have hctx :
-            spec.isPrecondFor Θ fval ∗ (st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
-              st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
+            spec.isPrecondFor Θ fval ∗ (st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
+              st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
           istart
           iintro ⟨□Hspec, Howns, □HS, HR⟩
           isplitl [Howns]
@@ -1035,40 +1035,41 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
         have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
           TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
-        have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
+        have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args.env) = vs := by
           have hsnd :
               List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
             simpa using
               (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
                 (Nat.le_of_eq hlen_typed.symm))
           calc
-            typedArgs.map (fun p => p.2.eval ρ_args)
-                = sargs.map (fun t => t.eval ρ_args) := by
+            typedArgs.map (fun p => p.2.eval ρ_args.env)
+                = sargs.map (fun t => t.eval ρ_args.env) := by
                     simpa [typedArgs, List.map_map] using
-                      congrArg (List.map (fun t => t.eval ρ_args)) hsnd
+                      congrArg (List.map (fun t => t.eval ρ_args.env)) hsnd
             _ = vs := Terms.Eval.map_eval heval_sargs
         have happly' :
-            st_args.owns.interp ρ_args ∗ R ⊢
+            st_args.sl ρ_args ∗ R ⊢
               PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
-                (Spec.argsEnv Env.empty spec.args vs) := by
+                (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
           rw [heval_sargs_map] at happly
           exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
             Spec.argsEnv_agreeOn (Δ := Signature.empty)
-              (ρ₁ := FiniteSubst.id.subst.eval ρ_args) (ρ₂ := Env.empty)
-              ⟨nofun, nofun, nofun, nofun⟩ spec.args vs
+              (ρ₁ := VerifM.Env.withEnv ρ_args (FiniteSubst.id.subst.eval ρ_args.env))
+              (ρ₂ := VerifM.Env.empty)
+              (by exact ⟨nofun, nofun, nofun, nofun⟩) spec.args vs
               (by have := htyped.length_eq; simp [List.length_map] at this; omega)
         have happly'' :
-            st_args.owns.interp ρ_args ∗
+            st_args.sl ρ_args ∗
                 (S.satisfiedBy Θ γ ∗ R) ⊢
               PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
-                (Spec.argsEnv Env.empty spec.args vs) := by
+                (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
           have hdrop :
-              st_args.owns.interp ρ_args ∗
+              st_args.sl ρ_args ∗
                   (S.satisfiedBy Θ γ ∗ R) ⊢
-                st_args.owns.interp ρ_args ∗ R := by
+                st_args.sl ρ_args ∗ R := by
             simpa [sep_assoc] using
               (SpecMap.satisfiedBy_drop
-                (A := st_args.owns.interp ρ_args)
+                (A := st_args.sl ρ_args)
                 (Θ := Θ) (S := S) (γ := γ)
                 (R := R))
           exact hdrop.trans happly'
@@ -1101,7 +1102,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
     obtain ⟨_, _, hΨ⟩ := hΨ
     obtain hΨ := VerifM.eval_ret hΨ
-    have heval_tuple : (Term.unop .ofValList (Terms.toValList terms)).eval ρ' = Runtime.Val.tuple vs := by
+    have heval_tuple : (Term.unop .ofValList (Terms.toValList terms)).eval ρ'.env = Runtime.Val.tuple vs := by
       simp [Term.eval, UnOp.eval, Terms.toValList_eval heval_terms]
     have hwf_tuple : (Term.unop UnOp.ofValList (Terms.toValList terms)).wfIn st'.decls := by
       simp only [Term.wfIn]
@@ -1167,7 +1168,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
                 SpecMap.satisfiedBy_drop.trans <| hpost v ρ' st' se hΨ hse_wf hse_eval
                   ((htys (branches[j]) (List.getElem_mem _)) ▸ htyped))
               tag htag_branches (by simpa [Nat.zero_add, hty_eq] using heval_tag)
-            have hsc_eval : se_scrut.eval ρ_scrut = Runtime.Val.inj tag ts.length v_payload :=
+            have hsc_eval : se_scrut.eval ρ_scrut.env = Runtime.Val.inj tag ts.length v_payload :=
               heval_se
             have hpayload_ty : TinyML.ValHasType Θ v_payload (ts[tag]?.getD .value) := by
               simpa [hty_eq] using htype_payload
@@ -1182,20 +1183,20 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
 
 theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder × Expr) (S : SpecMap) (B : Bindings)
     (Γ : TinyML.TyCtx) (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
-    (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → Env → Prop)
+    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp) :
     VerifM.eval (compileBranch Θ S B Γ sc n i ty_i branch) st ρ Ψ →
-    B.agreeOnLinked ρ γ →
+    B.agreeOnLinked ρ.env γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
-    ∀ payload, sc.eval ρ = Runtime.Val.inj i n payload →
+      se.eval ρ'.env = v → TinyML.ValHasType Θ v branch.2.ty → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+    ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
       TinyML.ValHasType Θ payload ty_i →
-      st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
+      st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
   intro heval hagree hbwf hts hSwf hsc_wf hpost payload hsc_eval htype_payload
   obtain ⟨binder, body⟩ := branch
   simp only [compileBranch] at heval
@@ -1227,9 +1228,9 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
         exact Signature.wf_unique_const
           (TransState.freshConst.wf _ (VerifM.eval.wf heval_decl)).namesDisjoint
           (List.mem_cons_self ..) hc'
-    have hsc_eval_ρ₁ : sc.eval ρ₁ = sc.eval ρ :=
+    have hsc_eval_ρ₁ : sc.eval ρ₁.env = sc.eval ρ.env :=
       Term.eval_env_agree hsc_wf (Env.agreeOn_symm (agreeOn_update_fresh_const hxv_fresh))
-    have hformula_eval : Formula.eval ρ₁
+    have hformula_eval : Formula.eval ρ₁.env
         (Formula.eq .value sc (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value)))) := by
       simp [Formula.eval, Term.eval, UnOp.eval]
       rw [hsc_eval_ρ₁, hsc_eval]
@@ -1246,22 +1247,22 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
         exact Signature.wf_unique_const
           (TransState.freshConst.wf _ (VerifM.eval.wf heval_decl)).namesDisjoint
           (List.mem_cons_self ..) hc'
-    have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁ = payload := by
+    have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁.env = payload := by
       simp [Term.eval, Const.denote, ρ₁, Env.updateConst]
     have hassume_bind₂ := VerifM.eval_bind _ _ _ _ heval_assumeAll
     obtain ⟨st₂, hst₂_decls, hst₂_owns, heval_body'⟩ := VerifM.eval_assumeAll hassume_bind₂
       (fun φ hφ => typeConstraints_wfIn hxv_wf φ hφ)
       (fun φ hφ => typeConstraints_hold hxv_eval htype_payload φ hφ)
     have hst₂_owns_eq : st₂.owns = st.owns := hst₂_owns
-    have hinterp_eq : SpatialContext.interp ρ st.owns ⊢ SpatialContext.interp ρ₁ st.owns :=
+    have hinterp_eq : SpatialContext.interp ρ.env st.owns ⊢ SpatialContext.interp ρ₁.env st.owns :=
       (SpatialContext.interp_env_agree (VerifM.eval.wf heval_decl).ownsWf
         (agreeOn_update_fresh_const hxv_fresh)).1
-    have hagreeOn_st : Env.agreeOn st.decls ρ ρ₁ :=
+    have hagreeOn_st : Env.agreeOn st.decls ρ.env ρ₁.env :=
       agreeOn_update_fresh_const hxv_fresh
     cases hname : binder.name with
     | none =>
       simp [hname] at heval_body'
-      have hagree₁ : B.agreeOnLinked ρ₁ γ :=
+      have hagree₁ : B.agreeOnLinked ρ₁.env γ :=
         Bindings.agreeOnLinked_env_agree hagree hagreeOn_st hbwf
       have hbwf₁ : B.wf st₂.decls := hst₂_decls ▸ fun p hp => List.Mem.tail _ (hbwf p hp)
       have hts₁ : B.typedSubst Θ (Γ.extendBinder binder ty_i) γ := by
@@ -1271,7 +1272,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       rw [Binder.runtime_of_name_none hname]
       simp only [Runtime.Expr.subst_fix]
       apply BIBase.Entails.trans _ wp.app_lambda_single
-      change SpatialContext.interp ρ st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+      change SpatialContext.interp ρ.env st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
         wp
           ((body.runtime.subst ((γ.remove' .none).removeAll' [.none])).subst
             ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.none] [payload]))
@@ -1286,7 +1287,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
               by simpa [hty] using hpost v ρ' st' se hΨ hs hw ht))
     | some x =>
       simp [hname, TinyML.TyCtx.extendBinder] at heval_body'
-      have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁ ρ := by
+      have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁.env ρ.env := by
         constructor
         · intro w hw
           cases hw
@@ -1296,9 +1297,9 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
             exact (hagreeOn_st.2.1 p.2 (hbwf p hp)).symm
           · constructor <;> intro z hz <;> cases hz
       have hbwf₂ : Bindings.wf ((x, xv) :: B) st₂.decls := hst₂_decls ▸ Bindings.wf_cons hbwf
-      have hρ₁_lookup : ρ₁.consts .value xv.name = payload := by
-        simp [ρ₁, Env.updateConst]
-      have hagree₁ : Bindings.agreeOnLinked ((x, xv) :: B) ρ₁ (Runtime.Subst.update γ x payload) := by
+      have hρ₁_lookup : ρ₁.env.consts .value xv.name = payload := by
+        simp [ρ₁, VerifM.Env.updateConst, Env.updateConst]
+      have hagree₁ : Bindings.agreeOnLinked ((x, xv) :: B) ρ₁.env (Runtime.Subst.update γ x payload) := by
         have h := Bindings.agreeOnLinked_cons (x := x) (v := xv) (γ := γ) hagree hagreeOn_B (hvty := rfl)
         rwa [hρ₁_lookup] at h
       have hts₁ : Bindings.typedSubst Θ ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) := by
@@ -1309,7 +1310,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       rw [Binder.runtime_of_name_some hname]
       simp only [Runtime.Expr.subst_fix]
       apply BIBase.Entails.trans _ wp.app_lambda_single
-      change SpatialContext.interp ρ st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+      change SpatialContext.interp ρ.env st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
         wp
           ((body.runtime.subst ((γ.remove' .none).removeAll' [.named x])).subst
             ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.named x] [payload]))
@@ -1330,21 +1331,21 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
 theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : List (Binder × Expr)) (S : SpecMap) (B : Bindings)
     (Γ : TinyML.TyCtx) (sc : Term .value) (n : Nat) (ts : List TinyML.Typ)
     (idx : Nat)
-    (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → Env → Prop)
+    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp) :
-    B.agreeOnLinked ρ γ →
+    B.agreeOnLinked ρ.env γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
       VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
-      ∀ payload, sc.eval ρ = Runtime.Val.inj (idx + j) n payload →
+      ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
         TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
-        st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
+        st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
   intro hagree hbwf hts hSwf hsc_wf hpost
   match branches with
   | [] =>
@@ -1369,16 +1370,16 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : Li
           simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
         k hk
 
-theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : List (Term .value) → TransState → Env → Prop) (Φ : List Runtime.Val → iProp) :
+theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : List (Term .value) → TransState → VerifM.Env → Prop) (Φ : List Runtime.Val → iProp) :
     VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
-    B.agreeOnLinked ρ γ → B.wf st.decls → B.typedSubst Θ Γ γ →
+    B.agreeOnLinked ρ.env γ → B.wf st.decls → B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
-      Terms.Eval ρ' terms vs →
-      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
-    st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
+      Terms.Eval ρ'.env terms vs →
+      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
+    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
   intro heval hagree hbwf hts hSwf hpost
   match es with
   | [] =>
@@ -1395,7 +1396,7 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
         (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hSwf ?_
     intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
     obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
-    have hagree_vs : B.agreeOnLinked ρ_vs γ :=
+    have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
     have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
     have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
@@ -1411,7 +1412,7 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
       rcases ht with rfl | ht
       · exact hse_wf
       · exact Term.wfIn_mono _ (hwf_rest t ht) hdecls_e hwfst'
-    have heval_cons : Terms.Eval ρ' (se :: rest_terms) (v :: vs) :=
+    have heval_cons : Terms.Eval ρ'.env (se :: rest_terms) (v :: vs) :=
       Terms.Eval.cons heval_se
         (Terms.Eval.env_agree
           (fun t ht => hwf_rest t ht)

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -52,17 +52,17 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     (vs : List Runtime.Val)
     (htyped_args : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd))
     (P : Runtime.Val → iProp)
-    {argVars : List FOL.Const} {st' : TransState} {ρ' : Env} {Q : iProp}
+    {argVars : List FOL.Const} {st' : TransState} {ρ' : VerifM.Env} {Q : iProp}
     (hargVars_mem : ∀ v ∈ argVars, v ∈ st'.decls.consts)
     (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
-    (hargVars_lookup : List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs)
+    (hargVars_lookup : List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs)
     (hbody_eval : VerifM.eval
         (checkBody Θ (SpecMap.eraseAll argNames (S.insert' fb s)) s argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
-          st''.owns.interp ρ'' ∗ Q ∗
-            ((⌜TinyML.ValHasType Θ (result.eval ρ'') s.retTy⌝ -∗ P (result.eval ρ'')) -∗ S) ⊢ S)) :
-    st'.owns.interp ρ' ∗ Q ⊢
+          st''.sl ρ'' ∗ Q ∗
+            ((⌜TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy⌝ -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
+    st'.sl ρ' ∗ Q ⊢
       (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
         wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
   simp only [checkBody] at hbody_eval
@@ -80,14 +80,14 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
   have hlen_avs : argNames.length = argVars.length := by
     have := hargVars_lookup.length_eq
     have := htyped_args.length_eq; simp at this; omega
-  have hagree : Bindings.agreeOnLinked B ρ' γ_body := by
-    show Bindings.agreeOnLinked (Bindings.empty ++ (argNames.zip argVars).reverse) ρ'
+  have hagree : Bindings.agreeOnLinked B ρ'.env γ_body := by
+    show Bindings.agreeOnLinked (Bindings.empty ++ (argNames.zip argVars).reverse) ρ'.env
       ((γ.update' fb.runtime fval).updateAll' bs vs)
     rw [show Bindings.empty ++ (argNames.zip argVars).reverse =
         (argNames.zip argVars).reverse ++ Bindings.empty from by simp [Bindings.empty]]
     rw [hbs_runtime]
     apply Bindings.agreeOnLinked_updateAll' Bindings.empty argNames argVars vs
-      (γ.update' fb.runtime fval) ρ'
+      (γ.update' fb.runtime fval) ρ'.env
     · intro x x' h; simp [Bindings.empty] at h
     · exact hlen_avs
     · exact hlen_nv
@@ -101,13 +101,13 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
   have hts : Bindings.typedSubst Θ B Γ γ_body := by
     apply Bindings.typedSubst_of_agreeOnLinked hagree
     intro x x' t hmem hΓ
-    show TinyML.ValHasType Θ (ρ'.consts .value x'.name) t
+    show TinyML.ValHasType Θ (ρ'.env.consts .value x'.name) t
     set args' := argNames.zip (s.args.map Prod.snd)
     have hfst : args'.map Prod.fst = argNames := by
       simp [args']; exact List.map_fst_zip (by simp; omega)
     have hsnd : args'.map Prod.snd = s.args.map Prod.snd := by
       simp [args']; exact List.map_snd_zip (by simp; omega)
-    exact val_typed_of_last_wins args' argVars vs ρ' TinyML.TyCtx.empty x x' t
+    exact val_typed_of_last_wins args' argVars vs ρ'.env TinyML.TyCtx.empty x x' t
       (by rw [hfst]; exact hlen_avs)
       (by rw [hfst]; exact hlen_nv)
       (by rw [hfst]; simp [B, Bindings.empty] at hmem; exact hmem)
@@ -127,7 +127,7 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
       SpecMap.satisfiedBy_eraseAll_updateAll' hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
-      st'.owns.interp ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Q) ⊢
+      st'.sl ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Q) ⊢
         wp (body.runtime.subst γ_body) P := by
     refine compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
       (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'wf ?_
@@ -141,12 +141,12 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     have hΨ' := VerifM.eval_ret hΨ
     dsimp only at hΨ'
     subst heval_se
-    have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
+    have hret : TinyML.ValHasType Θ (se.eval ρ''.env) s.retTy :=
       TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
-    refine (show st''.owns.interp ρ'' ∗ Q ⊢
-        st''.owns.interp ρ'' ∗ Q ∗
-          ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
-            P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
+    refine (show st''.sl ρ'' ∗ Q ⊢
+        st''.sl ρ'' ∗ Q ∗
+          ((⌜TinyML.ValHasType Θ (se.eval ρ''.env) s.retTy⌝ -∗ P (se.eval ρ''.env)) -∗
+            P (se.eval ρ''.env)) from ?_).trans (hΨ' _ hse_wf)
     istart
     iintro ⟨Howns, HQ⟩
     isplitl [Howns]
@@ -170,7 +170,7 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (ρ : Env) :
+    (ρ : VerifM.Env) :
     VerifM.eval (checkSpec Θ S e s) TransState.empty ρ (fun _ _ _ => True) →
     S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
   intro heval
@@ -216,7 +216,7 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
       simp only [] at hsub; rw [hsub]
       have hbody' : PredTrans.apply (fun r => iprop(⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r)) s.pred
-          (Spec.argsEnv Env.empty s.args vs) ⊢
+          (Spec.argsEnv VerifM.Env.empty s.args vs) ⊢
           SpecMap.satisfiedBy Θ S γ ∗ s.isPrecondFor Θ fval -∗
             wp (Runtime.Expr.subst ((Runtime.Subst.update' fb.runtime fval γ).updateAll' bs vs) body.runtime) P := by
         refine emp_sep.2.trans ?_

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -63,6 +63,60 @@ instance : Monad VerifM where
   pure := VerifM.ret
   bind := VerifM.bind
 
+structure VerifM.Env where
+  env : _root_.Env
+
+def VerifM.Env.empty : VerifM.Env :=
+  { env := _root_.Env.empty }
+
+@[simp] theorem VerifM.Env.empty_env : VerifM.Env.empty.env = _root_.Env.empty := rfl
+
+def VerifM.Env.updateConst (ρ : VerifM.Env) (t : Srt) (x : String) (u : t.denote) : VerifM.Env :=
+  { ρ with env := _root_.Env.updateConst ρ.env t x u }
+
+@[simp] theorem VerifM.Env.updateConst_env (ρ : VerifM.Env) (t : Srt) (x : String) (u : t.denote) :
+    (ρ.updateConst t x u).env = ρ.env.updateConst t x u := rfl
+
+def VerifM.Env.withEnv (ρ : VerifM.Env) (env' : _root_.Env) : VerifM.Env :=
+  { ρ with env := env' }
+
+@[simp] theorem VerifM.Env.withEnv_env (ρ : VerifM.Env) (env' : _root_.Env) :
+    (ρ.withEnv env').env = env' := rfl
+
+def VerifM.Env.agreeOn (Δ : Signature) (ρ ρ' : VerifM.Env) : Prop :=
+  _root_.Env.agreeOn Δ ρ.env ρ'.env
+
+theorem VerifM.Env.agreeOn_refl : VerifM.Env.agreeOn Δ ρ ρ :=
+  _root_.Env.agreeOn_refl
+
+theorem VerifM.Env.agreeOn_mono {Δ₁ Δ₂ : Signature} (hsub : Δ₁.Subset Δ₂)
+    (h : VerifM.Env.agreeOn Δ₂ ρ ρ') : VerifM.Env.agreeOn Δ₁ ρ ρ' :=
+  _root_.Env.agreeOn_mono hsub h
+
+theorem VerifM.Env.agreeOn_symm {Δ : Signature} (h : VerifM.Env.agreeOn Δ ρ ρ') :
+    VerifM.Env.agreeOn Δ ρ' ρ :=
+  _root_.Env.agreeOn_symm h
+
+theorem VerifM.Env.agreeOn_trans {Δ : Signature}
+    (h₁₂ : VerifM.Env.agreeOn Δ ρ₁ ρ₂) (h₂₃ : VerifM.Env.agreeOn Δ ρ₂ ρ₃) :
+    VerifM.Env.agreeOn Δ ρ₁ ρ₃ :=
+  _root_.Env.agreeOn_trans h₁₂ h₂₃
+
+theorem VerifM.Env.agreeOn_declVar {ρ ρ' : VerifM.Env} {Δ : Signature} {τ : Srt} {x : String} {v : τ.denote} :
+    VerifM.Env.agreeOn Δ ρ ρ' →
+    VerifM.Env.agreeOn (Δ.declVar ⟨x, τ⟩) (ρ.updateConst τ x v) (ρ'.updateConst τ x v) := by
+  intro hagree
+  simpa [VerifM.Env.agreeOn, VerifM.Env.updateConst] using
+    (_root_.Env.agreeOn_declVar (ρ := ρ.env) (ρ' := ρ'.env) (Δ := Δ) (τ := τ) (x := x) (v := v) hagree)
+
+theorem VerifM.Env.agreeOn_update_fresh {ρ : VerifM.Env} {c : FOL.Const} {u : c.sort.denote}
+    {Δ : Signature} (hfresh : c.name ∉ Δ.allNames) :
+    VerifM.Env.agreeOn Δ ρ (ρ.updateConst c.sort c.name u) := by
+  simpa [VerifM.Env.agreeOn, VerifM.Env.updateConst] using
+    (agreeOn_update_fresh_const (ρ := ρ.env) (c := c) (u := u) (Δ := Δ) hfresh)
+
+
+
 /-- Read the current pure assertion context (backwards-compatible wrapper around `ctx`). -/
 def VerifM.ctxPure (f : List Formula → α) : VerifM α :=
   VerifM.ctx (fun st => (f st.asserts, st.owns))
@@ -111,9 +165,9 @@ def TransState.empty : TransState := ⟨Signature.empty, [], []⟩
 
 @[simp] theorem TransState.empty_toFlatCtx : TransState.empty.toFlatCtx = FlatCtx.empty := rfl
 
-def TransState.holdsFor (st : TransState) (ρ : Env) := ∀ φ ∈ st.asserts, φ.eval ρ
+def TransState.holdsFor (st : TransState) (ρ : VerifM.Env) := ∀ φ ∈ st.asserts, φ.eval ρ.env
 
-theorem TransState.holdsFor_mono {st st' : TransState} {ρ : Env}
+theorem TransState.holdsFor_mono {st st' : TransState} {ρ : VerifM.Env}
     (hsub : st.asserts ⊆ st'.asserts) (h : st'.holdsFor ρ) : st.holdsFor ρ :=
   fun φ hφ => h φ (hsub hφ)
 
@@ -232,7 +286,7 @@ def VerifM.translate :
 
 /-! ### Eval_rec: postcondition-based semantics (raw) -/
 
-def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState → Env → Prop) → Prop
+def VerifM.eval_rec : VerifM α → TransState → VerifM.Env → (α → TransState → VerifM.Env → Prop) → Prop
   | .ret a, st, ρ, P => P a st ρ
   | .bind m k, st, ρ, P => m.eval_rec st ρ (fun r st' ρ' => (k r).eval_rec st' ρ' P)
   | .decl hint t, st, ρ, P =>
@@ -240,9 +294,9 @@ def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState �
       ∀ u, P c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u)
   | .assume item, st, ρ, P =>
       match item with
-      | .pure φ => φ.wfIn st.decls → φ.eval ρ → P () { st with asserts := φ :: st.asserts } ρ
+      | .pure φ => φ.wfIn st.decls → φ.eval ρ.env → P () { st with asserts := φ :: st.asserts } ρ
       | .spatial a => a.wfIn st.decls → P () { st with owns := a :: st.owns } ρ
-  | .check φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ) ∧ P b st ρ
+  | .check φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ.env) ∧ P b st ρ
   | .fatal _, _, _, _ => False
   | .failed _, _, _, _ => False
   | .all items, st, ρ, P => ∀ a ∈ items, P a st ρ
@@ -253,44 +307,45 @@ def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState �
   | .seq m m2, st, ρ, P =>
       m.eval_rec st ρ (fun () _ _ => True) ∧ m2.eval_rec st ρ P
 
-theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : m.eval_rec st ρ P)
-    (hPQ : ∀ a st' ρ', st.decls.Subset st'.decls → Env.agreeOn st.decls ρ ρ' → P a st' ρ' → Q a st' ρ') :
+theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : VerifM.Env) (st : TransState) (h : m.eval_rec st ρ P)
+    (hPQ : ∀ a st' (ρ' : VerifM.Env),
+      st.decls.Subset st'.decls → VerifM.Env.agreeOn st.decls ρ ρ' → P a st' ρ' → Q a st' ρ') :
     m.eval_rec st ρ Q := by
   induction m generalizing st ρ with
-  | ret => exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) h
+  | ret => exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) h
   | bind m k ihm ihk =>
     exact ihm ρ st h fun r st' ρ' hsub hag hr =>
       ihk r ρ' st' hr fun a st'' ρ'' hsub' hag' hp =>
-        hPQ a st'' ρ'' (hsub.trans hsub') (Env.agreeOn_trans hag (Env.agreeOn_mono hsub hag')) hp
+        hPQ a st'' ρ'' (hsub.trans hsub') (VerifM.Env.agreeOn_trans hag (VerifM.Env.agreeOn_mono hsub hag')) hp
   | decl hint t =>
     intro u
     refine hPQ _ _ _ (Signature.Subset.subset_addConst _ _) ?_ (h u)
-    exact agreeOn_update_fresh_const
+    exact VerifM.Env.agreeOn_update_fresh
       (c := ⟨fresh (addNumbers (hint.getD "_v")) st.decls.allNames, t⟩)
       (fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _))
   | assume item =>
     cases item with
     | pure φ =>
       intro hwf hφ
-      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf hφ)
+      exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h hwf hφ)
     | spatial a =>
       intro hwf
-      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf)
+      exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h hwf)
   | check =>
     intro hwf
     obtain ⟨b, hb, hp⟩ := h hwf
-    exact ⟨b, hb, hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) hp⟩
+    exact ⟨b, hb, hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) hp⟩
   | fatal => exact h.elim
   | failed => exact h.elim
   | all items =>
     intro a ha
-    exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h a ha)
+    exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h a ha)
   | any items =>
     obtain ⟨a, ha, hp⟩ := h
-    exact ⟨a, ha, hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) hp⟩
+    exact ⟨a, ha, hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) hp⟩
   | ctx f =>
     intro howns
-    exact hPQ _ _ _ (Signature.Subset.refl _) Env.agreeOn_refl (h howns)
+    exact hPQ _ _ _ (Signature.Subset.refl _) VerifM.Env.agreeOn_refl (h howns)
   | seq m m2 ihm ihf =>
     exact ⟨ihm ρ st h.1 fun () _ _ _ _ ha => trivial,
            ihf ρ st h.2 hPQ⟩
@@ -300,13 +355,13 @@ theorem VerifM.eval_rec.mono {m : VerifM α} (h : m.eval_rec st ρ P) (hPQ : ∀
   h.mono' ρ st fun a st' ρ' _ _ => hPQ a st' ρ'
 
 theorem VerifM.eval_rec.decls_grow {m : VerifM α} ρ (h : m.eval_rec st ρ P) :
-    m.eval_rec st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
+    m.eval_rec st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
   h.mono' ρ st fun _ _ _ hsub hag hp => ⟨hsub, hag, hp⟩
 
 /-! ### Adequacy: translate success implies eval -/
 
 
-theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
+theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: VerifM.Env)
     (h : VerifM.eval_rec m st ρ P) (g : st.holdsFor ρ) (hwf : st.wf) :
     VerifM.eval_rec m st ρ (fun a st' ρ' => st'.holdsFor ρ' ∧ st'.wf ∧ P a st' ρ') := by
   induction m generalizing st ρ with
@@ -323,8 +378,8 @@ theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
     specialize (h u)
     let w := fresh (addNumbers (hint.getD "_v")) st.decls.allNames
     have hfresh := fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _)
-    have hagree : Env.agreeOn st.decls ρ (ρ.updateConst t w u) := by
-      exact agreeOn_update_fresh_const (c := ⟨w, t⟩) hfresh
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateConst t w u) := by
+      exact VerifM.Env.agreeOn_update_fresh (c := ⟨w, t⟩) hfresh
     constructor
     · intro φ hφ
       exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
@@ -412,7 +467,7 @@ private theorem translateAny_eval (items : List α) (st : TransState)
       simp only [ScopedM.eval_ret] at hk1
       exact absurd hk1.1 (by simp)
 
-theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
+theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: VerifM.Env)
     (f : TransCont (Except VerifError α))
     (hf : ∀ e st', ¬∃ Δ, ScopedM.eval (f (.error e) st') st'.toFlatCtx (.ok ()) Δ)
     (Δ : FlatCtx)
@@ -462,7 +517,7 @@ theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
     rcases hxx with ⟨hunsat, _⟩ | hfalse
     · have hunsat' : ¬Smt.State.satisfiable st.decls (Formula.not φ :: st.asserts) := by
         simp only [FlatCtx.addAssert] at hunsat; exact hunsat
-      exact Smt.State.satisfiable.to_impl' st.decls st.asserts hunsat' ρ g
+      exact Smt.State.satisfiable.to_impl' st.decls st.asserts hunsat' ρ.env g
     · simp [ScopedM.eval_ret] at hfalse
   | fatal msg =>
     simp only [VerifM.translate] at h
@@ -505,20 +560,20 @@ theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
 
 /-- The main verification predicate. Requires `st` to be well-formed and satisfy `ρ`,
     and guarantees the same for every reachable `st'`. -/
-def VerifM.eval (m : VerifM α) (st : TransState) (ρ : Env) (Q : α → TransState → Env → Prop) : Prop :=
+def VerifM.eval (m : VerifM α) (st : TransState) (ρ : VerifM.Env) (Q : α → TransState → VerifM.Env → Prop) : Prop :=
   st.wf ∧ st.holdsFor ρ ∧
   m.eval_rec st ρ (fun a st' ρ' => st'.wf ∧ st'.holdsFor ρ' ∧ Q a st' ρ')
 
 /-! ### Structural properties -/
 
-theorem VerifM.eval.wf {m : VerifM α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval.wf {m : VerifM α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : m.eval st ρ Q) : st.wf := h.1
 
-theorem VerifM.eval.holdsFor {m : VerifM α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval.holdsFor {m : VerifM α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : m.eval st ρ Q) : st.holdsFor ρ := h.2.1
 
-theorem VerifM.eval.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : m.eval st ρ P)
-    (hPQ : ∀ a st' ρ', st.decls.Subset st'.decls → Env.agreeOn st.decls ρ ρ' →
+theorem VerifM.eval.mono' {m : VerifM α} (ρ : VerifM.Env) (st : TransState) (h : m.eval st ρ P)
+    (hPQ : ∀ a st' (ρ' : VerifM.Env), st.decls.Subset st'.decls → VerifM.Env.agreeOn st.decls ρ ρ' →
       st'.wf → st'.holdsFor ρ' → P a st' ρ' → Q a st' ρ') :
     m.eval st ρ Q :=
   ⟨h.1, h.2.1, h.2.2.mono' ρ st fun a st' ρ' hsub hag ⟨hwf', hg', hp⟩ =>
@@ -529,12 +584,12 @@ theorem VerifM.eval.mono {m : VerifM α} (h : m.eval st ρ P) (hPQ : ∀ a st' �
   h.mono' ρ st fun a st' ρ' _ _ _ _ => hPQ a st' ρ'
 
 theorem VerifM.eval.decls_grow {m : VerifM α} ρ (h : m.eval st ρ P) :
-    m.eval st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
+    m.eval st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
   h.mono' ρ st fun _ _ _ hsub hag _ _ hp => ⟨hsub, hag, hp⟩
 
 /-! ### Inversion lemmas for VerifM.eval (forward direction) -/
 
-theorem VerifM.eval_ret {a : α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_ret {a : α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.ret a) st ρ Q) : Q a st ρ :=
   h.2.2.2.2
 
@@ -554,37 +609,39 @@ theorem VerifM.eval_bind (m : VerifM α) (k : α → VerifM β) st ρ :
 
 
 
-theorem VerifM.eval_failed {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_failed {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.failed msg) st ρ Q) : False :=
   h.2.2
 
-theorem VerifM.eval_fatal {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_fatal {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.fatal msg) st ρ Q) : False :=
   h.2.2
 
-theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ : Env}
-    {Q : FOL.Const → TransState → Env → Prop}
+theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ : VerifM.Env}
+    {Q : FOL.Const → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.decl hint t) st ρ Q) :
     let c := st.freshConst hint t
     ∀ u, Q c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u) :=
   fun u => (h.2.2 u).2.2
 
-theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.assume (.pure φ)) st ρ Q) :
-    φ.wfIn st.decls → φ.eval ρ → Q () { st with asserts := φ :: st.asserts } ρ :=
+    φ.wfIn st.decls → φ.eval ρ.env → Q () { st with asserts := φ :: st.asserts } ρ :=
   fun hwf hφ => (h.2.2 hwf hφ).2.2
 
-theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.assume (.spatial a)) st ρ Q) :
     a.wfIn st.decls → Q () { st with owns := a :: st.owns } ρ :=
   fun hwf => (h.2.2 hwf).2.2
 
-theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.assume item) st ρ Q) :
-    item.wfIn st.decls → (match item with | .pure φ => φ.eval ρ | .spatial _ => True) → Q () (st.addItem item) ρ :=
+    item.wfIn st.decls →
+    (match item with | .pure φ => φ.eval ρ.env | .spatial _ => True) →
+    Q () (st.addItem item) ρ :=
   by
     cases item with
     | pure φ =>
@@ -594,19 +651,19 @@ theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : Env}
       simp [TransState.addItem]
       exact VerifM.eval_assumeSpatial h
 
-theorem VerifM.eval_check {φ : Formula} {st : TransState} {ρ : Env}
-    {Q : Bool → TransState → Env → Prop}
+theorem VerifM.eval_check {φ : Formula} {st : TransState} {ρ : VerifM.Env}
+    {Q : Bool → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.check φ) st ρ Q) :
     φ.wfIn st.decls →
-    ∃ b, (b = true → φ.eval ρ) ∧ Q b st ρ :=
+    ∃ b, (b = true → φ.eval ρ.env) ∧ Q b st ρ :=
   fun hwf =>
     let ⟨b, hb, _, _, hq⟩ := h.2.2 hwf
     ⟨b, hb, hq⟩
 
-theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.assert φ) st ρ Q) :
-    φ.wfIn st.decls → φ.eval ρ ∧ Q () st ρ := by
+    φ.wfIn st.decls → φ.eval ρ.env ∧ Q () st ρ := by
   intro hwf
   simp only [VerifM.assert] at h
   have hb := VerifM.eval_bind _ _ _ _ h
@@ -620,8 +677,8 @@ theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : Env}
     exact (VerifM.eval_failed hq).elim
 
 theorem VerifM.eval_expectEq [DecidableEq α] [Repr α]
-    {msg : String} {actual expected : α} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+    {msg : String} {actual expected : α} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.expectEq msg actual expected) st ρ Q) :
     actual = expected ∧ Q () st ρ := by
   unfold VerifM.expectEq at h
@@ -632,8 +689,8 @@ theorem VerifM.eval_expectEq [DecidableEq α] [Repr α]
     exact (VerifM.eval_fatal h).elim
 
 theorem VerifM.eval_expectSome
-    {msg : String} {x : Option α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+    {msg : String} {x : Option α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.expectSome msg x) st ρ Q) :
     ∃ y, x = some y ∧ Q y st ρ := by
   unfold VerifM.expectSome at h
@@ -647,7 +704,7 @@ theorem VerifM.eval_expectSome
 
 theorem VerifM.eval_bind_expectEq [DecidableEq α] [Repr α]
     {msg : String} {actual expected : α} {β : Type _} {k : Unit → VerifM β}
-    {st : TransState} {ρ : Env} {Q : β → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {Q : β → TransState → VerifM.Env → Prop}
     (h : VerifM.eval ((VerifM.expectEq msg actual expected).bind k) st ρ Q) :
     actual = expected ∧ VerifM.eval (k ()) st ρ Q := by
   have hb := VerifM.eval_bind _ _ _ _ h
@@ -656,28 +713,28 @@ theorem VerifM.eval_bind_expectEq [DecidableEq α] [Repr α]
 
 theorem VerifM.eval_bind_expectSome
     {msg : String} {x : Option α} {β : Type _} {k : α → VerifM β}
-    {st : TransState} {ρ : Env} {Q : β → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {Q : β → TransState → VerifM.Env → Prop}
     (h : VerifM.eval ((VerifM.expectSome msg x).bind k) st ρ Q) :
     ∃ y, x = some y ∧ VerifM.eval (k y) st ρ Q := by
   have hb := VerifM.eval_bind _ _ _ _ h
   obtain ⟨y, hx, hk⟩ := VerifM.eval_expectSome hb
   exact ⟨y, hx, hk⟩
 
-theorem VerifM.eval_all {items : List α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_all {items : List α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.all items) st ρ Q) :
     ∀ a ∈ items, Q a st ρ :=
   fun a ha => (h.2.2 a ha).2.2
 
-theorem VerifM.eval_any {items : List α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_any {items : List α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.any items) st ρ Q) :
     ∃ a ∈ items, Q a st ρ :=
   let ⟨a, ha, _, _, hq⟩ := h.2.2; ⟨a, ha, hq⟩
 
 
 theorem VerifM.eval_ctx {f : TransState → α × SpatialContext}
-    {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.ctx f) st ρ Q) :
     let (a, owns') := f st
     (owns'.wfIn st.decls → Q a { st with owns := owns' } ρ)
@@ -686,8 +743,8 @@ theorem VerifM.eval_ctx {f : TransState → α × SpatialContext}
     ∧ st.asserts.wfIn st.decls :=
   ⟨fun howns => (h.2.2 howns).2.2, h.1.ownsWf, h.2.1, h.1.assertsWf⟩
 
-theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.ctx (fun st => (f st.asserts, st.owns))) st ρ Q) :
     Q (f st.asserts) st ρ
     ∧ st.holdsFor ρ
@@ -695,8 +752,8 @@ theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : En
   let ⟨hq, howns, hg, hwf⟩ := VerifM.eval_ctx h
   ⟨hq howns, hg, hwf⟩
 
-theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : Env}
-    {Q : β → TransState → Env → Prop}
+theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : VerifM.Env}
+    {Q : β → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.seq m m2) st ρ Q) :
     VerifM.eval m st ρ (fun () _ _ => True) ∧ VerifM.eval m2 st ρ Q := by
   obtain ⟨hwf, hholds, hm, hm2⟩ := h
@@ -705,10 +762,10 @@ theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ
    ⟨hwf, hholds, hm2⟩⟩
 
 theorem VerifM.eval_assumeAll {φs : List Formula}
-    {st : TransState} {ρ : Env} {P : Unit → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {P : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.assumeAll φs) st ρ P) :
     (∀ φ ∈ φs, φ.wfIn st.decls) →
-    (∀ φ ∈ φs, φ.eval ρ) →
+    (∀ φ ∈ φs, φ.eval ρ.env) →
     ∃ st', st'.decls = st.decls ∧ st'.owns = st.owns ∧ P () st' ρ := by
   induction φs generalizing st with
   | nil =>
@@ -740,7 +797,7 @@ theorem VerifM.topCont_error_propagates :
   simp only [topCont, ScopedM.eval_ret] at h
   exact absurd h.1 (by cases e <;> simp)
 
-theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : Env)
+theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : VerifM.Env)
     (f : TransCont (Except VerifError α))
     (hf : ∀ e st', ¬∃ Δ, ScopedM.eval (f (.error e) st') st'.toFlatCtx (.ok ()) Δ)
     (Δ : FlatCtx)
@@ -750,7 +807,7 @@ theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : Env)
   ⟨hwf, g, (eval_rec_preserves_wf m st ρ (translate_eval_rec m st ρ f hf Δ h g hwf) g hwf).mono
     fun _ _ _ ⟨hg', hwf', hΔ'⟩ => ⟨hwf', hg', hΔ'⟩⟩
 
-theorem VerifM.eval_of_translate (m : VerifM Unit) (st : TransState) (ρ : Env) (Δ : FlatCtx)
+theorem VerifM.eval_of_translate (m : VerifM Unit) (st : TransState) (ρ : VerifM.Env) (Δ : FlatCtx)
     (h : ScopedM.eval (m.translate st topCont) st.toFlatCtx (.ok ()) Δ)
     (g : st.holdsFor ρ) (hwf : st.wf) :
     VerifM.eval m st ρ (fun _ _ _ => True) :=

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -52,9 +52,10 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def PredTrans.apply (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : Env) : iProp :=
+def PredTrans.apply (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
   Assertion.pre (fun post ρ' =>
-    BIBase.forall fun v : Runtime.Val => Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+    BIBase.forall fun v : Runtime.Val =>
+      Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
   ) m ρ
 
 -- ---------------------------------------------------------------------------
@@ -98,8 +99,8 @@ theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
     h hsub hwf
 
 theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
-    {ρ ρ' : Env} {Δ : Signature}
-    (hwf : pt.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
+    {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : pt.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') :
     PredTrans.apply Φ pt ρ ⊢ PredTrans.apply Φ pt ρ' := by
   unfold PredTrans.apply at ⊢
   apply Assertion.pre_env_agree hwf hagree
@@ -108,7 +109,7 @@ theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
   intro v
   exact (forall_elim v).trans <|
     Assertion.post_env_agree hwf_post
-      (Env.agreeOn_declVar hagree_post)
+      (VerifM.Env.agreeOn_declVar hagree_post)
       (fun _ _ _ _ _ _ => .rfl)
 
 -- ---------------------------------------------------------------------------
@@ -116,38 +117,38 @@ theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
 -- ---------------------------------------------------------------------------
 
 theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
-    (st : TransState) (ρ : Env)
-    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp) R :
+    (st : TransState) (ρ : VerifM.Env)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) R :
     pt.wfIn (Signature.ofVars σ.dom) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     VerifM.eval (PredTrans.call σ pt) st ρ Ψ →
-    (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
-      (st'.owns.interp ρ' ∗ R ⊢ Φ v)) →
-    st.owns.interp ρ ∗ R ⊢ PredTrans.apply Φ pt (σ.subst.eval ρ) := by
+    (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
+      (st'.sl ρ' ∗ R ⊢ Φ v)) →
+    st.sl ρ ∗ R ⊢ PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
   intro hwf hdomwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   let retWf : (String × Assertion Unit) → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let Φpost : (String × Assertion Unit) → Env → iProp :=
+  let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun post ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
-  let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → Env → Prop :=
+  let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → VerifM.Env → Prop :=
     fun r st' ρ' =>
       match r with
       | (σ₁, postName, postBody) => (do
           let resVar ← VerifM.decl (some postName) Srt.value
           let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
           Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
-  have hpre : st.owns.interp ρ ∗ R ⊢ Assertion.pre Φpost pt (σ.subst.eval ρ) := by
+  have hpre : st.sl ρ ∗ R ⊢ Assertion.pre Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
     exact Assertion.prove_correct pt σ retWf st ρ Ψcall Φpost R
       (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree =>
         forall_intro fun v =>
           (forall_elim v).trans <|
             Assertion.post_env_agree hwf_post
-              (Env.agreeOn_declVar hagree)
+              (VerifM.Env.agreeOn_declVar hagree)
               (fun _ _ _ _ _ _ => .rfl))
       hσwf hdomwf hwf hb
       (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ hcont hσ₁wf hσ₁domwf hwf₁ => by
@@ -177,7 +178,7 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
           (ρ₁.updateConst .value resVar.name v)
           (fun a st' ρ' =>
             { st₁ with decls := st₁.decls.addConst resVar }.decls.Subset st'.decls ∧
-              Env.agreeOn { st₁ with decls := st₁.decls.addConst resVar }.decls
+              VerifM.Env.agreeOn { st₁ with decls := st₁.decls.addConst resVar }.decls
                 (ρ₁.updateConst .value resVar.name v) ρ' ∧
               (Pure.pure (Term.const (.uninterpreted resVar.name .value)) : VerifM (Term .value)).eval st' ρ' Ψ)
           (fun () _ => Φ v) R
@@ -196,8 +197,8 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
             · simp only [Term.eval, Const.denote]
               have := hagree.2.1 resVar (List.Mem.head _)
               simpa [Env.lookupConst, Env.updateConst] using this.symm)
-        have hinterp_bi : SpatialContext.interp ρ₁ st₁.owns ⊣⊢
-            SpatialContext.interp (ρ₁.updateConst .value resVar.name v) st₁.owns :=
+        have hinterp_bi :
+            st₁.sl ρ₁ ⊣⊢ st₁.sl (ρ₁.updateConst .value resVar.name v) :=
           SpatialContext.interp_env_agree (VerifM.eval.wf hcont).ownsWf
             (agreeOn_update_fresh_const (c := resVar) hfresh_decls)
         exact (sep_mono hinterp_bi.1 (by
@@ -213,32 +214,32 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
 
 theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
     (body : VerifM (Term .value))
-    (st : TransState) (ρ : Env) (Φ : Runtime.Val → iProp) (R : iProp) :
+    (st : TransState) (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (R : iProp) :
     pt.wfIn (Signature.ofVars σ.dom) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     VerifM.eval (PredTrans.implement σ pt body) st ρ (fun _ _ _ => True) →
     (∀ st' ρ' (Q : iProp),
       st.decls.Subset st'.decls →
-      Env.agreeOn st.decls ρ ρ' →
+      VerifM.Env.agreeOn st.decls ρ ρ' →
       VerifM.eval body st' ρ'
       (fun result st'' ρ'' =>
         ∀ (S : iProp),
         result.wfIn st''.decls →
-        (st''.owns.interp ρ'' ∗ Q ∗ (Φ (result.eval ρ'') -∗ S) ⊢ S)) →
-      st'.owns.interp ρ' ∗ Q ⊢ R) →
-    st.owns.interp ρ ∗ PredTrans.apply Φ pt (σ.subst.eval ρ) ⊢ R := by
+        (st''.sl ρ'' ∗ Q ∗ (Φ (result.eval ρ''.env) -∗ S) ⊢ S)) →
+      st'.sl ρ' ∗ Q ⊢ R) →
+    st.sl ρ ∗ PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ⊢ R := by
   intro hwf hdomwf hσwf heval hbody
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   have hb_grow := VerifM.eval.decls_grow ρ hb
   let retWf : (String × Assertion Unit) → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let OuterQ : (String × Assertion Unit) → Env → iProp :=
+  let OuterQ : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun ⟨postName, postBody⟩ ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
-  let Φpost : (String × Assertion Unit) → Env → iProp :=
+  let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
   have hpost := Assertion.assume_correct pt σ retWf
     st ρ _ Φpost emp
@@ -258,7 +259,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
       apply BIBase.Entails.trans sep_comm.1
       apply BIBase.Entails.trans emp_sep.1
       have hcont_body := VerifM.eval_bind _ _ _ _ hcont
-      change st₁.owns.interp ρ₁ ⊢ OuterQ (postName, postBody) (σ₁.subst.eval ρ₁) -∗ R
+      change st₁.sl ρ₁ ⊢ OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) -∗ R
       refine wand_intro ?_
       refine hbody st₁ ρ₁ _ hdsub_st hagree_st ?_
       refine (VerifM.eval.decls_grow ρ₁ hcont_body).mono ?_
@@ -270,7 +271,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         fresh_not_mem (addNumbers postName) st₂.decls.allNames (addNumbers_injective _)
       have hfresh_range : resVar.name ∉ σ₁.range.allNames :=
         fun hmem => hfresh_decls (Signature.allNames_subset (Signature.Subset.trans hσ₁wf.2.1 hdsub_body) _ hmem)
-      specialize hdecl (result.eval ρ₂)
+      specialize hdecl (result.eval ρ₂.env)
       have hb3 := VerifM.eval_bind _ _ _ _ hdecl
       have heq_wf : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).wfIn
           (st₂.decls.addConst resVar) := by
@@ -284,7 +285,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         · intro τ' hc'
           exact Signature.wf_unique_const hwf' (List.Mem.head _) hc'
       have heq_holds : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).eval
-          (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) := by
+          (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env := by
         simp only [Formula.eval, Term.eval, Const.denote]
         simpa [Env.lookupConst, Env.updateConst] using
           (Term.eval_env_agree hwf_result (agreeOn_update_fresh_const hfresh_decls))
@@ -306,8 +307,8 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
           asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st₂.asserts }
       have hpre := @Assertion.prove_correct Unit postBody σ₂ (fun _ _ => True)
         st₃
-        (ρ₂.updateConst .value resVar.name (result.eval ρ₂))
-        _ (fun () _ => Φ (result.eval ρ₂) -∗ S) (Φ (result.eval ρ₂) -∗ S)
+        (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+        _ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) (Φ (result.eval ρ₂.env) -∗ S)
         (fun _ _ _ _ _ _ => .rfl)
         hσ₂wf hσ₂domwf hwf_postBody' hb4
         (fun _ () st' ρ' hret _ _ _ => by
@@ -315,12 +316,12 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
           icases H with ⟨_, HR⟩
           iexact HR)
       have hag_rename := @FiniteSubst.rename_agreeOn σ₁ ⟨postName, .value⟩ resVar
-        ρ₂ (result.eval ρ₂) hσ₁wf.1 hfresh_range rfl
+        ρ₂.env (result.eval ρ₂.env) hσ₁wf.1 hfresh_range rfl
       have hag_eval := FiniteSubst.eval_agreeOn hσ₁wf.1
         (Env.agreeOn_mono hσ₁wf.2.1 (Env.agreeOn_symm hagree_body))
       have hag_eval' : Env.agreeOn (Signature.ofVars σ₂.dom)
-          ((σ₁.subst.eval ρ₂).updateConst .value postName (result.eval ρ₂))
-          ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂)) := by
+          ((σ₁.subst.eval ρ₂.env).updateConst .value postName (result.eval ρ₂.env))
+          ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env)) := by
         apply Env.agreeOn_mono
           (Δ₁ := Signature.ofVars σ₂.dom)
           (Δ₂ := Signature.ofVars (⟨postName, .value⟩ :: σ₁.dom))
@@ -331,46 +332,52 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
               · exact Or.inl rfl
               · exact Or.inr hx))
         exact Env.agreeOn_update hag_eval
-      have hpost_transport : Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
-          ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂)) ⊢
-          Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
-            (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
+      have hpost_transport : Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+          (VerifM.Env.withEnv ρ₁ ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env))) ⊢
+          Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+            (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
         exact Assertion.post_env_agree hwf_postBody'
-          (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval'))
+          (by
+            simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv]
+              using (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval')))
           (fun _ _ _ _ _ _ => .rfl)
-      have howns_agree : st₃.owns.interp ρ₂
+      have howns_agree : st₃.sl ρ₂
             ⊢
-          st₃.owns.interp (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) := by
+          st₃.sl (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) := by
         simpa using
           (SpatialContext.interp_env_agree (VerifM.eval.wf hrest).ownsWf
             (agreeOn_update_fresh_const hfresh_decls)).1
       have hpre_final :
-          st₂.owns.interp ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
-            Assertion.pre (fun () _ => Φ (result.eval ρ₂) -∗ S) postBody
-              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
+          st₂.sl ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+            Assertion.pre (fun () _ => Φ (result.eval ρ₂.env) -∗ S) postBody
+              (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+                (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
         have hinput :
-            st₂.owns.interp ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
-              st₃.owns.interp (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) ∗
-                (Φ (result.eval ρ₂) -∗ S) := by
+            st₂.sl ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+              st₃.sl (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) ∗
+                (Φ (result.eval ρ₂.env) -∗ S) := by
           iintro H
           icases H with ⟨Howns, Hwand⟩
           isplitl [Howns]
           · iapply howns_agree
-            iexact Howns
+            simp [st₃, TransState.sl]
           · iexact Hwand
         exact hinput.trans hpre
       have hpost_final :
-          OuterQ (postName, postBody) (σ₁.subst.eval ρ₁) ⊢
-            Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
-              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
-        exact (forall_elim (result.eval ρ₂)).trans hpost_transport
+          OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) ⊢
+            Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+              (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+                (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
+        exact (forall_elim (result.eval ρ₂.env)).trans hpost_transport
       iintro H
       icases H with ⟨Howns, HQ, Hwand⟩
       iapply (Assertion.pre_post_combine
-        (ρ := σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))
+        (ρ := VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+          (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env))
         (m := postBody)
-        (Φ := fun () _ => Φ (result.eval ρ₂) -∗ S)
-        (Ψ := fun () _ => Φ (result.eval ρ₂))
+        (Φ := fun () _ => Φ (result.eval ρ₂.env) -∗ S)
+        (Ψ := fun () _ => Φ (result.eval ρ₂.env))
         (R := S)
         (fun () _ => by
           iintro H
@@ -385,7 +392,9 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
       · iapply hpost_final
         iexact HQ
       )
-  have hpre : PredTrans.apply Φ pt (σ.subst.eval ρ) = Assertion.pre OuterQ pt (σ.subst.eval ρ) := rfl
+  have hpre :
+      PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) =
+      Assertion.pre OuterQ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := rfl
   rw [hpre]
   exact BIBase.Entails.trans
     (by
@@ -393,12 +402,14 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
       icases H with ⟨Howns, Happ⟩
       isplitr [Howns]
       · iexact Happ
-      · iapply hpost
+      · have hpost' : st.sl ρ ∗ emp ⊢ Assertion.post Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+          simpa [VerifM.Env.withEnv] using hpost
+        iapply hpost'
         isplitl
         . iexact Howns
         . iemp_intro)
     (Assertion.pre_post_combine
-      (ρ := σ.subst.eval ρ)
+      (ρ := VerifM.Env.withEnv ρ (σ.subst.eval ρ.env))
       (m := pt)
       (Φ := OuterQ)
       (Ψ := Φpost)

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -98,8 +98,8 @@ def Program.verify (prog : Untyped.Program Untyped.Expr) : Smt.Strategy Smt.Stra
 /-! ## Correctness -/
 
 theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
-    (st : TransState) (ρ : Env)
-    {Q : (TinyML.TypeEnv × Typed.Program Untyped.Expr) → TransState → Env → Prop}
+    (st : TransState) (ρ : VerifM.Env)
+    {Q : (TinyML.TypeEnv × Typed.Program Untyped.Expr) → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (Program.prepare prog) st ρ Q) :
     ∃ Θ typed, Typed.Program.runtime typed = Untyped.Program.runtime prog ∧ Q (Θ, typed) st ρ := by
   unfold Program.prepare at heval
@@ -114,8 +114,8 @@ theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
     exact VerifM.eval_ret heval
 
 theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : Env)
-    {Q : Unit → TransState → Env → Prop}
+    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env)
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (ValDecl.checkExpr Θ S d) TransState.empty ρ Q) :
     (S.satisfiedBy Θ γ ⊢ Φ) →
     S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
@@ -148,8 +148,8 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed
     . iexact Hspec
 
 theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : Env)
-    {Q : Spec → TransState → Env → Prop}
+    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env)
+    {Q : Spec → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (ValDecl.check Θ S d) TransState.empty ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
             (S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
@@ -189,7 +189,7 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
                  VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : Env) :
+    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env) :
     VerifM.eval (Program.check Θ S prog) TransState.empty ρ (fun _ _ _ => True) →
     S.satisfiedBy Θ γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ ρ with
@@ -299,7 +299,7 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
   | .error e =>
     cases e <;> simp [ScopedM.eval_ret] at hcont
   | .ok () =>
-    have hholdsFor : TransState.holdsFor TransState.empty default :=
+    have hholdsFor : TransState.holdsFor TransState.empty VerifM.Env.empty :=
       fun φ hφ => by simp [TransState.empty] at hφ
     have hwf : TransState.wf TransState.empty :=
       ⟨fun φ hφ => by simp [TransState.empty] at hφ,
@@ -309,11 +309,11 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
                       (do
                         let (Θ, typed) ← Program.prepare p
                         Program.check Θ ∅ typed)
-                      TransState.empty default ctx_mid hverif hholdsFor hwf
+                      TransState.empty VerifM.Env.empty ctx_mid hverif hholdsFor hwf
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
-    obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty default hbind
+    obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty VerifM.Env.empty hbind
     have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
-                       (SpecMap.empty_wfIn _) default hcheck
+                       (SpecMap.empty_wfIn _) VerifM.Env.empty hcheck
     rw [Runtime.Program.subst_id] at hcorrect
     have hsat : (⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) Runtime.Subst.id) :=
       SpecMap.empty_satisfiedBy _

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -44,7 +44,7 @@ def Spec.argVars (args : List (String × TinyML.Typ)) : List Var :=
 
 /-- Build an environment binding each argument name to its value, left-to-right.
     Later arguments shadow earlier ones with the same name. -/
-def Spec.argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val → Env
+def Spec.argsEnv (ρ : VerifM.Env) : List (String × TinyML.Typ) → List Runtime.Val → VerifM.Env
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => Spec.argsEnv (ρ.updateConst .value name v) rest vs
 
@@ -52,7 +52,7 @@ def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : iProp
   iprop(□ ∀ (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-          (Spec.argsEnv Env.empty s.args vs) -∗
+          (Spec.argsEnv VerifM.Env.empty s.args vs) -∗
         wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
 instance : Iris.BI.Persistent (Spec.isPrecondFor Θ f s) := by
@@ -66,7 +66,7 @@ theorem Spec.isPrecondFor_fold (Θ : TinyML.TypeEnv) (s : Spec)
     iprop(□ ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
       (⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-          (Spec.argsEnv Env.empty s.args vs)) -∗
+          (Spec.argsEnv VerifM.Env.empty s.args vs)) -∗
         wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ f := by
   unfold Spec.isPrecondFor
   iintro □H
@@ -89,13 +89,13 @@ theorem Spec.isPrecondFor_fix {Θ : TinyML.TypeEnv} {s : Spec}
         ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
           PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-              (Spec.argsEnv Env.empty s.args vs) -∗
+              (Spec.argsEnv VerifM.Env.empty s.args vs) -∗
           wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
     R ⊢ s.isPrecondFor Θ (.fix f args e) := by
   refine (SpatialContext.wp_fix' (Φ := fun P vs =>
       iprop(⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-            (Spec.argsEnv Env.empty s.args vs))) (h.trans ?_)).trans
+            (Spec.argsEnv VerifM.Env.empty s.args vs))) (h.trans ?_)).trans
     (Spec.isPrecondFor_fold Θ s _)
   istart
   iintro □HR
@@ -186,9 +186,9 @@ end
 
 mutual
   /-- If `ValHasType v ty` and `t.eval ρ = v`, then all formulas in `typeConstraints ty t` hold. -/
-  theorem typeConstraints_hold {ty : TinyML.Typ} {t : Term .value} {ρ : Env}
-      {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ = v) (hty : TinyML.ValHasType Θ v ty) :
-      ∀ φ ∈ typeConstraints ty t, φ.eval ρ := by
+  theorem typeConstraints_hold {ty : TinyML.Typ} {t : Term .value} {ρ : VerifM.Env}
+      {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ.env = v) (hty : TinyML.ValHasType Θ v ty) :
+      ∀ φ ∈ typeConstraints ty t, φ.eval ρ.env := by
     cases hty with
     | int n =>
       intro φ hφ; simp [typeConstraints] at hφ; subst hφ
@@ -208,9 +208,9 @@ mutual
     | any => simp [typeConstraints]
     | _ => simp [typeConstraints]
 
-  theorem typeConstraintsList_hold {ts : List TinyML.Typ} {tl : Term .vallist} {ρ : Env}
-      {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} (htl : tl.eval ρ = vs) (hty : TinyML.ValsHaveTypes Θ vs ts) :
-      ∀ φ ∈ typeConstraints.typeConstraintsList ts tl, φ.eval ρ := by
+  theorem typeConstraintsList_hold {ts : List TinyML.Typ} {tl : Term .vallist} {ρ : VerifM.Env}
+      {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} (htl : tl.eval ρ.env = vs) (hty : TinyML.ValsHaveTypes Θ vs ts) :
+      ∀ φ ∈ typeConstraints.typeConstraintsList ts tl, φ.eval ρ.env := by
     cases hty with
     | nil => simp [typeConstraints.typeConstraintsList]
     | cons hv hvs =>
@@ -546,13 +546,13 @@ theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {S : SpecMap
 -- Spec correctness
 -- ---------------------------------------------------------------------------
 
-/-- `argsEnv` preserves `agreeOn`: if two base envs agree on `Δ`,
+/-- `argsEnv` preserves `agreeOn`: if two envs agree on `Δ`,
     then after applying the same updates, they agree on `argVars args ++ Δ`. -/
-theorem Spec.argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : Env}
-    (h : Env.agreeOn Δ ρ₁ ρ₂) :
+theorem Spec.argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : VerifM.Env}
+    (h : VerifM.Env.agreeOn Δ ρ₁ ρ₂) :
     ∀ (args : List (String × TinyML.Typ)) (vals : List Runtime.Val),
     args.length ≤ vals.length →
-    Env.agreeOn (Δ.declVars (Spec.argVars args))
+    VerifM.Env.agreeOn (Δ.declVars (Spec.argVars args))
       (Spec.argsEnv ρ₁ args vals) (Spec.argsEnv ρ₂ args vals) := by
   intro args
   induction args generalizing Δ ρ₁ ρ₂ with
@@ -565,14 +565,14 @@ theorem Spec.argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : Env}
     | cons v vs =>
       simp only [Spec.argsEnv, Spec.argVars, List.map]
       simpa [Signature.declVars] using
-        ih (Env.agreeOn_declVar h) vs (by simp [List.length] at hlen ⊢; omega)
+        ih (VerifM.Env.agreeOn_declVar h) vs (by simp [List.length] at hlen ⊢; omega)
 
 /-- Correctness of `declareArgs`: after processing all arguments, the resulting
     substitution is well-formed, types match, and the env agrees with `argsEnv`. -/
 theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
     ∀ (args : List (String × TinyML.Typ)) (sargs : List (TinyML.Typ × Term .value))
-      (σ : FiniteSubst) (st : TransState) (ρ : Env)
-      (Ψ : FiniteSubst → TransState → Env → Prop),
+      (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
+      (Ψ : FiniteSubst → TransState → VerifM.Env → Prop),
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
@@ -583,8 +583,10 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
       st'.owns = st.owns ∧
       @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
       (((Signature.ofVars σ.dom).declVars (Spec.argVars args)).vars ⊆ σ'.dom) ∧
-      Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args)) (σ'.subst.eval ρ')
-        (Spec.argsEnv (σ.subst.eval ρ) args (sargs.map fun p => p.2.eval ρ)) := by
+      VerifM.Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args))
+        (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env))
+        (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) args
+          (sargs.map fun p => p.2.eval ρ.env)) := by
   intro args
   induction args with
   | nil =>
@@ -594,7 +596,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
       simp [Spec.declareArgs] at heval
       have := VerifM.eval_ret heval
       exact ⟨σ, st, ρ, this, hσwf, hσdomwf, rfl, .nil, fun x hx => hx,
-        by simp [Spec.argVars, Spec.argsEnv]; exact Env.agreeOn_refl⟩
+        by simp [Spec.argVars, Spec.argsEnv]; exact VerifM.Env.agreeOn_refl⟩
     | cons _ _ =>
       simp [Spec.declareArgs] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -634,7 +636,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           fresh_not_mem (addNumbers name) st.decls.allNames (addNumbers_injective _)
         have hfresh_range : argVar.name ∉ σ.range.allNames :=
           fun h => hfresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-        specialize hdecl (sarg.eval ρ)
+        specialize hdecl (sarg.eval ρ.env)
         set σ' := σ.rename ⟨name, .value⟩ argVar.name
         have hσ'wf : σ'.wf (st.decls.addConst argVar) := by
           simpa [σ'] using
@@ -653,21 +655,21 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
               exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
           · exact (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
         have heq_holds : (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg).eval
-            (ρ.updateConst .value argVar.name (sarg.eval ρ)) := by
+            (ρ.updateConst .value argVar.name (sarg.eval ρ.env)).env := by
           simp only [Formula.eval, Term.eval, Const.denote]
           simpa [Env.lookupConst, Env.updateConst] using
             (Term.eval_env_agree hsarg_wf (agreeOn_update_fresh_const hfresh_decls))
         have hbind'' := VerifM.eval_bind _ _ _ _ hdecl
         have hassume := VerifM.eval_assumePure hbind'' heq_wf heq_holds
-        set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ)
+        set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ.env)
         have hsargs_rest : ∀ p ∈ sargs_rest, (p : TinyML.Typ × Term .value).2.wfIn
             (st.decls.addConst argVar) := by
           intro p hp
           exact Term.wfIn_mono _ (hsargs p (List.mem_cons_of_mem _ hp))
             (Signature.Subset.subset_addConst _ _)
             ((TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint)
-        have hsargs_eval : sargs_rest.map (fun p => p.2.eval ρ₁) =
-            sargs_rest.map (fun p => p.2.eval ρ) := by
+        have hsargs_eval : sargs_rest.map (fun p => p.2.eval ρ₁.env) =
+            sargs_rest.map (fun p => p.2.eval ρ.env) := by
           apply List.map_congr_left
           intro p hp
           exact Term.eval_env_agree
@@ -683,34 +685,40 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
         · simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
             using hdom_sub
         · have hag_rename := FiniteSubst.rename_agreeOn_declVar
-            (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ) (u := sarg.eval ρ)
+            (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ.env) (u := sarg.eval ρ.env)
             hσwf hfresh_decls rfl
           have hlen : rest.length ≤ sargs_rest.length := by
             have := TinyML.Typ.SubList.length_eq hsublist
             simp [List.length_map] at this; omega
-          have hag_env := Spec.argsEnv_agreeOn hag_rename rest
-            (sargs_rest.map fun p => p.2.eval ρ) (by simp [List.length_map]; omega)
+          have hag_env := Spec.argsEnv_agreeOn
+            (ρ₁ := VerifM.Env.withEnv ρ (σ'.subst.eval ρ₁.env))
+            (ρ₂ := VerifM.Env.withEnv ρ ((σ.subst.eval ρ.env).updateConst .value name (sarg.eval ρ.env)))
+            (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', FiniteSubst.rename]
+              using hag_rename)
+            rest (sargs_rest.map fun p => p.2.eval ρ.env) (by simp [List.length_map]; omega)
           rw [hsargs_eval] at hagree
-          simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar] using
-            (Env.agreeOn_trans hagree hag_env)
+          simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars,
+            Signature.declVar, VerifM.Env.withEnv, VerifM.Env.agreeOn] using
+            (VerifM.Env.agreeOn_trans hagree hag_env)
       · simp [hsub_ty] at heval
         have hb := VerifM.eval_bind _ _ _ _ heval
         exact (VerifM.eval_fatal hb).elim
 
 theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
-    (st : TransState) (ρ : Env)
-    (Ψ : (TinyML.Typ × Term .value) → TransState → Env → Prop)
+    (st : TransState) (ρ : VerifM.Env)
+    (Ψ : (TinyML.Typ × Term .value) → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp) (R : iProp) :
     s.pred.wfIn ((Signature.ofVars σ.dom).declVars (Spec.argVars s.args)) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.call Θ σ s sargs) st ρ Ψ →
-    (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
-      TinyML.ValHasType Θ v s.retTy → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
+    (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
+      TinyML.ValHasType Θ v s.retTy → st'.sl ρ' ∗ R ⊢ Φ v) →
     @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
-    (st.owns.interp ρ ∗ R ⊢ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-      (Spec.argsEnv (σ.subst.eval ρ) s.args (sargs.map fun p => p.2.eval ρ))) := by
+    (st.sl ρ ∗ R ⊢ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+      (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) s.args
+        (sargs.map fun p => p.2.eval ρ.env))) := by
   intro hwf hσdomwf hσwf hsargs heval hΨ
   simp only [Spec.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
@@ -751,9 +759,9 @@ theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (s
         isplitl [Howns]
         · simp [hst₃_owns]
         · iexact HR)
-    have hcall' : st.owns.interp ρ' ∗ R ⊢
+    have hcall' : st.sl ρ' ∗ R ⊢
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-          (σ'.subst.eval ρ') := by
+          (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) := by
       simpa [howns] using hcall
     exact (sep_mono_l (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1).trans <|
       hcall'.trans <| PredTrans.apply_env_agree hwf hagree
@@ -763,8 +771,8 @@ theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (s
     and the env agrees with `argsEnv`. -/
 theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
     ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
-      (σ : FiniteSubst) (st : TransState) (ρ : Env)
-      (Ψ : (FiniteSubst × List FOL.Const) → TransState → Env → Prop),
+      (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
+      (Ψ : (FiniteSubst × List FOL.Const) → TransState → VerifM.Env → Prop),
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     TinyML.ValsHaveTypes Θ vs (args.map Prod.snd) →
@@ -773,14 +781,15 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       σ'.wf st'.decls ∧
       (Signature.ofVars σ'.dom).wf ∧
       st.decls.Subset st'.decls ∧
-      Env.agreeOn st.decls ρ ρ' ∧
+      VerifM.Env.agreeOn st.decls ρ ρ' ∧
       st'.owns = st.owns ∧
       (((Signature.ofVars σ.dom).declVars (Spec.argVars args)).vars ⊆ σ'.dom) ∧
-      Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args)) (σ'.subst.eval ρ')
-        (Spec.argsEnv (σ.subst.eval ρ) args vs) ∧
+      VerifM.Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args))
+        (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env))
+        (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) args vs) ∧
       (∀ v ∈ argVars, v ∈ st'.decls.consts) ∧
       (∀ v ∈ argVars, v.sort = .value) ∧
-      Terms.Eval ρ' (argVars.map (fun av => .const (.uninterpreted av.name .value))) vs := by
+      Terms.Eval ρ'.env (argVars.map (fun av => .const (.uninterpreted av.name .value))) vs := by
   intro args
   induction args with
   | nil =>
@@ -790,8 +799,8 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       simp [Spec.declareImplArgs] at heval
       have := VerifM.eval_ret heval
       exact ⟨σ, [], st, ρ, this, hσwf, hσdomwf,
-        Signature.Subset.refl _, Env.agreeOn_refl, rfl, fun x hx => hx,
-        by simp [Spec.argVars, Spec.argsEnv]; exact Env.agreeOn_refl,
+        Signature.Subset.refl _, VerifM.Env.agreeOn_refl, rfl, fun x hx => hx,
+        by simp [Spec.argVars, Spec.argsEnv]; exact VerifM.Env.agreeOn_refl,
         nofun,
         nofun,
         .nil⟩
@@ -821,7 +830,7 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
           exact hfresh_decls (Signature.mem_allNames_of_var hvar)
         · intro τ' hc'
           exact Signature.wf_unique_const hwfst₁ (List.Mem.head _) hc'
-      have hvar_eval : (Term.const (.uninterpreted argVar.name .value)).eval ρ₁ = v := by
+      have hvar_eval : (Term.const (.uninterpreted argVar.name .value)).eval ρ₁.env = v := by
         simp [ρ₁, Term.eval, Const.denote, Env.updateConst]
       have hassume_bind := VerifM.eval_bind _ _ _ _ hdecl
       set σ' := σ.rename ⟨name, .value⟩ argVar.name
@@ -859,14 +868,15 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
             σ''.wf st'.decls ∧
             (Signature.ofVars σ''.dom).wf ∧
             st₂.decls.Subset st'.decls ∧
-            Env.agreeOn st₂.decls ρ₁ ρ' ∧
+            VerifM.Env.agreeOn st₂.decls ρ₁ ρ' ∧
             st'.owns = st₂.owns ∧
             (((Signature.ofVars σ'.dom).declVars (Spec.argVars rest)).vars ⊆ σ''.dom) ∧
-            Env.agreeOn ((Signature.ofVars σ'.dom).declVars (Spec.argVars rest)) (σ''.subst.eval ρ')
-              (Spec.argsEnv (σ'.subst.eval ρ₁) rest vs') ∧
+            VerifM.Env.agreeOn ((Signature.ofVars σ'.dom).declVars (Spec.argVars rest))
+              (VerifM.Env.withEnv ρ' (σ''.subst.eval ρ'.env))
+              (Spec.argsEnv (VerifM.Env.withEnv ρ₁ (σ'.subst.eval ρ₁.env)) rest vs') ∧
             (∀ v ∈ argVars', v ∈ st'.decls.consts) ∧
             (∀ v ∈ argVars', v.sort = .value) ∧
-            Terms.Eval ρ' (argVars'.map (fun av => .const (.uninterpreted av.name .value))) vs' :=
+            Terms.Eval ρ'.env (argVars'.map (fun av => .const (.uninterpreted av.name .value))) vs' :=
         ih vs' σ' st₂ ρ₁
           (fun p st' ρ' => Ψ (p.1, argVar :: p.2) st' ρ')
           hσ'wf₂ hσ'domwf hvs_rest hbind₂'
@@ -884,9 +894,9 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         Signature.Subset.trans hst_st₂ hdsub', ?_⟩
       have hst_st₂_sig : st.decls.Subset st₂.decls :=
         hst₂_decls ▸ Signature.Subset.subset_addConst st.decls argVar
-      have hragree_final : Env.agreeOn st.decls ρ ρ' :=
-        Env.agreeOn_trans (agreeOn_update_fresh_const hfresh_decls)
-          (Env.agreeOn_mono hst_st₂_sig hragree')
+      have hragree_final : VerifM.Env.agreeOn st.decls ρ ρ' :=
+        VerifM.Env.agreeOn_trans (VerifM.Env.agreeOn_update_fresh (ρ := ρ) (c := argVar) (u := v) hfresh_decls)
+          (VerifM.Env.agreeOn_mono hst_st₂_sig hragree')
       have howns_final : st'.owns = st.owns := by
         calc
           st'.owns = st₂.owns := howns
@@ -897,16 +907,22 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
           using hdom_sub
       have hag_rename := FiniteSubst.rename_agreeOn_declVar
-          (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ) (u := v)
+          (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ.env) (u := v)
           hσwf hfresh_decls rfl
-      have hag_env := Spec.argsEnv_agreeOn hag_rename rest vs' (by
+      have hag_env := Spec.argsEnv_agreeOn
+          (ρ₁ := VerifM.Env.withEnv ρ₁ (σ'.subst.eval ρ₁.env))
+          (ρ₂ := VerifM.Env.withEnv ρ ((σ.subst.eval ρ.env).updateConst .value name v))
+          (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', FiniteSubst.rename] using hag_rename)
+          rest vs' (by
           have := hvs_rest.length_eq
           simp [List.length_map] at this; omega)
       have hagree_final :
-          Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars ((name, ty) :: rest))) (σ''.subst.eval ρ')
-            (Spec.argsEnv (σ.subst.eval ρ) ((name, ty) :: rest) (v :: vs')) := by
-        simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar] using
-          (Env.agreeOn_trans hagree hag_env)
+          VerifM.Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars ((name, ty) :: rest)))
+            (VerifM.Env.withEnv ρ' (σ''.subst.eval ρ'.env))
+            (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ((name, ty) :: rest) (v :: vs')) := by
+        simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar,
+          VerifM.Env.withEnv, VerifM.Env.agreeOn] using
+          (VerifM.Env.agreeOn_trans hagree hag_env)
       have hmem_final : ∀ w ∈ argVar :: argVars', w ∈ st'.decls.consts := by
         intro w hw
         cases List.mem_cons.mp hw with
@@ -918,32 +934,32 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         | inl h => subst h; rfl
         | inr h => exact hsorts w h
       have hlookups_final :
-          Terms.Eval ρ' ((argVar :: argVars').map (fun av => .const (.uninterpreted av.name .value))) (v :: vs') := by
+          Terms.Eval ρ'.env ((argVar :: argVars').map (fun av => .const (.uninterpreted av.name .value))) (v :: vs') := by
         constructor
         · have h1 := hragree'.2.1 argVar (hst₂_decls ▸ List.mem_cons_self ..)
-          have h1' : Term.eval ρ' (Term.const (.uninterpreted argVar.name .value)) =
-              Term.eval ρ₁ (Term.const (.uninterpreted argVar.name .value)) := by
+          have h1' : Term.eval ρ'.env (Term.const (.uninterpreted argVar.name .value)) =
+              Term.eval ρ₁.env (Term.const (.uninterpreted argVar.name .value)) := by
             simpa [Term.eval, Const.denote, Env.lookupConst] using h1.symm
           exact h1'.trans hvar_eval
         · exact hlookups
       exact ⟨hragree_final, howns_final, hdom_sub_final, hagree_final, hmem_final, hsorts_final, hlookups_final⟩
 
 theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
-    (st : TransState) (ρ : Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
+    (st : TransState) (ρ : VerifM.Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
     s.wfIn Signature.empty →
     TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) →
     VerifM.eval (Spec.implement s body) st ρ (fun _ _ _ => True) →
-    (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : Env) (Q : iProp),
+    (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : VerifM.Env) (Q : iProp),
       (∀ v ∈ argVars, v ∈ st'.decls.consts) →
       (∀ v ∈ argVars, v.sort = .value) →
-      List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs →
+      List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs →
       VerifM.eval (body argVars) st' ρ'
         (fun result st'' ρ'' =>
           ∀ (S : iProp), result.wfIn st''.decls →
-            st''.owns.interp ρ'' ∗ Q ∗ ((⌜TinyML.ValHasType Θ (result.eval ρ'') s.retTy⌝ -∗ Φ (result.eval ρ'')) -∗ S) ⊢ S) →
-      st'.owns.interp ρ' ∗ Q ⊢ R) →
-    st.owns.interp ρ ∗ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-      (Spec.argsEnv Env.empty s.args vs) ⊢ R := by
+            st''.sl ρ'' ∗ Q ∗ ((⌜TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy⌝ -∗ Φ (result.eval ρ''.env)) -∗ S) ⊢ S) →
+      st'.sl ρ' ∗ Q ⊢ R) →
+    st.sl ρ ∗ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+      (Spec.argsEnv VerifM.Env.empty s.args vs) ⊢ R := by
   intro hswf hvs heval hR
   simp only [Spec.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
@@ -952,25 +968,29 @@ theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL
     Spec.declareImplArgs_correct Θ s.args vs FiniteSubst.id st ρ _ (FiniteSubst.id_wf st.decls)
       (by simpa [Signature.ofVars] using Signature.wf_empty) hvs hb
   -- Transport apply from argsEnv Env.empty to σ'.subst.eval ρ'
-  have hag_empty : Env.agreeOn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars s.args))
-      (Spec.argsEnv Env.empty s.args vs)
-      (Spec.argsEnv (FiniteSubst.id.subst.eval ρ) s.args vs) :=
-    Spec.argsEnv_agreeOn (Δ := Signature.empty) (ρ₁ := Env.empty) (ρ₂ := FiniteSubst.id.subst.eval ρ)
-      ⟨nofun, nofun, nofun, nofun⟩ s.args vs
+  have hag_empty : VerifM.Env.agreeOn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars s.args))
+      (Spec.argsEnv VerifM.Env.empty s.args vs)
+      (Spec.argsEnv (VerifM.Env.withEnv ρ (FiniteSubst.id.subst.eval ρ.env)) s.args vs) :=
+    Spec.argsEnv_agreeOn (Δ := Signature.empty)
+      (ρ₁ := VerifM.Env.empty)
+      (ρ₂ := VerifM.Env.withEnv ρ (FiniteSubst.id.subst.eval ρ.env))
+      (by exact ⟨nofun, nofun, nofun, nofun⟩) s.args vs
       (by have := hvs.length_eq; simp [List.length_map] at this; omega)
-  refine (show st.owns.interp ρ ∗
+  refine (show st.sl ρ ∗
       PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-        (Spec.argsEnv Env.empty s.args vs) ⊢
-      st'.owns.interp ρ' ∗
+        (Spec.argsEnv VerifM.Env.empty s.args vs) ⊢
+      st'.sl ρ' ∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-          (σ'.subst.eval ρ') from by
+          (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) from by
       iintro H
       icases H with ⟨Howns, Happ⟩
       isplitr [Happ]
-      · iapply (show st.owns.interp ρ' ⊢ st'.owns.interp ρ' by simp [howns])
-        iapply (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1
+      · iapply (show st.sl ρ' ⊢ st'.sl ρ' by simp [howns, TransState.sl])
+        iapply (show st.sl ρ ⊢ st.sl ρ' by
+          simpa [TransState.sl] using
+            (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1)
         iexact Howns
-      · iapply (PredTrans.apply_env_agree hswf (Env.agreeOn_trans hag_empty (Env.agreeOn_symm hagree)))
+      · iapply (PredTrans.apply_env_agree hswf (VerifM.Env.agreeOn_trans hag_empty (VerifM.Env.agreeOn_symm hagree)))
         iexact Happ).trans
     (PredTrans.implement_correct s.pred σ' (body argVars) st' ρ'
       (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) R
@@ -995,7 +1015,7 @@ theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL
             exact hdsub'.consts v (hmem_decls v hv)
           · exact hsorts
           · apply Terms.Eval.lookup_const
-            apply Terms.Eval.env_agree (ρ := ρ')
+            apply Terms.Eval.env_agree (ρ := ρ'.env)
             · intro t ht
               obtain ⟨av, hav, rfl⟩ := List.mem_map.mp ht
               simp only [Term.wfIn, Const.wfIn]


### PR DESCRIPTION
This PR is a simple refactoring that introduces a separate verifier environment. This allows us to decouple the two, more easily extend the verifier environment in the future, and makes the proofs a little more robust.