### PR TITLE
Add separation logic support

### DIFF
--- a/Examples/references.ml
+++ b/Examples/references.ml
@@ -1,0 +1,96 @@
+(* Examples that exercise allocation, dereference, assignment, and sequencing. *)
+
+(* Swap the contents of two integer references. *)
+let swap (x : int ref) (y : int ref) : unit =
+  let tmp = !x in
+  x := !y;
+  y := tmp
+[@@spec fun x y ->
+  bind (own x) @@ fun vx ->
+  bind (isint vx) @@ fun a ->
+  bind (own y) @@ fun vy ->
+  bind (isint vy) @@ fun b ->
+  ret (fun r ->
+    assert (r = ());
+    bind (own x) @@ fun vx2 ->
+    bind (isint vx2) @@ fun a2 ->
+    bind (own y) @@ fun vy2 ->
+    bind (isint vy2) @@ fun b2 ->
+    assert (a2 = b);
+    assert (b2 = a))];;
+
+(* Swap two local cells and return the observed pair. *)
+let swap_pair_via_refs (a : int) (b : int) : int * int =
+  let x = ref a in
+  let y = ref b in
+  swap x y;
+  (!x, !y)
+[@@spec fun a b ->
+  bind (isint a) @@ fun n ->
+  bind (isint b) @@ fun m ->
+  ret (fun v ->
+    bind (isint v.0) @@ fun fst ->
+    bind (isint v.1) @@ fun snd ->
+    assert (fst = m);
+    assert (snd = n))];;
+
+(* Reuse swap twice; the state returns to the start. *)
+let id_by_swapping_twice (a : int) (b : int) : int * int =
+  let x = ref a in
+  let y = ref b in
+  swap x y;
+  swap x y;
+  (!x, !y)
+[@@spec fun a b ->
+  bind (isint a) @@ fun n ->
+  bind (isint b) @@ fun m ->
+  ret (fun v ->
+    bind (isint v.0) @@ fun fst ->
+    bind (isint v.1) @@ fun snd ->
+    assert (fst = n);
+    assert (snd = m))];;
+
+(* Sum into the left cell while keeping the right one unchanged. *)
+let sum_into_left_local (a : int) (b : int) : int * int =
+  let x = ref a in
+  let y = ref b in
+  x := !x + !y;
+  (!x, !y)
+[@@spec fun a b ->
+  bind (isint a) @@ fun n ->
+  bind (isint b) @@ fun m ->
+  ret (fun v ->
+    bind (isint v.0) @@ fun left ->
+    bind (isint v.1) @@ fun right ->
+    assert (left = n + m);
+    assert (right = m))];;
+
+(* A slightly more creative reference program: conditionally normalize order by swapping. *)
+let sort2_via_swap (a : int) (b : int) : int * int =
+  let x = ref a in
+  let y = ref b in
+  if !x > !y then swap x y else ();
+  (!x, !y)
+[@@spec fun a b ->
+  bind (isint a) @@ fun n ->
+  bind (isint b) @@ fun m ->
+  ret (fun v ->
+    bind (isint v.0) @@ fun fst ->
+    bind (isint v.1) @@ fun snd ->
+    assert (fst <= snd);
+    if n > m then
+      assert (fst = m && snd = n)
+    else
+      assert (fst = n && snd = m))];;
+
+(* Two increments through the same local cell. *)
+let bump_twice (n : int) : int =
+  let x = ref n in
+  x := !x + 1;
+  x := !x + 1;
+  !x
+[@@spec fun n ->
+  bind (isint n) @@ fun m ->
+  ret (fun v ->
+    bind (isint v) @@ fun r ->
+    assert (r = m + 2))];;

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -84,6 +84,10 @@ def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyM
     | "int"  => if args'.isEmpty then .ok .int  else err loc (.arityMismatch 0 args'.length)
     | "bool" => if args'.isEmpty then .ok .bool else err loc (.arityMismatch 0 args'.length)
     | "unit" => if args'.isEmpty then .ok .unit else err loc (.arityMismatch 0 args'.length)
+    | "ref" =>
+      match args' with
+      | [arg] => .ok (.ref arg)
+      | _ => err loc (.arityMismatch 1 args'.length)
     | _ =>
       if env.types.elem name then .ok (.named name args')
       else err loc (.unknownType name)

--- a/Mica/Frontend/Spec.lean
+++ b/Mica/Frontend/Spec.lean
@@ -40,6 +40,7 @@ inductive Pred where
   | isint (arg : Term)
   | isbool (arg : Term)
   | isinj (tag arity : Nat) (arg : Term)
+  | own (loc : Term)
   deriving Repr, BEq, Inhabited
 
 inductive Assert (α : Type) where

--- a/Mica/Frontend/SpecParser.lean
+++ b/Mica/Frontend/SpecParser.lean
@@ -43,7 +43,8 @@ private def parsePred : Untyped.Expr → M Pred
   | .app (.var "isbool") [e] => do .ok (.isbool (← parseTerm e))
   | .app (.var "isinj") [.const (.int tag), .const (.int arity), e] => do
     .ok (.isinj tag.toNat arity.toNat (← parseTerm e))
-  | e => .error s!"expected type predicate (isint, isbool, isinj), got {repr e}"
+  | .app (.var "own") [e] => do .ok (.own (← parseTerm e))
+  | e => .error s!"expected type predicate (isint, isbool, isinj, own), got {repr e}"
 
 private def parseAssert (inner : Untyped.Expr → M α)
     (bareAssert : Untyped.Expr → M (Assert α)) : Untyped.Expr → M (Assert α)

--- a/Mica/SeparationLogic.lean
+++ b/Mica/SeparationLogic.lean
@@ -1,3 +1,4 @@
 import Mica.SeparationLogic.Axioms
 import Mica.SeparationLogic.SpatialAtom
 import Mica.SeparationLogic.Interpretations
+import Mica.SeparationLogic.PrimitiveLaws

--- a/Mica/SeparationLogic/Axioms.lean
+++ b/Mica/SeparationLogic/Axioms.lean
@@ -43,12 +43,6 @@ axiom wp.bind {k : TinyML.K} {e : Runtime.Expr} {Q : Runtime.Val → iProp} :
 axiom wp.mono {e : Runtime.Expr} {P Q : Runtime.Val → iProp} :
     (∀ v, P v -∗ Q v) ∗ wp e P ⊢ wp e Q
 
-axiom wp.fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
-    {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp} :
-    ((∀ vs, Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
-      ∀ vs, Φ vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)
-    ⊢ (∀ (vs : List Runtime.Val), Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
-
 axiom wp.app {fn : Runtime.Expr} {args : Runtime.Exprs} {P : Runtime.Val → iProp} :
     wps args (fun vs => wp fn (fun fv =>
       wp (.app (.val fv) (vs.map Runtime.Expr.val)) P)) ⊢
@@ -58,15 +52,18 @@ axiom wp.func {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Exp
     (P : Runtime.Val → iProp) :
     P (.fix f args e) ⊢ wp (.fix f args e) P
 
--- @agent: wp.fix' needs several persistency modalities that are currently missing
+axiom wp.fix {vs : List Runtime.Val} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
+    {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp} :
+      wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P
+    ⊢ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P
+
 axiom wp.fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp} :
-    ((∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+    □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
         Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
       ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
         Φ P vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)
-    ⊢ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-        Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
+    ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp), Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
 
 axiom wp.unop {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iProp} :
     TinyML.evalUnOp op v = some res →
@@ -166,17 +163,10 @@ theorem wp.letIn {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.V
   isplitl []
   · iintro %v Hv
     iapply wp.func
-    iapply (@wp.fix .none [b] body Q
-      (fun vs => ∃ v', ⌜vs = [v']⌝ ∗ wp (body.subst (Runtime.Subst.id.update' b v')) Q))
-    · iintro _IH %vs ⟨%v', %Heq, Hwp⟩
-      subst Heq
-      simp only [Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left,
-                  Runtime.Subst.update']
-      iexact Hwp
-    · iexists v
-      isplitr
-      · ipure_intro; rfl
-      · iexact Hv
+    iapply (wp.fix (Φ := fun _ => emp) (vs := [v]))
+    simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons,
+               Runtime.Subst.updateAll'_nil_left]
+    iexact Hv
   · iexact Hbound
 
 /-- Applying a single-argument lambda `(fun b -> body)` to a value reduces to substituting. -/
@@ -190,14 +180,7 @@ theorem wp.app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Run
   simp only [wps_cons, wps_nil]
   iapply wp.val
   iapply wp.func
-  iapply (@wp.fix .none [b] body Φ
-    (fun vs => ∃ v', ⌜vs = [v']⌝ ∗ wp (body.subst (Runtime.Subst.id.update' b v')) Φ))
-  · iintro _IH %vs ⟨%v', %Heq, Hwp'⟩
-    subst Heq
-    simp only [Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left,
-               Runtime.Subst.update']
-    iexact Hwp'
-  · iexists v
-    isplitr
-    · ipure_intro; rfl
-    · iexact Hwp
+  iapply (wp.fix (Φ := fun _ => emp) (vs := [v]))
+  simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons,
+             Runtime.Subst.updateAll'_nil_left]
+  iexact Hwp

--- a/Mica/SeparationLogic/Axioms.lean
+++ b/Mica/SeparationLogic/Axioms.lean
@@ -58,6 +58,7 @@ axiom wp.func {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Exp
     (P : Runtime.Val → iProp) :
     P (.fix f args e) ⊢ wp (.fix f args e) P
 
+-- @agent: wp.fix' needs several persistency modalities that are currently missing
 axiom wp.fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp} :
     ((∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
@@ -177,3 +178,26 @@ theorem wp.letIn {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.V
       · ipure_intro; rfl
       · iexact Hv
   · iexact Hbound
+
+/-- Applying a single-argument lambda `(fun b -> body)` to a value reduces to substituting. -/
+theorem wp.app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Runtime.Val}
+    {Φ : Runtime.Val → iProp} :
+    wp (body.subst (Runtime.Subst.id.update' b v)) Φ ⊢
+    wp (.app (.fix .none [b] body) [.val v]) Φ := by
+  istart
+  iintro Hwp
+  iapply wp.app
+  simp only [wps_cons, wps_nil]
+  iapply wp.val
+  iapply wp.func
+  iapply (@wp.fix .none [b] body Φ
+    (fun vs => ∃ v', ⌜vs = [v']⌝ ∗ wp (body.subst (Runtime.Subst.id.update' b v')) Φ))
+  · iintro _IH %vs ⟨%v', %Heq, Hwp'⟩
+    subst Heq
+    simp only [Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left,
+               Runtime.Subst.update']
+    iexact Hwp'
+  · iexists v
+    isplitr
+    · ipure_intro; rfl
+    · iexact Hwp

--- a/Mica/SeparationLogic/Interpretations.lean
+++ b/Mica/SeparationLogic/Interpretations.lean
@@ -20,11 +20,11 @@ def interp (ρ : Env) : SpatialAtom → iProp
     symbols in the ambient signature. -/
 theorem interp_env_agree {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
     (hwf : a.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    interp ρ a = interp ρ' a := by
+    interp ρ a ⊣⊢ interp ρ' a := by
   cases a with
   | pointsTo l v =>
-    simp only [interp]
-    rw [Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
+    simp only [interp, Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
+    exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 
 /-- If a points-to atom's location term evaluates to `loc`, its interpretation
     is equivalent to the raw points-to assertion for `loc`. -/
@@ -60,16 +60,16 @@ def interp (ρ : Env) : SpatialContext → iProp
     symbols in the ambient signature. -/
 theorem interp_env_agree {ctx : SpatialContext} {Δ : Signature} {ρ ρ' : Env}
     (hwf : wfIn ctx Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    interp ρ ctx = interp ρ' ctx := by
+    interp ρ ctx ⊣⊢ interp ρ' ctx := by
   induction ctx with
   | nil => simp [interp]
   | cons a ctx ih =>
-    have ha : SpatialAtom.interp ρ a = SpatialAtom.interp ρ' a :=
+    have ha : SpatialAtom.interp ρ a ⊣⊢ SpatialAtom.interp ρ' a :=
       SpatialAtom.interp_env_agree (hwf a (by simp)) hagree
     have htail : wfIn ctx Δ := (wfIn_cons a ctx Δ).1 hwf |>.2
-    have hctx : interp ρ ctx = interp ρ' ctx :=
-      ih htail
-    simp [interp, ha, hctx]
+    have hctx : interp ρ ctx ⊣⊢ interp ρ' ctx := ih htail
+    simp only [interp]
+    exact ⟨sep_mono ha.1 hctx.1, sep_mono ha.2 hctx.2⟩
 
 @[simp] theorem interp_nil (ρ : Env) : interp ρ [] = emp := rfl
 @[simp] theorem interp_cons (ρ : Env) (a : SpatialAtom) (Γ : SpatialContext) :

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -342,25 +342,23 @@ theorem wp_fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Ex
     {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp}
     R
     (h : R ⊢
-      ((∀ vs, Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
-        ∀ vs, Φ vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
+      (wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
     R ⊢
-      (∀ vs, Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
-  h.trans wp.fix
+      (wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
+  h.trans (wp.fix (Φ := Φ))
 
 /-- Fixpoint unfolding with a continuation-indexed invariant. -/
 theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢
-      ((∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
         ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
-    R ⊢
-      (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+    R ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
-  h.trans wp.fix'
+  h.trans (wp.fix' (Φ := Φ))
 
 /-- Let-bindings: evaluate the bound expression, then continue in the body with
     the resulting value substituted. -/
@@ -376,5 +374,22 @@ theorem wp_app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Run
     (h : R ⊢ wp (body.subst (Runtime.Subst.id.update' b v)) Φ) :
     R ⊢ wp (.app (.fix .none [b] body) [.val v]) Φ :=
   h.trans wp.app_lambda_single
+
+
+/-- Strengthen the postcondition of a `wp` using a persistent resource:
+    if `R` (persistent) entails `wp e P`, and `R` together with `P v` entails `Q v`,
+    then `R` entails `wp e Q`. -/
+theorem wp_strengthen_persistent
+    {R : iProp} [Iris.BI.Persistent R] {e : Runtime.Expr}
+    {P Q : Runtime.Val → iProp}
+    (hwp : R ⊢ wp e P) (hpost : ∀ v, R ⊢ P v -∗ Q v) :
+    R ⊢ wp e Q := by
+  iintro □HR
+  iapply wp.mono
+  isplitr
+  · iintro %v
+    iapply (hpost v)
+    iexact HR
+  · iapply hwp; iexact HR
 
 end SpatialContext

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -39,35 +39,35 @@ private theorem wp_bind_tuple_aux {left : Runtime.Exprs} {es : Runtime.Exprs} {r
 
 /-- Value: context unchanged. -/
 theorem wp_val {v : Runtime.Val} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ Q v) :
-    ctx.interp ρ ⊢ wp (.val v) Q :=
+    {R : iProp}
+    (h : R ⊢ Q v) :
+    R ⊢ wp (.val v) Q :=
   h.trans wp.val
 
 /-- Unary operation under evaluation: first evaluate the operand, then take the
     head unary-operation step. -/
 theorem wp_bind_unop {op : TinyML.UnOp} {e : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp e (fun v => wp (.unop op (.val v)) Q)) :
-    ctx.interp ρ ⊢ wp (.unop op e) Q :=
+    {R : iProp}
+    (h : R ⊢ wp e (fun v => wp (.unop op (.val v)) Q)) :
+    R ⊢ wp (.unop op e) Q :=
   h.trans (wp.bind (k := TinyML.K.unop op .hole))
 
 /-- Unary operation at values: context unchanged. -/
 theorem wp_unop {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ Q res) :
+    {R : iProp}
+    (h : R ⊢ Q res) :
     TinyML.evalUnOp op v = some res →
-    ctx.interp ρ ⊢ wp (.unop op (.val v)) Q := by
+    R ⊢ wp (.unop op (.val v)) Q := by
   intro heval
   exact h.trans (wp.unop heval)
 
 /-- Binary operation under evaluation: first evaluate the right operand, then the
     left operand, then take the head binary-operation step. -/
 theorem wp_bind_binop {op : TinyML.BinOp} {l r : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp r (fun vr => wp l (fun vl =>
+    {R : iProp}
+    (h : R ⊢ wp r (fun vr => wp l (fun vl =>
       wp (.binop op (.val vl) (.val vr)) Q))) :
-    ctx.interp ρ ⊢ wp (.binop op l r) Q := by
+    R ⊢ wp (.binop op l r) Q := by
   have hr :
       wp r (fun vr => wp l (fun vl => wp (.binop op (.val vl) (.val vr)) Q)) ⊢
       wp r (fun vr => wp (.binop op l (.val vr)) Q) := by
@@ -78,10 +78,10 @@ theorem wp_bind_binop {op : TinyML.BinOp} {l r : Runtime.Expr} {Q : Runtime.Val 
 
 /-- Binary operation at values: context unchanged. -/
 theorem wp_binop {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ Q res) :
+    {R : iProp}
+    (h : R ⊢ Q res) :
     TinyML.evalBinOp op vl vr = some res →
-    ctx.interp ρ ⊢ wp (.binop op (.val vl) (.val vr)) Q := by
+    R ⊢ wp (.binop op (.val vl) (.val vr)) Q := by
   intro heval
   apply h.trans
   iapply (wp.binop heval)
@@ -89,37 +89,37 @@ theorem wp_binop {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val 
 /-- Conditional under evaluation: first evaluate the condition, then take the
     appropriate branch head step. -/
 theorem wp_bind_if {cond thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp cond (fun v => wp (.ifThenElse (.val v) thn els) Q)) :
-    ctx.interp ρ ⊢ wp (.ifThenElse cond thn els) Q :=
+    {R : iProp}
+    (h : R ⊢ wp cond (fun v => wp (.ifThenElse (.val v) thn els) Q)) :
+    R ⊢ wp (.ifThenElse cond thn els) Q :=
   h.trans (wp.bind (k := TinyML.K.ifCond .hole thn els))
 
 /-- Conditional on `true`: context unchanged. -/
 theorem wp_if_true {thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp thn Q) :
-    ctx.interp ρ ⊢ wp (.ifThenElse (.val (.bool true)) thn els) Q :=
+    {R : iProp}
+    (h : R ⊢ wp thn Q) :
+    R ⊢ wp (.ifThenElse (.val (.bool true)) thn els) Q :=
   h.trans wp.if_true
 
 /-- Conditional on `false`: context unchanged. -/
 theorem wp_if_false {thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp els Q) :
-    ctx.interp ρ ⊢ wp (.ifThenElse (.val (.bool false)) thn els) Q :=
+    {R : iProp}
+    (h : R ⊢ wp els Q) :
+    R ⊢ wp (.ifThenElse (.val (.bool false)) thn els) Q :=
   h.trans wp.if_false
 
 /-- Reference allocation under evaluation: first evaluate the payload, then
     allocate. -/
 theorem wp_bind_ref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp e (fun v => wp (.ref (.val v)) Q)) :
-    ctx.interp ρ ⊢ wp (.ref e) Q :=
+    {R : iProp}
+    (h : R ⊢ wp e (fun v => wp (.ref (.val v)) Q)) :
+    R ⊢ wp (.ref e) Q :=
   h.trans (wp.bind (k := TinyML.K.ref .hole))
 
 /-- Reference allocation at values. The continuation receives fresh ownership in
     the updated environment for a caller-chosen fresh value constant. -/
 theorem wp_ref {v : Runtime.Val} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env} {Δ : Signature}
+    {ctx : SpatialContext} {ρ : Env} {R : iProp} {Δ : Signature}
     {vt : Term .value} {name : String} {newctx : SpatialContext}
     (hctx : wfIn ctx Δ)
     (hvt : vt.wfIn Δ)
@@ -127,19 +127,19 @@ theorem wp_ref {v : Runtime.Val} {Q : Runtime.Val → iProp}
     (hfresh : name ∉ Δ.allNames)
     (hnewctx : insert (.pointsTo (.const (.uninterpreted name .value)) vt) ctx = newctx)
     (h : ∀ loc,
-      newctx.interp (ρ.updateConst .value name (.loc loc)) ⊢
+      newctx.interp (ρ.updateConst .value name (.loc loc)) ∗ R ⊢
       Q (.loc loc)) :
-    ctx.interp ρ ⊢ wp (.ref (.val v)) Q := by
-  have hforall : ctx.interp ρ ⊢ BIBase.forall fun (loc : Runtime.Location) => loc ↦ v -∗ Q (.loc loc) := by
+    ctx.interp ρ ∗ R  ⊢ wp (.ref (.val v)) Q := by
+  have hforall : ctx.interp ρ ∗ R ⊢ BIBase.forall fun (loc : Runtime.Location) => loc ↦ v -∗ Q (.loc loc) := by
     apply forall_intro
     intro loc
     apply wand_intro
+    -- goal: (ctx.interp ρ ∗ R) ∗ (loc ↦ v) ⊢ Q (.loc loc)
     let ρ' := ρ.updateConst .value name (.loc loc)
     let a : SpatialAtom := .pointsTo (.const (.uninterpreted name .value)) vt
     have hagree : Env.agreeOn Δ ρ ρ' := agreeOn_update_fresh_const (c := ⟨name, .value⟩) hfresh
     have hctxeq : ctx.interp ρ ⊢ ctx.interp ρ' := by
-      rw [SpatialContext.interp_env_agree hctx hagree]
-      exact .rfl
+      exact (SpatialContext.interp_env_agree hctx hagree).1
     have hveq : Term.eval ρ' vt = v := by
       simpa [ρ'] using (Term.eval_update_fresh (t := vt) hvt hfresh).trans hv
     have hloc : Term.eval ρ' (.const (.uninterpreted name .value)) = .loc loc := by
@@ -152,15 +152,18 @@ theorem wp_ref {v : Runtime.Val} {Q : Runtime.Val → iProp}
       apply sep_comm.1.trans
       apply (sep_mono_l hptIntro).trans
       simp [a, SpatialContext.interp]
-    exact hinsert.trans (by simpa [ρ', a, hnewctx] using h loc)
+    -- rearrange (ctx.interp ρ ∗ R) ∗ (loc ↦ v) to (ctx.interp ρ ∗ (loc ↦ v)) ∗ R
+    have hrearrange : (ctx.interp ρ ∗ R) ∗ (loc ↦ v) ⊢ (ctx.interp ρ ∗ (loc ↦ v)) ∗ R :=
+      sep_assoc.1.trans (sep_mono_r sep_comm.1) |>.trans sep_assoc.2
+    exact hrearrange.trans ((sep_mono_l hinsert).trans (by simpa [ρ', a, hnewctx] using h loc))
   exact hforall.trans wp.ref
 
 /-- Dereference under evaluation: first evaluate the scrutinee, then dereference
     the resulting value. -/
 theorem wp_bind_deref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp e (fun v => wp (.deref (.val v)) Q)) :
-    ctx.interp ρ ⊢ wp (.deref e) Q :=
+    {R : iProp}
+    (h : R ⊢ wp e (fun v => wp (.deref (.val v)) Q)) :
+    R ⊢ wp (.deref e) Q :=
   h.trans (wp.bind (k := TinyML.K.deref .hole))
 
 /-- Dereference at values: the context must contain a matching points-to.
@@ -172,43 +175,45 @@ theorem wp_bind_deref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     by `lt`, and the continuation premise `h` works with the remaining
     context. -/
 theorem wp_deref {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
+    {ctx : SpatialContext} {ρ : Env} {R : iProp}
     {n : Nat} {lt vt : Term .value} {rest : SpatialContext}
     {v : Runtime.Val} {loc : Runtime.Location}
-    (h : ctx.interp ρ ⊢ Q (Term.eval ρ vt)) :
+    (h : ctx.interp ρ ∗ R ⊢ Q (Term.eval ρ vt)) :
     remove ctx n = some (.pointsTo lt vt, rest) →
     Term.eval ρ lt = v →
     v = .loc loc →
-    ctx.interp ρ ⊢ wp (.deref (.val v)) Q := by
+    ctx.interp ρ ∗ R ⊢ wp (.deref (.val v)) Q := by
   intro hrem hlt hv
   subst hv
   -- Split the context and rewrite the selected atom to a raw points-to fact.
   have hsplit : ctx.interp ρ ⊢ (loc ↦ Term.eval ρ vt) ∗ rest.interp ρ :=
     (interp_remove ρ ctx n _ _ hrem).1 |>.trans (sep_mono_l (SpatialAtom.interp_pointsTo hlt).1)
   -- Rebuild the original context inside the wand, since reading preserves it.
-  apply hsplit.trans
+  apply (sep_mono_l hsplit).trans
   istart
-  iintro ⟨Hpt, Hrest⟩
+  iintro ⟨⟨Hpt, Hrest⟩, HR⟩
   iapply wp.deref
   isplitl [Hpt]
   · iexact Hpt
   · iintro Hpt
     have hctx : (loc ↦ Term.eval ρ vt) ∗ rest.interp ρ ⊢ ctx.interp ρ :=
       (sep_mono_l (SpatialAtom.interp_pointsTo hlt).2).trans (interp_remove ρ ctx n _ _ hrem).2
-    have hq : (loc ↦ Term.eval ρ vt) ∗ rest.interp ρ ⊢ Q (Term.eval ρ vt) :=
-      hctx.trans h
+    have hq : (loc ↦ Term.eval ρ vt) ∗ rest.interp ρ ∗ R ⊢ Q (Term.eval ρ vt) :=
+      sep_assoc.2.trans ((sep_mono_l hctx).trans h)
     iapply hq
     isplitl [Hpt]
     · iexact Hpt
-    · iexact Hrest
+    · isplitr [HR]
+      · iexact Hrest
+      · iexact HR
 
 /-- Store under evaluation: first evaluate the value expression, then the
     location expression, then take the head store step. -/
 theorem wp_bind_store {loc val : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp val (fun vv => wp loc (fun vl =>
+    {R : iProp}
+    (h : R ⊢ wp val (fun vv => wp loc (fun vl =>
       wp (.store (.val vl) (.val vv)) Q))) :
-    ctx.interp ρ ⊢ wp (.store loc val) Q := by
+    R ⊢ wp (.store loc val) Q := by
   have hloc :
       wp val (fun vv => wp loc (fun vl => wp (.store (.val vl) (.val vv)) Q)) ⊢
       wp val (fun vv => wp (.store loc (.val vv)) Q) := by
@@ -219,22 +224,22 @@ theorem wp_bind_store {loc val : Runtime.Expr} {Q : Runtime.Val → iProp}
 
 /-- Store at values: replace the selected points-to atom with the updated one. -/
 theorem wp_store {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
+    {ctx : SpatialContext} {ρ : Env} {R : iProp}
     {n : Nat} {lt vt_old vt_new : Term .value} {rest : SpatialContext}
     {vloc vnew : Runtime.Val} {loc : Runtime.Location}
-    (h : (insert (.pointsTo lt vt_new) rest).interp ρ ⊢ Q .unit) :
+    (h : (insert (.pointsTo lt vt_new) rest).interp ρ ∗ R ⊢ Q .unit) :
     remove ctx n = some (.pointsTo lt vt_old, rest) →
     Term.eval ρ lt = vloc →
     vloc = .loc loc →
     Term.eval ρ vt_new = vnew →
-    ctx.interp ρ ⊢ wp (.store (.val vloc) (.val vnew)) Q := by
+    ctx.interp ρ ∗ R ⊢ wp (.store (.val vloc) (.val vnew)) Q := by
   intro hrem hlt hvloc hvnew
   subst hvloc
   have hsplit : ctx.interp ρ ⊢ (loc ↦ Term.eval ρ vt_old) ∗ rest.interp ρ :=
     (interp_remove ρ ctx n _ _ hrem).1 |>.trans (sep_mono_l (SpatialAtom.interp_pointsTo hlt).1)
-  apply hsplit.trans
+  apply (sep_mono_l hsplit).trans
   istart
-  iintro ⟨Hold, Hrest⟩
+  iintro ⟨⟨Hold, Hrest⟩, HR⟩
   iapply wp.store
   isplitl [Hold]
   · iexact Hold
@@ -243,114 +248,116 @@ theorem wp_store {Q : Runtime.Val → iProp}
       simpa [← hvnew] using (SpatialAtom.interp_pointsTo hlt).2
     have hctx : (loc ↦ vnew) ∗ rest.interp ρ ⊢ (insert (.pointsTo lt vt_new) rest).interp ρ := by
       simpa [insert, interp] using (sep_mono_l hnew)
-    have hq : (loc ↦ vnew) ∗ rest.interp ρ ⊢ Q .unit :=
-      hctx.trans h
+    have hq : (loc ↦ vnew) ∗ rest.interp ρ ∗ R ⊢ Q .unit :=
+      sep_assoc.2.trans ((sep_mono_l hctx).trans h)
     iapply hq
     isplitl [Hnew]
     · iexact Hnew
-    · iexact Hrest
+    · isplitr [HR]
+      · iexact Hrest
+      · iexact HR
 
 /-- Assert under evaluation: first evaluate the tested expression, then take
     the head assert step. -/
 theorem wp_bind_assert {e : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp e (fun v => wp (.assert (.val v)) Q)) :
-    ctx.interp ρ ⊢ wp (.assert e) Q :=
+    {R : iProp}
+    (h : R ⊢ wp e (fun v => wp (.assert (.val v)) Q)) :
+    R ⊢ wp (.assert e) Q :=
   h.trans (wp.bind (k := TinyML.K.assert .hole))
 
 /-- Assert on `true`: context unchanged. -/
 theorem wp_assert {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ Q .unit) :
-    ctx.interp ρ ⊢ wp (.assert (.val (.bool true))) Q :=
+    {R : iProp}
+    (h : R ⊢ Q .unit) :
+    R ⊢ wp (.assert (.val (.bool true))) Q :=
   h.trans wp.assert
 
 /-- Injection under evaluation: first evaluate the payload, then take the head
     injection step. -/
 theorem wp_bind_inj {tag arity : Nat} {payload : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp payload (fun v => wp (.inj tag arity (.val v)) Q)) :
-    ctx.interp ρ ⊢ wp (.inj tag arity payload) Q :=
+    {R : iProp}
+    (h : R ⊢ wp payload (fun v => wp (.inj tag arity (.val v)) Q)) :
+    R ⊢ wp (.inj tag arity payload) Q :=
   h.trans (wp.bind (k := TinyML.K.injK tag arity .hole))
 
 /-- Injection at values: context unchanged. -/
 theorem wp_inj {tag arity : Nat} {payload : Runtime.Val} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ Q (.inj tag arity payload)) :
-    ctx.interp ρ ⊢ wp (.inj tag arity (.val payload)) Q :=
+    {R : iProp}
+    (h : R ⊢ Q (.inj tag arity payload)) :
+    R ⊢ wp (.inj tag arity (.val payload)) Q :=
   h.trans wp.inj
 
 /-- Tuple under evaluation: evaluate the components right-to-left, then take
     the head tuple step on the resulting values. -/
 theorem wp_bind_tuple {es : Runtime.Exprs} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wps es (fun vs => wp (.tuple (vs.map Runtime.Expr.val)) Q)) :
-    ctx.interp ρ ⊢ wp (.tuple es) Q := by
+    {R : iProp}
+    (h : R ⊢ wps es (fun vs => wp (.tuple (vs.map Runtime.Expr.val)) Q)) :
+    R ⊢ wp (.tuple es) Q := by
   apply h.trans
   simpa using (wp_bind_tuple_aux (left := []) (es := es) (right := []) (Q := Q))
 
 /-- Tuple at values: context unchanged. -/
 theorem wp_tuple {vs : Runtime.Vals} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ Q (.tuple vs)) :
-    ctx.interp ρ ⊢ wp (.tuple (vs.map Runtime.Expr.val)) Q :=
+    {R : iProp}
+    (h : R ⊢ Q (.tuple vs)) :
+    R ⊢ wp (.tuple (vs.map Runtime.Expr.val)) Q :=
   h.trans wp.tuple
 
 /-- Match under evaluation: first evaluate the scrutinee, then dispatch on the
     resulting injected value. -/
 theorem wp_bind_match {scrut : Runtime.Expr} {branches : Runtime.Exprs} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp scrut (fun v => wp (.match_ (.val v) branches) Q)) :
-    ctx.interp ρ ⊢ wp (.match_ scrut branches) Q :=
+    {R : iProp}
+    (h : R ⊢ wp scrut (fun v => wp (.match_ (.val v) branches) Q)) :
+    R ⊢ wp (.match_ scrut branches) Q :=
   h.trans (wp.bind (k := TinyML.K.matchK branches .hole))
 
 /-- Match on an injected value: context unchanged. -/
 theorem wp_match {tag arity : Nat} {payload : Runtime.Val} {branches : Runtime.Exprs}
     {branch : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp (.app branch [.val payload]) Q) :
+    {R : iProp}
+    (h : R ⊢ wp (.app branch [.val payload]) Q) :
     branches[tag]? = some branch →
-    ctx.interp ρ ⊢ wp (.match_ (.val (.inj tag arity payload)) branches) Q := by
+    R ⊢ wp (.match_ (.val (.inj tag arity payload)) branches) Q := by
   intro hbranch
   exact h.trans (wp.match_ hbranch)
 
 /-- Function values: context unchanged. -/
 theorem wp_func {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
-    {Q : Runtime.Val → iProp} {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ Q (.fix f args e)) :
-    ctx.interp ρ ⊢ wp (.fix f args e) Q :=
+    {Q : Runtime.Val → iProp} {R : iProp}
+    (h : R ⊢ Q (.fix f args e)) :
+    R ⊢ wp (.fix f args e) Q :=
   h.trans (wp.func Q)
 
 /-- Application under evaluation: first evaluate the arguments right-to-left,
     then the function, then take the head application step. -/
 theorem wp_bind_app {fn : Runtime.Expr} {args : Runtime.Exprs} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wps args (fun vs => wp fn (fun fv =>
+    {R : iProp}
+    (h : R ⊢ wps args (fun vs => wp fn (fun fv =>
       wp (.app (.val fv) (vs.map Runtime.Expr.val)) Q))) :
-    ctx.interp ρ ⊢ wp (.app fn args) Q :=
+    R ⊢ wp (.app fn args) Q :=
   h.trans wp.app
 
 /-- Fixpoint unfolding: spatially lifted version of `wp.fix`. -/
 theorem wp_fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢
+    R
+    (h : R ⊢
       ((∀ vs, Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
         ∀ vs, Φ vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
-    ctx.interp ρ ⊢
+    R ⊢
       (∀ vs, Φ vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
   h.trans wp.fix
 
 /-- Fixpoint unfolding with a continuation-indexed invariant. -/
 theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢
+    {R : iProp}
+    (h : R ⊢
       ((∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
         ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
-    ctx.interp ρ ⊢
+    R ⊢
       (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
   h.trans wp.fix'
@@ -358,9 +365,16 @@ theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.E
 /-- Let-bindings: evaluate the bound expression, then continue in the body with
     the resulting value substituted. -/
 theorem wp_letIn {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.Val → iProp}
-    {ctx : SpatialContext} {ρ : Env}
-    (h : ctx.interp ρ ⊢ wp bound (fun v => wp (body.subst (Runtime.Subst.id.update' b v)) Q)) :
-    ctx.interp ρ ⊢ wp (Runtime.Expr.letIn b bound body) Q :=
+    {R : iProp}
+    (h : R ⊢ wp bound (fun v => wp (body.subst (Runtime.Subst.id.update' b v)) Q)) :
+    R ⊢ wp (Runtime.Expr.letIn b bound body) Q :=
   h.trans wp.letIn
+
+
+theorem wp_app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Runtime.Val}
+    {Φ : Runtime.Val → iProp} {R : iProp}
+    (h : R ⊢ wp (body.subst (Runtime.Subst.id.update' b v)) Φ) :
+    R ⊢ wp (.app (.fix .none [b] body) [.val v]) Φ :=
+  h.trans wp.app_lambda_single
 
 end SpatialContext

--- a/Mica/SeparationLogic/ProofModePatterns.lean
+++ b/Mica/SeparationLogic/ProofModePatterns.lean
@@ -218,8 +218,18 @@ example (P : Nat → iProp) : (∀ n, P n) ⊢ P 42 := by
   ispecialize Hall $$ %42
   iexact Hall
 
+/-! ## 10. Persistency -/
 
-/-! ## 10. Hypothesis management -/
+/-- Introduce a persistent assertion, cross a persistency modality, and use it twice. -/
+example (R Q : iProp): R ∗ □ Q ⊢ □ (Q ∗ Q) := by
+  iintro ⟨HR, □HQ⟩
+  imodintro
+  isplitl
+  . iexact HQ
+  . iexact HQ
+
+
+/-! ## 11. Hypothesis management -/
 
 /-- `irevert` moves a hypothesis back into the goal as a wand. -/
 example (P Q : iProp) : P ∗ Q ⊢ Q ∗ P := by
@@ -233,7 +243,7 @@ example (P Q : iProp) : P ∗ Q ⊢ Q ∗ P := by
   · iexact HP
 
 
-/-! ## 11. Combining Iris and Lean reasoning
+/-! ## 12. Combining Iris and Lean reasoning
 
 Often the best approach is to use Lean term mode for simple entailment chains
 and only enter proof mode for the parts that need hypothesis management.

--- a/Mica/TinyML/LogicalRelation.lean
+++ b/Mica/TinyML/LogicalRelation.lean
@@ -10,6 +10,7 @@ mutual
     | int  (n : Int)  : ValHasType Θ (.int n)  .int
     | bool (b : Bool) : ValHasType Θ (.bool b) .bool
     | unit            : ValHasType Θ .unit      .unit
+    | ref l τ         : ValHasType Θ (.loc l)   (.ref τ)
     | inj  : (ht : ts[tag]? = some t)
             → ValHasType Θ payload t
             → ValHasType Θ (.inj tag ts.length payload) (.sum ts)

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -47,26 +47,26 @@ def Assertion.toStringHum {α : Type} (showA : α → String) : Assertion α →
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Assertion.pre (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
+def Assertion.pre (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   (match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ⌝ ∗ Assertion.pre Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ; Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ.env⌝ ∗ Assertion.pre Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ.env; Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => ∃ (v : x.sort.denote), p.eval ρ v ∗ Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ⌝ -∗ Assertion.pre Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ⌝ -∗ Assertion.pre Φ ke ρ)))
+      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.pre Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.pre Φ ke ρ)))
 
-def Assertion.post {α} (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
+def Assertion.post {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ⌝ -∗ Assertion.post Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ; Assertion.post Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ.env⌝ -∗ Assertion.post Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ.env; Assertion.post Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => iprop(∀ (v : x.sort.denote),
       p.eval ρ v -∗ Assertion.post Φ k (ρ.updateConst x.sort x.name v))
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ⌝ -∗ Assertion.post Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ⌝ -∗ Assertion.post Φ ke ρ))
+      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.post Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.post Φ ke ρ))
 
 
 -- ---------------------------------------------------------------------------
@@ -134,9 +134,9 @@ theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Pro
 -- ---------------------------------------------------------------------------
 
 theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature → Prop}
-    {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
-    (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     Assertion.pre Φ m ρ ⊢ Assertion.pre Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
@@ -154,7 +154,7 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.pre]
     rw [← Term.eval_env_agree htwf hagree]
-    exact ih hkwf (Env.agreeOn_declVar hagree)
+    exact ih hkwf (VerifM.Env.agreeOn_declVar hagree)
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.pre]
@@ -164,7 +164,7 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     iapply (sep_mono
       (show p.eval ρ w ⊢ p.eval ρ' w by
         simp [(Atom.eval_env_agree hpwf hagree)])
-      (ih hkwf (Env.agreeOn_declVar hagree)))
+      (ih hkwf (VerifM.Env.agreeOn_declVar hagree)))
     iexact Hsep
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
@@ -173,7 +173,7 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     · apply BI.and_elim_l.trans
       iintro Hkt
       iintro Hφ
-      have hφ : BIBase.Entails (⌜φ.eval ρ'⌝ : iProp) ⌜φ.eval ρ⌝ := by
+      have hφ : BIBase.Entails (⌜φ.eval ρ'.env⌝ : iProp) ⌜φ.eval ρ.env⌝ := by
         iintro %hφ
         ipure_intro
         exact (Formula.eval_env_agree hφwf hagree).mpr hφ
@@ -184,7 +184,7 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     · apply BI.and_elim_r.trans
       iintro Hke
       iintro Hnφ
-      have hnφ : BIBase.Entails (⌜¬ φ.eval ρ'⌝ : iProp) ⌜¬ φ.eval ρ⌝ := by
+      have hnφ : BIBase.Entails (⌜¬ φ.eval ρ'.env⌝ : iProp) ⌜¬ φ.eval ρ.env⌝ := by
         iintro %hnφ
         ipure_intro
         exact mt (Formula.eval_env_agree hφwf hagree).mp hnφ
@@ -194,9 +194,9 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
       iapply Hnφ
 
 theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature → Prop}
-    {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
-    (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     Assertion.post Φ m ρ ⊢ Assertion.post Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
@@ -205,7 +205,7 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     simp only [Assertion.post]
     iintro H
     iintro %hφ
-    have hφ' : φ.eval ρ := (Formula.eval_env_agree hφwf hagree).mpr hφ
+    have hφ' : φ.eval ρ.env := (Formula.eval_env_agree hφwf hagree).mpr hφ
     iapply (ih hkwf hagree)
     iapply H
     ipure_intro
@@ -214,13 +214,13 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.post]
     rw [← Term.eval_env_agree htwf hagree]
-    exact ih hkwf (Env.agreeOn_declVar hagree)
+    exact ih hkwf (VerifM.Env.agreeOn_declVar hagree)
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.post]
     iintro H
     iintro %w Hw
-    iapply (ih hkwf (Env.agreeOn_declVar hagree))
+    iapply (ih hkwf (VerifM.Env.agreeOn_declVar hagree))
     iapply H
     iapply (show p.eval ρ' w ⊢ p.eval ρ w by simp [(Atom.eval_env_agree hpwf hagree)])
     iexact Hw
@@ -231,7 +231,7 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     · apply BI.and_elim_l.trans
       iintro Hkt
       iintro %hφ
-      have hφ' : φ.eval ρ := (Formula.eval_env_agree hφwf hagree).mpr hφ
+      have hφ' : φ.eval ρ.env := (Formula.eval_env_agree hφwf hagree).mpr hφ
       iapply (iht hktwf hagree)
       iapply Hkt
       ipure_intro
@@ -239,7 +239,7 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     · apply BI.and_elim_r.trans
       iintro Hke
       iintro %hnφ
-      have hnφ' : ¬ φ.eval ρ := mt (Formula.eval_env_agree hφwf hagree).mp hnφ
+      have hnφ' : ¬ φ.eval ρ.env := mt (Formula.eval_env_agree hφwf hagree).mp hnφ
       iapply (ihe hkewf hagree)
       iapply Hke
       ipure_intro
@@ -248,10 +248,10 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
 /-- Combining caller-side `pre` with verifier-side `post`. -/
 theorem Assertion.pre_post_combine {α : Type}
     {m : Assertion α}
-    {Φ Ψ : α → Env → iProp}
-    {ρ : Env}
+    {Φ : α → VerifM.Env → iProp} {Ψ : α → VerifM.Env → iProp}
+    {ρ : VerifM.Env}
     {R : iProp}
-    (hR : ∀ (a : α) (ρ0 : Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
+    (hR : ∀ (a : α) (ρ0 : VerifM.Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
     : (Assertion.pre Φ m ρ ∗ Assertion.post Ψ m ρ) ⊢ R := by
   induction m generalizing ρ R with
   | ret a =>
@@ -269,7 +269,7 @@ theorem Assertion.pre_post_combine {α : Type}
       exact hφ
   | let_ v t k ih =>
     simp only [Assertion.pre, Assertion.post]
-    simpa using ih (ρ := ρ.updateConst v.sort v.name (t.eval ρ)) (R := R) hR
+    simpa using ih (ρ := ρ.updateConst v.sort v.name (t.eval ρ.env)) (R := R) hR
   | pred v p k ih =>
     simp only [Assertion.pre, Assertion.post]
     istart
@@ -282,7 +282,7 @@ theorem Assertion.pre_post_combine {α : Type}
       iexact Hpre1
   | ite φ kt ke iht ihe =>
     simp only [Assertion.pre, Assertion.post]
-    by_cases hφ : φ.eval ρ
+    by_cases hφ : φ.eval ρ.env
     · istart
       iintro ⟨Hpre, Hpost⟩
       iapply (iht (ρ := ρ) (R := R) hR)
@@ -370,16 +370,17 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
 
 theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
-    (st : TransState) (ρ : Env)
-    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    (st : TransState) (ρ : VerifM.Env)
+    (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     m.wfIn retWf (Signature.ofVars σ.dom) →
     VerifM.eval (Assertion.assume σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wf st'.decls → (Signature.ofVars σ'.dom).wf →
-      retWf a (Signature.ofVars σ'.dom) → st'.owns.interp ρ' ∗ R ⊢ Φ a (σ'.subst.eval ρ')) →
-    st.owns.interp ρ ∗ R ⊢ Assertion.post Φ m (σ.subst.eval ρ) := by
+      retWf a (Signature.ofVars σ'.dom) →
+      st'.sl ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
+    st.sl ρ ∗ R ⊢ Assertion.post Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
   intro hσwf hdomwf hwf heval hpost
   have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
   induction m generalizing σ st ρ Ψ with
@@ -396,7 +397,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
     have hassume := VerifM.eval_assumePure hb hsubst_wf hsubst_eval
     iapply (ih σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkwf hassume hpost hwfst)
-    iexact Howns
+    simp [TransState.sl]
   | let_ v t k ih =>
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.assume] at heval
@@ -408,7 +409,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       fresh_not_mem (addNumbers (v.name)) (st.decls.allNames) (addNumbers_injective _)
     have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
       fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-    set u := t.eval (σ.subst.eval ρ)
+    set u := t.eval (σ.subst.eval ρ.env)
     specialize hdecl u
     have hb2 := VerifM.eval_bind _ _ _ _ hdecl
     -- Show the equality formula is well-formed and holds
@@ -430,7 +431,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
           exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
       · exact Term.wfIn_mono _ ht_subst_wf (Signature.Subset.subset_addConst _ _) (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
     have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).eval
-        (ρ.updateConst v.sort v'.name u) := by
+        (ρ.updateConst v.sort v'.name u).env := by
       rw [Formula.eval, Term.eval, Const.denote]
       rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
       simpa [u, Env.lookupConst, Env.updateConst] using
@@ -447,8 +448,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
       (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
         (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
-        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+    have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
       SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
         (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
     exact (sep_mono hinterp_bi.1 (by
@@ -474,7 +474,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
       have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
-      iexact Howns
+      simp [TransState.sl]
     · iintro Howns %hnφ
       have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
       simp at hfalse
@@ -486,7 +486,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
       have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
-      iexact Howns
+      simp [TransState.sl]
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.post]
@@ -523,20 +523,25 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       Atom.toItem_wfIn
         (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint) hvar_wf
-    have hpu' : p.eval (σ.subst.eval ρ) u ⊢ (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
-        ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval (ρ.updateConst v.sort v'.name u)) := by
+    have hpu' : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢ (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
+        ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval (ρ.updateConst v.sort v'.name u).env) := by
       have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
-          (ρ.updateConst v.sort v'.name u)) = u := by
+          (ρ.updateConst v.sort v'.name u).env) = u := by
         simp [Term.eval, Const.denote, Env.updateConst]
       rw [hconst]
       rw [Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
-      have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ)
+      have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
         (τ := v.sort) (name' := v'.name) (u := u) hσwf.1 hv'_fresh_range
       have heval_agree :
-          p.eval (σ.subst.eval ρ) = p.eval (σ.subst.eval (ρ.updateConst v.sort v'.name u)) :=
-        Atom.eval_env_agree (p := p) (ρ := σ.subst.eval ρ)
-          (ρ' := σ.subst.eval (ρ.updateConst v.sort v'.name u))
-          (Δ := Signature.ofVars σ.dom) hpwf hagree
+          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) =
+            p.eval ((ρ.updateConst v.sort v'.name u).withEnv
+              (σ.subst.eval (ρ.updateConst v.sort v'.name u).env)) :=
+        Atom.eval_env_agree (p := p)
+          (ρ := ρ.withEnv (σ.subst.eval ρ.env))
+          (ρ' := (ρ.updateConst v.sort v'.name u).withEnv
+            (σ.subst.eval (ρ.updateConst v.sort v'.name u).env))
+          (Δ := Signature.ofVars σ.dom) hpwf (by
+            simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv_env] using hagree)
       rw [heval_agree]
       exact .rfl
     set item := (p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))
@@ -549,14 +554,15 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
     cases hitem : item with
     | pure φ =>
-      have hφ_entail : p.eval (σ.subst.eval ρ) u ⊢ ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ := by
+      have hφ_entail : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+          ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ := by
         simpa [item, hitem] using
           (hpu'.trans (Atom.eval_purePart (p := p.subst σ.subst)
             (t := .const (.uninterpreted v'.name v.sort))
-            (ρ := ρ.updateConst v.sort v'.name u)))
-      ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ $$ [Hpu]
+            (ρ := (ρ.updateConst v.sort v'.name u))))
+      ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ $$ [Hpu]
       · iapply hφ_entail
-        iexact Hpu
+        simp [VerifM.Env.withEnv]
       icases Hφ with %hφ
       have hb2' : (VerifM.assume (.pure φ)).eval
           { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
@@ -569,8 +575,8 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
         (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
       have hframe :
-          st.owns.interp ρ ∗ R ⊢
-            (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).owns.interp
+          st.sl ρ ∗ R ⊢
+            (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).sl
               (ρ.updateConst v.sort v'.name u) ∗ R := by
         simp [TransState.addItem]
         exact sep_mono
@@ -597,19 +603,19 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
         (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
       have hitem_interp :
-          p.eval (σ.subst.eval ρ) u ⊢
+          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
             CtxItem.interp (ρ.updateConst v.sort v'.name u) item := by
         simpa [item] using
           (hpu'.trans (Atom.eval_toItem (p := p.subst σ.subst)
             (t := .const (.uninterpreted v'.name v.sort))
-            (ρ := ρ.updateConst v.sort v'.name u)))
+            (ρ := (ρ.updateConst v.sort v'.name u))))
       have hspatial_interp :
-          p.eval (σ.subst.eval ρ) u ⊢
-            SpatialAtom.interp (ρ.updateConst v.sort v'.name u) a := by
+          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+            SpatialAtom.interp (ρ.updateConst v.sort v'.name u).env a := by
         simpa [item, hitem, CtxItem.interp] using hitem_interp
       have howns_agree :
-          SpatialContext.interp ρ st.owns ⊢
-            SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+          st.sl ρ ⊢
+            st.sl (ρ.updateConst v.sort v'.name u) :=
         (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
           (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
       iapply (hih.trans <| Assertion.post_env_agree hkwf'
@@ -621,24 +627,32 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       icases Howns with ⟨HS, HR⟩
       isplitr [HR]
       · isplitr [HS]
-        · iapply hspatial_interp
-          iexact Hpu
-        · iapply howns_agree
-          iexact HS
+        · have hspatial_interp' :
+            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+              SpatialAtom.interp (Env.updateConst ρ.env v.sort v'.name u) a := by
+            simpa [VerifM.Env.updateConst] using hspatial_interp
+          iapply hspatial_interp'
+          simp [VerifM.Env.withEnv]
+        · have howns_agree' :
+            st.sl ρ ⊢ SpatialContext.interp (Env.updateConst ρ.env v.sort v'.name u) st.owns := by
+            simpa [TransState.sl, VerifM.Env.updateConst] using howns_agree
+          iapply howns_agree'
+          simp [TransState.sl]
       · iexact HR
 
 theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
-    (st : TransState) (ρ : Env)
-    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    (st : TransState) (ρ : VerifM.Env)
+    (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     m.wfIn retWf (Signature.ofVars σ.dom) →
     VerifM.eval (Assertion.prove σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wf st'.decls → (Signature.ofVars σ'.dom).wf →
-      retWf a (Signature.ofVars σ'.dom) → st'.owns.interp ρ' ∗ R ⊢ Φ a (σ'.subst.eval ρ')) →
-    st.owns.interp ρ ∗ R ⊢ Assertion.pre Φ m (σ.subst.eval ρ) := by
+      retWf a (Signature.ofVars σ'.dom) →
+      st'.sl ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
+    st.sl ρ ∗ R ⊢ Assertion.pre Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
   intro hσwf hdomwf hwf heval hpost
   have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
   induction m generalizing σ st ρ Ψ with
@@ -652,8 +666,8 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
     have hassert := VerifM.eval_assert hb hsubst_wf
     have hφ_holds := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mp hassert.1
-    show SpatialContext.interp ρ st.owns ∗ R ⊢
-      (⌜φ.eval (σ.subst.eval ρ)⌝ ∗ Assertion.pre Φ k (σ.subst.eval ρ) : iProp)
+    show st.sl ρ ∗ R ⊢
+      (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
     istart
     iintro ⟨Howns, HR⟩
     isplitr [Howns HR]
@@ -674,7 +688,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       fresh_not_mem (addNumbers (v.name)) (st.decls.allNames) (addNumbers_injective _)
     have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
       fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-    set u := t.eval (σ.subst.eval ρ)
+    set u := t.eval (σ.subst.eval ρ.env)
     specialize hdecl u
     have hb2 := VerifM.eval_bind _ _ _ _ hdecl
     have ht_subst_wf_range : (t.subst σ.subst).wfIn σ.range :=
@@ -695,7 +709,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
           exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
       · exact Term.wfIn_mono _ ht_subst_wf (Signature.Subset.subset_addConst _ _) (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
     have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).eval
-        (ρ.updateConst v.sort v'.name u) := by
+        (ρ.updateConst v.sort v'.name u).env := by
       rw [Formula.eval, Term.eval, Const.denote]
       rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
       simpa [u, Env.lookupConst, Env.updateConst] using
@@ -711,8 +725,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
     have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
       (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
         (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
-        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+    have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
       SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
         (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
     exact (sep_mono hinterp_bi.1 (by
@@ -737,15 +750,23 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
         simp at hq
         exact (VerifM.eval_fatal hq).elim)
       (fun t st' hq hdecls htwf => by
-        simp only [Assertion.pre]
+        simp [Assertion.pre]
         have hwfst' : st'.decls.wf := by simpa [hdecls] using hwfst
         have htwf' : t.wfIn st'.decls := by simpa [hdecls] using htwf
         istart
         iintro H
         icases H with ⟨Hpred, Howns, HR⟩
-        iexists (t.eval ρ)
+        iexists (t.eval ρ.env)
         isplitr [Howns HR]
-        · rw [← Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
+        · have hpred_subst :
+              (p.subst σ.subst).eval ρ (t.eval ρ.env) ⊢
+                p.eval (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ.env) := by
+              simpa [VerifM.Env.withEnv] using
+                (show (p.subst σ.subst).eval ρ (t.eval ρ.env) ⊢
+                    p.eval (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ.env) by
+                  rw [Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
+                  exact BIBase.Entails.rfl)
+          iapply hpred_subst
           iexact Hpred
         · have hb2 := VerifM.eval_bind _ _ _ _ hq
           have hdecl := VerifM.eval_decl hb2
@@ -757,7 +778,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
             apply hv'_fresh_decls
             rw [hdecls]
             exact Signature.allNames_subset hσwf.2.1 _ h
-          specialize hdecl (t.eval ρ)
+          specialize hdecl (t.eval ρ.env)
           have hb3 := VerifM.eval_bind _ _ _ _ hdecl
           have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
               (st'.decls.addConst v') := by
@@ -772,7 +793,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
             · exact Term.wfIn_mono _ htwf' (Signature.Subset.subset_addConst _ _)
                 (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
           have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
-              (ρ.updateConst v.sort v'.name (t.eval ρ)) := by
+              (ρ.updateConst v.sort v'.name (t.eval ρ.env)).env := by
             simp only [Formula.eval, Term.eval, Const.denote]
             simpa [Env.lookupConst, Env.updateConst] using
               (Term.eval_env_agree htwf' (agreeOn_update_fresh_const hv'_fresh_decls))
@@ -786,14 +807,13 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
           have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
             simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
           have hih := ih σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
-            (ρ.updateConst v.sort v'.name (t.eval ρ)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-              (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
-          have hinterp_bi : SpatialContext.interp ρ st'.owns ⊣⊢
-              SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st'.owns :=
+            (ρ.updateConst v.sort v'.name (t.eval ρ.env)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
+            (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
+          have hinterp_bi : st'.sl ρ ⊣⊢ st'.sl (ρ.updateConst v.sort v'.name (t.eval ρ.env)) :=
             SpatialContext.interp_env_agree (VerifM.eval.wf hq).ownsWf
               (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-          have hframe : SpatialContext.interp ρ st'.owns ∗ R ⊢
-              SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st'.owns ∗ R := by
+          have hframe : st'.sl ρ ∗ R ⊢
+              st'.sl (ρ.updateConst v.sort v'.name (t.eval ρ.env)) ∗ R := by
             exact sep_mono hinterp_bi.1 (by
               iintro HR
               iexact HR)
@@ -803,7 +823,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
                 (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
             hΦ)
           isplitl [Howns]
-          · iexact Howns
+          · simp [TransState.sl]
           · iexact HR)
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
@@ -824,7 +844,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
       have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
-      iexact Howns
+      simp [TransState.sl]
     · apply wand_intro
       iintro H
       icases H with ⟨Howns, %hnφ⟩
@@ -838,4 +858,4 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
       have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
-      iexact Howns
+      simp [TransState.sl]

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -1,12 +1,14 @@
 import Mica.TinyML.Typed
 import Mica.TinyML.Typing
-import Mica.TinyML.WeakestPre
+import Mica.SeparationLogic
 import Mica.FOL.Printing
 import Mica.Verifier.Utils
 import Mica.Verifier.Monad
 import Mica.Verifier.Atoms
 import Mica.Base.Fresh
 import Mica.Base.Except
+
+open Iris Iris.BI
 
 /-!
 # Assertions
@@ -45,24 +47,26 @@ def Assertion.toStringHum {α : Type} (showA : α → String) : Assertion α →
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Assertion.pre (Φ : α → Env → Prop) (m : Assertion α) (ρ : Env) : Prop :=
-  match m with
+def Assertion.pre (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
+  (match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => φ.eval ρ ∧ Assertion.pre Φ k ρ
+  | .assert φ k   => ⌜φ.eval ρ⌝ ∗ Assertion.pre Φ k ρ
   | .let_ x t k   => let v := t.eval ρ; Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
-  | .pred x p k   => ∃ v : x.sort.denote, p.eval ρ v ∧ Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
+  | .pred x p k   => ∃ (v : x.sort.denote), p.eval ρ v ∗ Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
   | .ite φ kt ke  =>
-    (φ.eval ρ → Assertion.pre Φ kt ρ) ∧ (¬ φ.eval ρ → Assertion.pre Φ ke ρ)
+      iprop((⌜φ.eval ρ⌝ -∗ Assertion.pre Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ⌝ -∗ Assertion.pre Φ ke ρ)))
 
-def Assertion.post {α} (Φ : α → Env → Prop) (m : Assertion α) (ρ : Env) : Prop :=
+def Assertion.post {α} (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => φ.eval ρ → Assertion.post Φ k ρ
+  | .assert φ k   => ⌜φ.eval ρ⌝ -∗ Assertion.post Φ k ρ
   | .let_ x t k   => let v := t.eval ρ; Assertion.post Φ k (ρ.updateConst x.sort x.name v)
-  | .pred x p k   => ∀ v : x.sort.denote, p.eval ρ v → Assertion.post Φ k (ρ.updateConst x.sort x.name v)
+  | .pred x p k   => iprop(∀ (v : x.sort.denote),
+      p.eval ρ v -∗ Assertion.post Φ k (ρ.updateConst x.sort x.name v))
   | .ite φ kt ke  =>
-    (φ.eval ρ → Assertion.post Φ kt ρ)
-  ∧ (¬ φ.eval ρ → Assertion.post Φ ke ρ)
+      iprop((⌜φ.eval ρ⌝ -∗ Assertion.post Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ⌝ -∗ Assertion.post Φ ke ρ))
 
 
 -- ---------------------------------------------------------------------------
@@ -130,81 +134,175 @@ theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Pro
 -- ---------------------------------------------------------------------------
 
 theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature → Prop}
-    {Φ : α → Env → Prop} {ρ ρ' : Env} {Δ : Signature}
+    {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ → Φ a ρ₂)
-    (h : Assertion.pre Φ m ρ) : Assertion.pre Φ m ρ' := by
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    Assertion.pre Φ m ρ ⊢ Assertion.pre Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
-  | ret a => exact hΦ a Δ ρ ρ' hwf hagree h
+  | ret a => exact hΦ a Δ ρ ρ' hwf hagree
   | assert φ k ih =>
     obtain ⟨hφwf, hkwf⟩ := hwf
-    exact ⟨(Formula.eval_env_agree hφwf hagree).mp h.1, ih hkwf hagree h.2⟩
+    simp only [Assertion.pre]
+    istart
+    iintro ⟨%hφ, Hk⟩
+    isplitr
+    · ipure_intro
+      exact (Formula.eval_env_agree hφwf hagree).mp hφ
+    · iapply (ih hkwf hagree)
+      iexact Hk
   | let_ v t k ih =>
     obtain ⟨htwf, hkwf⟩ := hwf
-    simp only [Assertion.pre] at h ⊢
+    simp only [Assertion.pre]
     rw [← Term.eval_env_agree htwf hagree]
-    exact ih hkwf (Env.agreeOn_declVar hagree) h
+    exact ih hkwf (Env.agreeOn_declVar hagree)
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
-    obtain ⟨w, hpw, hk⟩ := h
-    exact ⟨w, (Atom.eval_env_agree hpwf hagree) ▸ hpw,
-      ih hkwf (Env.agreeOn_declVar hagree) hk⟩
+    simp only [Assertion.pre]
+    istart
+    iintro ⟨%w, Hsep⟩
+    iexists w
+    iapply (sep_mono
+      (show p.eval ρ w ⊢ p.eval ρ' w by
+        simp [(Atom.eval_env_agree hpwf hagree)])
+      (ih hkwf (Env.agreeOn_declVar hagree)))
+    iexact Hsep
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
-    constructor
-    · intro hφ
-      exact iht hktwf hagree (h.1 ((Formula.eval_env_agree hφwf hagree).mpr hφ))
-    · intro hnφ
-      exact ihe hkewf hagree (h.2 (mt (Formula.eval_env_agree hφwf hagree).mp hnφ))
+    simp only [Assertion.pre]
+    apply BI.and_intro
+    · apply BI.and_elim_l.trans
+      iintro Hkt
+      iintro Hφ
+      have hφ : BIBase.Entails (⌜φ.eval ρ'⌝ : iProp) ⌜φ.eval ρ⌝ := by
+        iintro %hφ
+        ipure_intro
+        exact (Formula.eval_env_agree hφwf hagree).mpr hφ
+      iapply (iht hktwf hagree)
+      iapply Hkt
+      iapply hφ
+      iapply Hφ
+    · apply BI.and_elim_r.trans
+      iintro Hke
+      iintro Hnφ
+      have hnφ : BIBase.Entails (⌜¬ φ.eval ρ'⌝ : iProp) ⌜¬ φ.eval ρ⌝ := by
+        iintro %hnφ
+        ipure_intro
+        exact mt (Formula.eval_env_agree hφwf hagree).mp hnφ
+      iapply (ihe hkewf hagree)
+      iapply Hke
+      iapply hnφ
+      iapply Hnφ
 
 theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature → Prop}
-    {Φ : α → Env → Prop} {ρ ρ' : Env} {Δ : Signature}
+    {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ → Φ a ρ₂)
-    (h : Assertion.post Φ m ρ) : Assertion.post Φ m ρ' := by
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    Assertion.post Φ m ρ ⊢ Assertion.post Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
-  | ret a => exact hΦ a Δ ρ ρ' hwf hagree h
+  | ret a => exact hΦ a Δ ρ ρ' hwf hagree
   | assert φ k ih =>
     obtain ⟨hφwf, hkwf⟩ := hwf
-    intro hφ
-    exact ih hkwf hagree (h ((Formula.eval_env_agree hφwf hagree).mpr hφ))
+    simp only [Assertion.post]
+    iintro H
+    iintro %hφ
+    have hφ' : φ.eval ρ := (Formula.eval_env_agree hφwf hagree).mpr hφ
+    iapply (ih hkwf hagree)
+    iapply H
+    ipure_intro
+    exact hφ'
   | let_ v t k ih =>
     obtain ⟨htwf, hkwf⟩ := hwf
-    simp only [Assertion.post] at h ⊢
+    simp only [Assertion.post]
     rw [← Term.eval_env_agree htwf hagree]
-    exact ih hkwf (Env.agreeOn_declVar hagree) h
+    exact ih hkwf (Env.agreeOn_declVar hagree)
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
-    intro w hpw
-    exact ih hkwf (Env.agreeOn_declVar hagree)
-      (h w ((Atom.eval_env_agree hpwf hagree) ▸ hpw))
+    simp only [Assertion.post]
+    iintro H
+    iintro %w Hw
+    iapply (ih hkwf (Env.agreeOn_declVar hagree))
+    iapply H
+    iapply (show p.eval ρ' w ⊢ p.eval ρ w by simp [(Atom.eval_env_agree hpwf hagree)])
+    iexact Hw
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
-    constructor
-    · intro hφ
-      exact iht hktwf hagree (h.1 ((Formula.eval_env_agree hφwf hagree).mpr hφ))
-    · intro hnφ
-      exact ihe hkewf hagree (h.2 (mt (Formula.eval_env_agree hφwf hagree).mp hnφ))
+    simp only [Assertion.post]
+    apply BI.and_intro
+    · apply BI.and_elim_l.trans
+      iintro Hkt
+      iintro %hφ
+      have hφ' : φ.eval ρ := (Formula.eval_env_agree hφwf hagree).mpr hφ
+      iapply (iht hktwf hagree)
+      iapply Hkt
+      ipure_intro
+      exact hφ'
+    · apply BI.and_elim_r.trans
+      iintro Hke
+      iintro %hnφ
+      have hnφ' : ¬ φ.eval ρ := mt (Formula.eval_env_agree hφwf hagree).mp hnφ
+      iapply (ihe hkewf hagree)
+      iapply Hke
+      ipure_intro
+      exact hnφ'
 
-/-- Combining Assertion.pre (caller-side) with Assertion.post (verifier-side):
-    if both hold for the same assertion and environment, we can extract a combined conclusion
-    at the leaves. -/
-theorem Assertion.pre_post_combine {m : Assertion α} {Φ Ψ : α → Env → Prop} {ρ : Env}
-    (hpre : Assertion.pre Φ m ρ) (hpost : Assertion.post Ψ m ρ)
-    {R : Prop} (hR : ∀ a ρ', Φ a ρ' → Ψ a ρ' → R) : R := by
+/-- Combining caller-side `pre` with verifier-side `post`. -/
+theorem Assertion.pre_post_combine {α : Type}
+    {m : Assertion α}
+    {Φ Ψ : α → Env → iProp}
+    {ρ : Env}
+    {R : iProp}
+    (hR : ∀ (a : α) (ρ0 : Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
+    : (Assertion.pre Φ m ρ ∗ Assertion.post Ψ m ρ) ⊢ R := by
   induction m generalizing ρ R with
-  | ret a => exact hR a ρ hpre hpost
+  | ret a =>
+    simpa [Assertion.pre, Assertion.post] using hR a ρ
   | assert φ k ih =>
-    exact ih hpre.2 (hpost hpre.1) hR
+    simp only [Assertion.pre, Assertion.post]
+    istart
+    iintro ⟨Hpre, Hpost⟩
+    icases Hpre with ⟨%hφ, Hpre⟩
+    iapply (ih (ρ := ρ) (R := R) hR)
+    isplitl [Hpre]
+    · iexact Hpre
+    · iapply Hpost
+      ipure_intro
+      exact hφ
   | let_ v t k ih =>
-    exact ih hpre hpost hR
+    simp only [Assertion.pre, Assertion.post]
+    simpa using ih (ρ := ρ.updateConst v.sort v.name (t.eval ρ)) (R := R) hR
   | pred v p k ih =>
-    obtain ⟨u, hpu, hpre'⟩ := hpre
-    exact ih hpre' (hpost u hpu) hR
+    simp only [Assertion.pre, Assertion.post]
+    istart
+    iintro ⟨Hex, Hpost⟩
+    icases Hex with ⟨%u, Hpre1, Hpre2⟩
+    iapply (ih (ρ := ρ.updateConst v.sort v.name u) (R := R) hR)
+    isplitl [Hpre2]
+    · iexact Hpre2
+    · iapply Hpost
+      iexact Hpre1
   | ite φ kt ke iht ihe =>
+    simp only [Assertion.pre, Assertion.post]
     by_cases hφ : φ.eval ρ
-    · exact iht (hpre.1 hφ) (hpost.1 hφ) hR
-    · exact ihe (hpre.2 hφ) (hpost.2 hφ) hR
+    · istart
+      iintro ⟨Hpre, Hpost⟩
+      iapply (iht (ρ := ρ) (R := R) hR)
+      isplitl [Hpre]
+      · iapply Hpre
+        ipure_intro
+        exact hφ
+      · iapply Hpost
+        ipure_intro
+        exact hφ
+    · istart
+      iintro ⟨Hpre, Hpost⟩
+      iapply (ihe (ρ := ρ) (R := R) hR)
+      isplitl [Hpre]
+      · iapply Hpre
+        ipure_intro
+        exact hφ
+      · iapply Hpost
+        ipure_intro
+        exact hφ
 
 -- ---------------------------------------------------------------------------
 -- VerifM helpers
@@ -273,15 +371,15 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
 theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : Env)
-    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → Prop)
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ → Φ a ρ₂) :
+    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     m.wfIn retWf (Signature.ofVars σ.dom) →
     VerifM.eval (Assertion.assume σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wf st'.decls → (Signature.ofVars σ'.dom).wf →
-      retWf a (Signature.ofVars σ'.dom) → Φ a (σ'.subst.eval ρ')) →
-    Assertion.post Φ m (σ.subst.eval ρ) := by
+      retWf a (Signature.ofVars σ'.dom) → st'.owns.interp ρ' ∗ R ⊢ Φ a (σ'.subst.eval ρ')) →
+    st.owns.interp ρ ∗ R ⊢ Assertion.post Φ m (σ.subst.eval ρ) := by
   intro hσwf hdomwf hwf heval hpost
   have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
   induction m generalizing σ st ρ Ψ with
@@ -292,12 +390,13 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     simp only [Assertion.assume] at heval
     have hb := VerifM.eval_bind _ _ _ _ heval
     simp only [Assertion.post]
-    intro hφ
+    iintro Howns %hφ
     have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
       FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
     have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
     have hassume := VerifM.eval_assume hb hsubst_wf hsubst_eval
-    exact ih σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkwf hassume hpost hwfst
+    iapply (ih σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkwf hassume hpost hwfst)
+    iexact Howns
   | let_ v t k ih =>
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.assume] at heval
@@ -348,15 +447,52 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
       (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
         (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    exact Assertion.post_env_agree hkwf
+    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
+        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+      SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+        (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+    exact (sep_mono hinterp_bi.1 (by
+      iintro HR
+      iexact HR)).trans <| hih.trans <| Assertion.post_env_agree hkwf
       (by
         simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
           (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-      hΦ hih
+      hΦ
+  | ite φ kt ke iht ihe =>
+    obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
+    simp only [Assertion.assume] at heval
+    have hb := VerifM.eval_bind _ _ _ _ heval
+    have hall := VerifM.eval_all hb
+    simp only [Assertion.post]
+    apply and_intro
+    · iintro Howns %hφ
+      have htrue := hall true (List.mem_cons_self ..)
+      simp at htrue
+      have hb2 := VerifM.eval_bind _ _ _ _ htrue
+      have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
+        FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
+      have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
+      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
+      iexact Howns
+    · iintro Howns %hnφ
+      have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
+      simp at hfalse
+      have hb2 := VerifM.eval_bind _ _ _ _ hfalse
+      have hnot_wf : (Formula.not φ).wfIn (Signature.ofVars σ.dom) := by
+        simp only [Formula.wfIn]; exact hφwf
+      have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
+        FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
+      have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
+      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
+      iexact Howns
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.post]
-    intro u hpu
+    apply forall_intro; intro u
+    iintro Howns
+    iintro Hpu
     simp only [Assertion.assume] at heval
     have hb := VerifM.eval_bind _ _ _ _ heval
     have hdecl := VerifM.eval_decl hb
@@ -387,12 +523,28 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       Atom.toFormula_wfIn
         (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint) hvar_wf
-    have hpu' : (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u) u := by
+    have hpu' : p.eval (σ.subst.eval ρ) u ⊢ (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
+        ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval (ρ.updateConst v.sort v'.name u)) := by
+      have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
+          (ρ.updateConst v.sort v'.name u)) = u := by
+        simp [Term.eval, Const.denote, Env.updateConst]
+      rw [hconst]
       rw [Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
-      exact (congrFun (Atom.eval_env_agree hpwf (FiniteSubst.eval_update_fresh hσwf.1 hv'_fresh_range)) u).mp hpu
-    have hformula_holds : ((p.subst σ.subst).toFormula (.const (.uninterpreted v'.name v.sort))).eval
-        (ρ.updateConst v.sort v'.name u) :=
-      Atom.toFormula_eval_1 (by simpa [Term.eval, Const.denote, Env.lookupConst, Env.updateConst] using hpu')
+      have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ)
+        (τ := v.sort) (name' := v'.name) (u := u) hσwf.1 hv'_fresh_range
+      have heval_agree :
+          p.eval (σ.subst.eval ρ) = p.eval (σ.subst.eval (ρ.updateConst v.sort v'.name u)) :=
+        Atom.eval_env_agree (p := p) (ρ := σ.subst.eval ρ)
+          (ρ' := σ.subst.eval (ρ.updateConst v.sort v'.name u))
+          (Δ := Signature.ofVars σ.dom) hpwf hagree
+      rw [heval_agree]
+      exact .rfl
+    ihave Hformula : (⌜((p.subst σ.subst).toFormula (.const (.uninterpreted v'.name v.sort))).eval
+        (ρ.updateConst v.sort v'.name u)⌝ : iProp) $$ [Hpu]
+    · iapply Atom.toFormula_eval_1
+      iapply hpu'
+      iexact Hpu
+    icases Hformula with %hformula_holds
     have hassume := VerifM.eval_assume hb2 hformula_wf hformula_holds
     set σ' := σ.rename v v'.name
     have hσ'wf : σ'.wf (st.decls.addConst v') :=
@@ -404,51 +556,33 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
       (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
         (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    exact Assertion.post_env_agree hkwf
+    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
+        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+      SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+        (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+    have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
+        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns ∗ R := by
+      exact sep_mono hinterp_bi.1 (by
+        iintro HR
+        iexact HR)
+    exact hframe.trans <| hih.trans <| Assertion.post_env_agree hkwf'
       (by
         simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
           (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-      hΦ hih
-  | ite φ kt ke iht ihe =>
-    obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
-    simp only [Assertion.assume] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    have hall := VerifM.eval_all hb
-    simp only [Assertion.post]
-    constructor
-    · intro hφ
-      have htrue := hall true (List.mem_cons_self ..)
-      simp at htrue
-      have hb2 := VerifM.eval_bind _ _ _ _ htrue
-      have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
-        FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
-      have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
-      exact iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst
-    · intro hnφ
-      have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
-      simp at hfalse
-      have hb2 := VerifM.eval_bind _ _ _ _ hfalse
-      have hnot_wf : (Formula.not φ).wfIn (Signature.ofVars σ.dom) := by
-        simp only [Formula.wfIn]; exact hφwf
-      have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
-        FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
-      have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
-      exact ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst
+      hΦ
 
 theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : Env)
-    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → Prop)
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ → Φ a ρ₂) :
+    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     m.wfIn retWf (Signature.ofVars σ.dom) →
     VerifM.eval (Assertion.prove σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wf st'.decls → (Signature.ofVars σ'.dom).wf →
-      retWf a (Signature.ofVars σ'.dom) → Φ a (σ'.subst.eval ρ')) →
-    Assertion.pre Φ m (σ.subst.eval ρ) := by
+      retWf a (Signature.ofVars σ'.dom) → st'.owns.interp ρ' ∗ R ⊢ Φ a (σ'.subst.eval ρ')) →
+    st.owns.interp ρ ∗ R ⊢ Assertion.pre Φ m (σ.subst.eval ρ) := by
   intro hσwf hdomwf hwf heval hpost
   have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
   induction m generalizing σ st ρ Ψ with
@@ -462,7 +596,17 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
     have hassert := VerifM.eval_assert hb hsubst_wf
     have hφ_holds := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mp hassert.1
-    exact ⟨hφ_holds, ih σ st ρ Ψ hσwf hdomwf hkwf hassert.2 hpost hwfst⟩
+    show SpatialContext.interp ρ st.owns ∗ R ⊢
+      (⌜φ.eval (σ.subst.eval ρ)⌝ ∗ Assertion.pre Φ k (σ.subst.eval ρ) : iProp)
+    istart
+    iintro ⟨Howns, HR⟩
+    isplitr [Howns HR]
+    · ipure_intro
+      exact hφ_holds
+    · iapply (ih σ st ρ Ψ hσwf hdomwf hkwf hassert.2 hpost hwfst)
+      isplitl [Howns]
+      · iexact Howns
+      · iexact HR
   | let_ v t k ih =>
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.prove] at heval
@@ -511,11 +655,17 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
     have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
       (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
         (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    exact Assertion.pre_env_agree hkwf
+    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
+        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+      SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+        (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+    exact (sep_mono hinterp_bi.1 (by
+      iintro HR
+      iexact HR)).trans <| hih.trans <| Assertion.pre_env_agree hkwf'
       (by
         simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
           (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-      hΦ hih
+      hΦ
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.prove] at heval
@@ -537,61 +687,78 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       specialize hresult_wf t rfl
       simp only [Assertion.pre]
       -- The witness is t.eval ρ
-      have hpu : p.eval (σ.subst.eval ρ) (t.eval ρ) := by
+      have hpu : ⊢ p.eval (σ.subst.eval ρ) (t.eval ρ) := by
         rw [← Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
-        exact Atom.toFormula_eval_iff.mp hresult_eval
-      refine ⟨t.eval ρ, hpu, ?_⟩
-      -- Now decompose: decl, assert eq, then prove σ' k
-      have hb2 := VerifM.eval_bind _ _ _ _ hq
-      have hdecl := VerifM.eval_decl hb2
-      set v' := st.freshConst (some v.name) v.sort
-      have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
-        fresh_not_mem (addNumbers (v.name)) (st.decls.allNames) (addNumbers_injective _)
-      have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
-        fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-      specialize hdecl (t.eval ρ)
-      have hb3 := VerifM.eval_bind _ _ _ _ hdecl
-      have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
-          (st.decls.addConst v') := by
-        refine ⟨?_, ?_⟩
-        · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
-          have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
-          refine ⟨List.Mem.head _, ?_, ?_⟩
-          · intro τ' hvar
-            exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
-          · intro τ' hc'
-            exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-        · exact Term.wfIn_mono _ hresult_wf (Signature.Subset.subset_addConst _ _)
+        iapply Atom.toFormula_eval_2
+        ipure_intro
+        exact hresult_eval
+      istart
+      iintro Howns
+      iexists (t.eval ρ)
+      isplitr
+      · iapply hpu
+      · have hb2 := VerifM.eval_bind _ _ _ _ hq
+        have hdecl := VerifM.eval_decl hb2
+        set v' := st.freshConst (some v.name) v.sort
+        have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
+          fresh_not_mem (addNumbers (v.name)) (st.decls.allNames) (addNumbers_injective _)
+        have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
+          fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
+        specialize hdecl (t.eval ρ)
+        have hb3 := VerifM.eval_bind _ _ _ _ hdecl
+        have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
+            (st.decls.addConst v') := by
+          refine ⟨?_, ?_⟩
+          · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+            have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
+            refine ⟨List.Mem.head _, ?_, ?_⟩
+            · intro τ' hvar
+              exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
+            · intro τ' hc'
+              exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
+          · exact Term.wfIn_mono _ hresult_wf (Signature.Subset.subset_addConst _ _)
+              (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
+        have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
+            (ρ.updateConst v.sort v'.name (t.eval ρ)) := by
+          simp only [Formula.eval, Term.eval, Const.denote]
+          simpa [Env.lookupConst, Env.updateConst] using
+            (Term.eval_env_agree hresult_wf (agreeOn_update_fresh_const hv'_fresh_decls))
+        have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
+        set σ' := σ.rename v v'.name
+        have hσ'wf : σ'.wf (st.decls.addConst v') :=
+          by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
+        have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
+          simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
+        have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
+          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
+        have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
+          (ρ.updateConst v.sort v'.name (t.eval ρ)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
             (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-      have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
-          (ρ.updateConst v.sort v'.name (t.eval ρ)) := by
-        simp only [Formula.eval, Term.eval, Const.denote]
-        simpa [Env.lookupConst, Env.updateConst] using
-          (Term.eval_env_agree hresult_wf (agreeOn_update_fresh_const hv'_fresh_decls))
-      have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
-      set σ' := σ.rename v v'.name
-      have hσ'wf : σ'.wf (st.decls.addConst v') :=
-        by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
-      have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
-        simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
-      have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
-        simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-      have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
-        (ρ.updateConst v.sort v'.name (t.eval ρ)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-          (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-      exact Assertion.pre_env_agree hkwf
-        (by
-          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-            (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-        hΦ hih
+        have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
+            SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st.owns :=
+          SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+            (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+        have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
+            SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st.owns ∗ R := by
+          exact sep_mono hinterp_bi.1 (by
+            iintro HR
+            iexact HR)
+        exact hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
+          (by
+            simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
+              (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
+          hΦ
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
     simp only [Assertion.prove] at heval
     have hb := VerifM.eval_bind _ _ _ _ heval
     have hall := VerifM.eval_all hb
     simp only [Assertion.pre]
-    constructor
-    · intro hφ
+    iintro Howns
+    apply BI.and_intro
+    · apply wand_intro
+      iintro H
+      icases H with ⟨Howns, %hφ⟩
       have htrue := hall true (List.mem_cons_self ..)
       simp at htrue
       have hb2 := VerifM.eval_bind _ _ _ _ htrue
@@ -599,8 +766,11 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
         FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
       have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
-      exact iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst
-    · intro hnφ
+      iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
+      iexact Howns
+    · apply wand_intro
+      iintro H
+      icases H with ⟨Howns, %hnφ⟩
       have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
       simp at hfalse
       have hb2 := VerifM.eval_bind _ _ _ _ hfalse
@@ -610,4 +780,5 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
         FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
       have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
-      exact ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst
+      iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
+      iexact Howns

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -313,25 +313,25 @@ theorem Assertion.pre_post_combine {α : Type}
 def Assertion.assume (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst × α)
   | .ret a => pure (σ, a)
   | .assert φ k => do
-    VerifM.assume (φ.subst σ.subst σ.range.allNames)
+    VerifM.assume (.pure (φ.subst σ.subst σ.range.allNames))
     Assertion.assume σ k
   | .let_ v t k => do
     let v' ← VerifM.decl (some v.name) v.sort
     let σ' := σ.rename v v'.name
-    VerifM.assume (.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst))
+    VerifM.assume (.pure (.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)))
     Assertion.assume σ' k
   | .pred v p k => do
     let v' ← VerifM.decl (some v.name) v.sort
     let σ' := σ.rename v v'.name
-    VerifM.assume ((p.subst σ.subst).toFormula (.const (.uninterpreted v'.name v.sort)))
+    VerifM.assume ((p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort)))
     Assertion.assume σ' k
   | .ite φ kt ke => do
     let branch ← VerifM.all [true, false]
     if branch then do
-      VerifM.assume (φ.subst σ.subst σ.range.allNames)
+      VerifM.assume (.pure (φ.subst σ.subst σ.range.allNames))
       Assertion.assume σ kt
     else do
-      VerifM.assume (.not (φ.subst σ.subst σ.range.allNames))
+      VerifM.assume (.pure (.not (φ.subst σ.subst σ.range.allNames)))
       Assertion.assume σ ke
 
 /-- Assert postconditions: assert formulas, declare and bind let-variables.
@@ -344,23 +344,23 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
   | .let_ v t k => do
     let v' ← VerifM.decl (some v.name) v.sort
     let σ' := σ.rename v v'.name
-    VerifM.assume (.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst))
+    VerifM.assume (.pure (.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)))
     Assertion.prove σ' k
   | .pred v p k => do
     match ← VerifM.resolve (p.subst σ.subst) with
     | some t =>
       let v' ← VerifM.decl (some v.name) v.sort
       let σ' := σ.rename v v'.name
-      VerifM.assume (.eq v.sort (.const (.uninterpreted v'.name v.sort)) t)
+      VerifM.assume (.pure (.eq v.sort (.const (.uninterpreted v'.name v.sort)) t))
       Assertion.prove σ' k
     | none => VerifM.fatal s!"could not resolve type predicate for {v.name}"
   | .ite φ kt ke => do
     let branch ← VerifM.all [true, false]
     if branch then do
-      VerifM.assume (φ.subst σ.subst σ.range.allNames)
+      VerifM.assume (.pure (φ.subst σ.subst σ.range.allNames))
       Assertion.prove σ kt
     else do
-      VerifM.assume (.not (φ.subst σ.subst σ.range.allNames))
+      VerifM.assume (.pure (.not (φ.subst σ.subst σ.range.allNames)))
       Assertion.prove σ ke
 
 
@@ -394,7 +394,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
     have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
       FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
     have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-    have hassume := VerifM.eval_assume hb hsubst_wf hsubst_eval
+    have hassume := VerifM.eval_assumePure hb hsubst_wf hsubst_eval
     iapply (ih σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkwf hassume hpost hwfst)
     iexact Howns
   | let_ v t k ih =>
@@ -435,7 +435,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
       simpa [u, Env.lookupConst, Env.updateConst] using
         (Term.eval_env_agree htwf (FiniteSubst.eval_update_fresh hσwf.1 hv'_fresh_range))
-    have hassume := VerifM.eval_assume hb2 heq_wf heq_holds
+    have hassume := VerifM.eval_assumePure hb2 heq_wf heq_holds
     -- Apply IH with σ' = σ.rename v v'.name
     set σ' := σ.rename v v'.name
     have hσ'wf : σ'.wf (st.decls.addConst v') :=
@@ -472,7 +472,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
         FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
       iexact Howns
     · iintro Howns %hnφ
@@ -484,7 +484,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
         FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
       iexact Howns
   | pred v p k ih =>
@@ -518,9 +518,9 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
         exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
       · intro τ' hc'
         exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-    have hformula_wf : ((p.subst σ.subst).toFormula (.const (.uninterpreted v'.name v.sort))).wfIn
+    have hitem_wf : ((p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))).wfIn
         (st.decls.addConst v') :=
-      Atom.toFormula_wfIn
+      Atom.toItem_wfIn
         (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
           (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint) hvar_wf
     have hpu' : p.eval (σ.subst.eval ρ) u ⊢ (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
@@ -539,13 +539,7 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
           (Δ := Signature.ofVars σ.dom) hpwf hagree
       rw [heval_agree]
       exact .rfl
-    ihave Hformula : (⌜((p.subst σ.subst).toFormula (.const (.uninterpreted v'.name v.sort))).eval
-        (ρ.updateConst v.sort v'.name u)⌝ : iProp) $$ [Hpu]
-    · iapply Atom.toFormula_eval_1
-      iapply hpu'
-      iexact Hpu
-    icases Hformula with %hformula_holds
-    have hassume := VerifM.eval_assume hb2 hformula_wf hformula_holds
+    set item := (p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))
     set σ' := σ.rename v v'.name
     have hσ'wf : σ'.wf (st.decls.addConst v') :=
       by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
@@ -553,23 +547,85 @@ theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
       simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
     have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
       simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-    have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
-      (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-        (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
-        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
-      SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
-        (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-    have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
-        SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns ∗ R := by
-      exact sep_mono hinterp_bi.1 (by
-        iintro HR
-        iexact HR)
-    exact hframe.trans <| hih.trans <| Assertion.post_env_agree hkwf'
-      (by
-        simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-          (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-      hΦ
+    cases hitem : item with
+    | pure φ =>
+      have hφ_entail : p.eval (σ.subst.eval ρ) u ⊢ ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ := by
+        simpa [item, hitem] using
+          (hpu'.trans (Atom.eval_purePart (p := p.subst σ.subst)
+            (t := .const (.uninterpreted v'.name v.sort))
+            (ρ := ρ.updateConst v.sort v'.name u)))
+      ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ $$ [Hpu]
+      · iapply hφ_entail
+        iexact Hpu
+      icases Hφ with %hφ
+      have hb2' : (VerifM.assume (.pure φ)).eval
+          { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
+          (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
+        simpa [item, hitem] using hb2
+      have hitem_wf' : (.pure φ : CtxItem).wfIn (st.decls.addConst v') := by
+        simpa [item, hitem] using hitem_wf
+      have hassume := VerifM.eval_assume hb2' hitem_wf' hφ
+      have hih := ih σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ))
+        (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
+          (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
+      have hframe :
+          st.owns.interp ρ ∗ R ⊢
+            (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).owns.interp
+              (ρ.updateConst v.sort v'.name u) ∗ R := by
+        simp [TransState.addItem]
+        exact sep_mono
+          (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+            (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
+          (by
+            iintro HR
+            iexact HR)
+      iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree hkwf'
+        (by
+          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
+            (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
+        hΦ)
+      iexact Howns
+    | spatial a =>
+      have hb2' : (VerifM.assume (.spatial a)).eval
+          { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
+          (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
+        simpa [item, hitem] using hb2
+      have hitem_wf' : (.spatial a : CtxItem).wfIn (st.decls.addConst v') := by
+        simpa [item, hitem] using hitem_wf
+      have hassume := VerifM.eval_assume hb2' hitem_wf' trivial
+      have hih := ih σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.spatial a))
+        (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
+          (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
+      have hitem_interp :
+          p.eval (σ.subst.eval ρ) u ⊢
+            CtxItem.interp (ρ.updateConst v.sort v'.name u) item := by
+        simpa [item] using
+          (hpu'.trans (Atom.eval_toItem (p := p.subst σ.subst)
+            (t := .const (.uninterpreted v'.name v.sort))
+            (ρ := ρ.updateConst v.sort v'.name u)))
+      have hspatial_interp :
+          p.eval (σ.subst.eval ρ) u ⊢
+            SpatialAtom.interp (ρ.updateConst v.sort v'.name u) a := by
+        simpa [item, hitem, CtxItem.interp] using hitem_interp
+      have howns_agree :
+          SpatialContext.interp ρ st.owns ⊢
+            SpatialContext.interp (ρ.updateConst v.sort v'.name u) st.owns :=
+        (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+          (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
+      iapply (hih.trans <| Assertion.post_env_agree hkwf'
+        (by
+          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
+            (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
+        hΦ)
+      simp [TransState.addItem]
+      icases Howns with ⟨HS, HR⟩
+      isplitr [HR]
+      · isplitr [HS]
+        · iapply hspatial_interp
+          iexact Hpu
+        · iapply howns_agree
+          iexact HS
+      · iexact HR
 
 theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
@@ -644,7 +700,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
       simpa [u, Env.lookupConst, Env.updateConst] using
         (Term.eval_env_agree htwf (FiniteSubst.eval_update_fresh hσwf.1 hv'_fresh_range))
-    have hassume := VerifM.eval_assume hb2 heq_wf heq_holds
+    have hassume := VerifM.eval_assumePure hb2 heq_wf heq_holds
     set σ' := σ.rename v v'.name
     have hσ'wf : σ'.wf (st.decls.addConst v') :=
       by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
@@ -676,78 +732,79 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
         hσwf.2.2
     have hpwf_decls : (p.subst σ.subst).wfIn st.decls :=
       Atom.wfIn_mono hpwf_range hσwf.2.1 hwfst
-    obtain ⟨result, hq, hresult_eval, hresult_wf⟩ := VerifM.eval_resolve hb hpwf_decls
-    cases hr : result with
-    | none =>
-      simp [hr] at hq
-      exact (VerifM.eval_fatal hq).elim
-    | some t =>
-      simp only [hr] at hq hresult_eval hresult_wf
-      specialize hresult_eval t rfl
-      specialize hresult_wf t rfl
-      simp only [Assertion.pre]
-      -- The witness is t.eval ρ
-      have hpu : ⊢ p.eval (σ.subst.eval ρ) (t.eval ρ) := by
-        rw [← Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
-        iapply Atom.toFormula_eval_2
-        ipure_intro
-        exact hresult_eval
-      istart
-      iintro Howns
-      iexists (t.eval ρ)
-      isplitr
-      · iapply hpu
-      · have hb2 := VerifM.eval_bind _ _ _ _ hq
-        have hdecl := VerifM.eval_decl hb2
-        set v' := st.freshConst (some v.name) v.sort
-        have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
-          fresh_not_mem (addNumbers (v.name)) (st.decls.allNames) (addNumbers_injective _)
-        have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
-          fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-        specialize hdecl (t.eval ρ)
-        have hb3 := VerifM.eval_bind _ _ _ _ hdecl
-        have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
-            (st.decls.addConst v') := by
-          refine ⟨?_, ?_⟩
-          · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
-            have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
-            refine ⟨List.Mem.head _, ?_, ?_⟩
-            · intro τ' hvar
-              exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
-            · intro τ' hc'
-              exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-          · exact Term.wfIn_mono _ hresult_wf (Signature.Subset.subset_addConst _ _)
-              (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-        have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
-            (ρ.updateConst v.sort v'.name (t.eval ρ)) := by
-          simp only [Formula.eval, Term.eval, Const.denote]
-          simpa [Env.lookupConst, Env.updateConst] using
-            (Term.eval_env_agree hresult_wf (agreeOn_update_fresh_const hv'_fresh_decls))
-        have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
-        set σ' := σ.rename v v'.name
-        have hσ'wf : σ'.wf (st.decls.addConst v') :=
-          by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
-        have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
-          simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
-        have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
-          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-        have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
-          (ρ.updateConst v.sort v'.name (t.eval ρ)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-            (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-        have hinterp_bi : SpatialContext.interp ρ st.owns ⊣⊢
-            SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st.owns :=
-          SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
-            (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-        have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
-            SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st.owns ∗ R := by
-          exact sep_mono hinterp_bi.1 (by
-            iintro HR
-            iexact HR)
-        exact hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
-          (by
-            simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-              (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-          hΦ
+    exact VerifM.eval_resolve hb hpwf_decls
+      (fun st' hq hdecls => by
+        simp at hq
+        exact (VerifM.eval_fatal hq).elim)
+      (fun t st' hq hdecls htwf => by
+        simp only [Assertion.pre]
+        have hwfst' : st'.decls.wf := by simpa [hdecls] using hwfst
+        have htwf' : t.wfIn st'.decls := by simpa [hdecls] using htwf
+        istart
+        iintro H
+        icases H with ⟨Hpred, Howns, HR⟩
+        iexists (t.eval ρ)
+        isplitr [Howns HR]
+        · rw [← Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
+          iexact Hpred
+        · have hb2 := VerifM.eval_bind _ _ _ _ hq
+          have hdecl := VerifM.eval_decl hb2
+          set v' := st'.freshConst (some v.name) v.sort
+          have hv'_fresh_decls : v'.name ∉ st'.decls.allNames :=
+            fresh_not_mem (addNumbers (v.name)) (st'.decls.allNames) (addNumbers_injective _)
+          have hv'_fresh_range : v'.name ∉ σ.range.allNames := by
+            intro h
+            apply hv'_fresh_decls
+            rw [hdecls]
+            exact Signature.allNames_subset hσwf.2.1 _ h
+          specialize hdecl (t.eval ρ)
+          have hb3 := VerifM.eval_bind _ _ _ _ hdecl
+          have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
+              (st'.decls.addConst v') := by
+            refine ⟨?_, ?_⟩
+            · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+              have hwf_add : (st'.decls.addConst v').wf := Signature.wf_addConst hwfst' hv'_fresh_decls
+              refine ⟨List.Mem.head _, ?_, ?_⟩
+              · intro τ' hvar
+                exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
+              · intro τ' hc'
+                exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
+            · exact Term.wfIn_mono _ htwf' (Signature.Subset.subset_addConst _ _)
+                (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
+          have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
+              (ρ.updateConst v.sort v'.name (t.eval ρ)) := by
+            simp only [Formula.eval, Term.eval, Const.denote]
+            simpa [Env.lookupConst, Env.updateConst] using
+              (Term.eval_env_agree htwf' (agreeOn_update_fresh_const hv'_fresh_decls))
+          have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
+          set σ' := σ.rename v v'.name
+          have hσ'wf : σ'.wf (st'.decls.addConst v') := by
+            rw [hdecls]
+            simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
+          have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
+            simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
+          have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
+            simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
+          have hih := ih σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
+            (ρ.updateConst v.sort v'.name (t.eval ρ)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
+              (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
+          have hinterp_bi : SpatialContext.interp ρ st'.owns ⊣⊢
+              SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st'.owns :=
+            SpatialContext.interp_env_agree (VerifM.eval.wf hq).ownsWf
+              (agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+          have hframe : SpatialContext.interp ρ st'.owns ∗ R ⊢
+              SpatialContext.interp (ρ.updateConst v.sort v'.name (t.eval ρ)) st'.owns ∗ R := by
+            exact sep_mono hinterp_bi.1 (by
+              iintro HR
+              iexact HR)
+          iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
+            (by
+              simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
+                (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
+            hΦ)
+          isplitl [Howns]
+          · iexact Howns
+          · iexact HR)
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
     simp only [Assertion.prove] at heval
@@ -765,7 +822,7 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
         FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
       iexact Howns
     · apply wand_intro
@@ -779,6 +836,6 @@ theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
       have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
         FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
       have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
-      have hassume := VerifM.eval_assume hb2 hsubst_wf hsubst_eval
+      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
       iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
       iexact Howns

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -25,6 +25,13 @@ inductive Atom : Srt → Type where
   | isinj  (tag : Nat) (arity : Nat) : Term .value → Atom .value
 
 
+def Atom.pure {τ: Srt} (a : Atom τ) : Bool :=
+  match a with
+  | isint _ => true
+  | isbool _ => true
+  | isinj _ _ _ => true
+
+
 -- ---------------------------------------------------------------------------
 -- Substitution
 -- ---------------------------------------------------------------------------
@@ -35,15 +42,37 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
   | .isinj tag arity t => .isinj tag arity (t.subst σ)
 
 
+namespace CtxItem
+
+/-- Semantic interpretation of a verifier context item. -/
+def interp (ρ : Env) : CtxItem → iProp
+  | .pure φ => ⌜φ.eval ρ⌝
+  | .spatial a => a.interp ρ
+
+def purePart (i : CtxItem) (ρ : Env) : Prop :=
+  match i with
+  | .pure φ => φ.eval ρ
+  | .spatial _ => True
+
+end CtxItem
+
+/-- Convert an instantiated atom into the corresponding verifier context item. -/
+def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
+  match a with
+  | .isint v => .pure (.eq .value v (.unop .ofInt t))
+  | .isbool v => .pure (.eq .value v (.unop .ofBool t))
+  | .isinj tag arity v => .pure (.eq .value v (.unop (.mkInj tag arity) t))
+
 -- ---------------------------------------------------------------------------
--- Conversion to formula
+-- Semantics
 -- ---------------------------------------------------------------------------
 
-/-- Convert an atom applied to a typed term into a formula. -/
-def Atom.toFormula : Atom τ → Term τ → Formula
-  | .isint  v, t => .eq .value v (.unop .ofInt t)
-  | .isbool v, t => .eq .value v (.unop .ofBool t)
-  | .isinj tag arity v, t => .eq .value v (.unop (.mkInj tag arity) t)
+def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
+  match p with
+  | isint t  => λ v => ⌜.int v = t.eval ρ⌝
+  | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
+  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
+
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
 def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
@@ -62,8 +91,22 @@ def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
       if v' = v ∧ tag = tag' ∧ arity = arity' then some t else none
     | _ => none
 
+theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : Signature}
+    (h : φ.matchAtom a = some t) (hφ : φ.wfIn Δ) : t.wfIn Δ := by
+  cases a with
+  | isint v =>
+    simp only [Formula.matchAtom] at h
+    split at h <;> simp_all [Formula.wfIn, Term.wfIn]
+  | isbool v =>
+    simp only [Formula.matchAtom] at h
+    split at h <;> simp_all [Formula.wfIn, Term.wfIn]
+  | isinj tag arity v =>
+    simp only [Formula.matchAtom] at h
+    split at h <;> simp_all [Formula.wfIn, Term.wfIn]
+
+
 theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
-    (h : φ.matchAtom a = some t) : φ = a.toFormula t := by
+    (h : φ.matchAtom a = some t) : a.toItem t = .pure φ := by
   cases a with
   | isint v =>
     simp only [Formula.matchAtom] at h
@@ -87,29 +130,17 @@ def Atom.resolve (a : Atom τ) (C : List Formula) : Option (Term τ) :=
 
 theorem Atom.resolve_correct {a : Atom τ} {C : List Formula} {t : Term τ}
     (h : a.resolve C = some t) (ρ : Env) (hC : ∀ φ ∈ C, φ.eval ρ) :
-    (a.toFormula t).eval ρ := by
+    ⊢ (a.toItem t).interp ρ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
-  have heq := Formula.matchAtom_correct hφ_match
-  subst heq
-  exact hC _ hφ_mem
+  rw [Formula.matchAtom_correct hφ_match]
+  simp [CtxItem.interp, hC _ hφ_mem]
+  exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
 
 theorem Atom.resolve_wfIn {a : Atom τ} {C : List Formula} {t : Term τ} {Δ : Signature}
     (h : a.resolve C = some t) (hwf : ∀ φ ∈ C, φ.wfIn Δ) :
     t.wfIn Δ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
-  have heq := Formula.matchAtom_correct hφ_match
-  subst heq
-  have hφwf := hwf _ hφ_mem
-  cases a with
-  | isint u =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn] at hφwf
-    exact hφwf.2.2
-  | isbool u =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn] at hφwf
-    exact hφwf.2.2
-  | isinj tag arity u =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn] at hφwf
-    exact hφwf.2.2
+  exact Formula.matchAtom_wfIn hφ_match (hwf _ hφ_mem)
 
 
 -- ---------------------------------------------------------------------------
@@ -120,18 +151,6 @@ def Atom.toStringHum : {τ : Srt} → Atom τ → String
   | _, .isint  t => s!"isint {t.toStringHum}"
   | _, .isbool t => s!"isbool {t.toStringHum}"
   | _, .isinj tag arity t => s!"isinj {tag}/{arity} {t.toStringHum}"
-
-
--- ---------------------------------------------------------------------------
--- Semantics
--- ---------------------------------------------------------------------------
-
-def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
-  match p with
-  | isint t  => λ v => ⌜.int v = t.eval ρ⌝
-  | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
-  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
-
 
 -- ---------------------------------------------------------------------------
 -- Well-formedness
@@ -169,37 +188,48 @@ theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isinj tag arity t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
 
-theorem Atom.toFormula_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
+theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     (hp : p.wfIn Δ) (ht : t.wfIn Δ) :
-    (p.toFormula t).wfIn Δ := by
+    (p.toItem t).wfIn Δ := by
   cases p with
   | isint v =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn]
+    simp only [Atom.toItem, CtxItem.wfIn]
     exact ⟨hp, trivial, ht⟩
   | isbool v =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn]
+    simp only [Atom.toItem, CtxItem.wfIn]
     exact ⟨hp, trivial, ht⟩
   | isinj tag arity v =>
-    simp only [Atom.toFormula, Formula.wfIn, Term.wfIn]
+    simp only [Atom.toItem, CtxItem.wfIn]
     exact ⟨hp, trivial, ht⟩
 
 theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
-    p.eval ρ (t.eval ρ) ⊣⊢ ⌜(p.toFormula t).eval ρ⌝ := by
+    p.eval ρ (t.eval ρ) ⊣⊢ CtxItem.interp ρ (p.toItem t) := by
   cases p with
-  | isint v  => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
-  | isbool v => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
-  | isinj tag arity v => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
+  | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
 
-/-- If `p.eval ρ u` holds and `p` is wfIn fresh decls, then `p.toFormula (.var τ x)` holds
-    after updating `ρ` with `x ↦ u`. -/
-theorem Atom.toFormula_eval_1 {p : Atom τ} {t : Term τ} {ρ : Env} :
-     p.eval ρ (t.eval ρ) ⊢ ⌜(p.toFormula t).eval ρ⌝ := by
-  exact Atom.eval_pure.1
-
-/-- If `(p.toFormula t).eval ρ` holds, then `p.eval ρ (t.eval ρ)`. -/
-theorem Atom.toFormula_eval_2 {p : Atom τ} {t : Term τ} {ρ : Env}
-    : ⌜(p.toFormula t).eval ρ⌝ ⊢ p.eval ρ (t.eval ρ) := by
+/-- If `p.toItem t` holds semantically, then `p.eval ρ (t.eval ρ)`. -/
+theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : Env}
+    : CtxItem.interp ρ (p.toItem t) ⊢ p.eval ρ (t.eval ρ) := by
   exact Atom.eval_pure.2
+
+theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : Env} :
+    p.eval ρ (t.eval ρ) ⊢ CtxItem.interp ρ (p.toItem t) := by
+  cases p with
+  | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+
+theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
+    p.eval ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
+  cases p with
+  | isint v =>
+    simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+  | isbool v =>
+    simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+  | isinj tag arity v =>
+    simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
 
 
 -- ---------------------------------------------------------------------------
@@ -247,23 +277,26 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .isinj tag arity v => [(.unpred (.isInj tag arity) v, .unop .payloadOf v)]
 
 theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : Env}
-    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : (a.toFormula t).eval ρ := by
+    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : ⊢ (a.toItem t).interp ρ := by
   cases a with
   | isint v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
-    simp [toFormula, Formula.eval, Term.eval, UnOp.eval]
+    simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ <;> simp_all
+    · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isbool v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
-    simp [toFormula, Formula.eval, Term.eval, UnOp.eval]
+    simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ <;> simp_all
+    · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isinj tag arity v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
-    simp [toFormula, Formula.eval, Term.eval, UnOp.eval]
+    simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ <;> simp_all
+    · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
 
 theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Signature}
     (hmem : (φ, t) ∈ a.candidates) (h : a.wfIn Δ) : φ.wfIn Δ ∧ t.wfIn Δ := by
@@ -292,7 +325,7 @@ private theorem VerifM.eval_tryCandidates
     (hpwf : a.wfIn st.decls) :
     ∃ result : Option (Term τ),
       Q result st ρ
-      ∧ (∀ t, result = some t → (a.toFormula t).eval ρ)
+      ∧ (∀ t, result = some t → ⊢ (a.toItem t).interp ρ)
       ∧ (∀ t, result = some t → t.wfIn st.decls) := by
   induction candidates with
   | nil =>
@@ -316,31 +349,250 @@ private theorem VerifM.eval_tryCandidates
       simp at hq
       exact ih hq (fun p hp => hcands p (List.mem_cons_of_mem _ hp))
 
+
+-- ---------------------------------------------------------------------------
+-- Spatial resolution (linear search over st.owns)
+-- ---------------------------------------------------------------------------
+
+namespace SpatialAtom
+
+/-- Two points-to atoms with semantically equal locations have equal Iris
+    interpretations. -/
+theorem interp_pointsTo_loc_congr {ρ : Env} {l l' v : Term .value}
+    (h : Term.eval ρ l = Term.eval ρ l') :
+    interp ρ (.pointsTo l v) ⊣⊢ interp ρ (.pointsTo l' v) := by
+  simp only [interp, h]
+  exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
+
+end SpatialAtom
+
+/-- Walk a spatial context and return the index and stored value at the first
+    `pointsTo` whose location the SMT solver can prove equal to `lq`. The
+    returned index is into the input list; consumption is the caller's job. -/
+def VerifM.findMatchIn (lq : Term .value) :
+    SpatialContext → VerifM (Option (Nat × Term .value))
+  | [] => pure none
+  | .pointsTo l v :: rest => do
+      if ← VerifM.check (.eq .value lq l) then
+        pure (some (0, v))
+      else
+        return (← VerifM.findMatchIn lq rest).map fun (n, v') => (n + 1, v')
+
+/-- Search the current ownership context for a `pointsTo` at location `lq`,
+    returning the stored value and consuming the matched entry from `st.owns`. -/
+def VerifM.findMatch (lq : Term .value) : VerifM (Option (Term .value)) := do
+  let owns ← VerifM.ctx (fun st => (st.owns, st.owns))
+  match ← VerifM.findMatchIn lq owns with
+  | none => pure none
+  | some (n, v) =>
+      match SpatialContext.remove owns n with
+      | none => VerifM.fatal "findMatch: returned index out of range"
+      | some (_, rest) => do
+          let _ ← VerifM.ctx (fun _ => ((), rest))
+          pure (some v)
+
+/-- Correctness of `findMatchIn`: on a `some (n, v)` result, `remove ctx n`
+    extracts a points-to whose location the solver has proved equal to `lq`. -/
+theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
+    {st : TransState} {ρ : Env}
+    {Q : Option (Nat × Term .value) → TransState → Env → Prop}
+    (h : VerifM.eval (VerifM.findMatchIn lq ctx) st ρ Q)
+    (hlq : lq.wfIn st.decls) (hctx : ctx.wfIn st.decls) :
+    ∃ result,
+      Q result st ρ ∧
+      (∀ n v, result = some (n, v) →
+        ∃ l rest,
+          SpatialContext.remove ctx n = some (.pointsTo l v, rest) ∧
+          Term.eval ρ lq = Term.eval ρ l) := by
+  induction ctx generalizing Q with
+  | nil =>
+    simp only [VerifM.findMatchIn] at h
+    refine ⟨none, VerifM.eval_ret h, ?_⟩
+    intros n v hvr; simp at hvr
+  | cons a ctx ih =>
+    cases a with
+    | pointsTo l v =>
+      simp only [VerifM.findMatchIn] at h
+      have hb := VerifM.eval_bind _ _ _ _ h
+      have hcons := (SpatialContext.wfIn_cons _ _ _).1 hctx
+      have hatom := hcons.1
+      have hrest := hcons.2
+      have hwfeq : (Formula.eq .value lq l).wfIn st.decls := ⟨hlq, hatom.1⟩
+      obtain ⟨b, hb_sound, hq⟩ := VerifM.eval_check hb hwfeq
+      cases b with
+      | true =>
+        simp at hq
+        refine ⟨some (0, v), VerifM.eval_ret hq, ?_⟩
+        intros n' v' hnv
+        simp at hnv
+        obtain ⟨rfl, rfl⟩ := hnv
+        have heq : Term.eval ρ lq = Term.eval ρ l := by
+          have := hb_sound rfl
+          simpa [Formula.eval] using this
+        exact ⟨l, ctx, rfl, heq⟩
+      | false =>
+        simp at hq
+        have hb' := VerifM.eval_bind _ _ _ _ hq
+        obtain ⟨result', hres', hsome'⟩ := ih hb' hrest
+        cases result' with
+        | none =>
+          simp at hres'
+          refine ⟨none, VerifM.eval_ret hres', ?_⟩
+          intros n' v' hnv; simp at hnv
+        | some pair =>
+          obtain ⟨n₀, v₀⟩ := pair
+          simp at hres'
+          refine ⟨some (n₀ + 1, v₀), VerifM.eval_ret hres', ?_⟩
+          intros n' v' hnv
+          simp at hnv
+          obtain ⟨rfl, rfl⟩ := hnv
+          obtain ⟨l', rest', hrem, heq⟩ := hsome' n₀ v₀ rfl
+          refine ⟨l', .pointsTo l v :: rest', ?_, heq⟩
+          simp [SpatialContext.remove, hrem]
+
+/-- Correctness of `findMatch` in CPS style: the caller supplies Iris-level
+    continuations for the `some` and `none` branches. On `some v`, the
+    postcondition state has the matched points-to consumed from `st.owns`, and
+    the caller receives separate ownership of `lq ↦ v`. -/
+theorem VerifM.eval_findMatch {lq : Term .value}
+    {st : TransState} {ρ : Env}
+    {Q : Option (Term .value) → TransState → Env → Prop}
+    {R Φ : iProp}
+    (h : VerifM.eval (VerifM.findMatch lq) st ρ Q)
+    (hlq : lq.wfIn st.decls)
+    (hsome : ∀ v st', Q (some v) st' ρ →
+        st'.decls = st.decls → v.wfIn st.decls →
+        SpatialAtom.interp ρ (.pointsTo lq v) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hnone : Q none st ρ → SpatialContext.interp ρ st.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+  unfold VerifM.findMatch at h
+  have hb := VerifM.eval_bind _ _ _ _ h
+  have ⟨hk, howns, _, _⟩ := VerifM.eval_ctx hb
+  have hst_eq : ({ st with owns := st.owns } : TransState) = st := rfl
+  rw [hst_eq] at hk
+  have hk' := hk howns
+  have hb2 := VerifM.eval_bind _ _ _ _ hk'
+  obtain ⟨result, hres, hprop⟩ := eval_findMatchIn hb2 hlq howns
+  cases result with
+  | none =>
+    simp at hres
+    exact hnone (VerifM.eval_ret hres)
+  | some pair =>
+    obtain ⟨n, v⟩ := pair
+    obtain ⟨l, rest, hrem, heq⟩ := hprop n v rfl
+    have hrest_wf : SpatialContext.wfIn rest st.decls :=
+      (SpatialContext.wfIn_remove howns hrem).2
+    have hatom_wf : SpatialAtom.wfIn (.pointsTo l v) st.decls :=
+      (SpatialContext.wfIn_remove howns hrem).1
+    have hv_wf : v.wfIn st.decls := hatom_wf.2
+    simp [hrem] at hres
+    -- hres : (VerifM.ctx (fun _ => ((), rest)) >>= fun _ => pure (some v)).eval st ρ Q
+    have hb3 := VerifM.eval_bind _ _ _ _ hres
+    have ⟨hk3, _, _, _⟩ := VerifM.eval_ctx hb3
+    have hk3' := hk3 hrest_wf
+    have hQ : Q (some v) { st with owns := rest } ρ := VerifM.eval_ret hk3'
+    have hsplit := SpatialContext.interp_remove ρ st.owns n _ _ hrem
+    have hcong := SpatialAtom.interp_pointsTo_loc_congr (v := v) heq.symm
+    -- goal: st.owns.interp ρ ∗ R ⊢ Φ
+    -- st.owns.interp ρ ⊣⊢ (pointsTo l v).interp ρ ∗ rest.interp ρ
+    --                ⊣⊢ (pointsTo lq v).interp ρ ∗ rest.interp ρ
+    refine (Iris.BI.sep_mono hsplit.1 BIBase.Entails.rfl).trans ?_
+    refine (Iris.BI.sep_mono (Iris.BI.sep_mono hcong.1 BIBase.Entails.rfl) BIBase.Entails.rfl).trans ?_
+    refine Iris.BI.sep_assoc.1.trans ?_
+    exact hsome v { st with owns := rest } hQ rfl hv_wf
+
+/-- Like `findMatch`, but aborts with a fatal error if no matching points-to
+    is found in the current ownership context. -/
+def VerifM.findMatchForce (lq : Term .value) : VerifM (Term .value) := do
+  match ← VerifM.findMatch lq with
+  | some v => pure v
+  | none => VerifM.fatal s!"no matching points-to for location"
+
+/-- CPS correctness for `findMatchForce`: only a `some`-style continuation is
+    required, since the `none` branch is discharged by the fatal error. -/
+theorem VerifM.eval_findMatchForce {lq : Term .value}
+    {st : TransState} {ρ : Env}
+    {Q : Term .value → TransState → Env → Prop}
+    {R Φ : iProp}
+    (h : VerifM.eval (VerifM.findMatchForce lq) st ρ Q)
+    (hlq : lq.wfIn st.decls)
+    (hsome : ∀ v st', Q v st' ρ →
+        st'.decls = st.decls → v.wfIn st.decls →
+        SpatialAtom.interp ρ (.pointsTo lq v) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+  unfold VerifM.findMatchForce at h
+  have hb := VerifM.eval_bind _ _ _ _ h
+  refine eval_findMatch (R := R) (Φ := Φ) hb hlq ?_ ?_
+  · intros v st' hQ hdecls hv
+    simp at hQ
+    exact hsome v st' (VerifM.eval_ret hQ) hdecls hv
+  · intro hQ
+    simp at hQ
+    exact (VerifM.eval_fatal hQ).elim
+
+
 /-- Look up an atom in the assertion context.
     Tier 1: syntactic search through the context.
     Tier 2: try candidate resolutions via the SMT solver. -/
 def VerifM.resolve (a : Atom τ) : VerifM (Option (Term τ)) := do
-  match ← VerifM.ctxPure (a.resolve ·) with
-  | some t => pure (some t)
-  | none => VerifM.tryCandidates a.candidates
+  if a.pure then
+    match ← VerifM.ctxPure (a.resolve ·) with
+    | some t => pure (some t)
+    | none => VerifM.tryCandidates a.candidates
+  else
+    VerifM.fatal "here will be the points-to case"
 
 theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
     {Q : Option (Term τ) → TransState → Env → Prop}
+    {R Φ : iProp}
     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
-    (hpwf : pred.wfIn st.decls) :
-    ∃ result : Option (Term τ),
-      Q result st ρ
-      ∧ (∀ t, result = some t → (pred.toFormula t).eval ρ)
-      ∧ (∀ t, result = some t → t.wfIn st.decls) := by
+    (hwf : pred.wfIn st.decls)
+    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
+      Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
   unfold VerifM.resolve at h
-  have hb1 := VerifM.eval_bind _ _ _ _ h
-  have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
-  cases hres : pred.resolve st.asserts with
-  | some t =>
-    simp [hres] at hctx_q
-    exact ⟨some t, VerifM.eval_ret hctx_q,
-           fun t' ht' => by cases ht'; exact Atom.resolve_correct hres ρ hholds,
-           fun t' ht' => by cases ht'; exact Atom.resolve_wfIn hres hwfAsserts⟩
-  | none =>
-    simp [hres] at hctx_q
-    exact eval_tryCandidates hctx_q (fun p hp => hp) hpwf
+  cases hpure : pred.pure with
+  | false =>
+    simp [hpure] at h
+    exact (VerifM.eval_fatal h).elim
+  | true =>
+    simp [hpure] at h
+    have hb1 := VerifM.eval_bind _ _ _ _ h
+    have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
+    cases hres : pred.resolve st.asserts with
+    | some t =>
+      simp [hres] at hctx_q
+      have hq := VerifM.eval_ret hctx_q
+      have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
+      have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
+        exact (Atom.resolve_correct hres ρ hholds).trans Atom.toItem_eval
+      have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
+          Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
+        istart
+        iintro H
+        isplitr [H]
+        · iapply hpred
+        · iexact H
+      exact hframe.trans (hsome t st hq rfl htwf)
+    | none =>
+      simp [hres] at hctx_q
+      obtain ⟨result, hq, hresult_eval, hresult_wf⟩ :=
+        eval_tryCandidates hctx_q (fun p hp => hp) hwf
+      cases hr : result with
+      | none =>
+        have hqnone : Q .none st ρ := by simpa [hr] using hq
+        exact hnone st hqnone rfl
+      | some t =>
+        have htwf : t.wfIn st.decls := hresult_wf t hr
+        have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
+        have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
+          exact (hresult_eval t hr).trans Atom.toItem_eval
+        have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
+            Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
+          istart
+          iintro H
+          isplitr [H]
+          · iapply hpred
+          · iexact H
+        exact hframe.trans (hsome t st hqsome rfl htwf)

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -23,6 +23,7 @@ inductive Atom : Srt → Type where
   | isint  : Term .value → Atom .int
   | isbool : Term .value → Atom .bool
   | isinj  (tag : Nat) (arity : Nat) : Term .value → Atom .value
+  | own    : Term .value → Atom .value
 
 
 def Atom.pure {τ: Srt} (a : Atom τ) : Bool :=
@@ -30,6 +31,7 @@ def Atom.pure {τ: Srt} (a : Atom τ) : Bool :=
   | isint _ => true
   | isbool _ => true
   | isinj _ _ _ => true
+  | own _ => false
 
 
 -- ---------------------------------------------------------------------------
@@ -40,6 +42,7 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
   | .isint t  => .isint (t.subst σ)
   | .isbool t => .isbool (t.subst σ)
   | .isinj tag arity t => .isinj tag arity (t.subst σ)
+  | .own t    => .own (t.subst σ)
 
 
 namespace CtxItem
@@ -62,6 +65,7 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
   | .isint v => .pure (.eq .value v (.unop .ofInt t))
   | .isbool v => .pure (.eq .value v (.unop .ofBool t))
   | .isinj tag arity v => .pure (.eq .value v (.unop (.mkInj tag arity) t))
+  | .own l => .spatial (.pointsTo l t)
 
 -- ---------------------------------------------------------------------------
 -- Semantics
@@ -72,6 +76,7 @@ def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
   | isint t  => λ v => ⌜.int v = t.eval ρ⌝
   | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
   | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
+  | own l => λ v => ∃ loc : Runtime.Location, ⌜l.eval ρ = .loc loc⌝ ∗ loc ↦ v
 
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
@@ -90,6 +95,7 @@ def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
     | .eq .value v' (.unop (.mkInj tag' arity') t) =>
       if v' = v ∧ tag = tag' ∧ arity = arity' then some t else none
     | _ => none
+  | .own _ => none
 
 theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : Signature}
     (h : φ.matchAtom a = some t) (hφ : φ.wfIn Δ) : t.wfIn Δ := by
@@ -103,6 +109,7 @@ theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : 
   | isinj tag arity v =>
     simp only [Formula.matchAtom] at h
     split at h <;> simp_all [Formula.wfIn, Term.wfIn]
+  | own l => simp only [Formula.matchAtom] at h; cases h
 
 
 theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
@@ -118,6 +125,7 @@ theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
     simp only [Formula.matchAtom] at h
     split at h <;> simp_all
     obtain ⟨⟨rfl, rfl, rfl⟩, rfl⟩ := h; rfl
+  | own l => simp only [Formula.matchAtom] at h; cases h
 
 
 -- ---------------------------------------------------------------------------
@@ -151,6 +159,7 @@ def Atom.toStringHum : {τ : Srt} → Atom τ → String
   | _, .isint  t => s!"isint {t.toStringHum}"
   | _, .isbool t => s!"isbool {t.toStringHum}"
   | _, .isinj tag arity t => s!"isinj {tag}/{arity} {t.toStringHum}"
+  | _, .own t => s!"own {t.toStringHum}"
 
 -- ---------------------------------------------------------------------------
 -- Well-formedness
@@ -161,18 +170,21 @@ def Atom.wfIn (Δ : Signature) : Atom τ → Prop
   | .isint t  => t.wfIn Δ
   | .isbool t => t.wfIn Δ
   | .isinj _ _ t => t.wfIn Δ
+  | .own t    => t.wfIn Δ
 
 def Atom.checkWf (p : Atom τ) (Δ : Signature) : Except String Unit :=
   match p with
   | .isint t  => t.checkWf Δ
   | .isbool t => t.checkWf Δ
   | .isinj _ _ t => t.checkWf Δ
+  | .own t    => t.checkWf Δ
 
 theorem Atom.checkWf_ok {p : Atom τ} {Δ : Signature} (h : p.checkWf Δ = .ok ()) : p.wfIn Δ := by
   cases p with
   | isint t  => exact Term.checkWf_ok h
   | isbool t => exact Term.checkWf_ok h
   | isinj tag arity t => exact Term.checkWf_ok h
+  | own t => exact Term.checkWf_ok h
 
 theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
     (h : p.wfIn Δ) (hmono : Δ.Subset Δ') (hwf : Δ'.wf) : p.wfIn Δ' := by
@@ -180,6 +192,7 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | isint t  => exact Term.wfIn_mono t h hmono hwf
   | isbool t => exact Term.wfIn_mono t h hmono hwf
   | isinj tag arity t => exact Term.wfIn_mono t h hmono hwf
+  | own t => exact Term.wfIn_mono t h hmono hwf
 
 theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
     (hwf : p.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') : p.eval ρ = p.eval ρ' := by
@@ -187,6 +200,7 @@ theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isinj tag arity t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
+  | own l => simp [Atom.eval, Term.eval_env_agree hwf hagree]
 
 theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     (hp : p.wfIn Δ) (ht : t.wfIn Δ) :
@@ -201,6 +215,9 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
   | isinj tag arity v =>
     simp only [Atom.toItem, CtxItem.wfIn]
     exact ⟨hp, trivial, ht⟩
+  | own l =>
+    simp only [Atom.toItem, CtxItem.wfIn, SpatialAtom.wfIn]
+    exact ⟨hp, ht⟩
 
 theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊣⊢ CtxItem.interp ρ (p.toItem t) := by
@@ -208,6 +225,9 @@ theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  | own l =>
+    simp only [Atom.eval, Atom.toItem, CtxItem.interp, SpatialAtom.interp]
+    exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 
 /-- If `p.toItem t` holds semantically, then `p.eval ρ (t.eval ρ)`. -/
 theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : Env}
@@ -216,10 +236,7 @@ theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : Env}
 
 theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊢ CtxItem.interp ρ (p.toItem t) := by
-  cases p with
-  | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
-  | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
-  | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
+  exact Atom.eval_pure.1
 
 theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
     p.eval ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
@@ -230,6 +247,9 @@ theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
   | isinj tag arity v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
+  | own l =>
+    simp only [Atom.toItem, CtxItem.purePart]
+    exact pure_intro trivial
 
 
 -- ---------------------------------------------------------------------------
@@ -253,6 +273,10 @@ theorem Atom.eval_subst {p : Atom τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signatur
     funext v
     simp only [Atom.subst, Atom.eval]
     rw [Term.eval_subst hp hσ hwfΔ']
+  | own l =>
+    funext v
+    simp only [Atom.subst, Atom.eval]
+    rw [Term.eval_subst hp hσ hwfΔ']
 
 theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn dom Δ') (hdom : Δ.vars ⊆ dom)
@@ -263,6 +287,7 @@ theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Sign
   | isint t  => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
   | isbool t => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
   | isinj tag arity t => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
+  | own t => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
 
 
 -- ---------------------------------------------------------------------------
@@ -275,6 +300,7 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .isint  v => [(.unpred .isInt v, .unop .toInt v)]
   | .isbool v => [(.unpred .isBool v, .unop .toBool v)]
   | .isinj tag arity v => [(.unpred (.isInj tag arity) v, .unop .payloadOf v)]
+  | .own _ => []
 
 theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : Env}
     (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : ⊢ (a.toItem t).interp ρ := by
@@ -297,6 +323,7 @@ theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ :
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
+  | own l => simp [candidates] at hmem
 
 theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Signature}
     (hmem : (φ, t) ∈ a.candidates) (h : a.wfIn Δ) : φ.wfIn Δ ∧ t.wfIn Δ := by
@@ -304,6 +331,7 @@ theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Si
   | isint v  => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
   | isbool v => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
   | isinj tag arity v => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
+  | own l => simp [candidates] at hmem
 
 
 -- ---------------------------------------------------------------------------
@@ -534,30 +562,27 @@ theorem VerifM.eval_findMatchForce {lq : Term .value}
 /-- Look up an atom in the assertion context.
     Tier 1: syntactic search through the context.
     Tier 2: try candidate resolutions via the SMT solver. -/
-def VerifM.resolve (a : Atom τ) : VerifM (Option (Term τ)) := do
-  if a.pure then
-    match ← VerifM.ctxPure (a.resolve ·) with
-    | some t => pure (some t)
-    | none => VerifM.tryCandidates a.candidates
-  else
-    VerifM.fatal "here will be the points-to case"
+def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
+  | _, .own l => do
+      VerifM.findMatch l
+  | _, a => do
+      match ← VerifM.ctxPure (a.resolve ·) with
+      | some t => pure (some t)
+      | none => VerifM.tryCandidates a.candidates
 
-theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
+/-- Helper: resolution of a pure atom via formula matching or SMT candidates. -/
+private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ : Env}
     {Q : Option (Term τ) → TransState → Env → Prop}
     {R Φ : iProp}
-    (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
+    (h : VerifM.eval (do
+      match ← VerifM.ctxPure (pred.resolve ·) with
+      | some t => pure (some t)
+      | none => VerifM.tryCandidates pred.candidates) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
     (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
       Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
     SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
-  unfold VerifM.resolve at h
-  cases hpure : pred.pure with
-  | false =>
-    simp [hpure] at h
-    exact (VerifM.eval_fatal h).elim
-  | true =>
-    simp [hpure] at h
     have hb1 := VerifM.eval_bind _ _ _ _ h
     have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
     cases hres : pred.resolve st.asserts with
@@ -596,3 +621,34 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
           · iapply hpred
           · iexact H
         exact hframe.trans (hsome t st hqsome rfl htwf)
+
+theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
+    {Q : Option (Term τ) → TransState → Env → Prop}
+    {R Φ : iProp}
+    (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
+    (hwf : pred.wfIn st.decls)
+    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
+      Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
+    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+  match pred, hwf, hsome, h with
+  | .own l, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    refine VerifM.eval_findMatch (R := R) (Φ := Φ) h hwf ?_ ?_
+    · intros v st' hqsome hdecls hvwf
+      have hsome' := hsome v st' hqsome hdecls hvwf
+      have heq : SpatialAtom.interp ρ (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ) := by
+        simp only [Atom.eval, SpatialAtom.interp]
+        exact BIBase.Entails.rfl
+      exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
+    · intros hqnone
+      exact hnone st hqnone rfl
+  | .isint t, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    exact VerifM.eval_resolve_pure (pred := .isint t) h hwf hnone hsome
+  | .isbool t, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    exact VerifM.eval_resolve_pure (pred := .isbool t) h hwf hnone hsome
+  | .isinj tag arity t, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    exact VerifM.eval_resolve_pure (pred := .isinj tag arity t) h hwf hnone hsome

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -1,6 +1,9 @@
 import Mica.FOL.Printing
 import Mica.FOL.Subst
+import Mica.SeparationLogic
 import Mica.Verifier.Monad
+
+open Iris Iris.BI
 
 /-!
 # Atoms
@@ -123,11 +126,11 @@ def Atom.toStringHum : {τ : Srt} → Atom τ → String
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → Prop :=
+def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
   match p with
-  | isint t  => λ v => .int v = t.eval ρ
-  | isbool t => λ v => .bool v = t.eval ρ
-  | isinj tag arity t => λ v => .inj tag arity v = t.eval ρ
+  | isint t  => λ v => ⌜.int v = t.eval ρ⌝
+  | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
+  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
 
 
 -- ---------------------------------------------------------------------------
@@ -180,8 +183,8 @@ theorem Atom.toFormula_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     simp only [Atom.toFormula, Formula.wfIn, Term.wfIn]
     exact ⟨hp, trivial, ht⟩
 
-theorem Atom.toFormula_eval_iff {p : Atom τ} {t : Term τ} {ρ : Env} :
-    (p.toFormula t).eval ρ ↔ p.eval ρ (t.eval ρ) := by
+theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
+    p.eval ρ (t.eval ρ) ⊣⊢ ⌜(p.toFormula t).eval ρ⌝ := by
   cases p with
   | isint v  => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.toFormula, Atom.eval, Formula.eval, Term.eval, eq_comm]
@@ -189,20 +192,21 @@ theorem Atom.toFormula_eval_iff {p : Atom τ} {t : Term τ} {ρ : Env} :
 
 /-- If `p.eval ρ u` holds and `p` is wfIn fresh decls, then `p.toFormula (.var τ x)` holds
     after updating `ρ` with `x ↦ u`. -/
-theorem Atom.toFormula_eval_1 {p : Atom τ} {ρ : Env}  :
-     p.eval ρ (t.eval ρ) → (p.toFormula t).eval ρ :=
-  Atom.toFormula_eval_iff.mpr
+theorem Atom.toFormula_eval_1 {p : Atom τ} {t : Term τ} {ρ : Env} :
+     p.eval ρ (t.eval ρ) ⊢ ⌜(p.toFormula t).eval ρ⌝ := by
+  exact Atom.eval_pure.1
 
 /-- If `(p.toFormula t).eval ρ` holds, then `p.eval ρ (t.eval ρ)`. -/
 theorem Atom.toFormula_eval_2 {p : Atom τ} {t : Term τ} {ρ : Env}
-    (h : (p.toFormula t).eval ρ) : p.eval ρ (t.eval ρ) :=
-  Atom.toFormula_eval_iff.mp h
+    : ⌜(p.toFormula t).eval ρ⌝ ⊢ p.eval ρ (t.eval ρ) := by
+  exact Atom.eval_pure.2
 
 
 -- ---------------------------------------------------------------------------
 -- Substitution lemmas
 -- ---------------------------------------------------------------------------
 
+-- @agent: change eval_subst to a bi-entailment in the future.
 theorem Atom.eval_subst {p : Atom τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hwfΔ' : Δ'.wf) :
     (p.subst σ).eval ρ = p.eval (σ.eval ρ) := by

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -48,16 +48,26 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
 namespace CtxItem
 
 /-- Semantic interpretation of a verifier context item. -/
-def interp (ρ : Env) : CtxItem → iProp
-  | .pure φ => ⌜φ.eval ρ⌝
-  | .spatial a => a.interp ρ
+def interp (ρ : VerifM.Env) : CtxItem → iProp
+  | .pure φ => ⌜φ.eval ρ.env⌝
+  | .spatial a => a.interp ρ.env
 
-def purePart (i : CtxItem) (ρ : Env) : Prop :=
+def purePart (i : CtxItem) (ρ : VerifM.Env) : Prop :=
   match i with
-  | .pure φ => φ.eval ρ
+  | .pure φ => φ.eval ρ.env
   | .spatial _ => True
 
 end CtxItem
+
+namespace TransState
+
+def sl (st : TransState) (ρ : VerifM.Env) : iProp :=
+  SpatialContext.interp ρ.env st.owns
+
+@[simp] theorem sl_eq (st : TransState) (ρ : VerifM.Env) :
+    st.sl ρ = SpatialContext.interp ρ.env st.owns := rfl
+
+end TransState
 
 /-- Convert an instantiated atom into the corresponding verifier context item. -/
 def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
@@ -71,12 +81,12 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Atom.eval {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
+def Atom.eval {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
   match p with
-  | isint t  => λ v => ⌜.int v = t.eval ρ⌝
-  | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
-  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
-  | own l => λ v => ∃ loc : Runtime.Location, ⌜l.eval ρ = .loc loc⌝ ∗ loc ↦ v
+  | isint t  => λ v => ⌜.int v = t.eval ρ.env⌝
+  | isbool t => λ v => ⌜.bool v = t.eval ρ.env⌝
+  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ.env⌝
+  | own l => λ v => ∃ loc : Runtime.Location, ⌜l.eval ρ.env = .loc loc⌝ ∗ loc ↦ v
 
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
@@ -137,12 +147,11 @@ def Atom.resolve (a : Atom τ) (C : List Formula) : Option (Term τ) :=
   C.findSome? (·.matchAtom a)
 
 theorem Atom.resolve_correct {a : Atom τ} {C : List Formula} {t : Term τ}
-    (h : a.resolve C = some t) (ρ : Env) (hC : ∀ φ ∈ C, φ.eval ρ) :
+    (h : a.resolve C = some t) (ρ : VerifM.Env) (hC : ∀ φ ∈ C, φ.eval ρ.env) :
     ⊢ (a.toItem t).interp ρ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
   rw [Formula.matchAtom_correct hφ_match]
-  simp [CtxItem.interp, hC _ hφ_mem]
-  exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
+  simpa [CtxItem.interp, hC _ hφ_mem] using (pure_intro (PROP := iProp) trivial)
 
 theorem Atom.resolve_wfIn {a : Atom τ} {C : List Formula} {t : Term τ} {Δ : Signature}
     (h : a.resolve C = some t) (hwf : ∀ φ ∈ C, φ.wfIn Δ) :
@@ -194,8 +203,8 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | isinj tag arity t => exact Term.wfIn_mono t h hmono hwf
   | own t => exact Term.wfIn_mono t h hmono hwf
 
-theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
-    (hwf : p.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') : p.eval ρ = p.eval ρ' := by
+theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : p.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') : p.eval ρ = p.eval ρ' := by
   cases p with
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
@@ -219,8 +228,8 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     simp only [Atom.toItem, CtxItem.wfIn, SpatialAtom.wfIn]
     exact ⟨hp, ht⟩
 
-theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
-    p.eval ρ (t.eval ρ) ⊣⊢ CtxItem.interp ρ (p.toItem t) := by
+theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    p.eval ρ (t.eval ρ.env) ⊣⊢ CtxItem.interp ρ (p.toItem t) := by
   cases p with
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
@@ -230,16 +239,16 @@ theorem Atom.eval_pure {p : Atom τ} {t : Term τ} {ρ : Env} :
     exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 
 /-- If `p.toItem t` holds semantically, then `p.eval ρ (t.eval ρ)`. -/
-theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : Env}
-    : CtxItem.interp ρ (p.toItem t) ⊢ p.eval ρ (t.eval ρ) := by
+theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : VerifM.Env}
+    : CtxItem.interp ρ (p.toItem t) ⊢ p.eval ρ (t.eval ρ.env) := by
   exact Atom.eval_pure.2
 
-theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : Env} :
-    p.eval ρ (t.eval ρ) ⊢ CtxItem.interp ρ (p.toItem t) := by
+theorem Atom.eval_toItem {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    p.eval ρ (t.eval ρ.env) ⊢ CtxItem.interp ρ (p.toItem t) := by
   exact Atom.eval_pure.1
 
-theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
-    p.eval ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
+theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    p.eval ρ (t.eval ρ.env) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
   cases p with
   | isint v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
@@ -257,25 +266,25 @@ theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : Env} :
 -- ---------------------------------------------------------------------------
 
 -- @agent: change eval_subst to a bi-entailment in the future.
-theorem Atom.eval_subst {p : Atom τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signature}
+theorem Atom.eval_subst {p : Atom τ} {σ : Subst} {ρ : VerifM.Env} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hwfΔ' : Δ'.wf) :
-    (p.subst σ).eval ρ = p.eval (σ.eval ρ) := by
+    (p.subst σ).eval ρ = p.eval (ρ.withEnv (σ.eval ρ.env)) := by
   cases p with
   | isint t =>
     funext v
-    simp only [Atom.subst, Atom.eval]
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
   | isbool t =>
     funext v
-    simp only [Atom.subst, Atom.eval]
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
   | isinj tag arity t =>
     funext v
-    simp only [Atom.subst, Atom.eval]
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
   | own l =>
     funext v
-    simp only [Atom.subst, Atom.eval]
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
 
 theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Signature}
@@ -302,26 +311,26 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .isinj tag arity v => [(.unpred (.isInj tag arity) v, .unop .payloadOf v)]
   | .own _ => []
 
-theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : Env}
-    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : ⊢ (a.toItem t).interp ρ := by
+theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : VerifM.Env}
+    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ.env) : ⊢ (a.toItem t).interp ρ := by
   cases a with
   | isint v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ <;> simp_all
+    cases hv : v.eval ρ.env <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isbool v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ <;> simp_all
+    cases hv : v.eval ρ.env <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isinj tag arity v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ <;> simp_all
+    cases hv : v.eval ρ.env <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | own l => simp [candidates] at hmem
 
@@ -347,7 +356,7 @@ def VerifM.tryCandidates : List (Formula × Term τ) → VerifM (Option (Term τ
 
 private theorem VerifM.eval_tryCandidates
     {candidates : List (Formula × Term τ)} {a : Atom τ}
-    {st : TransState} {ρ : Env} {Q : Option (Term τ) → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.tryCandidates candidates) st ρ Q)
     (hcands : ∀ p ∈ candidates, p ∈ a.candidates)
     (hpwf : a.wfIn st.decls) :
@@ -422,8 +431,8 @@ def VerifM.findMatch (lq : Term .value) : VerifM (Option (Term .value)) := do
 /-- Correctness of `findMatchIn`: on a `some (n, v)` result, `remove ctx n`
     extracts a points-to whose location the solver has proved equal to `lq`. -/
 theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
-    {st : TransState} {ρ : Env}
-    {Q : Option (Nat × Term .value) → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Option (Nat × Term .value) → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.findMatchIn lq ctx) st ρ Q)
     (hlq : lq.wfIn st.decls) (hctx : ctx.wfIn st.decls) :
     ∃ result,
@@ -431,7 +440,7 @@ theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
       (∀ n v, result = some (n, v) →
         ∃ l rest,
           SpatialContext.remove ctx n = some (.pointsTo l v, rest) ∧
-          Term.eval ρ lq = Term.eval ρ l) := by
+          Term.eval ρ.env lq = Term.eval ρ.env l) := by
   induction ctx generalizing Q with
   | nil =>
     simp only [VerifM.findMatchIn] at h
@@ -454,7 +463,7 @@ theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
         intros n' v' hnv
         simp at hnv
         obtain ⟨rfl, rfl⟩ := hnv
-        have heq : Term.eval ρ lq = Term.eval ρ l := by
+        have heq : Term.eval ρ.env lq = Term.eval ρ.env l := by
           have := hb_sound rfl
           simpa [Formula.eval] using this
         exact ⟨l, ctx, rfl, heq⟩
@@ -483,16 +492,16 @@ theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
     postcondition state has the matched points-to consumed from `st.owns`, and
     the caller receives separate ownership of `lq ↦ v`. -/
 theorem VerifM.eval_findMatch {lq : Term .value}
-    {st : TransState} {ρ : Env}
-    {Q : Option (Term .value) → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Option (Term .value) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.findMatch lq) st ρ Q)
     (hlq : lq.wfIn st.decls)
     (hsome : ∀ v st', Q (some v) st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp ρ (.pointsTo lq v) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
-    (hnone : Q none st ρ → SpatialContext.interp ρ st.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+        SpatialAtom.interp ρ.env (.pointsTo lq v) ∗ st'.sl ρ ∗ R ⊢ Φ)
+    (hnone : Q none st ρ → st.sl ρ ∗ R ⊢ Φ) :
+    st.sl ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatch at h
   have hb := VerifM.eval_bind _ _ _ _ h
   have ⟨hk, howns, _, _⟩ := VerifM.eval_ctx hb
@@ -519,7 +528,7 @@ theorem VerifM.eval_findMatch {lq : Term .value}
     have ⟨hk3, _, _, _⟩ := VerifM.eval_ctx hb3
     have hk3' := hk3 hrest_wf
     have hQ : Q (some v) { st with owns := rest } ρ := VerifM.eval_ret hk3'
-    have hsplit := SpatialContext.interp_remove ρ st.owns n _ _ hrem
+    have hsplit := SpatialContext.interp_remove ρ.env st.owns n _ _ hrem
     have hcong := SpatialAtom.interp_pointsTo_loc_congr (v := v) heq.symm
     -- goal: st.owns.interp ρ ∗ R ⊢ Φ
     -- st.owns.interp ρ ⊣⊢ (pointsTo l v).interp ρ ∗ rest.interp ρ
@@ -539,15 +548,15 @@ def VerifM.findMatchForce (lq : Term .value) : VerifM (Term .value) := do
 /-- CPS correctness for `findMatchForce`: only a `some`-style continuation is
     required, since the `none` branch is discharged by the fatal error. -/
 theorem VerifM.eval_findMatchForce {lq : Term .value}
-    {st : TransState} {ρ : Env}
-    {Q : Term .value → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Term .value → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.findMatchForce lq) st ρ Q)
     (hlq : lq.wfIn st.decls)
     (hsome : ∀ v st', Q v st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp ρ (.pointsTo lq v) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+        SpatialAtom.interp ρ.env (.pointsTo lq v) ∗ st'.sl ρ ∗ R ⊢ Φ) :
+    st.sl ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatchForce at h
   have hb := VerifM.eval_bind _ _ _ _ h
   refine eval_findMatch (R := R) (Φ := Φ) hb hlq ?_ ?_
@@ -571,18 +580,18 @@ def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
       | none => VerifM.tryCandidates a.candidates
 
 /-- Helper: resolution of a pure atom via formula matching or SMT candidates. -/
-private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ : Env}
-    {Q : Option (Term τ) → TransState → Env → Prop}
+private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
+    {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (do
       match ← VerifM.ctxPure (pred.resolve ·) with
       | some t => pure (some t)
       | none => VerifM.tryCandidates pred.candidates) st ρ Q)
     (hwf : pred.wfIn st.decls)
-    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → st'.sl ρ ∗ R ⊢ Φ)
     (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
-      Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+      Atom.eval pred ρ (v.eval ρ.env) ∗ st'.sl ρ ∗ R ⊢ Φ) :
+    st.sl ρ ∗ R ⊢ Φ := by
     have hb1 := VerifM.eval_bind _ _ _ _ h
     have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
     cases hres : pred.resolve st.asserts with
@@ -590,10 +599,10 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
       simp [hres] at hctx_q
       have hq := VerifM.eval_ret hctx_q
       have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
-      have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
+      have hpred : ⊢ Atom.eval pred ρ (t.eval ρ.env) := by
         exact (Atom.resolve_correct hres ρ hholds).trans Atom.toItem_eval
-      have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
-          Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
+      have hframe : st.sl ρ ∗ R ⊢
+          Atom.eval pred ρ (t.eval ρ.env) ∗ st.sl ρ ∗ R := by
         istart
         iintro H
         isplitr [H]
@@ -611,10 +620,10 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
       | some t =>
         have htwf : t.wfIn st.decls := hresult_wf t hr
         have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
-        have hpred : ⊢ Atom.eval pred ρ (t.eval ρ) := by
+        have hpred : ⊢ Atom.eval pred ρ (t.eval ρ.env) := by
           exact (hresult_eval t hr).trans Atom.toItem_eval
-        have hframe : SpatialContext.interp ρ st.owns ∗ R ⊢
-            Atom.eval pred ρ (t.eval ρ) ∗ SpatialContext.interp ρ st.owns ∗ R := by
+        have hframe : st.sl ρ ∗ R ⊢
+            Atom.eval pred ρ (t.eval ρ.env) ∗ st.sl ρ ∗ R := by
           istart
           iintro H
           isplitr [H]
@@ -622,22 +631,22 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
           · iexact H
         exact hframe.trans (hsome t st hqsome rfl htwf)
 
-theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : Env}
-    {Q : Option (Term τ) → TransState → Env → Prop}
+theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
+    {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
     (hwf : pred.wfIn st.decls)
-    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ)
+    (hnone : ∀ st', Q .none st' ρ → st'.decls = st.decls → st'.sl ρ ∗ R ⊢ Φ)
     (hsome : ∀ v st', Q (.some v) st' ρ → st'.decls = st.decls → v.wfIn st.decls →
-      Atom.eval pred ρ (v.eval ρ) ∗ SpatialContext.interp ρ st'.owns ∗ R ⊢ Φ) :
-    SpatialContext.interp ρ st.owns ∗ R ⊢ Φ := by
+      Atom.eval pred ρ (v.eval ρ.env) ∗ st'.sl ρ ∗ R ⊢ Φ) :
+    st.sl ρ ∗ R ⊢ Φ := by
   match pred, hwf, hsome, h with
   | .own l, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
     refine VerifM.eval_findMatch (R := R) (Φ := Φ) h hwf ?_ ?_
     · intros v st' hqsome hdecls hvwf
       have hsome' := hsome v st' hqsome hdecls hvwf
-      have heq : SpatialAtom.interp ρ (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ) := by
+      have heq : SpatialAtom.interp ρ.env (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ.env) := by
         simp only [Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -59,16 +59,16 @@ theorem vtailN_wfIn {t : Term .vallist} {Δ : Signature} (ht : t.wfIn Δ) (n : N
   | zero => simpa [vtailN]
   | succ n ih => simp only [vtailN, Term.wfIn]; exact ⟨trivial, ih⟩
 
-@[simp] theorem vtailN_eval (t : Term .vallist) (ρ : Env) :
-    ∀ n, (vtailN t n).eval ρ = List.drop n (t.eval ρ)
+@[simp] theorem vtailN_eval (t : Term .vallist) (ρ : VerifM.Env) :
+    ∀ n, (vtailN t n).eval ρ.env = List.drop n (t.eval ρ.env)
   | 0 => by simp [vtailN]
   | n + 1 => by
     simp only [vtailN, Term.eval, UnOp.eval, vtailN_eval t ρ n]
     rw [List.tail_drop]
 
 theorem vhead_vtailN_eval {vs : List Runtime.Val} {w : Runtime.Val} {n : Nat}
-    (h : vs[n]? = some w) (t : Term .vallist) (ρ : Env) (ht : t.eval ρ = vs) :
-    (Term.unop .vhead (vtailN t n)).eval ρ = w := by
+    (h : vs[n]? = some w) (t : Term .vallist) (ρ : VerifM.Env) (ht : t.eval ρ.env = vs) :
+    (Term.unop .vhead (vtailN t n)).eval ρ.env = w := by
   simp [Term.eval, UnOp.eval, ht, h]
 
 def compileUnop (op : TinyML.UnOp) (s : Term .value) : Option (Term .value) :=
@@ -86,21 +86,21 @@ theorem compileUnop_wfIn {op : TinyML.UnOp} {s : Term .value} {Δ : Signature}
     simp only [Term.wfIn, UnOp.wfIn, true_and]
   all_goals first | exact hs | (have : (Term.unop UnOp.toValList s).wfIn _ := ⟨trivial, hs⟩; exact vtailN_wfIn this _)
 
-theorem compileUnop_eval {op : TinyML.UnOp} {s : Term .value} {ρ : Env}
+theorem compileUnop_eval {op : TinyML.UnOp} {s : Term .value} {ρ : VerifM.Env}
     {v w : Runtime.Val} {t : Term .value}
-    (hs : s.eval ρ = v) (heval : TinyML.evalUnOp op v = some w)
+    (hs : s.eval ρ.env = v) (heval : TinyML.evalUnOp op v = some w)
     (hcomp : compileUnop op s = some t) :
-    t.eval ρ = w := by
+    t.eval ρ.env = w := by
   subst hs
   cases op with
   | proj n =>
     simp only [compileUnop, Option.some.injEq] at hcomp; subst hcomp
-    cases h : s.eval ρ <;> simp_all [TinyML.evalUnOp]
+    cases h : s.eval ρ.env <;> simp_all [TinyML.evalUnOp]
     exact vhead_vtailN_eval heval _ ρ (by simp [Term.eval, UnOp.eval, h])
   | neg | not =>
     simp only [compileUnop, Option.some.injEq] at hcomp
     subst hcomp
-    cases h : s.eval ρ <;>
+    cases h : s.eval ρ.env <;>
     simp_all [TinyML.evalUnOp, Term.eval, UnOp.eval]
 
 theorem compileOp_wfIn {op : TinyML.BinOp} {sl sr : Term .value} {Δ : Signature}
@@ -113,18 +113,18 @@ theorem compileOp_wfIn {op : TinyML.BinOp} {sl sr : Term .value} {Δ : Signature
 /-- If `evalBinOp op v1 v2 = some w` and the input terms evaluate to `v1`, `v2`,
     then the compiled SMT term evaluates to `w`.
     Pair/store return `none` from `compileOp` so those cases are vacuous via `hcomp`. -/
-theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : Env}
+theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : VerifM.Env}
     {v1 v2 w : Runtime.Val} {t : Term .value}
-    (hsl : sl.eval ρ = v1) (hsr : sr.eval ρ = v2)
+    (hsl : sl.eval ρ.env = v1) (hsr : sr.eval ρ.env = v2)
     (heval : TinyML.evalBinOp op v1 v2 = some w)
     (hcomp : compileOp op sl sr = some t) :
-    t.eval ρ = w := by
+    t.eval ρ.env = w := by
   subst hsl hsr
   cases op <;>
     simp only [compileOp, Option.some.injEq] at hcomp <;>
     (try simp at hcomp) <;>
     subst hcomp <;>
-    (cases h1 : sl.eval ρ <;> cases h2 : sr.eval ρ) <;>
+    (cases h1 : sl.eval ρ.env <;> cases h2 : sr.eval ρ.env) <;>
     simp_all [TinyML.evalBinOp, Term.eval, UnOp.eval, BinOp.eval, Const.denote,
               Bool.cond_eq_ite, ge_iff_le, Bool.beq_eq_decide_eq]
 
@@ -341,16 +341,16 @@ theorem SpecMap.satisfiedBy_weaken {A R : iProp}
 
 mutual
 
-theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp) :
+theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) :
     VerifM.eval (compile Θ S B Γ e) st ρ Ψ →
-    B.agreeOnLinked ρ γ →
+    B.agreeOnLinked ρ.env γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
-    (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
-      TinyML.ValHasType Θ v e.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
-    st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ := by
+    (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
+      TinyML.ValHasType Θ v e.ty → st'.sl ρ' ∗ R ⊢ Φ v) →
+    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ := by
   intro heval hagree hbwf hts hSwf hpost
   cases e with
   | const c =>
@@ -408,7 +408,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           · intro τ' hc'
             exact Signature.wf_unique_const hwfst h hc'
       simp only [Expr.ty] at hpost
-      have htyping : TinyML.ValHasType Θ (ρ.consts .value x'.name) vty := by
+      have htyping : TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty := by
         rw [← hcheck]
         cases hΓ : Γ x with
         | none => exact .any
@@ -467,7 +467,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
     have hwf_φ : φ.wfIn st₁.decls := by
-      simp only [φ, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]; exact hse_wf
+      simpa [φ, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using hse_wf
     have heval_assert : (VerifM.assert φ).eval st₁ ρ_e _ := VerifM.eval_bind _ _ _ _ hΨ_e
     obtain ⟨hφ, hcont⟩ := VerifM.eval_assert heval_assert hwf_φ
     have hΨ_pure := VerifM.eval_ret hcont
@@ -507,7 +507,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
     have hdecl := VerifM.eval_decl hdecl_eval (.loc loc)
     have hassume_eval := VerifM.eval_bind _ _ _ _ hdecl
-    set ρ_e' : Env := ρ_e.updateConst .value c.name (.loc loc)
+    set ρ_e' : VerifM.Env := ρ_e.updateConst .value c.name (.loc loc)
     set st₂ : TransState := { st₁ with decls := st₁.decls.addConst c }
     have hc_wf : (Term.const (.uninterpreted c.name .value)).wfIn st₂.decls := by
       simp only [Term.wfIn, Const.wfIn]
@@ -524,8 +524,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       ⟨hc_wf, hse_wf_st₂⟩
     have hassume_res := VerifM.eval_assumeSpatial hassume_eval hatom_wf
     have hret := VerifM.eval_ret hassume_res
-    have hval_eval : Term.eval ρ_e' (Term.const (.uninterpreted c.name .value)) = .loc loc := by
-      simp [ρ_e', Term.eval, Const.denote, Env.updateConst]
+    have hval_eval : Term.eval ρ_e'.env (Term.const (.uninterpreted c.name .value)) = .loc loc := by
+      simp [Term.eval, Const.denote, ρ_e', VerifM.Env.updateConst, Env.updateConst]
     have hty : TinyML.ValHasType Θ (Runtime.Val.loc loc) (TinyML.Typ.ref e.ty) := by
       exact TinyML.ValHasType.ref loc e.ty
     exact hpost (.loc loc) ρ_e' _ _ hret hc_wf hval_eval hty
@@ -560,14 +560,14 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         have hret := VerifM.eval_ret hassume_res
         have hv_wf_final : v.wfIn (TransState.addItem st' (.spatial (.pointsTo se v))).decls := by
           simpa [TransState.addItem] using hv_wf_st'
-        have htype : TinyML.ValHasType Θ (v.eval ρ_e) .int := by
-          cases hv : v.eval ρ_e with
+        have htype : TinyML.ValHasType Θ (v.eval ρ_e.env) .int := by
+          cases hv : v.eval ρ_e.env with
           | int n => exact TinyML.ValHasType.int n
           | bool _ | unit | inj _ _ _ | loc _ | fix _ _ _ | tuple _ =>
               simp [Formula.eval, hv] at hv_int
         let st'' := TransState.addItem st' (.spatial (.pointsTo se v))
-        have hgoal : st''.owns.interp ρ_e ∗ R ⊢ Φ (v.eval ρ_e) :=
-          hpost (v.eval ρ_e) ρ_e st'' _ hret hv_wf_final rfl htype
+        have hgoal : st''.sl ρ_e ∗ R ⊢ Φ (v.eval ρ_e.env) :=
+          hpost (v.eval ρ_e.env) ρ_e st'' _ hret hv_wf_final rfl htype
         simp only [Atom.eval]
         istart
         iintro H
@@ -576,14 +576,14 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         icases Hpt' with ⟨%Hloc, Hpt⟩
         have hv_e : v_e = .loc loc := heval_se.symm.trans Hloc
         subst hv_e
-        have hptIntro : loc ↦ v.eval ρ_e ⊢ SpatialAtom.interp ρ_e (.pointsTo se v) := by
+        have hptIntro : loc ↦ v.eval ρ_e.env ⊢ SpatialAtom.interp ρ_e.env (.pointsTo se v) := by
           simpa [Hloc] using
-            (SpatialAtom.interp_pointsTo (ρ := ρ_e) (lt := se) (vt := v) (loc := loc) Hloc).2
-        have hctx : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ∗ R ⊢ Φ (v.eval ρ_e) := by
-          have hcons : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ⊢ st''.owns.interp ρ_e := by
+            (SpatialAtom.interp_pointsTo (ρ := ρ_e.env) (lt := se) (vt := v) (loc := loc) Hloc).2
+        have hctx : (loc ↦ v.eval ρ_e.env) ∗ SpatialContext.interp ρ_e.env st'.owns ∗ R ⊢ Φ (v.eval ρ_e.env) := by
+          have hcons : (loc ↦ v.eval ρ_e.env) ∗ SpatialContext.interp ρ_e.env st'.owns ⊢ st''.sl ρ_e := by
             simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hptIntro)
           exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
-        iapply (wp.deref (l := loc) (v := v.eval ρ_e))
+        iapply (wp.deref (l := loc) (v := v.eval ρ_e.env))
         isplitl [Hpt]
         · iexact Hpt
         · iintro Hpt
@@ -591,7 +591,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           isplitl [Hpt]
           · iexact Hpt
           · isplitl [Hrest]
-            · iexact Hrest
+            · simp [TransState.sl]
             · iexact HR
     | bool | unit | arrow _ _ | ref _ | sum _ | empty | value | tuple _ | tvar _ | named _ _ =>
       simp [hty] at heval
@@ -607,7 +607,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hts hSwf ?_)
     intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv htyv
     obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
-    have hagree_v : B.agreeOnLinked ρ_v γ :=
+    have hagree_v : B.agreeOnLinked ρ_v.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
     have hbwf_v : B.wf st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
     have heval_l : (compile Θ S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
@@ -615,7 +615,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hts hSwf ?_
     intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
     obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
-    have hsv_ρ_l : sv.eval ρ_l = v_v := by
+    have hsv_ρ_l : sv.eval ρ_l.env = v_v := by
       rw [Term.eval_env_agree hsv_wf (Env.agreeOn_symm hagreeOn_l)]
       exact heval_sv
     have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_l
@@ -637,7 +637,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           (TransState.addItem st' (.spatial (.pointsTo sl sv))).decls := by
         simp [Term.wfIn, Const.wfIn]
       let st'' := TransState.addItem st' (.spatial (.pointsTo sl sv))
-      have hgoal : st''.owns.interp ρ_l ∗ R ⊢ Φ .unit :=
+      have hgoal : st''.sl ρ_l ∗ R ⊢ Φ .unit :=
         hpost .unit ρ_l st'' _ hret hunit_wf (by simp [Term.eval]) (.unit)
       simp only [Atom.eval]
       istart
@@ -647,14 +647,14 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       icases Hold' with ⟨%Hloc, Hold⟩
       have hv_l : v_l = .loc loc := heval_sl.symm.trans Hloc
       subst hv_l
-      have hnewIntro : loc ↦ v_v ⊢ SpatialAtom.interp ρ_l (.pointsTo sl sv) := by
+      have hnewIntro : loc ↦ v_v ⊢ SpatialAtom.interp ρ_l.env (.pointsTo sl sv) := by
         simpa [Hloc, hsv_ρ_l] using
-          (SpatialAtom.interp_pointsTo (ρ := ρ_l) (lt := sl) (vt := sv) (loc := loc) Hloc).2
-      have hctx : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l st'.owns ∗ R ⊢ Φ .unit := by
-        have hcons : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l st'.owns ⊢ st''.owns.interp ρ_l := by
+          (SpatialAtom.interp_pointsTo (ρ := ρ_l.env) (lt := sl) (vt := sv) (loc := loc) Hloc).2
+      have hctx : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l.env st'.owns ∗ R ⊢ Φ .unit := by
+        have hcons : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l.env st'.owns ⊢ st''.sl ρ_l := by
           simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hnewIntro)
         exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
-      iapply (wp.store (l := loc) (old := old.eval ρ_l) (v := v_v))
+      iapply (wp.store (l := loc) (old := old.eval ρ_l.env) (v := v_v))
       isplitl [Hold]
       · iexact Hold
       · iintro Hnew
@@ -662,7 +662,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         isplitl [Hnew]
         · iexact Hnew
         · isplitl [Hrest]
-          · iexact Hrest
+          · simp [TransState.sl]
           · iexact HR
   | unop op e uty =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
@@ -677,7 +677,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     obtain ⟨t, hcompUnop, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
     obtain hΨ_e := VerifM.eval_ret hΨ_e
     obtain ⟨w, heval_op, hwt⟩ := evalUnOp_typed htypeOf htype_e
-    have ht_eval : t.eval ρ_e = w :=
+    have ht_eval : t.eval ρ_e.env = w :=
       compileUnop_eval heval_se heval_op hcompUnop
     simp only [Expr.ty] at hpost
     exact SpatialContext.wp_unop
@@ -694,7 +694,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hSwf ?_
     intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr htyr
     obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
-    have hagree_r : B.agreeOnLinked ρ_r γ :=
+    have hagree_r : B.agreeOnLinked ρ_r.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
     have hbwf_r : B.wf st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
     have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
@@ -706,7 +706,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     obtain ⟨hty_eq, hΨ_l'⟩ := VerifM.eval_bind_expectEq hΨ_l
     simp only [Expr.ty] at hpost
     -- transport sr's eval to the final env ρ_l
-    have hsr_ρ_l : sr.eval ρ_l = vr := by
+    have hsr_ρ_l : sr.eval ρ_l.env = vr := by
       rw [Term.eval_env_agree hsr_wf (Env.agreeOn_symm hagreeOn_l)]; exact heval_sr
     /- Split on whether op is division -/
     by_cases hdivmod : op = .div ∨ op = .mod
@@ -803,7 +803,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       obtain ⟨w, heval_op, hwt⟩ := evalBinOp_typed hdiv hmod htypeOf htyl htyr
       have hwf_sr_l : sr.wfIn st₂.decls :=
         Term.wfIn_mono sr hsr_wf hdecls_l hwfst₂
-      have ht_eval : t.eval ρ_l = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
+      have ht_eval : t.eval ρ_l.env = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
       exact SpatialContext.wp_binop
         (hpost w ρ_l st₂ t hΨ_ndiv
           (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval (hty_eq ▸ hwt))
@@ -830,7 +830,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           let ⟨_, _, hΨ'⟩ := hΨ
           hpost v ρ' st' se hΨ' hs hw ht)
       have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ Runtime.Binder.none v_e
-      have hbody' : st₁.owns.interp ρ_e ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp
+      have hbody' : st₁.sl ρ_e ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp
             (Runtime.Expr.subst
               (Runtime.Subst.update' Runtime.Binder.none v_e Runtime.Subst.id)
               (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
@@ -852,27 +852,27 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           owns := st₁.owns }
       set ρ_body := ρ_e.updateConst .value v.name v_e
       set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
-      suffices st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp (body.runtime.subst γ_body) Φ by
+      suffices st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp (body.runtime.subst γ_body) Φ by
         have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ (.named x) v_e
-        have hbody' : st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp
+        have hbody' : st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp
               (Runtime.Expr.subst
                 (Runtime.Subst.update' (.named x) v_e Runtime.Subst.id)
                 (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
               Φ :=
           hsubst.symm ▸ this
-        have hinterp_eq : SpatialContext.interp ρ_e st₁.owns ⊢ SpatialContext.interp ρ_body st₁.owns :=
+        have hinterp_eq : SpatialContext.interp ρ_e.env st₁.owns ⊢ SpatialContext.interp ρ_body.env st₁.owns :=
           (SpatialContext.interp_env_agree (VerifM.eval.wf hΨ_e).ownsWf
             (agreeOn_update_fresh_const hfresh)).1
         rw [Binder.runtime_of_name_some hname]
         have hsat :
-            st₂.owns.interp ρ_body ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
-              st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) := by
+            st₂.sl ρ_body ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+              st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) := by
           exact SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase
         exact (sep_mono_l hinterp_eq).trans <|
           hsat.trans <|
           by simpa [st₂, γ_body, base, Runtime.Subst.update', Runtime.Subst.update, Runtime.Subst.id]
             using hbody'
-      have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e ρ_body :=
+      have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
         agreeOn_update_fresh_const hfresh
       have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
         have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
@@ -894,12 +894,12 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
               (TransState.freshConst.wf _ (VerifM.eval.wf hdecl_eval)).namesDisjoint
               (List.mem_cons_self ..) hc'
         · simp only [Formula.eval, Term.eval, Const.denote]
-          have : v_e = Term.eval ρ_body se := by
+          have : v_e = Term.eval ρ_body.env se := by
             rw [Term.eval_env_agree hse_wf (Env.agreeOn_symm hagreeOn_body_e)]
             exact heval_e.symm
           simpa [ρ_body, Env.updateConst] using this
       have hbwf₂ : Bindings.wf ((x, v) :: B) st₂.decls := Bindings.wf_cons hbwf_e
-      have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ_body ρ := by
+      have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ_body.env ρ.env := by
         constructor
         · intro y hy
           cases hy
@@ -909,9 +909,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             exact ((hagreeOn_e.2.1 p.2 (hbwf p hp)).trans
               (hagreeOn_body_e.2.1 p.2 (hbwf_e p hp))).symm
           · constructor <;> intro z hz <;> cases hz
-      have hρ_body_lookup : ρ_body.consts .value v.name = v_e := by
-        simp [ρ_body, Env.updateConst]
-      have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body γ_body := by
+      have hρ_body_lookup : ρ_body.env.consts .value v.name = v_e := by
+        simp [ρ_body, VerifM.Env.updateConst, Env.updateConst]
+      have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body.env γ_body := by
         have h := Bindings.agreeOnLinked_cons (x := x) (γ := γ) hagree hρ_agree (hvty := (rfl : v.sort = .value))
         rwa [hρ_body_lookup] at h
       have hts_body : Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body :=
@@ -966,7 +966,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           | false => exact absurd rfl hvc_false
           | true  => rfl
       subst hvc_true
-      have heval_ne : sc.eval ρ_c ≠ Runtime.Val.bool false := by rw [heval_c]; simp
+      have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by rw [heval_c]; simp
       have heval_thn : (compile Θ S B Γ thn).eval st_thn ρ_c Ψ :=
         htrue_cont hwf_ne (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
@@ -982,7 +982,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [compile] at heval
       obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
       have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine SpecMap.project (P := st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R)) Θ S γ ?_ hlookup ?_
+      refine SpecMap.project (P := st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R)) Θ S γ ?_ hlookup ?_
       · istart
         iintro ⟨_, □HS, _⟩
         iexact HS
@@ -990,8 +990,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         simp [Expr.runtime, Runtime.Expr.subst, hγf]
         refine SpatialContext.wp_bind_app ?_
         have hctx :
-            spec.isPrecondFor Θ fval ∗ (st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
-              st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
+            spec.isPrecondFor Θ fval ∗ (st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
+              st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
           istart
           iintro ⟨□Hspec, Howns, □HS, HR⟩
           isplitl [Howns]
@@ -1035,40 +1035,41 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
         have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
           TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
-        have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
+        have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args.env) = vs := by
           have hsnd :
               List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
             simpa using
               (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
                 (Nat.le_of_eq hlen_typed.symm))
           calc
-            typedArgs.map (fun p => p.2.eval ρ_args)
-                = sargs.map (fun t => t.eval ρ_args) := by
+            typedArgs.map (fun p => p.2.eval ρ_args.env)
+                = sargs.map (fun t => t.eval ρ_args.env) := by
                     simpa [typedArgs, List.map_map] using
-                      congrArg (List.map (fun t => t.eval ρ_args)) hsnd
+                      congrArg (List.map (fun t => t.eval ρ_args.env)) hsnd
             _ = vs := Terms.Eval.map_eval heval_sargs
         have happly' :
-            st_args.owns.interp ρ_args ∗ R ⊢
+            st_args.sl ρ_args ∗ R ⊢
               PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
-                (Spec.argsEnv Env.empty spec.args vs) := by
+                (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
           rw [heval_sargs_map] at happly
           exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
             Spec.argsEnv_agreeOn (Δ := Signature.empty)
-              (ρ₁ := FiniteSubst.id.subst.eval ρ_args) (ρ₂ := Env.empty)
-              ⟨nofun, nofun, nofun, nofun⟩ spec.args vs
+              (ρ₁ := VerifM.Env.withEnv ρ_args (FiniteSubst.id.subst.eval ρ_args.env))
+              (ρ₂ := VerifM.Env.empty)
+              (by exact ⟨nofun, nofun, nofun, nofun⟩) spec.args vs
               (by have := htyped.length_eq; simp [List.length_map] at this; omega)
         have happly'' :
-            st_args.owns.interp ρ_args ∗
+            st_args.sl ρ_args ∗
                 (S.satisfiedBy Θ γ ∗ R) ⊢
               PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
-                (Spec.argsEnv Env.empty spec.args vs) := by
+                (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
           have hdrop :
-              st_args.owns.interp ρ_args ∗
+              st_args.sl ρ_args ∗
                   (S.satisfiedBy Θ γ ∗ R) ⊢
-                st_args.owns.interp ρ_args ∗ R := by
+                st_args.sl ρ_args ∗ R := by
             simpa [sep_assoc] using
               (SpecMap.satisfiedBy_drop
-                (A := st_args.owns.interp ρ_args)
+                (A := st_args.sl ρ_args)
                 (Θ := Θ) (S := S) (γ := γ)
                 (R := R))
           exact hdrop.trans happly'
@@ -1101,7 +1102,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
     obtain ⟨_, _, hΨ⟩ := hΨ
     obtain hΨ := VerifM.eval_ret hΨ
-    have heval_tuple : (Term.unop .ofValList (Terms.toValList terms)).eval ρ' = Runtime.Val.tuple vs := by
+    have heval_tuple : (Term.unop .ofValList (Terms.toValList terms)).eval ρ'.env = Runtime.Val.tuple vs := by
       simp [Term.eval, UnOp.eval, Terms.toValList_eval heval_terms]
     have hwf_tuple : (Term.unop UnOp.ofValList (Terms.toValList terms)).wfIn st'.decls := by
       simp only [Term.wfIn]
@@ -1167,7 +1168,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
                 SpecMap.satisfiedBy_drop.trans <| hpost v ρ' st' se hΨ hse_wf hse_eval
                   ((htys (branches[j]) (List.getElem_mem _)) ▸ htyped))
               tag htag_branches (by simpa [Nat.zero_add, hty_eq] using heval_tag)
-            have hsc_eval : se_scrut.eval ρ_scrut = Runtime.Val.inj tag ts.length v_payload :=
+            have hsc_eval : se_scrut.eval ρ_scrut.env = Runtime.Val.inj tag ts.length v_payload :=
               heval_se
             have hpayload_ty : TinyML.ValHasType Θ v_payload (ts[tag]?.getD .value) := by
               simpa [hty_eq] using htype_payload
@@ -1182,20 +1183,20 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
 
 theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder × Expr) (S : SpecMap) (B : Bindings)
     (Γ : TinyML.TyCtx) (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
-    (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → Env → Prop)
+    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp) :
     VerifM.eval (compileBranch Θ S B Γ sc n i ty_i branch) st ρ Ψ →
-    B.agreeOnLinked ρ γ →
+    B.agreeOnLinked ρ.env γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
-    ∀ payload, sc.eval ρ = Runtime.Val.inj i n payload →
+      se.eval ρ'.env = v → TinyML.ValHasType Θ v branch.2.ty → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+    ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
       TinyML.ValHasType Θ payload ty_i →
-      st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
+      st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
   intro heval hagree hbwf hts hSwf hsc_wf hpost payload hsc_eval htype_payload
   obtain ⟨binder, body⟩ := branch
   simp only [compileBranch] at heval
@@ -1227,9 +1228,9 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
         exact Signature.wf_unique_const
           (TransState.freshConst.wf _ (VerifM.eval.wf heval_decl)).namesDisjoint
           (List.mem_cons_self ..) hc'
-    have hsc_eval_ρ₁ : sc.eval ρ₁ = sc.eval ρ :=
+    have hsc_eval_ρ₁ : sc.eval ρ₁.env = sc.eval ρ.env :=
       Term.eval_env_agree hsc_wf (Env.agreeOn_symm (agreeOn_update_fresh_const hxv_fresh))
-    have hformula_eval : Formula.eval ρ₁
+    have hformula_eval : Formula.eval ρ₁.env
         (Formula.eq .value sc (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value)))) := by
       simp [Formula.eval, Term.eval, UnOp.eval]
       rw [hsc_eval_ρ₁, hsc_eval]
@@ -1246,22 +1247,22 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
         exact Signature.wf_unique_const
           (TransState.freshConst.wf _ (VerifM.eval.wf heval_decl)).namesDisjoint
           (List.mem_cons_self ..) hc'
-    have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁ = payload := by
+    have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁.env = payload := by
       simp [Term.eval, Const.denote, ρ₁, Env.updateConst]
     have hassume_bind₂ := VerifM.eval_bind _ _ _ _ heval_assumeAll
     obtain ⟨st₂, hst₂_decls, hst₂_owns, heval_body'⟩ := VerifM.eval_assumeAll hassume_bind₂
       (fun φ hφ => typeConstraints_wfIn hxv_wf φ hφ)
       (fun φ hφ => typeConstraints_hold hxv_eval htype_payload φ hφ)
     have hst₂_owns_eq : st₂.owns = st.owns := hst₂_owns
-    have hinterp_eq : SpatialContext.interp ρ st.owns ⊢ SpatialContext.interp ρ₁ st.owns :=
+    have hinterp_eq : SpatialContext.interp ρ.env st.owns ⊢ SpatialContext.interp ρ₁.env st.owns :=
       (SpatialContext.interp_env_agree (VerifM.eval.wf heval_decl).ownsWf
         (agreeOn_update_fresh_const hxv_fresh)).1
-    have hagreeOn_st : Env.agreeOn st.decls ρ ρ₁ :=
+    have hagreeOn_st : Env.agreeOn st.decls ρ.env ρ₁.env :=
       agreeOn_update_fresh_const hxv_fresh
     cases hname : binder.name with
     | none =>
       simp [hname] at heval_body'
-      have hagree₁ : B.agreeOnLinked ρ₁ γ :=
+      have hagree₁ : B.agreeOnLinked ρ₁.env γ :=
         Bindings.agreeOnLinked_env_agree hagree hagreeOn_st hbwf
       have hbwf₁ : B.wf st₂.decls := hst₂_decls ▸ fun p hp => List.Mem.tail _ (hbwf p hp)
       have hts₁ : B.typedSubst Θ (Γ.extendBinder binder ty_i) γ := by
@@ -1271,7 +1272,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       rw [Binder.runtime_of_name_none hname]
       simp only [Runtime.Expr.subst_fix]
       apply BIBase.Entails.trans _ wp.app_lambda_single
-      change SpatialContext.interp ρ st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+      change SpatialContext.interp ρ.env st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
         wp
           ((body.runtime.subst ((γ.remove' .none).removeAll' [.none])).subst
             ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.none] [payload]))
@@ -1286,7 +1287,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
               by simpa [hty] using hpost v ρ' st' se hΨ hs hw ht))
     | some x =>
       simp [hname, TinyML.TyCtx.extendBinder] at heval_body'
-      have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁ ρ := by
+      have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁.env ρ.env := by
         constructor
         · intro w hw
           cases hw
@@ -1296,9 +1297,9 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
             exact (hagreeOn_st.2.1 p.2 (hbwf p hp)).symm
           · constructor <;> intro z hz <;> cases hz
       have hbwf₂ : Bindings.wf ((x, xv) :: B) st₂.decls := hst₂_decls ▸ Bindings.wf_cons hbwf
-      have hρ₁_lookup : ρ₁.consts .value xv.name = payload := by
-        simp [ρ₁, Env.updateConst]
-      have hagree₁ : Bindings.agreeOnLinked ((x, xv) :: B) ρ₁ (Runtime.Subst.update γ x payload) := by
+      have hρ₁_lookup : ρ₁.env.consts .value xv.name = payload := by
+        simp [ρ₁, VerifM.Env.updateConst, Env.updateConst]
+      have hagree₁ : Bindings.agreeOnLinked ((x, xv) :: B) ρ₁.env (Runtime.Subst.update γ x payload) := by
         have h := Bindings.agreeOnLinked_cons (x := x) (v := xv) (γ := γ) hagree hagreeOn_B (hvty := rfl)
         rwa [hρ₁_lookup] at h
       have hts₁ : Bindings.typedSubst Θ ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) := by
@@ -1309,7 +1310,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       rw [Binder.runtime_of_name_some hname]
       simp only [Runtime.Expr.subst_fix]
       apply BIBase.Entails.trans _ wp.app_lambda_single
-      change SpatialContext.interp ρ st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+      change SpatialContext.interp ρ.env st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
         wp
           ((body.runtime.subst ((γ.remove' .none).removeAll' [.named x])).subst
             ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.named x] [payload]))
@@ -1330,21 +1331,21 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
 theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : List (Binder × Expr)) (S : SpecMap) (B : Bindings)
     (Γ : TinyML.TyCtx) (sc : Term .value) (n : Nat) (ts : List TinyML.Typ)
     (idx : Nat)
-    (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → Env → Prop)
+    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp) :
-    B.agreeOnLinked ρ γ →
+    B.agreeOnLinked ρ.env γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
       VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
-      ∀ payload, sc.eval ρ = Runtime.Val.inj (idx + j) n payload →
+      ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
         TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
-        st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
+        st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
   intro hagree hbwf hts hSwf hsc_wf hpost
   match branches with
   | [] =>
@@ -1369,16 +1370,16 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : Li
           simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
         k hk
 
-theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : List (Term .value) → TransState → Env → Prop) (Φ : List Runtime.Val → iProp) :
+theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : List (Term .value) → TransState → VerifM.Env → Prop) (Φ : List Runtime.Val → iProp) :
     VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
-    B.agreeOnLinked ρ γ → B.wf st.decls → B.typedSubst Θ Γ γ →
+    B.agreeOnLinked ρ.env γ → B.wf st.decls → B.typedSubst Θ Γ γ →
     S.wfIn Signature.empty →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
-      Terms.Eval ρ' terms vs →
-      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
-    st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
+      Terms.Eval ρ'.env terms vs →
+      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
+    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
   intro heval hagree hbwf hts hSwf hpost
   match es with
   | [] =>
@@ -1395,7 +1396,7 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
         (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hSwf ?_
     intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
     obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
-    have hagree_vs : B.agreeOnLinked ρ_vs γ :=
+    have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
     have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
     have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
@@ -1411,7 +1412,7 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
       rcases ht with rfl | ht
       · exact hse_wf
       · exact Term.wfIn_mono _ (hwf_rest t ht) hdecls_e hwfst'
-    have heval_cons : Terms.Eval ρ' (se :: rest_terms) (v :: vs) :=
+    have heval_cons : Terms.Eval ρ'.env (se :: rest_terms) (v :: vs) :=
       Terms.Eval.cons heval_se
         (Terms.Eval.env_agree
           (fun t ht => hwf_rest t ht)

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -262,7 +262,7 @@ end
 
 
 
-/-! ### Helper lemma for match compilation -/
+/-! ### Helper lemmas -/
 
 theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (ts : List TinyML.Typ)
@@ -286,6 +286,31 @@ theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) 
         have : idx + 1 + k = idx + (k + 1) := by omega
         rw [ih_get k hk, this]
 
+
+/-- Drop `satisfiedBy` from the resource. -/
+theorem SpecMap.satisfiedBy_drop {A R : iProp} {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ R :=
+  sep_mono_r sep_elim_r
+
+/-- Duplicate `satisfiedBy` (persistent) in the resource. -/
+theorem SpecMap.satisfiedBy_dup {A R : iProp} {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ (SpecMap.satisfiedBy Θ S γ ∗ (SpecMap.satisfiedBy Θ S γ ∗ R)) :=
+  by
+    iintro ⟨HA, □HS, HR⟩
+    isplitl [HA]
+    · iexact HA
+    · isplitl []
+      · iexact HS
+      · isplitl []
+        · iexact HS
+        · iexact HR
+
+/-- Weaken `satisfiedBy` in the resource via an entailment. -/
+theorem SpecMap.satisfiedBy_weaken {A R : iProp}
+    (h : SpecMap.satisfiedBy Θ S γ ⊢ SpecMap.satisfiedBy Θ' S' γ') :
+    A ∗ (SpecMap.satisfiedBy Θ S γ ∗ R) ⊢ A ∗ (SpecMap.satisfiedBy Θ' S' γ' ∗ R) :=
+  sep_mono_r (sep_mono_l h)
+
 /-! ### Correctness -/
 
 mutual
@@ -296,12 +321,11 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
-    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
       TinyML.ValHasType Θ v e.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
-    st.owns.interp ρ ∗ R ⊢ wp (e.runtime.subst γ) Φ := by
-  intro heval hagree hbwf hts hspec hSwf hpost
+    st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ := by
+  intro heval hagree hbwf hts hSwf hpost
   cases e with
   | const c =>
     cases c with
@@ -310,7 +334,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| hpost (.int n) ρ st _ heval
+      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost (.int n) ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
         (by simp [Term.eval, UnOp.eval, Const.denote])
         (.int n)
@@ -319,7 +343,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| hpost (.bool b) ρ st _ heval
+      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost (.bool b) ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
         (by simp [Term.eval, UnOp.eval, Const.denote])
         (.bool b)
@@ -328,7 +352,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| hpost .unit ρ st _ heval
+      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost .unit ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn])
         (by simp [Term.eval])
         .unit
@@ -366,7 +390,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           obtain ⟨w, hw, hwt⟩ := hts x x' t hbind hΓ
           rw [hγ] at hw
           exact (Option.some.inj hw) ▸ hwt
-      exact SpatialContext.wp_val <|
+      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <|
         hpost _ ρ st _ heval hwfv (by simp [Term.eval, Const.denote]) htyping
     · exact False.elim (hcheck (VerifM.eval_bind_expectEq heval).1)
   | inj tag arity payload =>
@@ -378,7 +402,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
       have heval_p : (compile Θ S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
       refine SpatialContext.wp_bind_inj <| compile_correct Θ R payload S B Γ st ρ γ _ _
-        (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hspec hSwf ?_
+        (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hSwf ?_
       intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p htype_p
       obtain ⟨hdecls_p, hagreeOn_p, hΨ_p⟩ := hΨ_p
       obtain hΨ_p := VerifM.eval_ret hΨ_p
@@ -397,7 +421,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     simp [Expr.runtime]
-    refine compile_correct Θ R e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+    refine compile_correct Θ R e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v ρ' st' se hΨ hse_wf heval_se htype_v
     obtain ⟨_, _, hΨ⟩ := hΨ
     cases hsub : TinyML.Typ.sub Θ e.ty ty
@@ -412,7 +436,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_assert <| compile_correct Θ R e S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
@@ -439,7 +463,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_unop <| compile_correct Θ R e S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se htype_e
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
@@ -459,8 +483,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     -- compile processes r first (matching runtime r-first evaluation order)
     have heval_r : (compile Θ S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_binop <| compile_correct Θ R r S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_binop <| (SpecMap.satisfiedBy_dup).trans <|
+      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) r S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hSwf ?_
     intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr htyr
     obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
     have hagree_r : B.agreeOnLinked ρ_r γ :=
@@ -468,7 +493,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     have hbwf_r : B.wf st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
     have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
     refine compile_correct Θ R l S B Γ st₁ ρ_r γ _ _
-      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hts hspec hSwf ?_
+      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hts hSwf ?_
     intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
     obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
     obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
@@ -585,8 +610,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     unfold Expr.runtime
     simp only [Runtime.Expr.letIn_subst]
     have heval_e_outer : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine (compile_correct Θ R e S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hspec hSwf ?_).trans wp.letIn
+    refine (SpecMap.satisfiedBy_dup.trans <| compile_correct Θ (S.satisfiedBy Θ γ ∗ R) e S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hSwf ?_).trans wp.letIn
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
     have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
@@ -596,12 +621,12 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     | none =>
       simp [hname] at hΨ_e
       have hbody := compile_correct Θ R body S B Γ st₁ ρ_e γ _ _
-        (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hspec hSwf
+        (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hSwf
         (fun v ρ' st' se hΨ hs hw ht =>
           let ⟨_, _, hΨ'⟩ := hΨ
           hpost v ρ' st' se hΨ' hs hw ht)
       have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ Runtime.Binder.none v_e
-      have hbody' : st₁.owns.interp ρ_e ∗ R ⊢ wp
+      have hbody' : st₁.owns.interp ρ_e ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp
             (Runtime.Expr.subst
               (Runtime.Subst.update' Runtime.Binder.none v_e Runtime.Subst.id)
               (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
@@ -623,9 +648,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           owns := st₁.owns }
       set ρ_body := ρ_e.updateConst .value v.name v_e
       set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
-      suffices st₂.owns.interp ρ_body ∗ R ⊢ wp (body.runtime.subst γ_body) Φ by
+      suffices st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp (body.runtime.subst γ_body) Φ by
         have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ (.named x) v_e
-        have hbody' : st₂.owns.interp ρ_body ∗ R ⊢ wp
+        have hbody' : st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp
               (Runtime.Expr.subst
                 (Runtime.Subst.update' (.named x) v_e Runtime.Subst.id)
                 (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
@@ -635,7 +660,14 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           (SpatialContext.interp_env_agree (VerifM.eval.wf hΨ_e).ownsWf
             (agreeOn_update_fresh_const hfresh)).1
         rw [Binder.runtime_of_name_some hname]
-        exact (sep_mono_l hinterp_eq).trans (by simpa [γ_body, base, Runtime.Subst.update', Runtime.Subst.update] using hbody')
+        have hsat :
+            st₂.owns.interp ρ_body ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+              st₂.owns.interp ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) := by
+          exact SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase
+        exact (sep_mono_l hinterp_eq).trans <|
+          hsat.trans <|
+          by simpa [st₂, γ_body, base, Runtime.Subst.update', Runtime.Subst.update, Runtime.Subst.id]
+            using hbody'
       have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e ρ_body :=
         agreeOn_update_fresh_const hfresh
       have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
@@ -682,7 +714,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         Bindings.typedSubst_cons hts htyping_e
       refine compile_correct Θ R body (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
         (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ hts_body
-        (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) ?_
+        (SpecMap.wfIn_erase hSwf) ?_
       intro v' ρ' st' se' hΨ hs hw ht
       obtain ⟨_, _, hΨ'⟩ := hΨ
       exact hpost v' ρ' st' se' hΨ' hs hw ht
@@ -692,8 +724,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [Runtime.Expr.subst]
     simp only [compile] at heval
     have heval_cond : (compile Θ S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_if <| compile_correct Θ R cond S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_if <| SpecMap.satisfiedBy_dup.trans <|
+      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) cond S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hSwf ?_
     intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c htypc
     obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
     have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
@@ -720,7 +753,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         hfalse_cont hwf_eq (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_c)
-      exact SpatialContext.wp_if_false <| compile_correct Θ R els S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hspec hSwf
+      exact SpatialContext.wp_if_false <| compile_correct Θ R els S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hels_ty ▸ ht))
     · have hvc_true : v_c = .bool true := by
         rw [hcond_bool] at htypc
@@ -734,7 +767,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         htrue_cont hwf_ne (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_ne)
-      exact SpatialContext.wp_if_true <| compile_correct Θ R thn S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hspec hSwf
+      exact SpatialContext.wp_if_true <| compile_correct Θ R thn S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hthn_ty ▸ ht))
   | app fn args aty =>
     simp only [Expr.ty] at hpost
@@ -744,63 +777,112 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     | var f fty =>
       simp only [compile] at heval
       obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
-      obtain ⟨fval, hγf, hisPrecond⟩ := hspec f spec hlookup
-      simp [Expr.runtime, Runtime.Expr.subst, hγf]
-      refine SpatialContext.wp_bind_app ?_
       have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine compileExprs_correct Θ R args S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hspec hSwf ?_
-      intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
-      obtain ⟨_, _, hΨ_args⟩ := hΨ_args
-      let typedArgs := (args.map Expr.ty).zip sargs
-      have hlen_sargs : sargs.length = vs.length := by
-        simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
-      have hlen_typed : (args.map Expr.ty).length = sargs.length := by
-        calc
-          (args.map Expr.ty).length = vs.length := by simpa using htyping_args.length_eq.symm
-          _ = sargs.length := hlen_sargs.symm
-      obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-      obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-      have hwf_pred : spec.pred.wfIn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars spec.args)) := by
-        simpa [Spec.wfIn, FiniteSubst.id, Signature.empty, Signature.ofVars] using hSwf f spec hlookup
-      have hid_wf : FiniteSubst.id.wf st_args.decls := FiniteSubst.id_wf st_args.decls
-      have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
-        intro p hp
-        have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
-        exact hsargs_wf _ hp''
-      have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
-          (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
-      have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
-        (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
-        hwf_pred
-        (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
-        hid_wf htypedArgs_wf hcall_eval
-        (fun v st' ρ' t hΨ hwf heval hty =>
-          hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval (hret_eq ▸ hty))
-      obtain ⟨hsub_ty, happly⟩ := hcall
-      have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
-        simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
-      have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
-        TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
-      refine SpatialContext.wp_val ?_
-      apply BIBase.Entails.trans _ (hisPrecond vs htyped Φ)
-      have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
-        have hsnd :
-            List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
-          simpa using
-            (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
-              (Nat.le_of_eq hlen_typed.symm))
-        calc
-          typedArgs.map (fun p => p.2.eval ρ_args)
-              = sargs.map (fun t => t.eval ρ_args) := by
-                  simpa [typedArgs, List.map_map] using
-                    congrArg (List.map (fun t => t.eval ρ_args)) hsnd
-          _ = vs := Terms.Eval.map_eval heval_sargs
-      rw [heval_sargs_map] at happly
-      exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
-        Spec.argsEnv_agreeOn (Δ := Signature.empty)
-          (ρ₁ := FiniteSubst.id.subst.eval ρ_args) (ρ₂ := Env.empty)
-          ⟨nofun, nofun, nofun, nofun⟩ spec.args vs
-          (by have := htyped.length_eq; simp [List.length_map] at this; omega)
+      refine SpecMap.project (P := st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R)) Θ S γ ?_ hlookup ?_
+      · istart
+        iintro ⟨_, □HS, _⟩
+        iexact HS
+      · intro fval hγf
+        simp [Expr.runtime, Runtime.Expr.subst, hγf]
+        refine SpatialContext.wp_bind_app ?_
+        have hctx :
+            spec.isPrecondFor Θ fval ∗ (st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
+              st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
+          istart
+          iintro ⟨□Hspec, Howns, □HS, HR⟩
+          isplitl [Howns]
+          · iexact Howns
+          · isplitl []
+            · iexact HS
+            · isplitl []
+              · iexact Hspec
+              · iexact HR
+        refine hctx.trans <| compileExprs_correct Θ (spec.isPrecondFor Θ fval ∗ R) args S B Γ st ρ γ _ _
+          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hSwf ?_
+        intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
+        obtain ⟨_, _, hΨ_args⟩ := hΨ_args
+        let typedArgs := (args.map Expr.ty).zip sargs
+        have hlen_sargs : sargs.length = vs.length := by
+          simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
+        have hlen_typed : (args.map Expr.ty).length = sargs.length := by
+          calc
+            (args.map Expr.ty).length = vs.length := by simpa using htyping_args.length_eq.symm
+            _ = sargs.length := hlen_sargs.symm
+        obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
+        obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
+        have hwf_pred : spec.pred.wfIn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars spec.args)) := by
+          simpa [Spec.wfIn, FiniteSubst.id, Signature.empty, Signature.ofVars] using hSwf f spec hlookup
+        have hid_wf : FiniteSubst.id.wf st_args.decls := FiniteSubst.id_wf st_args.decls
+        have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
+          intro p hp
+          have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
+          exact hsargs_wf _ hp''
+        have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
+            (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
+        have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
+          (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
+          hwf_pred
+          (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
+          hid_wf htypedArgs_wf hcall_eval
+          (fun v st' ρ' t hΨ hwf heval hty =>
+            hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval (hret_eq ▸ hty))
+        obtain ⟨hsub_ty, happly⟩ := hcall
+        have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
+          simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
+        have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
+          TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
+        have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
+          have hsnd :
+              List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
+            simpa using
+              (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
+                (Nat.le_of_eq hlen_typed.symm))
+          calc
+            typedArgs.map (fun p => p.2.eval ρ_args)
+                = sargs.map (fun t => t.eval ρ_args) := by
+                    simpa [typedArgs, List.map_map] using
+                      congrArg (List.map (fun t => t.eval ρ_args)) hsnd
+            _ = vs := Terms.Eval.map_eval heval_sargs
+        have happly' :
+            st_args.owns.interp ρ_args ∗ R ⊢
+              PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
+                (Spec.argsEnv Env.empty spec.args vs) := by
+          rw [heval_sargs_map] at happly
+          exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
+            Spec.argsEnv_agreeOn (Δ := Signature.empty)
+              (ρ₁ := FiniteSubst.id.subst.eval ρ_args) (ρ₂ := Env.empty)
+              ⟨nofun, nofun, nofun, nofun⟩ spec.args vs
+              (by have := htyped.length_eq; simp [List.length_map] at this; omega)
+        have happly'' :
+            st_args.owns.interp ρ_args ∗
+                (S.satisfiedBy Θ γ ∗ R) ⊢
+              PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
+                (Spec.argsEnv Env.empty spec.args vs) := by
+          have hdrop :
+              st_args.owns.interp ρ_args ∗
+                  (S.satisfiedBy Θ γ ∗ R) ⊢
+                st_args.owns.interp ρ_args ∗ R := by
+            simpa [sep_assoc] using
+              (SpecMap.satisfiedBy_drop
+                (A := st_args.owns.interp ρ_args)
+                (Θ := Θ) (S := S) (γ := γ)
+                (R := R))
+          exact hdrop.trans happly'
+        refine SpatialContext.wp_val ?_
+        unfold Spec.isPrecondFor
+        istart
+        iintro ⟨Howns, □HS, □Hspec, HR⟩
+        ispecialize Hspec $$ %Φ
+        ispecialize Hspec $$ %vs
+        iapply Hspec
+        · ipure_intro
+          exact htyped
+        · iapply happly''
+          isplitl [Howns]
+          · iexact Howns
+          · isplitl []
+            · iexact HS
+            · iexact HR
     | _ =>
       simp only [compile] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -811,7 +893,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_es : (compileExprs Θ S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_tuple <| compileExprs_correct Θ R es S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hspec hSwf ?_
+      (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hSwf ?_
     intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
     obtain ⟨_, _, hΨ⟩ := hΨ
     obtain hΨ := VerifM.eval_ret hΨ
@@ -820,7 +902,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     have hwf_tuple : (Term.unop UnOp.ofValList (Terms.toValList terms)).wfIn st'.decls := by
       simp only [Term.wfIn]
       exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
-    exact SpatialContext.wp_tuple <|
+    exact SpecMap.satisfiedBy_drop.trans <| SpatialContext.wp_tuple <|
       hpost (Runtime.Val.tuple vs) ρ' st' (.unop .ofValList (Terms.toValList terms))
         hΨ hwf_tuple heval_tuple (.tuple htyping)
   | match_ scrut branches ty =>
@@ -829,8 +911,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
     simp only [compile] at heval
     have heval_scrut : (compile Θ S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_match <| compile_correct Θ R scrut S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_match <| SpecMap.satisfiedBy_dup.trans <|
+      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) scrut S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hSwf ?_
     intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se htype_scrut
     obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
     cases hscrut_ty : scrut.ty with
@@ -875,9 +958,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             have hbwf_scrut : B.wf st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
             have hbranch_wp := compileBranches_correct Θ R branches S B Γ se_scrut ts.length ts 0
               st_scrut ρ_scrut γ Ψ Φ
-              hagree_scrut hbwf_scrut hts hspec hSwf hse_wf
+              hagree_scrut hbwf_scrut hts hSwf hse_wf
               (fun j hj v ρ' st' se hΨ hse_wf hse_eval htyped =>
-                hpost v ρ' st' se hΨ hse_wf hse_eval
+                SpecMap.satisfiedBy_drop.trans <| hpost v ρ' st' se hΨ hse_wf hse_eval
                   ((htys (branches[j]) (List.getElem_mem _)) ▸ htyped))
               tag htag_branches (by simpa [Nat.zero_add, hty_eq] using heval_tag)
             have hsc_eval : se_scrut.eval ρ_scrut = Runtime.Val.inj tag ts.length v_payload :=
@@ -902,15 +985,14 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
-    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
+      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
     ∀ payload, sc.eval ρ = Runtime.Val.inj i n payload →
       TinyML.ValHasType Θ payload ty_i →
-      st.owns.interp ρ ∗ R ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
-  intro heval hagree hbwf hts hspec hSwf hsc_wf hpost payload hsc_eval htype_payload
+      st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
+  intro heval hagree hbwf hts hSwf hsc_wf hpost payload hsc_eval htype_payload
   obtain ⟨binder, body⟩ := branch
   simp only [compileBranch] at heval
   by_cases hty : binder.ty = ty_i
@@ -985,17 +1067,19 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       rw [Binder.runtime_of_name_none hname]
       simp only [Runtime.Expr.subst_fix]
       apply BIBase.Entails.trans _ wp.app_lambda_single
-      change SpatialContext.interp ρ st.owns ∗ R ⊢
+      change SpatialContext.interp ρ st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
         wp
           ((body.runtime.subst ((γ.remove' .none).removeAll' [.none])).subst
             ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.none] [payload]))
           Φ
       rw [Runtime.Expr.subst_fix_comp body.runtime .none [.none] γ Runtime.Val.unit [payload] rfl]
       simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left]
-      exact (sep_mono_l hinterp_eq).trans (hst₂_owns_eq ▸
+      exact (sep_mono_l hinterp_eq).trans <| SpecMap.satisfiedBy_dup.trans <| (hst₂_owns_eq ▸
         by simpa [Runtime.Subst.update] using
-          compile_correct Θ R body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
-            heval_body'' hagree₁ hbwf₁ hts₁ hspec hSwf (by simpa [hty] using hpost))
+          compile_correct Θ (S.satisfiedBy Θ γ ∗ R) body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
+            heval_body'' hagree₁ hbwf₁ hts₁ hSwf
+            (fun v ρ' st' se hΨ hs hw ht =>
+              by simpa [hty] using hpost v ρ' st' se hΨ hs hw ht))
     | some x =>
       simp [hname, TinyML.TyCtx.extendBinder] at heval_body'
       have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁ ρ := by
@@ -1021,18 +1105,21 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       rw [Binder.runtime_of_name_some hname]
       simp only [Runtime.Expr.subst_fix]
       apply BIBase.Entails.trans _ wp.app_lambda_single
-      change SpatialContext.interp ρ st.owns ∗ R ⊢
+      change SpatialContext.interp ρ st.owns ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
         wp
           ((body.runtime.subst ((γ.remove' .none).removeAll' [.named x])).subst
             ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.named x] [payload]))
           Φ
       rw [Runtime.Expr.subst_fix_comp body.runtime .none [.named x] γ Runtime.Val.unit [payload] rfl]
       simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left]
-      exact (sep_mono_l hinterp_eq).trans (hst₂_owns_eq ▸
-        by simpa [Runtime.Subst.update] using
-          compile_correct Θ R body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
+      exact (sep_mono_l hinterp_eq).trans <| SpecMap.satisfiedBy_dup.trans <|
+        (SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase).trans <| by
+          simpa [hst₂_owns_eq, Runtime.Subst.update] using
+          compile_correct Θ (S.satisfiedBy Θ γ ∗ R) body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
             (Runtime.Subst.update γ x payload) Ψ Φ heval_body'' hagree₁ hbwf₂ hts₁
-            (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) (by simpa [hty] using hpost))
+            (SpecMap.wfIn_erase hSwf)
+            (fun v ρ' st' se hΨ hs hw ht =>
+              by simpa [hty] using hpost v ρ' st' se hΨ hs hw ht)
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
     exact False.elim (hty (VerifM.eval_expectEq hexpect).1)
 
@@ -1045,17 +1132,16 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : Li
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
-    S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
+      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
       VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ = Runtime.Val.inj (idx + j) n payload →
         TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
-        st.owns.interp ρ ∗ R ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
-  intro hagree hbwf hts hspec hSwf hsc_wf hpost
+        st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
+  intro hagree hbwf hts hSwf hsc_wf hpost
   match branches with
   | [] =>
     intro j hj
@@ -1067,13 +1153,13 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : Li
       simp only [Nat.add_zero, List.getElem_cons_zero]
       intro heval
       exact compileBranch_correct Θ R b S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
-        heval hagree hbwf hts hspec hSwf hsc_wf (by simpa using hpost 0 hj)
+        heval hagree hbwf hts hSwf hsc_wf (by simpa using hpost 0 hj)
     | succ k =>
       have hk : k < bs.length := by simp at hj; omega
       have hidx : idx + (k + 1) = (idx + 1) + k := by omega
       simp only [hidx, List.getElem_cons_succ]
       exact compileBranches_correct Θ R bs S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
-        hagree hbwf hts hspec hSwf hsc_wf
+        hagree hbwf hts hSwf hsc_wf
         (by
           intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
           simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
@@ -1083,13 +1169,13 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
     (Ψ : List (Term .value) → TransState → Env → Prop) (Φ : List Runtime.Val → iProp) :
     VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
     B.agreeOnLinked ρ γ → B.wf st.decls → B.typedSubst Θ Γ γ →
-    S.satisfiedBy Θ γ → S.wfIn Signature.empty →
+    S.wfIn Signature.empty →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ' terms vs →
-      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.owns.interp ρ' ∗ R ⊢ Φ vs) →
-    st.owns.interp ρ ∗ R ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
-  intro heval hagree hbwf hts hspec hSwf hpost
+      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.owns.interp ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
+    st.owns.interp ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
+  intro heval hagree hbwf hts hSwf hpost
   match es with
   | [] =>
     simp only [compileExprs] at heval
@@ -1100,14 +1186,17 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
     simp only [compileExprs] at heval
     simp only [List.map, wps_cons]
     have heval_rest : (compileExprs Θ S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compileExprs_correct Θ R rest S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hspec hSwf ?_
+    refine SpecMap.satisfiedBy_dup.trans <|
+      compileExprs_correct Θ (S.satisfiedBy Θ γ ∗ R) rest S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hSwf ?_
     intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
     obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
     have hagree_vs : B.agreeOnLinked ρ_vs γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
     have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
     have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
-    refine compile_correct Θ R e S B Γ st_vs ρ_vs γ _ _ (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hspec hSwf ?_
+    refine compile_correct Θ (S.satisfiedBy Θ γ ∗ R) e S B Γ st_vs ρ_vs γ _ _
+      (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hSwf ?_
     intro v ρ' st' se hΨ_e hse_wf heval_se htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
     have hwfst' : st'.decls.wf := (VerifM.eval.wf hΨ_e).namesDisjoint

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -1,16 +1,17 @@
 import Mica.TinyML.Typed
 import Mica.TinyML.Typing
 import Mica.TinyML.OpSem
-import Mica.TinyML.WeakestPre
+import Mica.SeparationLogic.PrimitiveLaws
+import Mica.Verifier.Utils
 import Mica.Verifier.Monad
 import Mica.Verifier.Assertions
 import Mica.Verifier.PredicateTransformers
 import Mica.Verifier.Specifications
-import Mica.Verifier.Utils
 import Mica.Engine.Driver
 import Mica.Base.Fresh
 import Mathlib.Data.Finmap
 
+open Iris Iris.BI
 open Typed
 
 /-! ## Expression Compilation
@@ -154,8 +155,8 @@ mutual
         VerifM.assert (Formula.eq .bool (Term.unop .toBool sl) (Term.const (.b true)))
         pure (Term.const .unit)
     | .binop op l r bty => do
-        let sl ← compile Θ S B Γ l
         let sr ← compile Θ S B Γ r
+        let sl ← compile Θ S B Γ l
         let ty ← VerifM.expectSome
           s!"type error: operator {repr op} cannot be applied to {repr l.ty} and {repr r.ty}"
           (TinyML.BinOp.typeOf op l.ty r.ty)
@@ -181,6 +182,7 @@ mutual
           compile Θ (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
     | .ifThenElse cond thn els ty => do
         let sc ← compile Θ S B Γ cond
+        VerifM.expectEq "if condition type mismatch" cond.ty .bool
         VerifM.expectEq "if branch type annotation mismatch" thn.ty ty
         VerifM.expectEq "if branch type annotation mismatch" els.ty ty
         let branch ← VerifM.all [true, false]
@@ -260,22 +262,7 @@ end
 
 
 
-/-! ### Helper lemmas for match compilation -/
-
-/-- Applying a single-argument lambda `(fun b -> body)` to a value reduces to substituting. -/
-theorem wp_app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Runtime.Val}
-    {Φ : Runtime.Val → Prop} :
-    wp (body.subst (Runtime.Subst.id.update' b v)) Φ →
-    wp (.app (.fix .none [b] body) [.val v]) Φ := by
-  intro h
-  apply wp.app
-  simp only [wps_cons, wps_nil]
-  apply wp.val; apply wp.func
-  exact (wp.fix Φ body (fun vs => vs = [v]) (by
-    intro _ vs hvs; subst hvs
-    simp only [Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left,
-               Runtime.Subst.update']
-    exact h)) [v] rfl
+/-! ### Helper lemma for match compilation -/
 
 theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (ts : List TinyML.Typ)
@@ -303,8 +290,8 @@ theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) 
 
 mutual
 
-theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → Prop) :
+theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp) :
     VerifM.eval (compile Θ S B Γ e) st ρ Ψ →
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
@@ -312,36 +299,36 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     S.satisfiedBy Θ γ →
     S.wfIn Signature.empty →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
-      TinyML.ValHasType Θ v e.ty → Φ v) →
-    wp (e.runtime.subst γ) Φ := by
+      TinyML.ValHasType Θ v e.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
+    st.owns.interp ρ ∗ R ⊢ wp (e.runtime.subst γ) Φ := by
   intro heval hagree hbwf hts hspec hSwf hpost
   cases e with
   | const c =>
     cases c with
     | int n =>
       simp only [compile] at heval
-      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]; apply wp.val
+      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact hpost (.int n) ρ st _ heval
+      exact SpatialContext.wp_val <| hpost (.int n) ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
         (by simp [Term.eval, UnOp.eval, Const.denote])
         (.int n)
     | bool b =>
       simp only [compile] at heval
-      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]; apply wp.val
+      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact hpost (.bool b) ρ st _ heval
+      exact SpatialContext.wp_val <| hpost (.bool b) ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
         (by simp [Term.eval, UnOp.eval, Const.denote])
         (.bool b)
     | unit =>
       simp only [compile] at heval
-      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]; apply wp.val
+      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
       obtain heval := VerifM.eval_ret heval
       simp only [Expr.ty, Const.ty] at hpost
-      exact hpost .unit ρ st _ heval
+      exact SpatialContext.wp_val <| hpost .unit ρ st _ heval
         (by simp [Term.wfIn, Const.wfIn])
         (by simp [Term.eval])
         .unit
@@ -353,7 +340,6 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
       unfold Expr.runtime; simp only [Runtime.Expr.subst]
       obtain ⟨hsort, hγ⟩ := hagree x x' hbind
       rw [hγ]; simp
-      apply wp.val
       have hmem : (x, x') ∈ B := by
         obtain ⟨l₁, l₂, heq, _⟩ := List.lookup_eq_some_iff.mp hbind
         rw [heq]; simp
@@ -380,37 +366,38 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
           obtain ⟨w, hw, hwt⟩ := hts x x' t hbind hΓ
           rw [hγ] at hw
           exact (Option.some.inj hw) ▸ hwt
-      exact hpost _ ρ st _ heval hwfv (by simp [Term.eval, Const.denote]) htyping
+      exact SpatialContext.wp_val <|
+        hpost _ ρ st _ heval hwfv (by simp [Term.eval, Const.denote]) htyping
     · exact False.elim (hcheck (VerifM.eval_bind_expectEq heval).1)
   | inj tag arity payload =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    apply wp.inj
     simp only [compile] at heval
     by_cases htag : tag ≥ arity
     · simp [htag] at heval; exact (VerifM.eval_fatal heval).elim
     · push_neg at htag
       simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
       have heval_p : (compile Θ S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine compile_correct Θ payload S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hspec hSwf ?_
+      refine SpatialContext.wp_bind_inj <| compile_correct Θ R payload S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hspec hSwf ?_
       intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p htype_p
       obtain ⟨hdecls_p, hagreeOn_p, hΨ_p⟩ := hΨ_p
       obtain hΨ_p := VerifM.eval_ret hΨ_p
       simp only [Expr.ty] at hpost
-      exact hpost (.inj tag arity v_p) ρ_p st_p _ hΨ_p
-        (by simp only [Term.wfIn]; exact ⟨trivial, hse_wf_p⟩)
-        (by simp [Term.eval, UnOp.eval, heval_se_p])
-        (by
-          let ts := (List.replicate arity TinyML.Typ.empty).set tag payload.ty
-          have hlen_ts : ts.length = arity := by simp [ts]
-          have : TinyML.ValHasType Θ (.inj tag ts.length v_p) (.sum ts) :=
-            .inj (ts := ts) (by simp [ts, htag]) htype_p
-          rwa [hlen_ts] at this)
+      refine SpatialContext.wp_inj <| hpost (.inj tag arity v_p) ρ_p st_p _ hΨ_p
+          (by simp only [Term.wfIn]; exact ⟨trivial, hse_wf_p⟩)
+          (by simp [Term.eval, UnOp.eval, heval_se_p])
+          (by
+            let ts := (List.replicate arity TinyML.Typ.empty).set tag payload.ty
+            have hlen_ts : ts.length = arity := by simp [ts]
+            have : TinyML.ValHasType Θ (.inj tag ts.length v_p) (.sum ts) :=
+              .inj (ts := ts) (by simp [ts, htag]) htype_p
+            rwa [hlen_ts] at this)
   | cast e ty =>
     simp only [Expr.ty] at hpost
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     simp [Expr.runtime]
-    refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+    refine compile_correct Θ R e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
     intro v ρ' st' se hΨ hse_wf heval_se htype_v
     obtain ⟨_, _, hΨ⟩ := hΨ
     cases hsub : TinyML.Typ.sub Θ e.ty ty
@@ -422,21 +409,25 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
       exact hpost v ρ' st' se hΨ hse_wf heval_se (TinyML.ValHasType_sub htype_v hsub')
   | assert e =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    apply wp.assert
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_assert <| compile_correct Θ R e S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
     have hwf_φ : φ.wfIn st₁.decls := by
       simp only [φ, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]; exact hse_wf
     have heval_assert : (VerifM.assert φ).eval st₁ ρ_e _ := VerifM.eval_bind _ _ _ _ hΨ_e
-    obtain ⟨_, hcont⟩ := VerifM.eval_assert heval_assert hwf_φ
+    obtain ⟨hφ, hcont⟩ := VerifM.eval_assert heval_assert hwf_φ
     have hΨ_pure := VerifM.eval_ret hcont
-    intro _
+    have hvtrue : v_e = .bool true := by
+      simp only [φ, Formula.eval, Term.eval, UnOp.eval, Const.denote] at hφ
+      rw [heval_se] at hφ
+      cases v_e <;> simp_all
     simp only [Expr.ty] at hpost
-    exact hpost .unit ρ_e st₁ (Term.const .unit) hΨ_pure
+    subst hvtrue
+    exact SpatialContext.wp_assert <| hpost .unit ρ_e st₁ (Term.const .unit) hΨ_pure
       trivial
       (by simp [Term.eval])
       .unit
@@ -445,10 +436,10 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     exact (VerifM.eval_fatal heval).elim
   | unop op e uty =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    apply wp.unop
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_unop <| compile_correct Θ R e S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hspec hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se htype_e
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
     obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
@@ -459,26 +450,33 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     have ht_eval : t.eval ρ_e = w :=
       compileUnop_eval heval_se heval_op hcompUnop
     simp only [Expr.ty] at hpost
-    exact ⟨w, heval_op, hpost w ρ_e st₁ t hΨ_e
-      (compileUnop_wfIn hse_wf hcompUnop) ht_eval (hty_eq ▸ hwt)⟩
+    exact SpatialContext.wp_unop
+      (hpost w ρ_e st₁ t hΨ_e
+        (compileUnop_wfIn hse_wf hcompUnop) ht_eval (hty_eq ▸ hwt))
+      heval_op
   | binop op l r bty =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    apply wp.binop
     simp only [compile] at heval
-    have heval_l : (compile Θ S B Γ l).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct Θ l S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_l) hagree hbwf hts hspec hSwf ?_
-    intro vl ρ_l st₁ sl hΨ_l hsl_wf heval_l htyl
-    obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
-    have hagree_l : B.agreeOnLinked ρ_l γ :=
-      Bindings.agreeOnLinked_env_agree hagree hagreeOn_l hbwf
-    have hbwf_l : B.wf st₁.decls := fun p hp => hdecls_l.consts _ (hbwf p hp)
-    have heval_r : (compile Θ S B Γ r).eval st₁ ρ_l _ := VerifM.eval_bind _ _ _ _ hΨ_l
-    refine compile_correct Θ r S B Γ st₁ ρ_l γ _ _ (VerifM.eval.decls_grow ρ_l heval_r) hagree_l hbwf_l hts hspec hSwf ?_
-    intro vr ρ_r st₂ sr hΨ_r hsr_wf heval_r htyr
+    -- compile processes r first (matching runtime r-first evaluation order)
+    have heval_r : (compile Θ S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_binop <| compile_correct Θ R r S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hspec hSwf ?_
+    intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr htyr
     obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
-    obtain ⟨ty, htypeOf, hΨ_r⟩ := VerifM.eval_bind_expectSome hΨ_r
-    obtain ⟨hty_eq, hΨ_r'⟩ := VerifM.eval_bind_expectEq hΨ_r
+    have hagree_r : B.agreeOnLinked ρ_r γ :=
+      Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
+    have hbwf_r : B.wf st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
+    have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
+    refine compile_correct Θ R l S B Γ st₁ ρ_r γ _ _
+      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hts hspec hSwf ?_
+    intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
+    obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
+    obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
+    obtain ⟨hty_eq, hΨ_l'⟩ := VerifM.eval_bind_expectEq hΨ_l
     simp only [Expr.ty] at hpost
+    -- transport sr's eval to the final env ρ_l
+    have hsr_ρ_l : sr.eval ρ_l = vr := by
+      rw [Term.eval_env_agree hsr_wf (Env.agreeOn_symm hagreeOn_l)]; exact heval_sr
     /- Split on whether op is division -/
     by_cases hdivmod : op = .div ∨ op = .mod
     · -- Division or modulo: both have the non-zero divisor assertion
@@ -487,8 +485,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
               let i t := Term.unop UnOp.toInt t
               let fol_op := if op == TinyML.BinOp.div then BinOp.div else BinOp.mod
               VerifM.assert (.not (.eq .int (i sr) (.const (.i 0))))
-              pure (Term.unop .ofInt (Term.binop fol_op (i sl) (i sr)))).eval st₂ ρ_r Ψ := by
-        simpa [hdivmod] using hΨ_r'
+              pure (Term.unop .ofInt (Term.binop fol_op (i sl) (i sr)))).eval st₂ ρ_l Ψ := by
+        simpa [hdivmod] using hΨ_l'
       rcases hdivmod with hdiv | hmod
       · subst hdiv
         have hlty : l.ty = .int := by
@@ -501,30 +499,30 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
           cases htyr with
           | int b =>
             have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
-              simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]; exact hsr_wf
+              simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]
+              exact Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
             have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
             have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
             simp [Formula.eval, Term.eval, Const.denote] at hne_zero
-            have hsr_eval : sr.eval ρ_r = Runtime.Val.int b := heval_r
-            rw [hsr_eval] at hne_zero
+            rw [hsr_ρ_l] at hne_zero
             simp at hne_zero
             obtain hΨ_post := VerifM.eval_ret hΨ_post
-            have hsl_ρ_r : sl.eval ρ_r = Runtime.Val.int a := by
-              rw [Term.eval_env_agree hsl_wf (Env.agreeOn_symm hagreeOn_r)]; exact heval_l
             have hty_int : ty = .int := by
               rw [hlty, hrty] at htypeOf
               simpa [TinyML.BinOp.typeOf] using htypeOf.symm
-            have hbty : bty = .int := by
-              exact hty_eq.symm.trans hty_int
+            have hbty : bty = .int := hty_eq.symm.trans hty_int
+            have hwf_sr_l : sr.wfIn st₂.decls :=
+              Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
             have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
               simp only [Term.wfIn, BinOp.wfIn, UnOp.wfIn, true_and]
-              exact ⟨Term.wfIn_mono sl hsl_wf hdecls_r (VerifM.eval.wf hΨ_div).namesDisjoint, hsr_wf⟩
-            have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_r := by
+              exact ⟨hsl_wf, hwf_sr_l⟩
+            have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
               simpa using hΨ_post
-            exact ⟨.int (a / b), by simp [TinyML.evalBinOp, hne_zero],
-              hpost (.int (a / b)) ρ_r st₂ _ hΨ_post' hwf_bin
-                (by simp [Term.eval, UnOp.eval, BinOp.eval, hsl_ρ_r, hsr_eval])
-                (hbty ▸ .int _)⟩
+            exact SpatialContext.wp_binop
+              (hpost (.int (a / b)) ρ_l st₂ _ hΨ_post' hwf_bin
+                (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l])
+                (hbty ▸ .int _))
+              (by simp [TinyML.evalBinOp, hne_zero])
       · subst hmod
         have hlty : l.ty = .int := by
           revert htypeOf; cases l.ty <;> simp [TinyML.BinOp.typeOf]
@@ -536,57 +534,59 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
           cases htyr with
           | int b =>
             have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
-              simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]; exact hsr_wf
+              simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]
+              exact Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
             have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
             have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
             simp [Formula.eval, Term.eval, Const.denote] at hne_zero
-            have hsr_eval : sr.eval ρ_r = Runtime.Val.int b := heval_r
-            rw [hsr_eval] at hne_zero
+            rw [hsr_ρ_l] at hne_zero
             simp at hne_zero
             obtain hΨ_post := VerifM.eval_ret hΨ_post
-            have hsl_ρ_r : sl.eval ρ_r = Runtime.Val.int a := by
-              rw [Term.eval_env_agree hsl_wf (Env.agreeOn_symm hagreeOn_r)]; exact heval_l
             have hty_int : ty = .int := by
               rw [hlty, hrty] at htypeOf
               simpa [TinyML.BinOp.typeOf] using htypeOf.symm
-            have hbty : bty = .int := by
-              exact hty_eq.symm.trans hty_int
+            have hbty : bty = .int := hty_eq.symm.trans hty_int
+            have hwf_sr_l : sr.wfIn st₂.decls :=
+              Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
             have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
               simp only [Term.wfIn, BinOp.wfIn, UnOp.wfIn, true_and]
-              exact ⟨Term.wfIn_mono sl hsl_wf hdecls_r (VerifM.eval.wf hΨ_div).namesDisjoint, hsr_wf⟩
-            have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_r := by
+              exact ⟨hsl_wf, hwf_sr_l⟩
+            have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
               simpa using hΨ_post
-            exact ⟨.int (a % b), by simp [TinyML.evalBinOp, hne_zero],
-              hpost (.int (a % b)) ρ_r st₂ _ hΨ_post' hwf_bin
-                (by simp [Term.eval, UnOp.eval, BinOp.eval, hsl_ρ_r, hsr_eval])
-                (hbty ▸ .int _)⟩
+            exact SpatialContext.wp_binop
+              (hpost (.int (a % b)) ρ_l st₂ _ hΨ_post' hwf_bin
+                (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l])
+                (hbty ▸ .int _))
+              (by simp [TinyML.evalBinOp, hne_zero])
     · have hndivmod : ¬(op = TinyML.BinOp.div ∨ op = TinyML.BinOp.mod) := hdivmod
       have hΨ_ndiv :
             (do
               let t ← VerifM.expectSome
                 s!"unsupported binary operator: {repr op}"
                 (compileOp op sl sr)
-              pure t).eval st₂ ρ_r Ψ := by
-        simpa [hndivmod] using hΨ_r'
+              pure t).eval st₂ ρ_l Ψ := by
+        simpa [hndivmod] using hΨ_l'
       obtain ⟨t, hcompOp, hΨ_ndiv⟩ := VerifM.eval_bind_expectSome hΨ_ndiv
       have hwfst₂ : st₂.decls.wf := (VerifM.eval.wf hΨ_ndiv).namesDisjoint
       obtain hΨ_ndiv := VerifM.eval_ret hΨ_ndiv
       have hdiv : op ≠ .div := fun h => hndivmod (Or.inl h)
       have hmod : op ≠ .mod := fun h => hndivmod (Or.inr h)
       obtain ⟨w, heval_op, hwt⟩ := evalBinOp_typed hdiv hmod htypeOf htyl htyr
-      have hsl_ρ_r : sl.eval ρ_r = vl := by
-        rw [Term.eval_env_agree hsl_wf (Env.agreeOn_symm hagreeOn_r)]; exact heval_l
-      have ht_eval : t.eval ρ_r = w := compileOp_eval hsl_ρ_r heval_r heval_op hcompOp
-      exact ⟨w, heval_op, hpost w ρ_r st₂ t hΨ_ndiv
-        (compileOp_wfIn (sl.wfIn_mono hsl_wf hdecls_r hwfst₂) hsr_wf hcompOp) ht_eval (hty_eq ▸ hwt)⟩
+      have hwf_sr_l : sr.wfIn st₂.decls :=
+        Term.wfIn_mono sr hsr_wf hdecls_l hwfst₂
+      have ht_eval : t.eval ρ_l = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
+      exact SpatialContext.wp_binop
+        (hpost w ρ_l st₂ t hΨ_ndiv
+          (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval (hty_eq ▸ hwt))
+        heval_op
   | letIn b e body =>
     simp only [compile] at heval
     simp only [Expr.ty] at hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.letIn_subst]
-    apply wp.letIn
     have heval_e_outer : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct Θ e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hspec hSwf ?_
+    refine (compile_correct Θ R e S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hspec hSwf ?_).trans wp.letIn
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
     have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
@@ -595,14 +595,13 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     cases hname : b.name with
     | none =>
       simp [hname] at hΨ_e
-      have hbody := compile_correct Θ body S B Γ st₁ ρ_e γ _ _
+      have hbody := compile_correct Θ R body S B Γ st₁ ρ_e γ _ _
         (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hspec hSwf
         (fun v ρ' st' se hΨ hs hw ht =>
           let ⟨_, _, hΨ'⟩ := hΨ
           hpost v ρ' st' se hΨ' hs hw ht)
       have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ Runtime.Binder.none v_e
-      have hbody' :
-          wp
+      have hbody' : st₁.owns.interp ρ_e ∗ R ⊢ wp
             (Runtime.Expr.subst
               (Runtime.Subst.update' Runtime.Binder.none v_e Runtime.Subst.id)
               (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
@@ -624,17 +623,19 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
           owns := st₁.owns }
       set ρ_body := ρ_e.updateConst .value v.name v_e
       set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
-      suffices wp (body.runtime.subst γ_body) Φ by
+      suffices st₂.owns.interp ρ_body ∗ R ⊢ wp (body.runtime.subst γ_body) Φ by
         have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ (.named x) v_e
-        have hbody' :
-            wp
+        have hbody' : st₂.owns.interp ρ_body ∗ R ⊢ wp
               (Runtime.Expr.subst
                 (Runtime.Subst.update' (.named x) v_e Runtime.Subst.id)
                 (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
               Φ :=
           hsubst.symm ▸ this
+        have hinterp_eq : SpatialContext.interp ρ_e st₁.owns ⊢ SpatialContext.interp ρ_body st₁.owns :=
+          (SpatialContext.interp_env_agree (VerifM.eval.wf hΨ_e).ownsWf
+            (agreeOn_update_fresh_const hfresh)).1
         rw [Binder.runtime_of_name_some hname]
-        simpa [γ_body, base, Runtime.Subst.update', Runtime.Subst.update] using hbody'
+        exact (sep_mono_l hinterp_eq).trans (by simpa [γ_body, base, Runtime.Subst.update', Runtime.Subst.update] using hbody')
       have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e ρ_body :=
         agreeOn_update_fresh_const hfresh
       have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
@@ -679,7 +680,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
         rwa [hρ_body_lookup] at h
       have hts_body : Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body :=
         Bindings.typedSubst_cons hts htyping_e
-      refine compile_correct Θ body (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
+      refine compile_correct Θ R body (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
         (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ hts_body
         (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) ?_
       intro v' ρ' st' se' hΨ hs hw ht
@@ -689,14 +690,15 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     simp only [Expr.ty] at hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
-    apply wp.ifThenElse
     simp only [compile] at heval
     have heval_cond : (compile Θ S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct Θ cond S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hspec hSwf ?_
-    intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c _
+    refine SpatialContext.wp_bind_if <| compile_correct Θ R cond S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hspec hSwf ?_
+    intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c htypc
     obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
     have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
     have hbwf_c : B.wf st₁.decls := fun p hp => hdecls_c.consts _ (hbwf p hp)
+    obtain ⟨hcond_bool, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
     obtain ⟨hthn_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
     obtain ⟨hels_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
     have heval_branches : (VerifM.all [true, false]).eval st₁ ρ_c _ := VerifM.eval_bind _ _ _ _ hΨ_c
@@ -704,28 +706,36 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     have htrue := hall true (by simp)
     have hfalse := hall false (by simp)
     have hwf_ne : (Formula.not (Formula.eq .value sc (.unop .ofBool (.const (.b false))))).wfIn st₁.decls := by
-      simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true]; exact hsc_wf
+      simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
     have hwf_eq : (Formula.eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))).wfIn st₁.decls := by
-      simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true]; exact hsc_wf
+      simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
     have htrue_cont := VerifM.eval_assume (VerifM.eval_bind _ _ _ _ htrue)
     have hfalse_cont := VerifM.eval_assume (VerifM.eval_bind _ _ _ _ hfalse)
-    constructor
-    · intro hvc_ne
-      have heval_ne : sc.eval ρ_c ≠ Runtime.Val.bool false := heval_c ▸ hvc_ne
-      have heval_thn : (compile Θ S B Γ thn).eval _ ρ_c Ψ :=
+    let φ_eq : Formula := .eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))
+    let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
+    let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
+    by_cases hvc_false : v_c = .bool false
+    · subst hvc_false
+      have heval_els : (compile Θ S B Γ els).eval st_els ρ_c Ψ :=
+        hfalse_cont hwf_eq (by
+          simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
+          exact heval_c)
+      exact SpatialContext.wp_if_false <| compile_correct Θ R els S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hspec hSwf
+        (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hels_ty ▸ ht))
+    · have hvc_true : v_c = .bool true := by
+        rw [hcond_bool] at htypc
+        cases htypc with
+        | bool b => cases b with
+          | false => exact absurd rfl hvc_false
+          | true  => rfl
+      subst hvc_true
+      have heval_ne : sc.eval ρ_c ≠ Runtime.Val.bool false := by rw [heval_c]; simp
+      have heval_thn : (compile Θ S B Γ thn).eval st_thn ρ_c Ψ :=
         htrue_cont hwf_ne (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_ne)
-      exact compile_correct Θ thn S B Γ _ ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hspec hSwf
+      exact SpatialContext.wp_if_true <| compile_correct Θ R thn S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hspec hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hthn_ty ▸ ht))
-    · intro hvc_eq
-      have heval_eq : sc.eval ρ_c = Runtime.Val.bool false := heval_c ▸ hvc_eq
-      have heval_els : (compile Θ S B Γ els).eval _ ρ_c Ψ :=
-        hfalse_cont hwf_eq (by
-          simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
-          exact heval_eq)
-      exact compile_correct Θ els S B Γ _ ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hspec hSwf
-        (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hels_ty ▸ ht))
   | app fn args aty =>
     simp only [Expr.ty] at hpost
     unfold Expr.runtime
@@ -736,9 +746,9 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
       obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
       obtain ⟨fval, hγf, hisPrecond⟩ := hspec f spec hlookup
       simp [Expr.runtime, Runtime.Expr.subst, hγf]
-      apply wp.app
+      refine SpatialContext.wp_bind_app ?_
       have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine compileExprs_correct Θ args S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hspec hSwf ?_
+      refine compileExprs_correct Θ R args S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hspec hSwf ?_
       intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
       obtain ⟨_, _, hΨ_args⟩ := hΨ_args
       let typedArgs := (args.map Expr.ty).zip sargs
@@ -750,7 +760,6 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
           _ = sargs.length := hlen_sargs.symm
       obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
       obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-      apply wp.val
       have hwf_pred : spec.pred.wfIn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars spec.args)) := by
         simpa [Spec.wfIn, FiniteSubst.id, Signature.empty, Signature.ofVars] using hSwf f spec hlookup
       have hid_wf : FiniteSubst.id.wf st_args.decls := FiniteSubst.id_wf st_args.decls
@@ -761,7 +770,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
       have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
           (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
       have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
-        (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ
+        (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
         hwf_pred
         (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
         hid_wf htypedArgs_wf hcall_eval
@@ -772,7 +781,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
         simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
       have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
         TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
-      apply hisPrecond vs htyped
+      refine SpatialContext.wp_val ?_
+      apply BIBase.Entails.trans _ (hisPrecond vs htyped Φ)
       have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
         have hsnd :
             List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
@@ -786,11 +796,11 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
                     congrArg (List.map (fun t => t.eval ρ_args)) hsnd
           _ = vs := Terms.Eval.map_eval heval_sargs
       rw [heval_sargs_map] at happly
-      apply PredTrans.apply_env_agree hwf_pred _ happly
-      exact Spec.argsEnv_agreeOn (Δ := Signature.empty)
-        (ρ₁ := FiniteSubst.id.subst.eval ρ_args) (ρ₂ := Env.empty)
-        ⟨nofun, nofun, nofun, nofun⟩ spec.args vs
-        (by have := htyped.length_eq; simp [List.length_map] at this; omega)
+      exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
+        Spec.argsEnv_agreeOn (Δ := Signature.empty)
+          (ρ₁ := FiniteSubst.id.subst.eval ρ_args) (ρ₂ := Env.empty)
+          ⟨nofun, nofun, nofun, nofun⟩ spec.args vs
+          (by have := htyped.length_eq; simp [List.length_map] at this; omega)
     | _ =>
       simp only [compile] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -798,10 +808,10 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     simp only [Expr.ty] at hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst, List.map_map]
-    apply wp.tuple
     simp only [compile] at heval
     have heval_es : (compileExprs Θ S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compileExprs_correct Θ es S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_tuple <| compileExprs_correct Θ R es S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hspec hSwf ?_
     intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
     obtain ⟨_, _, hΨ⟩ := hΨ
     obtain hΨ := VerifM.eval_ret hΨ
@@ -810,19 +820,23 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
     have hwf_tuple : (Term.unop UnOp.ofValList (Terms.toValList terms)).wfIn st'.decls := by
       simp only [Term.wfIn]
       exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
-    exact hpost (Runtime.Val.tuple vs) ρ' st' (.unop .ofValList (Terms.toValList terms))
-      hΨ hwf_tuple heval_tuple (.tuple htyping)
+    exact SpatialContext.wp_tuple <|
+      hpost (Runtime.Val.tuple vs) ρ' st' (.unop .ofValList (Terms.toValList terms))
+        hΨ hwf_tuple heval_tuple (.tuple htyping)
   | match_ scrut branches ty =>
     simp only [Expr.ty] at hpost
     unfold Expr.runtime
     simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
-    apply wp.match_
     simp only [compile] at heval
     have heval_scrut : (compile Θ S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compile_correct Θ scrut S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hspec hSwf ?_
+    refine SpatialContext.wp_bind_match <| compile_correct Θ R scrut S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hspec hSwf ?_
     intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se htype_scrut
     obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
     cases hscrut_ty : scrut.ty with
+    | unit | bool | int | arrow _ _ | ref _ | empty | value | tuple _ | tvar _ | named _ _ =>
+      simp only [hscrut_ty] at hΨ_scrut
+      exact (VerifM.eval_fatal hΨ_scrut).elim
     | sum ts =>
       simp [hscrut_ty] at hΨ_scrut htype_scrut
       by_cases hlen : ts.length ≠ branches.length
@@ -847,43 +861,43 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (e : Expr) (S : SpecMap) (B : Bind
             have htag_bound : tag < ts.length := by
               exact (List.getElem?_eq_some_iff.mp ht_tag).1
             have htag_branches : tag < branches.length := hlen ▸ htag_bound
-            refine ⟨tag, ts.length, v_payload, ?_, ?_, ?_, ?_⟩
-            · exact (Runtime.Expr.fix .none [(branches[tag]).1.runtime] (branches[tag]).2.runtime).subst γ
-            · simp
-            · simp [htag_branches]
-            · have htag_range : tag ∈ List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length := by
-                rw [hactions_len]
-                exact List.mem_range.mpr htag_branches
-              have heval_tag := hall tag htag_range
-              have hcb_get := hcb.2 tag htag_branches
-              simp [hcb_get, show branches[tag]? = some branches[tag] from
-                List.getElem?_eq_some_iff.mpr ⟨htag_branches, rfl⟩] at heval_tag
-              have hty_eq : ts[tag]?.getD .value = ty_payload := by
-                simp [ht_tag]
-              rw [hty_eq] at heval_tag
-              have hagree_scrut := Bindings.agreeOnLinked_env_agree hagree hagreeOn_scrut hbwf
-              have hbwf_scrut : B.wf st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
-              have hbranch_wp := compileBranches_correct Θ branches S B Γ se_scrut ts.length ts 0
-                st_scrut ρ_scrut γ Ψ Φ
-                hagree_scrut hbwf_scrut hts hspec hSwf hse_wf
-                (fun j hj v ρ' st' se hΨ hse_wf hse_eval htyped =>
-                  hpost v ρ' st' se hΨ hse_wf hse_eval
-                    ((htys (branches[j]) (List.getElem_mem _)) ▸ htyped))
-                tag htag_branches (by simpa [Nat.zero_add, hty_eq] using heval_tag)
-              simpa [Nat.zero_add] using
-                hbranch_wp v_payload (by simpa [Nat.zero_add] using heval_se) (by simpa [hty_eq] using htype_payload)
+            have htag_range : tag ∈ List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length := by
+              rw [hactions_len]
+              exact List.mem_range.mpr htag_branches
+            have heval_tag := hall tag htag_range
+            have hcb_get := hcb.2 tag htag_branches
+            simp [hcb_get, show branches[tag]? = some branches[tag] from
+              List.getElem?_eq_some_iff.mpr ⟨htag_branches, rfl⟩] at heval_tag
+            have hty_eq : ts[tag]?.getD .value = ty_payload := by
+              simp [ht_tag]
+            rw [hty_eq] at heval_tag
+            have hagree_scrut := Bindings.agreeOnLinked_env_agree hagree hagreeOn_scrut hbwf
+            have hbwf_scrut : B.wf st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
+            have hbranch_wp := compileBranches_correct Θ R branches S B Γ se_scrut ts.length ts 0
+              st_scrut ρ_scrut γ Ψ Φ
+              hagree_scrut hbwf_scrut hts hspec hSwf hse_wf
+              (fun j hj v ρ' st' se hΨ hse_wf hse_eval htyped =>
+                hpost v ρ' st' se hΨ hse_wf hse_eval
+                  ((htys (branches[j]) (List.getElem_mem _)) ▸ htyped))
+              tag htag_branches (by simpa [Nat.zero_add, hty_eq] using heval_tag)
+            have hsc_eval : se_scrut.eval ρ_scrut = Runtime.Val.inj tag ts.length v_payload :=
+              heval_se
+            have hpayload_ty : TinyML.ValHasType Θ v_payload (ts[tag]?.getD .value) := by
+              simpa [hty_eq] using htype_payload
+            have hbranch := hbranch_wp v_payload ((Nat.zero_add tag).symm ▸ hsc_eval)
+              ((Nat.zero_add tag).symm ▸ hpayload_ty)
+            exact SpatialContext.wp_match
+              (by simpa [Nat.zero_add] using hbranch)
+              (by simp [htag_branches])
         · have hΨ_bad : (VerifM.fatal "match branch type annotation mismatch").eval st_scrut ρ_scrut Ψ := by
             simpa [if_pos hlen, if_neg htys] using hΨ_scrut
           exact (VerifM.eval_fatal hΨ_bad).elim
-    | _ =>
-      simp [hscrut_ty] at hΨ_scrut
-      exact (VerifM.eval_fatal hΨ_scrut).elim
 
-theorem compileBranch_correct (Θ : TinyML.TypeEnv) (branch : Binder × Expr) (S : SpecMap) (B : Bindings)
+theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder × Expr) (S : SpecMap) (B : Bindings)
     (Γ : TinyML.TyCtx) (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
     (st : TransState) (ρ : Env) (γ : Runtime.Subst)
     (Ψ : Term .value → TransState → Env → Prop)
-    (Φ : Runtime.Val → Prop) :
+    (Φ : Runtime.Val → iProp) :
     VerifM.eval (compileBranch Θ S B Γ sc n i ty_i branch) st ρ Ψ →
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
@@ -892,10 +906,10 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (branch : Binder × Expr) (S
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → Φ v) →
+      se.eval ρ' = v → TinyML.ValHasType Θ v branch.2.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
     ∀ payload, sc.eval ρ = Runtime.Val.inj i n payload →
       TinyML.ValHasType Θ payload ty_i →
-      wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
+      st.owns.interp ρ ∗ R ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
   intro heval hagree hbwf hts hspec hSwf hsc_wf hpost payload hsc_eval htype_payload
   obtain ⟨binder, body⟩ := branch
   simp only [compileBranch] at heval
@@ -949,16 +963,13 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (branch : Binder × Expr) (S
     have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁ = payload := by
       simp [Term.eval, Const.denote, ρ₁, Env.updateConst]
     have hassume_bind₂ := VerifM.eval_bind _ _ _ _ heval_assumeAll
-    obtain ⟨st₂, hst₂_decls, heval_body'⟩ := VerifM.eval_assumeAll hassume_bind₂
+    obtain ⟨st₂, hst₂_decls, hst₂_owns, heval_body'⟩ := VerifM.eval_assumeAll hassume_bind₂
       (fun φ hφ => typeConstraints_wfIn hxv_wf φ hφ)
       (fun φ hφ => typeConstraints_hold hxv_eval htype_payload φ hφ)
-    simp only [Runtime.Expr.subst_fix, Runtime.Subst.remove'_none]
-    apply wp_app_lambda_single
-    show wp (Runtime.Expr.subst
-      ((Runtime.Subst.update' .none Runtime.Val.unit Runtime.Subst.id).updateAll' [binder.runtime] [payload])
-      (Runtime.Expr.subst ((γ.remove' .none).removeAll' [binder.runtime]) body.runtime)) Φ
-    rw [Runtime.Expr.subst_fix_comp body.runtime .none [binder.runtime] γ Runtime.Val.unit [payload] rfl]
-    simp only [Runtime.Subst.update']
+    have hst₂_owns_eq : st₂.owns = st.owns := hst₂_owns
+    have hinterp_eq : SpatialContext.interp ρ st.owns ⊢ SpatialContext.interp ρ₁ st.owns :=
+      (SpatialContext.interp_env_agree (VerifM.eval.wf heval_decl).ownsWf
+        (agreeOn_update_fresh_const hxv_fresh)).1
     have hagreeOn_st : Env.agreeOn st.decls ρ ρ₁ :=
       agreeOn_update_fresh_const hxv_fresh
     cases hname : binder.name with
@@ -972,9 +983,19 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (branch : Binder × Expr) (S
       have heval_body'' : (compile Θ S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, hname] using heval_body'
       rw [Binder.runtime_of_name_none hname]
-      simpa [Runtime.Subst.update] using
-        (compile_correct Θ body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
-          heval_body'' hagree₁ hbwf₁ hts₁ hspec hSwf (by simpa [hty] using hpost))
+      simp only [Runtime.Expr.subst_fix]
+      apply BIBase.Entails.trans _ wp.app_lambda_single
+      change SpatialContext.interp ρ st.owns ∗ R ⊢
+        wp
+          ((body.runtime.subst ((γ.remove' .none).removeAll' [.none])).subst
+            ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.none] [payload]))
+          Φ
+      rw [Runtime.Expr.subst_fix_comp body.runtime .none [.none] γ Runtime.Val.unit [payload] rfl]
+      simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left]
+      exact (sep_mono_l hinterp_eq).trans (hst₂_owns_eq ▸
+        by simpa [Runtime.Subst.update] using
+          compile_correct Θ R body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
+            heval_body'' hagree₁ hbwf₁ hts₁ hspec hSwf (by simpa [hty] using hpost))
     | some x =>
       simp [hname, TinyML.TyCtx.extendBinder] at heval_body'
       have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁ ρ := by
@@ -998,19 +1019,29 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (branch : Binder × Expr) (S
           (compile Θ (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, TinyML.TyCtx.extendBinder, hname] using heval_body'
       rw [Binder.runtime_of_name_some hname]
-      simpa [Runtime.Subst.update] using
-        (compile_correct Θ body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
-          (Runtime.Subst.update γ x payload) Ψ Φ heval_body'' hagree₁ hbwf₂ hts₁
-          (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) (by simpa [hty] using hpost))
+      simp only [Runtime.Expr.subst_fix]
+      apply BIBase.Entails.trans _ wp.app_lambda_single
+      change SpatialContext.interp ρ st.owns ∗ R ⊢
+        wp
+          ((body.runtime.subst ((γ.remove' .none).removeAll' [.named x])).subst
+            ((Runtime.Subst.id.update' .none Runtime.Val.unit).updateAll' [.named x] [payload]))
+          Φ
+      rw [Runtime.Expr.subst_fix_comp body.runtime .none [.named x] γ Runtime.Val.unit [payload] rfl]
+      simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left]
+      exact (sep_mono_l hinterp_eq).trans (hst₂_owns_eq ▸
+        by simpa [Runtime.Subst.update] using
+          compile_correct Θ R body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
+            (Runtime.Subst.update γ x payload) Ψ Φ heval_body'' hagree₁ hbwf₂ hts₁
+            (SpecMap.satisfiedBy_erase hspec) (SpecMap.wfIn_erase hSwf) (by simpa [hty] using hpost))
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
     exact False.elim (hty (VerifM.eval_expectEq hexpect).1)
 
-theorem compileBranches_correct (Θ : TinyML.TypeEnv) (branches : List (Binder × Expr)) (S : SpecMap) (B : Bindings)
+theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : List (Binder × Expr)) (S : SpecMap) (B : Bindings)
     (Γ : TinyML.TyCtx) (sc : Term .value) (n : Nat) (ts : List TinyML.Typ)
     (idx : Nat)
     (st : TransState) (ρ : Env) (γ : Runtime.Subst)
     (Ψ : Term .value → TransState → Env → Prop)
-    (Φ : Runtime.Val → Prop) :
+    (Φ : Runtime.Val → iProp) :
     B.agreeOnLinked ρ γ →
     B.wf st.decls →
     B.typedSubst Θ Γ γ →
@@ -1018,12 +1049,12 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (branches : List (Binder �
     S.wfIn Signature.empty →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → Φ v) →
+      se.eval ρ' = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
       VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ = Runtime.Val.inj (idx + j) n payload →
         TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
-        wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
+        st.owns.interp ρ ∗ R ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
   intro hagree hbwf hts hspec hSwf hsc_wf hpost
   match branches with
   | [] =>
@@ -1035,29 +1066,29 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (branches : List (Binder �
     | zero =>
       simp only [Nat.add_zero, List.getElem_cons_zero]
       intro heval
-      exact compileBranch_correct Θ b S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
+      exact compileBranch_correct Θ R b S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
         heval hagree hbwf hts hspec hSwf hsc_wf (by simpa using hpost 0 hj)
     | succ k =>
       have hk : k < bs.length := by simp at hj; omega
       have hidx : idx + (k + 1) = (idx + 1) + k := by omega
       simp only [hidx, List.getElem_cons_succ]
-      exact compileBranches_correct Θ bs S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
+      exact compileBranches_correct Θ R bs S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
         hagree hbwf hts hspec hSwf hsc_wf
         (by
           intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
           simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
         k hk
 
-theorem compileExprs_correct (Θ : TinyML.TypeEnv) (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
-    (Ψ : List (Term .value) → TransState → Env → Prop) (Φ : List Runtime.Val → Prop) :
+theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
+    (Ψ : List (Term .value) → TransState → Env → Prop) (Φ : List Runtime.Val → iProp) :
     VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
     B.agreeOnLinked ρ γ → B.wf st.decls → B.typedSubst Θ Γ γ →
     S.satisfiedBy Θ γ → S.wfIn Signature.empty →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ' terms vs →
-      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → Φ vs) →
-    wps (es.map (fun e => e.runtime.subst γ)) Φ := by
+      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.owns.interp ρ' ∗ R ⊢ Φ vs) →
+    st.owns.interp ρ ∗ R ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
   intro heval hagree hbwf hts hspec hSwf hpost
   match es with
   | [] =>
@@ -1069,14 +1100,14 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (es : List Expr) (S : SpecMap
     simp only [compileExprs] at heval
     simp only [List.map, wps_cons]
     have heval_rest : (compileExprs Θ S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine compileExprs_correct Θ rest S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hspec hSwf ?_
+    refine compileExprs_correct Θ R rest S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hspec hSwf ?_
     intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
     obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
     have hagree_vs : B.agreeOnLinked ρ_vs γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
     have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
     have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
-    refine compile_correct Θ e S B Γ st_vs ρ_vs γ _ _ (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hspec hSwf ?_
+    refine compile_correct Θ R e S B Γ st_vs ρ_vs γ _ _ (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hspec hSwf ?_
     intro v ρ' st' se hΨ_e hse_wf heval_se htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
     have hwfst' : st'.decls.wf := (VerifM.eval.wf hΨ_e).namesDisjoint

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -227,7 +227,33 @@ mutual
         let se ← compile Θ S B Γ e
         if TinyML.Typ.sub Θ e.ty ty then pure se
         else VerifM.fatal s!"cast type mismatch"
-    | .app _ _ _ | .fix _ _ _ _ | .ref _ | .deref _ _ | .store _ _ => VerifM.fatal "unsupported expression"
+    | .ref e => do
+        let sv ← compile Θ S B Γ e
+        let l ← VerifM.decl none .value
+        VerifM.assume (.spatial (.pointsTo (.const (.uninterpreted l.name .value)) sv))
+        pure (.const (.uninterpreted l.name .value))
+    | .deref e ty => do
+        VerifM.expectEq "deref type annotation mismatch" e.ty (.ref ty)
+        match ty with
+        | .int =>
+          let sl ← compile Θ S B Γ e
+          match ← VerifM.resolve (.own sl) with
+          | some sv =>
+            VerifM.assert (.unpred .isInt sv)
+            VerifM.assume (.spatial (.pointsTo sl sv))
+            pure sv
+          | none => VerifM.failed "could not resolve points-to assertion"
+        | _ => VerifM.fatal "only int references are supported"
+    | .store loc val => do
+        VerifM.expectEq "store location type mismatch" loc.ty (.ref val.ty)
+        let sv ← compile Θ S B Γ val
+        let sl ← compile Θ S B Γ loc
+        match ← VerifM.resolve (.own sl) with
+        | some _ =>
+          VerifM.assume (.spatial (.pointsTo sl sv))
+          pure (Term.const .unit)
+        | none => VerifM.failed "could not resolve points-to assertion"
+    | .app _ _ _ | .fix _ _ _ _ => VerifM.fatal "unsupported expression"
 
   /-- Compile a single match branch: assume the scrutinee is `mkInj i n payload`, then compile the body. -/
   def compileBranch (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -455,9 +481,189 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       trivial
       (by simp [Term.eval])
       .unit
-  | fix _ _ _ _ | ref _ | deref _ _ | store _ _ =>
+  | fix _ _ _ _ =>
     simp only [compile] at heval
     exact (VerifM.eval_fatal heval).elim
+  | ref e =>
+    unfold Expr.runtime; simp only [Runtime.Expr.subst]
+    simp only [compile] at heval
+    simp only [Expr.ty] at hpost
+    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_ref <| compile_correct Θ R e S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+    intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
+    obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
+    have hwf_st₁ := VerifM.eval.wf hΨ_e
+    set c : FOL.Const := st₁.freshConst none .value
+    have hfresh : c.name ∉ st₁.decls.allNames :=
+      fresh_not_mem _ _ (addNumbers_injective _)
+    have hwf_addConst : TransState.wf { st₁ with decls := st₁.decls.addConst c } :=
+      TransState.freshConst.wf _ hwf_st₁
+    refine SpatialContext.wp_ref (ctx := st₁.owns) (Δ := st₁.decls) (vt := se)
+      (name := c.name)
+      (newctx := .pointsTo (.const (.uninterpreted c.name .value)) se :: st₁.owns)
+      hwf_st₁.ownsWf hse_wf heval_se hfresh rfl ?_
+    intro loc
+    have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
+    have hdecl := VerifM.eval_decl hdecl_eval (.loc loc)
+    have hassume_eval := VerifM.eval_bind _ _ _ _ hdecl
+    set ρ_e' : Env := ρ_e.updateConst .value c.name (.loc loc)
+    set st₂ : TransState := { st₁ with decls := st₁.decls.addConst c }
+    have hc_wf : (Term.const (.uninterpreted c.name .value)).wfIn st₂.decls := by
+      simp only [Term.wfIn, Const.wfIn]
+      refine ⟨List.Mem.head _, ?_, ?_⟩
+      · intro τ' hvar
+        exact Signature.wf_no_var_of_const hwf_addConst.namesDisjoint
+          (List.Mem.head _) hvar
+      · intro τ' hc'
+        exact Signature.wf_unique_const hwf_addConst.namesDisjoint (List.Mem.head _) hc'
+    have hse_wf_st₂ : se.wfIn st₂.decls :=
+      Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _) hwf_addConst.namesDisjoint
+    have hatom_wf : SpatialAtom.wfIn
+        (.pointsTo (.const (.uninterpreted c.name .value)) se) st₂.decls :=
+      ⟨hc_wf, hse_wf_st₂⟩
+    have hassume_res := VerifM.eval_assumeSpatial hassume_eval hatom_wf
+    have hret := VerifM.eval_ret hassume_res
+    have hval_eval : Term.eval ρ_e' (Term.const (.uninterpreted c.name .value)) = .loc loc := by
+      simp [ρ_e', Term.eval, Const.denote, Env.updateConst]
+    have hty : TinyML.ValHasType Θ (Runtime.Val.loc loc) (TinyML.Typ.ref e.ty) := by
+      exact TinyML.ValHasType.ref loc e.ty
+    exact hpost (.loc loc) ρ_e' _ _ hret hc_wf hval_eval hty
+  | deref e ty =>
+    unfold Expr.runtime; simp only [Runtime.Expr.subst]
+    simp only [compile] at heval
+    simp only [Expr.ty] at hpost
+    obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
+    cases hty : ty with
+    | int =>
+      simp [hty] at heval hpost
+      have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+      refine SpatialContext.wp_bind_deref <| compile_correct Θ R e S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+      intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
+      obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
+      have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_e
+      refine VerifM.eval_resolve (pred := .own se) (R := R)
+        (Φ := wp (.deref (.val v_e)) Φ) hres_bind hse_wf ?_ ?_
+      · intro st' hQ _
+        exact (VerifM.eval_failed hQ).elim
+      · intro v st' hQ hdecls hvwf
+        have hassert_bind := VerifM.eval_bind _ _ _ _ hQ
+        have hse_wf_st' : se.wfIn st'.decls := hdecls ▸ hse_wf
+        have hv_wf_st' : v.wfIn st'.decls := hdecls ▸ hvwf
+        have hassert_wf : (Formula.unpred .isInt v).wfIn st'.decls := hv_wf_st'
+        have ⟨hv_int, hQ⟩ := VerifM.eval_assert hassert_bind hassert_wf
+        have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
+        have hatom_wf : SpatialAtom.wfIn (.pointsTo se v) st'.decls :=
+          ⟨hse_wf_st', hv_wf_st'⟩
+        have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
+        have hret := VerifM.eval_ret hassume_res
+        have hv_wf_final : v.wfIn (TransState.addItem st' (.spatial (.pointsTo se v))).decls := by
+          simpa [TransState.addItem] using hv_wf_st'
+        have htype : TinyML.ValHasType Θ (v.eval ρ_e) .int := by
+          cases hv : v.eval ρ_e with
+          | int n => exact TinyML.ValHasType.int n
+          | bool _ | unit | inj _ _ _ | loc _ | fix _ _ _ | tuple _ =>
+              simp [Formula.eval, hv] at hv_int
+        let st'' := TransState.addItem st' (.spatial (.pointsTo se v))
+        have hgoal : st''.owns.interp ρ_e ∗ R ⊢ Φ (v.eval ρ_e) :=
+          hpost (v.eval ρ_e) ρ_e st'' _ hret hv_wf_final rfl htype
+        simp only [Atom.eval]
+        istart
+        iintro H
+        icases H with ⟨Hex, Hrest, HR⟩
+        icases Hex with ⟨%loc, Hpt'⟩
+        icases Hpt' with ⟨%Hloc, Hpt⟩
+        have hv_e : v_e = .loc loc := heval_se.symm.trans Hloc
+        subst hv_e
+        have hptIntro : loc ↦ v.eval ρ_e ⊢ SpatialAtom.interp ρ_e (.pointsTo se v) := by
+          simpa [Hloc] using
+            (SpatialAtom.interp_pointsTo (ρ := ρ_e) (lt := se) (vt := v) (loc := loc) Hloc).2
+        have hctx : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ∗ R ⊢ Φ (v.eval ρ_e) := by
+          have hcons : (loc ↦ v.eval ρ_e) ∗ SpatialContext.interp ρ_e st'.owns ⊢ st''.owns.interp ρ_e := by
+            simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hptIntro)
+          exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
+        iapply (wp.deref (l := loc) (v := v.eval ρ_e))
+        isplitl [Hpt]
+        · iexact Hpt
+        · iintro Hpt
+          iapply hctx
+          isplitl [Hpt]
+          · iexact Hpt
+          · isplitl [Hrest]
+            · iexact Hrest
+            · iexact HR
+    | bool | unit | arrow _ _ | ref _ | sum _ | empty | value | tuple _ | tvar _ | named _ _ =>
+      simp [hty] at heval
+      exact (VerifM.eval_fatal heval).elim
+  | store loc val =>
+    unfold Expr.runtime; simp only [Runtime.Expr.subst]
+    simp only [compile] at heval
+    simp only [Expr.ty] at hpost
+    obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
+    have heval_v : (compile Θ S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_store <| (SpecMap.satisfiedBy_dup.trans <|
+      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) val S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hts hSwf ?_)
+    intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv htyv
+    obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
+    have hagree_v : B.agreeOnLinked ρ_v γ :=
+      Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
+    have hbwf_v : B.wf st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
+    have heval_l : (compile Θ S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
+    refine compile_correct Θ R loc S B Γ st₁ ρ_v γ _ _
+      (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hts hSwf ?_
+    intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
+    obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
+    have hsv_ρ_l : sv.eval ρ_l = v_v := by
+      rw [Term.eval_env_agree hsv_wf (Env.agreeOn_symm hagreeOn_l)]
+      exact heval_sv
+    have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_l
+    refine VerifM.eval_resolve (pred := .own sl) (R := R)
+      (Φ := wp (.store (.val v_l) (.val v_v)) Φ) hres_bind hsl_wf ?_ ?_
+    · intro st' hQ _
+      exact (VerifM.eval_failed hQ).elim
+    · intro old st' hQ hdecls hold_wf
+      have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
+      have hsl_wf_st' : sl.wfIn st'.decls := hdecls ▸ hsl_wf
+      have hsv_wf_st₂ : sv.wfIn st₂.decls :=
+        Term.wfIn_mono sv hsv_wf hdecls_l (VerifM.eval.wf hΨ_l).namesDisjoint
+      have hsv_wf_st' : sv.wfIn st'.decls := hdecls ▸ hsv_wf_st₂
+      have hatom_wf : SpatialAtom.wfIn (.pointsTo sl sv) st'.decls :=
+        ⟨hsl_wf_st', hsv_wf_st'⟩
+      have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
+      have hret := VerifM.eval_ret hassume_res
+      have hunit_wf : (Term.const .unit).wfIn
+          (TransState.addItem st' (.spatial (.pointsTo sl sv))).decls := by
+        simp [Term.wfIn, Const.wfIn]
+      let st'' := TransState.addItem st' (.spatial (.pointsTo sl sv))
+      have hgoal : st''.owns.interp ρ_l ∗ R ⊢ Φ .unit :=
+        hpost .unit ρ_l st'' _ hret hunit_wf (by simp [Term.eval]) (.unit)
+      simp only [Atom.eval]
+      istart
+      iintro H
+      icases H with ⟨Hex, Hrest, HR⟩
+      icases Hex with ⟨%loc, Hold'⟩
+      icases Hold' with ⟨%Hloc, Hold⟩
+      have hv_l : v_l = .loc loc := heval_sl.symm.trans Hloc
+      subst hv_l
+      have hnewIntro : loc ↦ v_v ⊢ SpatialAtom.interp ρ_l (.pointsTo sl sv) := by
+        simpa [Hloc, hsv_ρ_l] using
+          (SpatialAtom.interp_pointsTo (ρ := ρ_l) (lt := sl) (vt := sv) (loc := loc) Hloc).2
+      have hctx : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l st'.owns ∗ R ⊢ Φ .unit := by
+        have hcons : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l st'.owns ⊢ st''.owns.interp ρ_l := by
+          simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hnewIntro)
+        exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
+      iapply (wp.store (l := loc) (old := old.eval ρ_l) (v := v_v))
+      isplitl [Hold]
+      · iexact Hold
+      · iintro Hnew
+        iapply hctx
+        isplitl [Hnew]
+        · iexact Hnew
+        · isplitl [Hrest]
+          · iexact Hrest
+          · iexact HR
   | unop op e uty =>
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     simp only [compile] at heval
@@ -524,8 +730,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           cases htyr with
           | int b =>
             have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
-              simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]
-              exact Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
+              simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
+                (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
             have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
             have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
             simp [Formula.eval, Term.eval, Const.denote] at hne_zero
@@ -539,8 +745,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             have hwf_sr_l : sr.wfIn st₂.decls :=
               Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
             have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
-              simp only [Term.wfIn, BinOp.wfIn, UnOp.wfIn, true_and]
-              exact ⟨hsl_wf, hwf_sr_l⟩
+              simpa [Term.wfIn, BinOp.wfIn, UnOp.wfIn] using And.intro hsl_wf hwf_sr_l
             have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
               simpa using hΨ_post
             exact SpatialContext.wp_binop
@@ -559,8 +764,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
           cases htyr with
           | int b =>
             have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
-              simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, and_true, true_and]
-              exact Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
+              simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
+                (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
             have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
             have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
             simp [Formula.eval, Term.eval, Const.denote] at hne_zero
@@ -574,8 +779,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             have hwf_sr_l : sr.wfIn st₂.decls :=
               Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
             have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
-              simp only [Term.wfIn, BinOp.wfIn, UnOp.wfIn, true_and]
-              exact ⟨hsl_wf, hwf_sr_l⟩
+              simpa [Term.wfIn, BinOp.wfIn, UnOp.wfIn] using And.intro hsl_wf hwf_sr_l
             have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
               simpa using hΨ_post
             exact SpatialContext.wp_binop

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -178,7 +178,7 @@ mutual
         | none => compile Θ S B Γ body
         | some x =>
           let x' ← VerifM.decl (some x) .value
-          VerifM.assume (Formula.eq .value (.const (.uninterpreted x'.name .value)) se)
+          VerifM.assume (.pure (Formula.eq .value (.const (.uninterpreted x'.name .value)) se))
           compile Θ (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
     | .ifThenElse cond thn els ty => do
         let sc ← compile Θ S B Γ cond
@@ -187,10 +187,10 @@ mutual
         VerifM.expectEq "if branch type annotation mismatch" els.ty ty
         let branch ← VerifM.all [true, false]
         if branch then do
-          VerifM.assume (.not (.eq .value sc (.unop .ofBool (.const (.b false)))))
+          VerifM.assume (.pure (.not (.eq .value sc (.unop .ofBool (.const (.b false))))))
           compile Θ S B Γ thn
         else do
-          VerifM.assume (.eq .value sc (.unop .ofBool (.const (.b false))))
+          VerifM.assume (.pure (.eq .value sc (.unop .ofBool (.const (.b false)))))
           compile Θ S B Γ els
     | .app (.var f fty) args aty => do
         let spec ← VerifM.expectSome s!"no spec for function {f}" (S.lookup f)
@@ -236,7 +236,7 @@ mutual
     | (binder, body) => do
         VerifM.expectEq "match binder type annotation mismatch" binder.ty ty_i
         let xv ← VerifM.decl binder.name .value
-        VerifM.assume (.eq .value sc (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value))))
+        VerifM.assume (.pure (.eq .value sc (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value)))))
         VerifM.assumeAll (typeConstraints ty_i (.const (.uninterpreted xv.name .value)))
         match binder.name with
         | some x =>
@@ -675,7 +675,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         have hdecl := VerifM.eval_decl hdecl_eval
         have h := hdecl v_e
         obtain h := VerifM.eval_bind _ _ _ _ h
-        obtain h := VerifM.eval_assume h
+        obtain h := VerifM.eval_assumePure h
         apply h
         · simp only [Formula.wfIn, Term.wfIn, Const.wfIn]
           refine ⟨?_, Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _)
@@ -742,8 +742,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
     have hwf_eq : (Formula.eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))).wfIn st₁.decls := by
       simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
-    have htrue_cont := VerifM.eval_assume (VerifM.eval_bind _ _ _ _ htrue)
-    have hfalse_cont := VerifM.eval_assume (VerifM.eval_bind _ _ _ _ hfalse)
+    have htrue_cont := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ htrue)
+    have hfalse_cont := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ hfalse)
     let φ_eq : Formula := .eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))
     let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
     let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
@@ -1004,7 +1004,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
     let xv := TransState.freshConst hint .value st
     have heval_inst := hdecl payload
     have heval_assume := VerifM.eval_bind _ _ _ _ heval_inst
-    have hassume := VerifM.eval_assume heval_assume
+    have hassume := VerifM.eval_assumePure heval_assume
     let st₁ : TransState := { decls := st.decls.addConst xv, asserts := st.asserts, owns := st.owns }
     let ρ₁ := ρ.updateConst .value xv.name payload
     have hxv_fresh : xv.name ∉ st.decls.allNames :=

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -11,8 +11,22 @@ import Mica.Engine.Driver
 import Mica.Base.Fresh
 import Mathlib.Data.Finmap
 
+open Iris Iris.BI
 open Typed
 
+
+/-- Compile the body of a specification under its argument context and
+    check that the inferred return type is a subtype of the declared one. -/
+def checkBody (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
+    (argNames : List String) (body : Expr)
+    (argVars : List FOL.Const) : VerifM (Term .value) := do
+  let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
+  let Γ := (argNames.zip (s.args.map Prod.snd)).foldl
+    (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
+  let se ← compile Θ S B Γ body
+  if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
+  else VerifM.fatal s!"checkSpec: return type mismatch"
+  pure se
 
 def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
   let (fb, argNames, body) ← match e with
@@ -22,63 +36,44 @@ def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM
       | .error msg => VerifM.fatal msg
     | _ => VerifM.fatal "checkSpec: expected function"
   let S' := SpecMap.eraseAll argNames (S.insert' fb s)
-  Spec.implement s fun argVars => do
-    let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
-    let Γ := (argNames.zip (s.args.map Prod.snd)).foldl (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
-    let se ← compile Θ S' B Γ body
-    if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
-    else VerifM.fatal s!"checkSpec: return type mismatch"
-    pure se
+  Spec.implement s (checkBody Θ S' s argNames body)
 
-theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
+/-- Soundness of `checkBody`: given argument variables supplied by
+    `Spec.implement_correct` and a successful `checkBody` evaluation, the
+    compiled body's `wp` holds. -/
+theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (hS : S.satisfiedBy Θ γ)
-    (st : TransState) (ρ : Env)
     (fb : Binder) (argBinders : List Binder) (body : Expr)
     (argNames : List String)
     (hext : extractArgNames argBinders s.args = Except.ok argNames)
     (bs : List Runtime.Binder) (hbs_def : bs = argBinders.map (·.runtime))
     (fval : Runtime.Val)
-    (hbody : (Spec.implement s fun argVars => do
-        let S' := SpecMap.eraseAll argNames (S.insert' fb s)
-        let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
-        let Γ := (argNames.zip (s.args.map Prod.snd)).foldl
-          (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
-        let se ← compile Θ S' B Γ body
-        if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
-        else VerifM.fatal s!"checkSpec: return type mismatch"
-        pure se).eval st ρ (fun _ _ _ => True))
-    (vs : List Runtime.Val) (P : Runtime.Val → iProp)
+    (vs : List Runtime.Val)
     (htyped_args : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd))
-    (isPrecond_rec : s.isPrecondFor Θ fval) :
-    st.owns.interp ρ ∗
-      PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-        (Spec.argsEnv Env.empty s.args vs) ⊢
-      wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
-  obtain ⟨hlen1, hlen2, hbs_eq⟩ := extractArgNames_spec hext
-  have hbs_runtime : bs = argNames.map Runtime.Binder.named := by rw [hbs_def]; exact hbs_eq
+    (P : Runtime.Val → iProp)
+    {argVars : List FOL.Const} {st' : TransState} {ρ' : Env} {Q : iProp}
+    (hargVars_mem : ∀ v ∈ argVars, v ∈ st'.decls.consts)
+    (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
+    (hargVars_lookup : List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs)
+    (hbody_eval : VerifM.eval
+        (checkBody Θ (SpecMap.eraseAll argNames (S.insert' fb s)) s argNames body argVars)
+        st' ρ'
+        (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
+          st''.owns.interp ρ'' ∗ Q ∗
+            ((⌜TinyML.ValHasType Θ (result.eval ρ'') s.retTy⌝ -∗ P (result.eval ρ'')) -∗ S) ⊢ S)) :
+    st'.owns.interp ρ' ∗ Q ⊢
+      (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
+        wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
+  simp only [checkBody] at hbody_eval
+  obtain ⟨_, _, hbs_eq⟩ := extractArgNames_spec hext
+  have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_def ▸ hbs_eq
   have hlen_nv : argNames.length = vs.length := by
     have := htyped_args.length_eq; simp at this; omega
-  have hlen : bs.length = vs.length := by simp [hbs_runtime]; omega
   set γ_body := γ.update' fb.runtime fval |>.updateAll' bs vs
   set S' : SpecMap := SpecMap.eraseAll argNames (S.insert' fb s)
-  -- Use implement_correct
-  apply Spec.implement_correct Θ s _ st ρ vs P
-    (wp (body.runtime.subst γ_body) P)
-    hswf htyped_args hbody
-  intro argVars st' ρ' Q hargVars_mem hargVars_sort hargVars_lookup hbody_eval
-  -- Establish spec map satisfaction
   have hS'wf : S'.wfIn Signature.empty :=
     SpecMap.wfIn_eraseAll (SpecMap.wfIn_insert' hSwf hswf)
-  have hS'_sat : S'.satisfiedBy Θ γ_body := by
-    have hS_ext : (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) :=
-      SpecMap.satisfiedBy_insert'_update' hS isPrecond_rec
-    have hsat := SpecMap.satisfiedBy_eraseAll_updateAll' hS_ext hlen_nv
-    change (SpecMap.eraseAll argNames (S.insert' fb s)).satisfiedBy Θ
-      ((γ.update' fb.runtime fval).updateAll' bs vs)
-    rw [hbs_runtime]; exact hsat
-  -- Set up bindings, agreement, well-formedness, typed substitution
   set Γ := (argNames.zip (s.args.map Prod.snd)).foldl
     (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
   set B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
@@ -120,61 +115,69 @@ theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
       (by rw [hsnd]; exact htyped_args)
   -- Use compile_correct
   have hcompile := VerifM.eval_bind _ _ _ _ hbody_eval
-  exact compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
-    (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'_sat hS'wf
-    (fun v ρ'' st'' se hΨ hse_wf heval_se htyped => by
-      obtain ⟨hdecls, hagreeOn, hΨ⟩ := hΨ
-      by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
-      · simp [hsub] at hΨ
-        have hΨ' := VerifM.eval_ret hΨ
-        dsimp only at hΨ'
-        subst heval_se
-        have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
-          TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
-        refine (show st''.owns.interp ρ'' ∗ Q ⊢
-            st''.owns.interp ρ'' ∗ Q ∗
-              ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
-                P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
-        istart
-        iintro ⟨Howns, HQ⟩
-        isplitl [Howns]
-        · iexact Howns
-        · isplitl [HQ]
-          · iexact HQ
-          · iintro Hwand
-            iapply Hwand
-            ipure_intro
-            exact hret
-      · simp [hsub] at hΨ
-        exact (VerifM.eval_fatal hΨ).elim)
-
-/-- Sorry'd helper: extract `isPrecondFor` (a `Prop`) from an iProp wand.
-
-The hypothesis is a universally quantified wand asserting that the spec's predicate
-transformer entails `wp` of calling `f`. The conclusion `isPrecondFor` says the same
-at the `Prop` level. The only gap is the wand-to-entailment and `⌜ValsHaveTypes⌝`-to-Prop
-conversions.
-
-Once `isPrecondFor` is migrated to a persistent separation logic assertion, this becomes
-a direct consequence of the hypothesis. -/
-theorem isPrecondFor_of_wp_rec (Θ : TinyML.TypeEnv) (s : Spec)
-    (f : Runtime.Val) :
-    (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-      ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
-        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-          (Spec.argsEnv Env.empty s.args vs) -∗
-        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢
-    ⌜s.isPrecondFor Θ f⌝ := by
-  sorry
+  have hS'_sat :
+      S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval ⊢ S'.satisfiedBy Θ γ_body := by
+    have hinsert :
+        S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval ⊢
+          (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) :=
+      SpecMap.satisfiedBy_insert'_update'
+    have herase :
+        (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) ⊢
+          S'.satisfiedBy Θ ((γ.update' fb.runtime fval).updateAll' (argNames.map Runtime.Binder.named) vs) :=
+      SpecMap.satisfiedBy_eraseAll_updateAll' hlen_nv
+    exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
+  have hbody_wp :
+      st'.owns.interp ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Q) ⊢
+        wp (body.runtime.subst γ_body) P := by
+    refine compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
+      (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'wf ?_
+    intro v ρ'' st'' se hΨ hse_wf heval_se htyped
+    obtain ⟨_, _, hΨ⟩ := hΨ
+    by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
+    case neg =>
+      simp [hsub] at hΨ
+      exact (VerifM.eval_fatal hΨ).elim
+    simp [hsub] at hΨ
+    have hΨ' := VerifM.eval_ret hΨ
+    dsimp only at hΨ'
+    subst heval_se
+    have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
+      TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
+    refine (show st''.owns.interp ρ'' ∗ Q ⊢
+        st''.owns.interp ρ'' ∗ Q ∗
+          ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
+            P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
+    istart
+    iintro ⟨Howns, HQ⟩
+    isplitl [Howns]
+    · iexact Howns
+    · isplitl [HQ]
+      · iexact HQ
+      · iintro Hwand
+        iapply Hwand
+        ipure_intro
+        exact hret
+  iintro ⟨Howns, HQ⟩
+  iintro HSat
+  iapply hbody_wp
+  isplitl [Howns]
+  · iexact Howns
+  · isplitl [HSat]
+    · iapply hS'_sat
+      iexact HSat
+    · iexact HQ
 
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (hS : S.satisfiedBy Θ γ)
-    (st : TransState) (ρ : Env) :
-    VerifM.eval (checkSpec Θ S e s) st ρ (fun _ _ _ => True) →
-    st.owns.interp ρ ⊢ wp (e.runtime.subst γ) (fun v => ⌜s.isPrecondFor Θ v⌝) := by
+    (ρ : Env) :
+    VerifM.eval (checkSpec Θ S e s) TransState.empty ρ (fun _ _ _ => True) →
+    S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
   intro heval
+  -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
+  have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
+      VerifM.eval (VerifM.fatal msg >>= k) st ρ Ψ → False :=
+    fun h => VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ h)
   cases e
   case fix fb argBinders retTy body =>
     simp only [checkSpec] at heval
@@ -182,11 +185,11 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
     cases hext : extractArgNames argBinders s.args with
     | error msg =>
       simp [hext] at heval
-      exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim
+      exact (elim_bind_fatal heval).elim
     | ok argNames =>
       simp [hext] at heval
-      have hbody := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
-      dsimp only at hbody
+      have himpl := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
+      dsimp only at himpl
       set bs := argBinders.map (·.runtime)
       set γ' := (γ.remove' fb.runtime).removeAll' bs with hγ'_def
       set S' : SpecMap := SpecMap.eraseAll argNames (S.insert' fb s)
@@ -198,45 +201,37 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       rw [hgoal]
       set fval := Runtime.Val.fix fb.runtime (argBinders.map (·.runtime))
         (body.runtime.subst γ') with hfval_def
-      -- Use the extracted body correctness lemma
-      have body_correct := fun vs P htyped_args isPrecond_rec =>
-        checkSpec_body_correct Θ S s γ hswf hSwf hS st ρ fb argBinders body argNames
-          hext bs rfl fval hbody vs P htyped_args isPrecond_rec
-      -- Step 1: Apply wp.func to reduce wp (Expr.fix ...) to the value case
-      -- Goal: owns ⊢ wp (Expr.fix fb bs body') (fun v => ⌜isPrecondFor Θ v s⌝)
-      -- wp.func: P fval ⊢ wp (Expr.fix fb bs body') P, where fval = Val.fix fb bs body'
-      change st.owns.interp ρ ⊢ wp (Runtime.Expr.fix fb.runtime bs (body.runtime.subst γ'))
-        (fun v => ⌜s.isPrecondFor Θ v⌝)
-      -- Set up Φ for wp_fix': Φ P vs = ⌜ValsHaveTypes⌝ ∗ PredTrans.apply (... -∗ P) s.pred ...
-      set Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp :=
-        fun P vs => ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
-          PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-            (Spec.argsEnv Env.empty s.args vs)
-      -- Apply wp_fix' to get the recursive spec, then isPrecondFor_of_wp_rec to extract Prop
-      suffices hwp : st.owns.interp ρ ⊢
-          ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-            Φ P vs -∗ wp (Runtime.Expr.app (.val fval) (vs.map Runtime.Expr.val)) P by
-        -- Extract the Prop-level recursive spec, then lift it through `wp_func`.
-        have hgoal2 := hwp.trans (isPrecondFor_of_wp_rec Θ s fval)
-        exact SpatialContext.wp_func hgoal2
-      -- Prove the wp_fix' obligation
       obtain ⟨_, _, hbs_eq⟩ := extractArgNames_spec hext
       have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_eq
-      apply SpatialContext.wp_fix'
+      apply SpatialContext.wp_func
+      apply Spec.isPrecondFor_fix
       istart
-      iintro Howns IH %vs %P ⟨%htyped, Hpred⟩
-      -- Extract the Prop-level recursive spec from the recursive wp hypothesis.
-      ihave ⌜hipc⌝ := isPrecondFor_of_wp_rec Θ s fval $$ IH
-      -- Use body_correct: needs owns ∗ PredTrans ⊢ wp (body.subst (γ.update'...))
-      -- wp_fix' gives body.subst (id.update'...) — bridge via subst_fix_comp
+      iintro □Hspec
+      imodintro
+      iintro Hrec %vs %P %htyped Hpred
+      -- `isPrecondFor_fix` hands us the body's subst as `id.update' ... |>.updateAll' ...`;
+      -- fuse it with γ via `subst_fix_comp` so it matches `body_correct`.
       have hlen_vs : bs.length = vs.length := by
         simp [hbs_runtime]; have := htyped.length_eq; simp at this; omega
       have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
       simp only [] at hsub; rw [hsub]
-      iapply (body_correct vs _ htyped hipc)
-      isplitl [Howns]
-      · iexact Howns
+      have hbody' : PredTrans.apply (fun r => iprop(⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r)) s.pred
+          (Spec.argsEnv Env.empty s.args vs) ⊢
+          SpecMap.satisfiedBy Θ S γ ∗ s.isPrecondFor Θ fval -∗
+            wp (Runtime.Expr.subst ((Runtime.Subst.update' fb.runtime fval γ).updateAll' bs vs) body.runtime) P := by
+        refine emp_sep.2.trans ?_
+        apply Spec.implement_correct Θ s _ TransState.empty ρ vs P
+          ((S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
+            wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P)
+          hswf htyped himpl
+        intro argVars st' ρ' Q hargVars_mem hargVars_sort hargVars_lookup hbody_eval
+        exact checkBody_correct Θ S s γ hswf hSwf fb argBinders body argNames
+          hext bs rfl fval vs htyped P hargVars_mem hargVars_sort hargVars_lookup hbody_eval
+      iapply hbody' $$ [Hpred] [Hrec]
       · iexact Hpred
+      · isplitl []
+        · iexact Hspec
+        · iexact Hrec
   all_goals
     simp only [checkSpec] at heval
-    exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim
+    exact (elim_bind_fatal heval).elim

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -1,7 +1,6 @@
 import Mica.TinyML.Typed
 import Mica.TinyML.Typing
 import Mica.TinyML.OpSem
-import Mica.TinyML.WeakestPre
 import Mica.Verifier.Monad
 import Mica.Verifier.Assertions
 import Mica.Verifier.PredicateTransformers
@@ -31,16 +30,153 @@ def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM
     else VerifM.fatal s!"checkSpec: return type mismatch"
     pure se
 
+theorem checkSpec_body_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
+    (γ : Runtime.Subst)
+    (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
+    (hS : S.satisfiedBy Θ γ)
+    (st : TransState) (ρ : Env)
+    (fb : Binder) (argBinders : List Binder) (body : Expr)
+    (argNames : List String)
+    (hext : extractArgNames argBinders s.args = Except.ok argNames)
+    (bs : List Runtime.Binder) (hbs_def : bs = argBinders.map (·.runtime))
+    (fval : Runtime.Val)
+    (hbody : (Spec.implement s fun argVars => do
+        let S' := SpecMap.eraseAll argNames (S.insert' fb s)
+        let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
+        let Γ := (argNames.zip (s.args.map Prod.snd)).foldl
+          (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
+        let se ← compile Θ S' B Γ body
+        if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
+        else VerifM.fatal s!"checkSpec: return type mismatch"
+        pure se).eval st ρ (fun _ _ _ => True))
+    (vs : List Runtime.Val) (P : Runtime.Val → iProp)
+    (htyped_args : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd))
+    (isPrecond_rec : s.isPrecondFor Θ fval) :
+    st.owns.interp ρ ∗
+      PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
+        (Spec.argsEnv Env.empty s.args vs) ⊢
+      wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
+  obtain ⟨hlen1, hlen2, hbs_eq⟩ := extractArgNames_spec hext
+  have hbs_runtime : bs = argNames.map Runtime.Binder.named := by rw [hbs_def]; exact hbs_eq
+  have hlen_nv : argNames.length = vs.length := by
+    have := htyped_args.length_eq; simp at this; omega
+  have hlen : bs.length = vs.length := by simp [hbs_runtime]; omega
+  set γ_body := γ.update' fb.runtime fval |>.updateAll' bs vs
+  set S' : SpecMap := SpecMap.eraseAll argNames (S.insert' fb s)
+  -- Use implement_correct
+  apply Spec.implement_correct Θ s _ st ρ vs P
+    (wp (body.runtime.subst γ_body) P)
+    hswf htyped_args hbody
+  intro argVars st' ρ' Q hargVars_mem hargVars_sort hargVars_lookup hbody_eval
+  -- Establish spec map satisfaction
+  have hS'wf : S'.wfIn Signature.empty :=
+    SpecMap.wfIn_eraseAll (SpecMap.wfIn_insert' hSwf hswf)
+  have hS'_sat : S'.satisfiedBy Θ γ_body := by
+    have hS_ext : (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) :=
+      SpecMap.satisfiedBy_insert'_update' hS isPrecond_rec
+    have hsat := SpecMap.satisfiedBy_eraseAll_updateAll' hS_ext hlen_nv
+    change (SpecMap.eraseAll argNames (S.insert' fb s)).satisfiedBy Θ
+      ((γ.update' fb.runtime fval).updateAll' bs vs)
+    rw [hbs_runtime]; exact hsat
+  -- Set up bindings, agreement, well-formedness, typed substitution
+  set Γ := (argNames.zip (s.args.map Prod.snd)).foldl
+    (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
+  set B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
+  have hlen_avs : argNames.length = argVars.length := by
+    have := hargVars_lookup.length_eq
+    have := htyped_args.length_eq; simp at this; omega
+  have hagree : Bindings.agreeOnLinked B ρ' γ_body := by
+    show Bindings.agreeOnLinked (Bindings.empty ++ (argNames.zip argVars).reverse) ρ'
+      ((γ.update' fb.runtime fval).updateAll' bs vs)
+    rw [show Bindings.empty ++ (argNames.zip argVars).reverse =
+        (argNames.zip argVars).reverse ++ Bindings.empty from by simp [Bindings.empty]]
+    rw [hbs_runtime]
+    apply Bindings.agreeOnLinked_updateAll' Bindings.empty argNames argVars vs
+      (γ.update' fb.runtime fval) ρ'
+    · intro x x' h; simp [Bindings.empty] at h
+    · exact hlen_avs
+    · exact hlen_nv
+    · exact hargVars_sort
+    · exact hargVars_lookup
+  have hbwf : Bindings.wf B st'.decls := by
+    intro ⟨n, v⟩ hp
+    apply hargVars_mem v
+    have hmem : (n, v) ∈ (argNames.zip argVars) := by simp [B, Bindings.empty] at hp; exact hp
+    exact List.of_mem_zip hmem |>.2
+  have hts : Bindings.typedSubst Θ B Γ γ_body := by
+    apply Bindings.typedSubst_of_agreeOnLinked hagree
+    intro x x' t hmem hΓ
+    show TinyML.ValHasType Θ (ρ'.consts .value x'.name) t
+    set args' := argNames.zip (s.args.map Prod.snd)
+    have hfst : args'.map Prod.fst = argNames := by
+      simp [args']; exact List.map_fst_zip (by simp; omega)
+    have hsnd : args'.map Prod.snd = s.args.map Prod.snd := by
+      simp [args']; exact List.map_snd_zip (by simp; omega)
+    exact val_typed_of_last_wins args' argVars vs ρ' TinyML.TyCtx.empty x x' t
+      (by rw [hfst]; exact hlen_avs)
+      (by rw [hfst]; exact hlen_nv)
+      (by rw [hfst]; simp [B, Bindings.empty] at hmem; exact hmem)
+      hΓ hargVars_lookup
+      (by rw [hsnd]; exact htyped_args)
+  -- Use compile_correct
+  have hcompile := VerifM.eval_bind _ _ _ _ hbody_eval
+  exact compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
+    (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'_sat hS'wf
+    (fun v ρ'' st'' se hΨ hse_wf heval_se htyped => by
+      obtain ⟨hdecls, hagreeOn, hΨ⟩ := hΨ
+      by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
+      · simp [hsub] at hΨ
+        have hΨ' := VerifM.eval_ret hΨ
+        dsimp only at hΨ'
+        subst heval_se
+        have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
+          TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
+        refine (show st''.owns.interp ρ'' ∗ Q ⊢
+            st''.owns.interp ρ'' ∗ Q ∗
+              ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
+                P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
+        istart
+        iintro ⟨Howns, HQ⟩
+        isplitl [Howns]
+        · iexact Howns
+        · isplitl [HQ]
+          · iexact HQ
+          · iintro Hwand
+            iapply Hwand
+            ipure_intro
+            exact hret
+      · simp [hsub] at hΨ
+        exact (VerifM.eval_fatal hΨ).elim)
+
+/-- Sorry'd helper: extract `isPrecondFor` (a `Prop`) from an iProp wand.
+
+The hypothesis is a universally quantified wand asserting that the spec's predicate
+transformer entails `wp` of calling `f`. The conclusion `isPrecondFor` says the same
+at the `Prop` level. The only gap is the wand-to-entailment and `⌜ValsHaveTypes⌝`-to-Prop
+conversions.
+
+Once `isPrecondFor` is migrated to a persistent separation logic assertion, this becomes
+a direct consequence of the hypothesis. -/
+theorem isPrecondFor_of_wp_rec (Θ : TinyML.TypeEnv) (s : Spec)
+    (f : Runtime.Val) :
+    (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
+          (Spec.argsEnv Env.empty s.args vs) -∗
+        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢
+    ⌜s.isPrecondFor Θ f⌝ := by
+  sorry
+
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
     (hS : S.satisfiedBy Θ γ)
     (st : TransState) (ρ : Env) :
     VerifM.eval (checkSpec Θ S e s) st ρ (fun _ _ _ => True) →
-    wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
+    st.owns.interp ρ ⊢ wp (e.runtime.subst γ) (fun v => ⌜s.isPrecondFor Θ v⌝) := by
   intro heval
-  cases e with
-  | fix fb argBinders retTy body =>
+  cases e
+  case fix fb argBinders retTy body =>
     simp only [checkSpec] at heval
     -- Case split on extractArgNames result
     cases hext : extractArgNames argBinders s.args with
@@ -62,97 +198,45 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       rw [hgoal]
       set fval := Runtime.Val.fix fb.runtime (argBinders.map (·.runtime))
         (body.runtime.subst γ') with hfval_def
-      apply wp.func
-      intro vs htyped Φ happly
-      set Φ_inv : (Runtime.Val → Prop) → List Runtime.Val → Prop := fun P vs =>
-        TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∧
-          PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy → P r) s.pred
+      -- Use the extracted body correctness lemma
+      have body_correct := fun vs P htyped_args isPrecond_rec =>
+        checkSpec_body_correct Θ S s γ hswf hSwf hS st ρ fb argBinders body argNames
+          hext bs rfl fval hbody vs P htyped_args isPrecond_rec
+      -- Step 1: Apply wp.func to reduce wp (Expr.fix ...) to the value case
+      -- Goal: owns ⊢ wp (Expr.fix fb bs body') (fun v => ⌜isPrecondFor Θ v s⌝)
+      -- wp.func: P fval ⊢ wp (Expr.fix fb bs body') P, where fval = Val.fix fb bs body'
+      change st.owns.interp ρ ⊢ wp (Runtime.Expr.fix fb.runtime bs (body.runtime.subst γ'))
+        (fun v => ⌜s.isPrecondFor Θ v⌝)
+      -- Set up Φ for wp_fix': Φ P vs = ⌜ValsHaveTypes⌝ ∗ PredTrans.apply (... -∗ P) s.pred ...
+      set Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp :=
+        fun P vs => ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
+          PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
             (Spec.argsEnv Env.empty s.args vs)
-      suffices ∀ vs P, Φ_inv P vs → wp (Runtime.Expr.app (.val fval) (vs.map Runtime.Expr.val)) P from
-        this vs Φ ⟨htyped, happly⟩
-      exact wp.fix' (body.runtime.subst γ') Φ_inv (fun ih_rec vs P ⟨htyped_args, happly_args⟩ => by
-        -- Rewrite the double substitution into a single one
-        obtain ⟨hlen1, hlen2, hbs_eq⟩ := extractArgNames_spec hext
-        have hlen_nv0 : argNames.length = vs.length := by
-          have := htyped_args.length_eq; simp at this; omega
-        have hbs_runtime : bs = argNames.map Runtime.Binder.named := by
-          simp only [bs]
-          exact hbs_eq
-        have hlen : bs.length = vs.length := by simp [hbs_runtime]; omega
-        rw [Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen]
-        set γ_body := γ.update' fb.runtime fval |>.updateAll' bs vs
-        -- Use implement_correct to get into the body
-        apply Spec.implement_correct Θ s _ _ _ vs _ (wp (body.runtime.subst γ_body) P) hswf htyped_args hbody happly_args
-        intro argVars st' ρ' hargVars_mem hargVars_sort hargVars_lookup hbody_eval
-        -- Key facts about fval and the spec map
-        have isPrecond : s.isPrecondFor Θ fval := by
-          intro vs' htyped' Φ' happly'
-          exact ih_rec vs' Φ' ⟨htyped', happly'⟩
-        have hS'wf : S'.wfIn Signature.empty :=
-          SpecMap.wfIn_eraseAll (SpecMap.wfIn_insert' hSwf hswf)
-        have hS'_sat : S'.satisfiedBy Θ γ_body := by
-          -- Simplified using the new lemma
-          have hS_ext : (S.insert' fb s).satisfiedBy Θ (γ.update' fb.runtime fval) := by
-            apply SpecMap.satisfiedBy_insert'_update' hS isPrecond
-          have hsat := SpecMap.satisfiedBy_eraseAll_updateAll' hS_ext hlen_nv0
-          -- hsat : (eraseAll argNames (insert' S fb s)).satisfiedBy ((γ.update' fb.runtime fval).updateAll' (argNames.map .named) vs)
-          -- γ_body : (γ.update' fb.runtime fval).updateAll' bs vs
-          -- and bs = argNames.map .named (from hbs_eq)
-          change (SpecMap.eraseAll argNames (S.insert' fb s)).satisfiedBy Θ ((γ.update' fb.runtime fval).updateAll' bs vs)
-          rw [hbs_runtime]; exact hsat
-        set Γ := (argNames.zip (s.args.map Prod.snd)).foldl (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
-        set B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
-        have hlen_avs : argNames.length = argVars.length := by
-          have := hargVars_lookup.length_eq
-          have := htyped_args.length_eq; simp at this; omega
-        have hlen_vals : argNames.length = vs.length := by
-          have := htyped_args.length_eq; simp at this; omega
-        have hagree : Bindings.agreeOnLinked B ρ' γ_body := by
-          show Bindings.agreeOnLinked (Bindings.empty ++ (argNames.zip argVars).reverse) ρ'
-            ((γ.update' fb.runtime fval).updateAll' bs vs)
-          rw [show Bindings.empty ++ (argNames.zip argVars).reverse =
-              (argNames.zip argVars).reverse ++ Bindings.empty from by simp [Bindings.empty]]
-          rw [hbs_runtime]
-          apply Bindings.agreeOnLinked_updateAll' Bindings.empty argNames argVars vs
-            (γ.update' fb.runtime fval) ρ'
-          · intro x x' h; simp [Bindings.empty] at h
-          · exact hlen_avs
-          · exact hlen_vals
-          · exact hargVars_sort
-          · exact hargVars_lookup
-        have hbwf : Bindings.wf B st'.decls := by
-          intro ⟨n, v⟩ hp
-          apply hargVars_mem v
-          have hmem : (n, v) ∈ (argNames.zip argVars) := by simp [B, Bindings.empty] at hp; exact hp
-          exact List.of_mem_zip hmem |>.2
-        have hts : Bindings.typedSubst Θ B Γ γ_body := by
-          apply Bindings.typedSubst_of_agreeOnLinked hagree
-          intro x x' t hmem hΓ
-          show TinyML.ValHasType Θ (ρ'.consts .value x'.name) t
-          set args' := argNames.zip (s.args.map Prod.snd)
-          have hfst : args'.map Prod.fst = argNames := by
-            simp [args']; exact List.map_fst_zip (by simp; omega)
-          have hsnd : args'.map Prod.snd = s.args.map Prod.snd := by
-            simp [args']; exact List.map_snd_zip (by simp; omega)
-          exact val_typed_of_last_wins args' argVars vs ρ' TinyML.TyCtx.empty x x' t
-            (by rw [hfst]; exact hlen_avs)
-            (by rw [hfst]; exact hlen_vals)
-            (by rw [hfst]; simp [B, Bindings.empty] at hmem; exact hmem)
-            hΓ hargVars_lookup
-            (by rw [hsnd]; exact htyped_args)
-        have hcompile := VerifM.eval_bind _ _ _ _ hbody_eval
-        apply compile_correct Θ body S' B Γ st' ρ' γ_body _ P
-          hcompile hagree hbwf hts hS'_sat hS'wf
-        intro result ρ'' st'' se hΨ hse_wf hse_eval htyped_result
-        split at hΨ
-        · rename_i hsub
-          have hret := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ hΨ)
-          have hret' := VerifM.eval_ret hret
-          have hsub' : TinyML.Typ.Sub Θ body.ty s.retTy := TinyML.Typ.sub_sound hsub
-          rw [hse_eval] at hret'
-          exact hret' hse_wf (TinyML.ValHasType_sub htyped_result hsub')
-        · have hcheck := VerifM.eval_bind _ _ _ _ hΨ
-          exact (VerifM.eval_fatal hcheck).elim)
-  | _ =>
+      -- Apply wp_fix' to get the recursive spec, then isPrecondFor_of_wp_rec to extract Prop
+      suffices hwp : st.owns.interp ρ ⊢
+          ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+            Φ P vs -∗ wp (Runtime.Expr.app (.val fval) (vs.map Runtime.Expr.val)) P by
+        -- Extract the Prop-level recursive spec, then lift it through `wp_func`.
+        have hgoal2 := hwp.trans (isPrecondFor_of_wp_rec Θ s fval)
+        exact SpatialContext.wp_func hgoal2
+      -- Prove the wp_fix' obligation
+      obtain ⟨_, _, hbs_eq⟩ := extractArgNames_spec hext
+      have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_eq
+      apply SpatialContext.wp_fix'
+      istart
+      iintro Howns IH %vs %P ⟨%htyped, Hpred⟩
+      -- Extract the Prop-level recursive spec from the recursive wp hypothesis.
+      ihave ⌜hipc⌝ := isPrecondFor_of_wp_rec Θ s fval $$ IH
+      -- Use body_correct: needs owns ∗ PredTrans ⊢ wp (body.subst (γ.update'...))
+      -- wp_fix' gives body.subst (id.update'...) — bridge via subst_fix_comp
+      have hlen_vs : bs.length = vs.length := by
+        simp [hbs_runtime]; have := htyped.length_eq; simp at this; omega
+      have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
+      simp only [] at hsub; rw [hsub]
+      iapply (body_correct vs _ htyped hipc)
+      isplitl [Howns]
+      · iexact Howns
+      · iexact Hpred
+  all_goals
     simp only [checkSpec] at heval
     exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -52,17 +52,17 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     (vs : List Runtime.Val)
     (htyped_args : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd))
     (P : Runtime.Val → iProp)
-    {argVars : List FOL.Const} {st' : TransState} {ρ' : Env} {Q : iProp}
+    {argVars : List FOL.Const} {st' : TransState} {ρ' : VerifM.Env} {Q : iProp}
     (hargVars_mem : ∀ v ∈ argVars, v ∈ st'.decls.consts)
     (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
-    (hargVars_lookup : List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs)
+    (hargVars_lookup : List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs)
     (hbody_eval : VerifM.eval
         (checkBody Θ (SpecMap.eraseAll argNames (S.insert' fb s)) s argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
-          st''.owns.interp ρ'' ∗ Q ∗
-            ((⌜TinyML.ValHasType Θ (result.eval ρ'') s.retTy⌝ -∗ P (result.eval ρ'')) -∗ S) ⊢ S)) :
-    st'.owns.interp ρ' ∗ Q ⊢
+          st''.sl ρ'' ∗ Q ∗
+            ((⌜TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy⌝ -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
+    st'.sl ρ' ∗ Q ⊢
       (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
         wp (body.runtime.subst (γ.update' fb.runtime fval |>.updateAll' bs vs)) P := by
   simp only [checkBody] at hbody_eval
@@ -80,14 +80,14 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
   have hlen_avs : argNames.length = argVars.length := by
     have := hargVars_lookup.length_eq
     have := htyped_args.length_eq; simp at this; omega
-  have hagree : Bindings.agreeOnLinked B ρ' γ_body := by
-    show Bindings.agreeOnLinked (Bindings.empty ++ (argNames.zip argVars).reverse) ρ'
+  have hagree : Bindings.agreeOnLinked B ρ'.env γ_body := by
+    show Bindings.agreeOnLinked (Bindings.empty ++ (argNames.zip argVars).reverse) ρ'.env
       ((γ.update' fb.runtime fval).updateAll' bs vs)
     rw [show Bindings.empty ++ (argNames.zip argVars).reverse =
         (argNames.zip argVars).reverse ++ Bindings.empty from by simp [Bindings.empty]]
     rw [hbs_runtime]
     apply Bindings.agreeOnLinked_updateAll' Bindings.empty argNames argVars vs
-      (γ.update' fb.runtime fval) ρ'
+      (γ.update' fb.runtime fval) ρ'.env
     · intro x x' h; simp [Bindings.empty] at h
     · exact hlen_avs
     · exact hlen_nv
@@ -101,13 +101,13 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
   have hts : Bindings.typedSubst Θ B Γ γ_body := by
     apply Bindings.typedSubst_of_agreeOnLinked hagree
     intro x x' t hmem hΓ
-    show TinyML.ValHasType Θ (ρ'.consts .value x'.name) t
+    show TinyML.ValHasType Θ (ρ'.env.consts .value x'.name) t
     set args' := argNames.zip (s.args.map Prod.snd)
     have hfst : args'.map Prod.fst = argNames := by
       simp [args']; exact List.map_fst_zip (by simp; omega)
     have hsnd : args'.map Prod.snd = s.args.map Prod.snd := by
       simp [args']; exact List.map_snd_zip (by simp; omega)
-    exact val_typed_of_last_wins args' argVars vs ρ' TinyML.TyCtx.empty x x' t
+    exact val_typed_of_last_wins args' argVars vs ρ'.env TinyML.TyCtx.empty x x' t
       (by rw [hfst]; exact hlen_avs)
       (by rw [hfst]; exact hlen_nv)
       (by rw [hfst]; simp [B, Bindings.empty] at hmem; exact hmem)
@@ -127,7 +127,7 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
       SpecMap.satisfiedBy_eraseAll_updateAll' hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
-      st'.owns.interp ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Q) ⊢
+      st'.sl ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Q) ⊢
         wp (body.runtime.subst γ_body) P := by
     refine compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
       (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'wf ?_
@@ -141,12 +141,12 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     have hΨ' := VerifM.eval_ret hΨ
     dsimp only at hΨ'
     subst heval_se
-    have hret : TinyML.ValHasType Θ (se.eval ρ'') s.retTy :=
+    have hret : TinyML.ValHasType Θ (se.eval ρ''.env) s.retTy :=
       TinyML.ValHasType_sub htyped (TinyML.Typ.sub_sound hsub)
-    refine (show st''.owns.interp ρ'' ∗ Q ⊢
-        st''.owns.interp ρ'' ∗ Q ∗
-          ((⌜TinyML.ValHasType Θ (se.eval ρ'') s.retTy⌝ -∗ P (se.eval ρ'')) -∗
-            P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
+    refine (show st''.sl ρ'' ∗ Q ⊢
+        st''.sl ρ'' ∗ Q ∗
+          ((⌜TinyML.ValHasType Θ (se.eval ρ''.env) s.retTy⌝ -∗ P (se.eval ρ''.env)) -∗
+            P (se.eval ρ''.env)) from ?_).trans (hΨ' _ hse_wf)
     istart
     iintro ⟨Howns, HQ⟩
     isplitl [Howns]
@@ -170,7 +170,7 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (ρ : Env) :
+    (ρ : VerifM.Env) :
     VerifM.eval (checkSpec Θ S e s) TransState.empty ρ (fun _ _ _ => True) →
     S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
   intro heval
@@ -216,7 +216,7 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
       simp only [] at hsub; rw [hsub]
       have hbody' : PredTrans.apply (fun r => iprop(⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r)) s.pred
-          (Spec.argsEnv Env.empty s.args vs) ⊢
+          (Spec.argsEnv VerifM.Env.empty s.args vs) ⊢
           SpecMap.satisfiedBy Θ S γ ∗ s.isPrecondFor Θ fval -∗
             wp (Runtime.Expr.subst ((Runtime.Subst.update' fb.runtime fval γ).updateAll' bs vs) body.runtime) P := by
         refine emp_sep.2.trans ?_

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -23,13 +23,25 @@ structure TransState where
   asserts : Context
   owns    : SpatialContext
 
+inductive CtxItem where
+  | pure : Formula → CtxItem
+  | spatial : SpatialAtom → CtxItem
+
+namespace CtxItem
+
+def wfIn : CtxItem → Signature → Prop
+  | .pure φ, Δ => φ.wfIn Δ
+  | .spatial a, Δ => a.wfIn Δ
+
+end CtxItem
+
 inductive VerifM : Type → Type 1 where
   | ret : α → VerifM α
   | bind : VerifM α → (α → VerifM β) → VerifM β
   /-- Declare a fresh SMT constant. -/
   | decl : Option String → Srt → VerifM FOL.Const
-  /-- Add a formula to the assertion context (permanent, no check). -/
-  | assume : Formula → VerifM Unit
+  /-- Add a context item to the verifier state (permanent, no check). -/
+  | assume : CtxItem → VerifM Unit
   /-- Check whether φ is provable from the current context.
       Returns `true` if UNSAT (provable), `false` otherwise. Never fails. -/
   | check : Formula → VerifM Bool
@@ -74,7 +86,7 @@ def VerifM.expectSome (msg : String) (x : Option α) : VerifM α := do
 /-- Assume all formulas in a list via `VerifM.assume`. -/
 def VerifM.assumeAll : List Formula → VerifM Unit
   | [] => pure ()
-  | φ :: φs => do VerifM.assume φ; VerifM.assumeAll φs
+  | φ :: φs => do VerifM.assume (.pure φ); VerifM.assumeAll φs
 
 /-! ### Translation to ScopedM -/
 
@@ -115,6 +127,11 @@ def TransState.freshConst (hint : Option String) (t : Srt) (st : TransState) : F
   let x' := fresh (addNumbers base) st.decls.allNames
   ⟨x', t⟩
 
+def TransState.addItem (st: TransState) (item: CtxItem) :=
+  match item with
+  | .pure φ =>  { st with asserts := φ :: st.asserts }
+  | .spatial p => { st with owns := p :: st.owns }
+
 theorem TransState.freshConst.wf {hint t} (st : TransState) :
   TransState.wf st →
   TransState.wf { st with decls := st.decls.addConst (st.freshConst hint t) } := by
@@ -140,6 +157,16 @@ theorem TransState.addAssert.wf (st : TransState) :
     · exact hwf.assertsWf ψ hψ
   · exact hwf.namesDisjoint
   · exact hwf.ownsWf
+
+theorem TransState.addSpatial.wf (st : TransState) :
+  TransState.wf st →
+  a.wfIn st.decls →
+  TransState.wf { st with owns := a :: st.owns } := by
+  intro hwf ha
+  constructor
+  · exact hwf.assertsWf
+  · exact hwf.namesDisjoint
+  · simpa [SpatialContext.wfIn_cons] using And.intro ha hwf.ownsWf
 
 
 def TransCont α := α → TransState → ScopedM (Except VerifError Unit)
@@ -175,9 +202,13 @@ def VerifM.translate :
       let c := st.freshConst hint t
       .declareConst c.name t (fun () =>
         k (.ok c) { st with decls := st.decls.addConst c })
-  | .assume φ, st, k =>
-      ScopedM.assert φ (fun () =>
-        k (.ok ()) { st with asserts := φ :: st.asserts })
+  | .assume item, st, k =>
+      match item with
+      | .pure φ =>
+          ScopedM.assert φ (fun () =>
+            k (.ok ()) { st with asserts := φ :: st.asserts })
+      | .spatial a =>
+          k (.ok ()) { st with owns := a :: st.owns }
   | .check φ, st, k =>
       .bracket
         (ScopedM.assert (.not φ) (fun () =>
@@ -207,7 +238,10 @@ def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState �
   | .decl hint t, st, ρ, P =>
       let c := st.freshConst hint t
       ∀ u, P c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u)
-  | .assume φ, st, ρ, P => φ.wfIn st.decls → φ.eval ρ → P () { st with asserts := φ :: st.asserts } ρ
+  | .assume item, st, ρ, P =>
+      match item with
+      | .pure φ => φ.wfIn st.decls → φ.eval ρ → P () { st with asserts := φ :: st.asserts } ρ
+      | .spatial a => a.wfIn st.decls → P () { st with owns := a :: st.owns } ρ
   | .check φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ) ∧ P b st ρ
   | .fatal _, _, _, _ => False
   | .failed _, _, _, _ => False
@@ -234,9 +268,14 @@ theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : 
     exact agreeOn_update_fresh_const
       (c := ⟨fresh (addNumbers (hint.getD "_v")) st.decls.allNames, t⟩)
       (fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _))
-  | assume =>
-    intro hwf hφ
-    exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf hφ)
+  | assume item =>
+    cases item with
+    | pure φ =>
+      intro hwf hφ
+      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf hφ)
+    | spatial a =>
+      intro hwf
+      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf)
   | check =>
     intro hwf
     obtain ⟨b, hb, hp⟩ := h hwf
@@ -290,14 +329,20 @@ theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
     · intro φ hφ
       exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
     · exact ⟨TransState.freshConst.wf _ hwf, h⟩
-  | assume φ =>
-    simp only [VerifM.eval_rec] at h ⊢
-    intro hwf' hφ
-    refine ⟨?_, TransState.addAssert.wf _ hwf hwf', h hwf' hφ⟩
-    intro ψ hψ
-    cases hψ with
-    | head => exact hφ
-    | tail _ hψ => exact g ψ hψ
+  | assume item =>
+    cases item with
+    | pure φ =>
+      simp only [VerifM.eval_rec] at h ⊢
+      intro hwf' hφ
+      refine ⟨?_, TransState.addAssert.wf _ hwf hwf', h hwf' hφ⟩
+      intro ψ hψ
+      cases hψ with
+      | head => exact hφ
+      | tail _ hψ => exact g ψ hψ
+    | spatial a =>
+      simp only [VerifM.eval_rec] at h ⊢
+      intro hwf'
+      exact ⟨g, TransState.addSpatial.wf _ hwf hwf', h hwf'⟩
   | check φ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro hwf'
@@ -393,11 +438,17 @@ theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
     simp only [VerifM.eval_rec]
     intro u
     exact ⟨_, h⟩
-  | assume φ =>
-    simp only [VerifM.translate] at h
-    have h := ScopedM.eval_assert h
-    intro hwf' hφ
-    exact ⟨_, h⟩
+  | assume item =>
+    cases item with
+    | pure φ =>
+      simp only [VerifM.translate] at h
+      have h := ScopedM.eval_assert h
+      intro hwf' hφ
+      exact ⟨_, h⟩
+    | spatial a =>
+      simp only [VerifM.translate] at h
+      intro hwf'
+      exact ⟨_, h⟩
   | check φ =>
     simp only [VerifM.translate] at h
     obtain ⟨b, _, hxx, hk⟩ := ScopedM.eval_bracket h
@@ -518,11 +569,30 @@ theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ 
     ∀ u, Q c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u) :=
   fun u => (h.2.2 u).2.2
 
-theorem VerifM.eval_assume {φ : Formula} {st : TransState} {ρ : Env}
+theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : Env}
     {Q : Unit → TransState → Env → Prop}
-    (h : VerifM.eval (.assume φ) st ρ Q) :
+    (h : VerifM.eval (.assume (.pure φ)) st ρ Q) :
     φ.wfIn st.decls → φ.eval ρ → Q () { st with asserts := φ :: st.asserts } ρ :=
   fun hwf hφ => (h.2.2 hwf hφ).2.2
+
+theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
+    (h : VerifM.eval (.assume (.spatial a)) st ρ Q) :
+    a.wfIn st.decls → Q () { st with owns := a :: st.owns } ρ :=
+  fun hwf => (h.2.2 hwf).2.2
+
+theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
+    (h : VerifM.eval (.assume item) st ρ Q) :
+    item.wfIn st.decls → (match item with | .pure φ => φ.eval ρ | .spatial _ => True) → Q () (st.addItem item) ρ :=
+  by
+    cases item with
+    | pure φ =>
+      simp [TransState.addItem]
+      exact VerifM.eval_assumePure h
+    | spatial a =>
+      simp [TransState.addItem]
+      exact VerifM.eval_assumeSpatial h
 
 theorem VerifM.eval_check {φ : Formula} {st : TransState} {ρ : Env}
     {Q : Bool → TransState → Env → Prop}
@@ -649,7 +719,7 @@ theorem VerifM.eval_assumeAll {φs : List Formula}
     intro hwf heval
     simp only [VerifM.assumeAll] at h
     have hb := VerifM.eval_bind _ _ _ _ h
-    have hassume := VerifM.eval_assume hb
+    have hassume := VerifM.eval_assumePure hb
     have hcont := hassume
       (hwf φ (List.mem_cons_self ..))
       (heval φ (List.mem_cons_self ..))

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -63,6 +63,60 @@ instance : Monad VerifM where
   pure := VerifM.ret
   bind := VerifM.bind
 
+structure VerifM.Env where
+  env : _root_.Env
+
+def VerifM.Env.empty : VerifM.Env :=
+  { env := _root_.Env.empty }
+
+@[simp] theorem VerifM.Env.empty_env : VerifM.Env.empty.env = _root_.Env.empty := rfl
+
+def VerifM.Env.updateConst (ρ : VerifM.Env) (t : Srt) (x : String) (u : t.denote) : VerifM.Env :=
+  { ρ with env := _root_.Env.updateConst ρ.env t x u }
+
+@[simp] theorem VerifM.Env.updateConst_env (ρ : VerifM.Env) (t : Srt) (x : String) (u : t.denote) :
+    (ρ.updateConst t x u).env = ρ.env.updateConst t x u := rfl
+
+def VerifM.Env.withEnv (ρ : VerifM.Env) (env' : _root_.Env) : VerifM.Env :=
+  { ρ with env := env' }
+
+@[simp] theorem VerifM.Env.withEnv_env (ρ : VerifM.Env) (env' : _root_.Env) :
+    (ρ.withEnv env').env = env' := rfl
+
+def VerifM.Env.agreeOn (Δ : Signature) (ρ ρ' : VerifM.Env) : Prop :=
+  _root_.Env.agreeOn Δ ρ.env ρ'.env
+
+theorem VerifM.Env.agreeOn_refl : VerifM.Env.agreeOn Δ ρ ρ :=
+  _root_.Env.agreeOn_refl
+
+theorem VerifM.Env.agreeOn_mono {Δ₁ Δ₂ : Signature} (hsub : Δ₁.Subset Δ₂)
+    (h : VerifM.Env.agreeOn Δ₂ ρ ρ') : VerifM.Env.agreeOn Δ₁ ρ ρ' :=
+  _root_.Env.agreeOn_mono hsub h
+
+theorem VerifM.Env.agreeOn_symm {Δ : Signature} (h : VerifM.Env.agreeOn Δ ρ ρ') :
+    VerifM.Env.agreeOn Δ ρ' ρ :=
+  _root_.Env.agreeOn_symm h
+
+theorem VerifM.Env.agreeOn_trans {Δ : Signature}
+    (h₁₂ : VerifM.Env.agreeOn Δ ρ₁ ρ₂) (h₂₃ : VerifM.Env.agreeOn Δ ρ₂ ρ₃) :
+    VerifM.Env.agreeOn Δ ρ₁ ρ₃ :=
+  _root_.Env.agreeOn_trans h₁₂ h₂₃
+
+theorem VerifM.Env.agreeOn_declVar {ρ ρ' : VerifM.Env} {Δ : Signature} {τ : Srt} {x : String} {v : τ.denote} :
+    VerifM.Env.agreeOn Δ ρ ρ' →
+    VerifM.Env.agreeOn (Δ.declVar ⟨x, τ⟩) (ρ.updateConst τ x v) (ρ'.updateConst τ x v) := by
+  intro hagree
+  simpa [VerifM.Env.agreeOn, VerifM.Env.updateConst] using
+    (_root_.Env.agreeOn_declVar (ρ := ρ.env) (ρ' := ρ'.env) (Δ := Δ) (τ := τ) (x := x) (v := v) hagree)
+
+theorem VerifM.Env.agreeOn_update_fresh {ρ : VerifM.Env} {c : FOL.Const} {u : c.sort.denote}
+    {Δ : Signature} (hfresh : c.name ∉ Δ.allNames) :
+    VerifM.Env.agreeOn Δ ρ (ρ.updateConst c.sort c.name u) := by
+  simpa [VerifM.Env.agreeOn, VerifM.Env.updateConst] using
+    (agreeOn_update_fresh_const (ρ := ρ.env) (c := c) (u := u) (Δ := Δ) hfresh)
+
+
+
 /-- Read the current pure assertion context (backwards-compatible wrapper around `ctx`). -/
 def VerifM.ctxPure (f : List Formula → α) : VerifM α :=
   VerifM.ctx (fun st => (f st.asserts, st.owns))
@@ -111,9 +165,9 @@ def TransState.empty : TransState := ⟨Signature.empty, [], []⟩
 
 @[simp] theorem TransState.empty_toFlatCtx : TransState.empty.toFlatCtx = FlatCtx.empty := rfl
 
-def TransState.holdsFor (st : TransState) (ρ : Env) := ∀ φ ∈ st.asserts, φ.eval ρ
+def TransState.holdsFor (st : TransState) (ρ : VerifM.Env) := ∀ φ ∈ st.asserts, φ.eval ρ.env
 
-theorem TransState.holdsFor_mono {st st' : TransState} {ρ : Env}
+theorem TransState.holdsFor_mono {st st' : TransState} {ρ : VerifM.Env}
     (hsub : st.asserts ⊆ st'.asserts) (h : st'.holdsFor ρ) : st.holdsFor ρ :=
   fun φ hφ => h φ (hsub hφ)
 
@@ -232,7 +286,7 @@ def VerifM.translate :
 
 /-! ### Eval_rec: postcondition-based semantics (raw) -/
 
-def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState → Env → Prop) → Prop
+def VerifM.eval_rec : VerifM α → TransState → VerifM.Env → (α → TransState → VerifM.Env → Prop) → Prop
   | .ret a, st, ρ, P => P a st ρ
   | .bind m k, st, ρ, P => m.eval_rec st ρ (fun r st' ρ' => (k r).eval_rec st' ρ' P)
   | .decl hint t, st, ρ, P =>
@@ -240,9 +294,9 @@ def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState �
       ∀ u, P c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u)
   | .assume item, st, ρ, P =>
       match item with
-      | .pure φ => φ.wfIn st.decls → φ.eval ρ → P () { st with asserts := φ :: st.asserts } ρ
+      | .pure φ => φ.wfIn st.decls → φ.eval ρ.env → P () { st with asserts := φ :: st.asserts } ρ
       | .spatial a => a.wfIn st.decls → P () { st with owns := a :: st.owns } ρ
-  | .check φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ) ∧ P b st ρ
+  | .check φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ.env) ∧ P b st ρ
   | .fatal _, _, _, _ => False
   | .failed _, _, _, _ => False
   | .all items, st, ρ, P => ∀ a ∈ items, P a st ρ
@@ -253,44 +307,45 @@ def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState �
   | .seq m m2, st, ρ, P =>
       m.eval_rec st ρ (fun () _ _ => True) ∧ m2.eval_rec st ρ P
 
-theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : m.eval_rec st ρ P)
-    (hPQ : ∀ a st' ρ', st.decls.Subset st'.decls → Env.agreeOn st.decls ρ ρ' → P a st' ρ' → Q a st' ρ') :
+theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : VerifM.Env) (st : TransState) (h : m.eval_rec st ρ P)
+    (hPQ : ∀ a st' (ρ' : VerifM.Env),
+      st.decls.Subset st'.decls → VerifM.Env.agreeOn st.decls ρ ρ' → P a st' ρ' → Q a st' ρ') :
     m.eval_rec st ρ Q := by
   induction m generalizing st ρ with
-  | ret => exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) h
+  | ret => exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) h
   | bind m k ihm ihk =>
     exact ihm ρ st h fun r st' ρ' hsub hag hr =>
       ihk r ρ' st' hr fun a st'' ρ'' hsub' hag' hp =>
-        hPQ a st'' ρ'' (hsub.trans hsub') (Env.agreeOn_trans hag (Env.agreeOn_mono hsub hag')) hp
+        hPQ a st'' ρ'' (hsub.trans hsub') (VerifM.Env.agreeOn_trans hag (VerifM.Env.agreeOn_mono hsub hag')) hp
   | decl hint t =>
     intro u
     refine hPQ _ _ _ (Signature.Subset.subset_addConst _ _) ?_ (h u)
-    exact agreeOn_update_fresh_const
+    exact VerifM.Env.agreeOn_update_fresh
       (c := ⟨fresh (addNumbers (hint.getD "_v")) st.decls.allNames, t⟩)
       (fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _))
   | assume item =>
     cases item with
     | pure φ =>
       intro hwf hφ
-      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf hφ)
+      exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h hwf hφ)
     | spatial a =>
       intro hwf
-      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf)
+      exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h hwf)
   | check =>
     intro hwf
     obtain ⟨b, hb, hp⟩ := h hwf
-    exact ⟨b, hb, hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) hp⟩
+    exact ⟨b, hb, hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) hp⟩
   | fatal => exact h.elim
   | failed => exact h.elim
   | all items =>
     intro a ha
-    exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h a ha)
+    exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h a ha)
   | any items =>
     obtain ⟨a, ha, hp⟩ := h
-    exact ⟨a, ha, hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) hp⟩
+    exact ⟨a, ha, hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) hp⟩
   | ctx f =>
     intro howns
-    exact hPQ _ _ _ (Signature.Subset.refl _) Env.agreeOn_refl (h howns)
+    exact hPQ _ _ _ (Signature.Subset.refl _) VerifM.Env.agreeOn_refl (h howns)
   | seq m m2 ihm ihf =>
     exact ⟨ihm ρ st h.1 fun () _ _ _ _ ha => trivial,
            ihf ρ st h.2 hPQ⟩
@@ -300,13 +355,13 @@ theorem VerifM.eval_rec.mono {m : VerifM α} (h : m.eval_rec st ρ P) (hPQ : ∀
   h.mono' ρ st fun a st' ρ' _ _ => hPQ a st' ρ'
 
 theorem VerifM.eval_rec.decls_grow {m : VerifM α} ρ (h : m.eval_rec st ρ P) :
-    m.eval_rec st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
+    m.eval_rec st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
   h.mono' ρ st fun _ _ _ hsub hag hp => ⟨hsub, hag, hp⟩
 
 /-! ### Adequacy: translate success implies eval -/
 
 
-theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
+theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: VerifM.Env)
     (h : VerifM.eval_rec m st ρ P) (g : st.holdsFor ρ) (hwf : st.wf) :
     VerifM.eval_rec m st ρ (fun a st' ρ' => st'.holdsFor ρ' ∧ st'.wf ∧ P a st' ρ') := by
   induction m generalizing st ρ with
@@ -323,8 +378,8 @@ theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
     specialize (h u)
     let w := fresh (addNumbers (hint.getD "_v")) st.decls.allNames
     have hfresh := fresh_not_mem (addNumbers (hint.getD "_v")) st.decls.allNames (addNumbers_injective _)
-    have hagree : Env.agreeOn st.decls ρ (ρ.updateConst t w u) := by
-      exact agreeOn_update_fresh_const (c := ⟨w, t⟩) hfresh
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateConst t w u) := by
+      exact VerifM.Env.agreeOn_update_fresh (c := ⟨w, t⟩) hfresh
     constructor
     · intro φ hφ
       exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
@@ -412,7 +467,7 @@ private theorem translateAny_eval (items : List α) (st : TransState)
       simp only [ScopedM.eval_ret] at hk1
       exact absurd hk1.1 (by simp)
 
-theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
+theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: VerifM.Env)
     (f : TransCont (Except VerifError α))
     (hf : ∀ e st', ¬∃ Δ, ScopedM.eval (f (.error e) st') st'.toFlatCtx (.ok ()) Δ)
     (Δ : FlatCtx)
@@ -462,7 +517,7 @@ theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
     rcases hxx with ⟨hunsat, _⟩ | hfalse
     · have hunsat' : ¬Smt.State.satisfiable st.decls (Formula.not φ :: st.asserts) := by
         simp only [FlatCtx.addAssert] at hunsat; exact hunsat
-      exact Smt.State.satisfiable.to_impl' st.decls st.asserts hunsat' ρ g
+      exact Smt.State.satisfiable.to_impl' st.decls st.asserts hunsat' ρ.env g
     · simp [ScopedM.eval_ret] at hfalse
   | fatal msg =>
     simp only [VerifM.translate] at h
@@ -505,20 +560,20 @@ theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
 
 /-- The main verification predicate. Requires `st` to be well-formed and satisfy `ρ`,
     and guarantees the same for every reachable `st'`. -/
-def VerifM.eval (m : VerifM α) (st : TransState) (ρ : Env) (Q : α → TransState → Env → Prop) : Prop :=
+def VerifM.eval (m : VerifM α) (st : TransState) (ρ : VerifM.Env) (Q : α → TransState → VerifM.Env → Prop) : Prop :=
   st.wf ∧ st.holdsFor ρ ∧
   m.eval_rec st ρ (fun a st' ρ' => st'.wf ∧ st'.holdsFor ρ' ∧ Q a st' ρ')
 
 /-! ### Structural properties -/
 
-theorem VerifM.eval.wf {m : VerifM α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval.wf {m : VerifM α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : m.eval st ρ Q) : st.wf := h.1
 
-theorem VerifM.eval.holdsFor {m : VerifM α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval.holdsFor {m : VerifM α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : m.eval st ρ Q) : st.holdsFor ρ := h.2.1
 
-theorem VerifM.eval.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : m.eval st ρ P)
-    (hPQ : ∀ a st' ρ', st.decls.Subset st'.decls → Env.agreeOn st.decls ρ ρ' →
+theorem VerifM.eval.mono' {m : VerifM α} (ρ : VerifM.Env) (st : TransState) (h : m.eval st ρ P)
+    (hPQ : ∀ a st' (ρ' : VerifM.Env), st.decls.Subset st'.decls → VerifM.Env.agreeOn st.decls ρ ρ' →
       st'.wf → st'.holdsFor ρ' → P a st' ρ' → Q a st' ρ') :
     m.eval st ρ Q :=
   ⟨h.1, h.2.1, h.2.2.mono' ρ st fun a st' ρ' hsub hag ⟨hwf', hg', hp⟩ =>
@@ -529,12 +584,12 @@ theorem VerifM.eval.mono {m : VerifM α} (h : m.eval st ρ P) (hPQ : ∀ a st' �
   h.mono' ρ st fun a st' ρ' _ _ _ _ => hPQ a st' ρ'
 
 theorem VerifM.eval.decls_grow {m : VerifM α} ρ (h : m.eval st ρ P) :
-    m.eval st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
+    m.eval st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
   h.mono' ρ st fun _ _ _ hsub hag _ _ hp => ⟨hsub, hag, hp⟩
 
 /-! ### Inversion lemmas for VerifM.eval (forward direction) -/
 
-theorem VerifM.eval_ret {a : α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_ret {a : α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.ret a) st ρ Q) : Q a st ρ :=
   h.2.2.2.2
 
@@ -554,37 +609,39 @@ theorem VerifM.eval_bind (m : VerifM α) (k : α → VerifM β) st ρ :
 
 
 
-theorem VerifM.eval_failed {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_failed {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.failed msg) st ρ Q) : False :=
   h.2.2
 
-theorem VerifM.eval_fatal {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_fatal {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.fatal msg) st ρ Q) : False :=
   h.2.2
 
-theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ : Env}
-    {Q : FOL.Const → TransState → Env → Prop}
+theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ : VerifM.Env}
+    {Q : FOL.Const → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.decl hint t) st ρ Q) :
     let c := st.freshConst hint t
     ∀ u, Q c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u) :=
   fun u => (h.2.2 u).2.2
 
-theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.assume (.pure φ)) st ρ Q) :
-    φ.wfIn st.decls → φ.eval ρ → Q () { st with asserts := φ :: st.asserts } ρ :=
+    φ.wfIn st.decls → φ.eval ρ.env → Q () { st with asserts := φ :: st.asserts } ρ :=
   fun hwf hφ => (h.2.2 hwf hφ).2.2
 
-theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.assume (.spatial a)) st ρ Q) :
     a.wfIn st.decls → Q () { st with owns := a :: st.owns } ρ :=
   fun hwf => (h.2.2 hwf).2.2
 
-theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.assume item) st ρ Q) :
-    item.wfIn st.decls → (match item with | .pure φ => φ.eval ρ | .spatial _ => True) → Q () (st.addItem item) ρ :=
+    item.wfIn st.decls →
+    (match item with | .pure φ => φ.eval ρ.env | .spatial _ => True) →
+    Q () (st.addItem item) ρ :=
   by
     cases item with
     | pure φ =>
@@ -594,19 +651,19 @@ theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : Env}
       simp [TransState.addItem]
       exact VerifM.eval_assumeSpatial h
 
-theorem VerifM.eval_check {φ : Formula} {st : TransState} {ρ : Env}
-    {Q : Bool → TransState → Env → Prop}
+theorem VerifM.eval_check {φ : Formula} {st : TransState} {ρ : VerifM.Env}
+    {Q : Bool → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.check φ) st ρ Q) :
     φ.wfIn st.decls →
-    ∃ b, (b = true → φ.eval ρ) ∧ Q b st ρ :=
+    ∃ b, (b = true → φ.eval ρ.env) ∧ Q b st ρ :=
   fun hwf =>
     let ⟨b, hb, _, _, hq⟩ := h.2.2 hwf
     ⟨b, hb, hq⟩
 
-theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.assert φ) st ρ Q) :
-    φ.wfIn st.decls → φ.eval ρ ∧ Q () st ρ := by
+    φ.wfIn st.decls → φ.eval ρ.env ∧ Q () st ρ := by
   intro hwf
   simp only [VerifM.assert] at h
   have hb := VerifM.eval_bind _ _ _ _ h
@@ -620,8 +677,8 @@ theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : Env}
     exact (VerifM.eval_failed hq).elim
 
 theorem VerifM.eval_expectEq [DecidableEq α] [Repr α]
-    {msg : String} {actual expected : α} {st : TransState} {ρ : Env}
-    {Q : Unit → TransState → Env → Prop}
+    {msg : String} {actual expected : α} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.expectEq msg actual expected) st ρ Q) :
     actual = expected ∧ Q () st ρ := by
   unfold VerifM.expectEq at h
@@ -632,8 +689,8 @@ theorem VerifM.eval_expectEq [DecidableEq α] [Repr α]
     exact (VerifM.eval_fatal h).elim
 
 theorem VerifM.eval_expectSome
-    {msg : String} {x : Option α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+    {msg : String} {x : Option α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.expectSome msg x) st ρ Q) :
     ∃ y, x = some y ∧ Q y st ρ := by
   unfold VerifM.expectSome at h
@@ -647,7 +704,7 @@ theorem VerifM.eval_expectSome
 
 theorem VerifM.eval_bind_expectEq [DecidableEq α] [Repr α]
     {msg : String} {actual expected : α} {β : Type _} {k : Unit → VerifM β}
-    {st : TransState} {ρ : Env} {Q : β → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {Q : β → TransState → VerifM.Env → Prop}
     (h : VerifM.eval ((VerifM.expectEq msg actual expected).bind k) st ρ Q) :
     actual = expected ∧ VerifM.eval (k ()) st ρ Q := by
   have hb := VerifM.eval_bind _ _ _ _ h
@@ -656,28 +713,28 @@ theorem VerifM.eval_bind_expectEq [DecidableEq α] [Repr α]
 
 theorem VerifM.eval_bind_expectSome
     {msg : String} {x : Option α} {β : Type _} {k : α → VerifM β}
-    {st : TransState} {ρ : Env} {Q : β → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {Q : β → TransState → VerifM.Env → Prop}
     (h : VerifM.eval ((VerifM.expectSome msg x).bind k) st ρ Q) :
     ∃ y, x = some y ∧ VerifM.eval (k y) st ρ Q := by
   have hb := VerifM.eval_bind _ _ _ _ h
   obtain ⟨y, hx, hk⟩ := VerifM.eval_expectSome hb
   exact ⟨y, hx, hk⟩
 
-theorem VerifM.eval_all {items : List α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_all {items : List α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.all items) st ρ Q) :
     ∀ a ∈ items, Q a st ρ :=
   fun a ha => (h.2.2 a ha).2.2
 
-theorem VerifM.eval_any {items : List α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_any {items : List α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.any items) st ρ Q) :
     ∃ a ∈ items, Q a st ρ :=
   let ⟨a, ha, _, _, hq⟩ := h.2.2; ⟨a, ha, hq⟩
 
 
 theorem VerifM.eval_ctx {f : TransState → α × SpatialContext}
-    {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.ctx f) st ρ Q) :
     let (a, owns') := f st
     (owns'.wfIn st.decls → Q a { st with owns := owns' } ρ)
@@ -686,8 +743,8 @@ theorem VerifM.eval_ctx {f : TransState → α × SpatialContext}
     ∧ st.asserts.wfIn st.decls :=
   ⟨fun howns => (h.2.2 howns).2.2, h.1.ownsWf, h.2.1, h.1.assertsWf⟩
 
-theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : Env}
-    {Q : α → TransState → Env → Prop}
+theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.ctx (fun st => (f st.asserts, st.owns))) st ρ Q) :
     Q (f st.asserts) st ρ
     ∧ st.holdsFor ρ
@@ -695,8 +752,8 @@ theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : En
   let ⟨hq, howns, hg, hwf⟩ := VerifM.eval_ctx h
   ⟨hq howns, hg, hwf⟩
 
-theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : Env}
-    {Q : β → TransState → Env → Prop}
+theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : VerifM.Env}
+    {Q : β → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.seq m m2) st ρ Q) :
     VerifM.eval m st ρ (fun () _ _ => True) ∧ VerifM.eval m2 st ρ Q := by
   obtain ⟨hwf, hholds, hm, hm2⟩ := h
@@ -705,10 +762,10 @@ theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ
    ⟨hwf, hholds, hm2⟩⟩
 
 theorem VerifM.eval_assumeAll {φs : List Formula}
-    {st : TransState} {ρ : Env} {P : Unit → TransState → Env → Prop}
+    {st : TransState} {ρ : VerifM.Env} {P : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.assumeAll φs) st ρ P) :
     (∀ φ ∈ φs, φ.wfIn st.decls) →
-    (∀ φ ∈ φs, φ.eval ρ) →
+    (∀ φ ∈ φs, φ.eval ρ.env) →
     ∃ st', st'.decls = st.decls ∧ st'.owns = st.owns ∧ P () st' ρ := by
   induction φs generalizing st with
   | nil =>
@@ -740,7 +797,7 @@ theorem VerifM.topCont_error_propagates :
   simp only [topCont, ScopedM.eval_ret] at h
   exact absurd h.1 (by cases e <;> simp)
 
-theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : Env)
+theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : VerifM.Env)
     (f : TransCont (Except VerifError α))
     (hf : ∀ e st', ¬∃ Δ, ScopedM.eval (f (.error e) st') st'.toFlatCtx (.ok ()) Δ)
     (Δ : FlatCtx)
@@ -750,7 +807,7 @@ theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : Env)
   ⟨hwf, g, (eval_rec_preserves_wf m st ρ (translate_eval_rec m st ρ f hf Δ h g hwf) g hwf).mono
     fun _ _ _ ⟨hg', hwf', hΔ'⟩ => ⟨hwf', hg', hΔ'⟩⟩
 
-theorem VerifM.eval_of_translate (m : VerifM Unit) (st : TransState) (ρ : Env) (Δ : FlatCtx)
+theorem VerifM.eval_of_translate (m : VerifM Unit) (st : TransState) (ρ : VerifM.Env) (Δ : FlatCtx)
     (h : ScopedM.eval (m.translate st topCont) st.toFlatCtx (.ok ()) Δ)
     (g : st.holdsFor ρ) (hwf : st.wf) :
     VerifM.eval m st ρ (fun _ _ _ => True) :=

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -639,12 +639,12 @@ theorem VerifM.eval_assumeAll {φs : List Formula}
     (h : VerifM.eval (VerifM.assumeAll φs) st ρ P) :
     (∀ φ ∈ φs, φ.wfIn st.decls) →
     (∀ φ ∈ φs, φ.eval ρ) →
-    ∃ st', st'.decls = st.decls ∧ P () st' ρ := by
+    ∃ st', st'.decls = st.decls ∧ st'.owns = st.owns ∧ P () st' ρ := by
   induction φs generalizing st with
   | nil =>
     intro _ _
     simp only [VerifM.assumeAll] at h
-    exact ⟨st, rfl, VerifM.eval_ret h⟩
+    exact ⟨st, rfl, rfl, VerifM.eval_ret h⟩
   | cons φ φs ih =>
     intro hwf heval
     simp only [VerifM.assumeAll] at h
@@ -653,10 +653,10 @@ theorem VerifM.eval_assumeAll {φs : List Formula}
     have hcont := hassume
       (hwf φ (List.mem_cons_self ..))
       (heval φ (List.mem_cons_self ..))
-    obtain ⟨st', hst', hp⟩ := ih hcont
+    obtain ⟨st', hst', howns, hp⟩ := ih hcont
       (fun ψ hψ => hwf ψ (List.mem_cons_of_mem _ hψ))
       (fun ψ hψ => heval ψ (List.mem_cons_of_mem _ hψ))
-    exact ⟨st', by rw [hst'], hp⟩
+    exact ⟨st', by rw [hst'], by rw [howns], hp⟩
 
 
 /-! ### Top-level corollary -/

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -1,6 +1,5 @@
 import Mica.TinyML.Typed
 import Mica.TinyML.Typing
-import Mica.TinyML.WeakestPre
 import Mica.FOL.Printing
 import Mica.Verifier.Monad
 import Mica.Verifier.Atoms
@@ -8,6 +7,10 @@ import Mica.Verifier.Assertions
 import Mica.Verifier.Utils
 import Mica.Base.Fresh
 import Mathlib.Data.Finmap
+
+
+open Iris Iris.BI
+
 
 /-!
 # Predicate Transformers
@@ -49,9 +52,9 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def PredTrans.apply (Φ : Runtime.Val → Prop) (m : PredTrans) (ρ : Env) : Prop :=
+def PredTrans.apply (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : Env) : iProp :=
   Assertion.pre (fun post ρ' =>
-    ∀ v : Runtime.Val, Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+    BIBase.forall fun v : Runtime.Val => Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
   ) m ρ
 
 -- ---------------------------------------------------------------------------
@@ -94,16 +97,19 @@ theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
         (Signature.wf_declVar hwf'))
     h hsub hwf
 
-theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → Prop}
+theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
     {ρ ρ' : Env} {Δ : Signature}
-    (hwf : pt.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ')
-    (h : PredTrans.apply Φ pt ρ) : PredTrans.apply Φ pt ρ' := by
-  unfold PredTrans.apply at h ⊢
-  apply Assertion.pre_env_agree hwf hagree _ h
-  intro ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree_post hpost v
-  exact Assertion.post_env_agree hwf_post
-    (Env.agreeOn_declVar hagree_post)
-    (fun _ _ _ _ _ _ h => h) (hpost v)
+    (hwf : pt.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
+    PredTrans.apply Φ pt ρ ⊢ PredTrans.apply Φ pt ρ' := by
+  unfold PredTrans.apply at ⊢
+  apply Assertion.pre_env_agree hwf hagree
+  intro ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree_post
+  apply forall_intro
+  intro v
+  exact (forall_elim v).trans <|
+    Assertion.post_env_agree hwf_post
+      (Env.agreeOn_declVar hagree_post)
+      (fun _ _ _ _ _ _ => .rfl)
 
 -- ---------------------------------------------------------------------------
 -- Correctness
@@ -111,196 +117,294 @@ theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → Prop}
 
 theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
     (st : TransState) (ρ : Env)
-    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → Prop) :
+    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp) R :
     pt.wfIn (Signature.ofVars σ.dom) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     VerifM.eval (PredTrans.call σ pt) st ρ Ψ →
-    (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ' = v → Φ v) →
-    PredTrans.apply Φ pt (σ.subst.eval ρ) := by
+    (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
+      (st'.owns.interp ρ' ∗ R ⊢ Φ v)) →
+    st.owns.interp ρ ∗ R ⊢ PredTrans.apply Φ pt (σ.subst.eval ρ) := by
   intro hwf hdomwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   let retWf : (String × Assertion Unit) → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let Φpost : (String × Assertion Unit) → Env → Prop :=
-    fun post ρ' => ∀ v : Runtime.Val, Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
-  have hpre : Assertion.pre Φpost pt (σ.subst.eval ρ) := by
-    exact Assertion.prove_correct pt σ retWf st ρ _ Φpost
-      (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree hpost v =>
-        Assertion.post_env_agree hwf_post
-          (Env.agreeOn_declVar hagree)
-          (fun _ _ _ _ _ _ h => h) (hpost v))
+  let Φpost : (String × Assertion Unit) → Env → iProp :=
+    fun post ρ' =>
+      BIBase.forall fun v : Runtime.Val =>
+        Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+  let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → Env → Prop :=
+    fun r st' ρ' =>
+      match r with
+      | (σ₁, postName, postBody) => (do
+          let resVar ← VerifM.decl (some postName) Srt.value
+          let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
+          Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
+  have hpre : st.owns.interp ρ ∗ R ⊢ Assertion.pre Φpost pt (σ.subst.eval ρ) := by
+    exact Assertion.prove_correct pt σ retWf st ρ Ψcall Φpost R
+      (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree =>
+        forall_intro fun v =>
+          (forall_elim v).trans <|
+            Assertion.post_env_agree hwf_post
+              (Env.agreeOn_declVar hagree)
+              (fun _ _ _ _ _ _ => .rfl))
       hσwf hdomwf hwf hb
-      (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ hcont hσ₁wf hσ₁domwf hwf₁ v => by
-  have hb2 := VerifM.eval_bind _ _ _ _ hcont
-  have hdecl := VerifM.eval_decl hb2
-  set resVar := st₁.freshConst (some postName) .value
-  have hfresh_decls : resVar.name ∉ st₁.decls.allNames :=
-    fresh_not_mem (addNumbers postName) st₁.decls.allNames (addNumbers_injective _)
-  have hfresh_range : resVar.name ∉ σ₁.range.allNames :=
-    fun h => hfresh_decls (Signature.allNames_subset hσ₁wf.2.1 _ h)
-  specialize hdecl v
-  have hb3 := VerifM.eval_bind _ _ _ _ hdecl
-  set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
-  have hσ₂wf : σ₂.wf (st₁.decls.addConst resVar) := by
-    simpa [σ₂] using
-      (FiniteSubst.rename_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁wf hfresh_range)
-  have hσ₂domwf : (Signature.ofVars σ₂.dom).wf := by
-    simpa [σ₂] using
-      (FiniteSubst.rename_dom_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁domwf)
-  have hwf₁' : Assertion.wfIn (fun _ _ => True) (Signature.ofVars σ₂.dom) postBody := by
-    simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using hwf₁
-  -- Use decls_grow to track that resVar stays in decls and env agrees
-  have hgrow := VerifM.eval.decls_grow (ρ₁.updateConst .value resVar.name v) hb3
-  have hassume := Assertion.assume_correct postBody σ₂ (fun _ _ => True)
-    { st₁ with decls := st₁.decls.addConst resVar }
-    (ρ₁.updateConst .value resVar.name v) _ (fun () _ => Φ v)
-    (fun _ _ _ _ _ _ h => h)
-    hσ₂wf hσ₂domwf hwf₁' hgrow
-    (fun _ () st₂ ρ₂ ⟨hsub, hagree, hcont'⟩ _ _ _ => by
-      have hret := VerifM.eval_ret hcont'
-      have hwfst₂ : st₂.decls.wf := (VerifM.eval.wf hcont').namesDisjoint
-      apply hΨ _ st₂ ρ₂ (.const (.uninterpreted resVar.name .value)) hret
-      · simp only [Term.wfIn, Const.wfIn]
-        refine ⟨hsub.consts resVar (List.Mem.head _), ?_, ?_⟩
-        · intro τ' hvar
-          exact Signature.wf_no_var_of_const hwfst₂ (hsub.consts resVar (List.Mem.head _)) hvar
-        · intro τ' hc'
-          exact Signature.wf_unique_const hwfst₂ (hsub.consts resVar (List.Mem.head _)) hc'
-      · simp only [Term.eval, Const.denote]
-        have := hagree.2.1 resVar (List.Mem.head _)
-        simpa [Env.lookupConst, Env.updateConst] using this.symm
-        )
-  -- Transport from σ₂.subst.eval ρ₂ to (σ₁.subst.eval ρ₁).updateConst .value postName v
-  exact Assertion.post_env_agree hwf₁
-    (by
-      simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using
-        (FiniteSubst.rename_agreeOn (σ := σ₁) (v := ⟨postName, .value⟩) (c := resVar)
-          hσ₁wf.1 hfresh_range rfl))
-    (fun _ _ _ _ _ _ h => h) hassume)
-  simpa [PredTrans.apply, Φpost]
+      (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ hcont hσ₁wf hσ₁domwf hwf₁ => by
+        apply forall_intro
+        intro v
+        have hb2 := VerifM.eval_bind _ _ _ _ hcont
+        have hdecl := VerifM.eval_decl hb2
+        set resVar := st₁.freshConst (some postName) .value
+        have hfresh_decls : resVar.name ∉ st₁.decls.allNames :=
+          fresh_not_mem (addNumbers postName) st₁.decls.allNames (addNumbers_injective _)
+        have hfresh_range : resVar.name ∉ σ₁.range.allNames :=
+          fun h => hfresh_decls (Signature.allNames_subset hσ₁wf.2.1 _ h)
+        specialize hdecl v
+        have hb3 := VerifM.eval_bind _ _ _ _ hdecl
+        set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
+        have hσ₂wf : σ₂.wf (st₁.decls.addConst resVar) := by
+          simpa [σ₂] using
+            (FiniteSubst.rename_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁wf hfresh_range)
+        have hσ₂domwf : (Signature.ofVars σ₂.dom).wf := by
+          simpa [σ₂] using
+            (FiniteSubst.rename_dom_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁domwf)
+        have hwf₁' : Assertion.wfIn (fun _ _ => True) (Signature.ofVars σ₂.dom) postBody := by
+          simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using hwf₁
+        have hgrow := VerifM.eval.decls_grow (ρ₁.updateConst .value resVar.name v) hb3
+        have hassume := Assertion.assume_correct postBody σ₂ (fun _ _ => True)
+          { st₁ with decls := st₁.decls.addConst resVar }
+          (ρ₁.updateConst .value resVar.name v)
+          (fun a st' ρ' =>
+            { st₁ with decls := st₁.decls.addConst resVar }.decls.Subset st'.decls ∧
+              Env.agreeOn { st₁ with decls := st₁.decls.addConst resVar }.decls
+                (ρ₁.updateConst .value resVar.name v) ρ' ∧
+              (Pure.pure (Term.const (.uninterpreted resVar.name .value)) : VerifM (Term .value)).eval st' ρ' Ψ)
+          (fun () _ => Φ v) R
+          (fun _ _ _ _ _ _ => .rfl)
+          hσ₂wf hσ₂domwf hwf₁' hgrow
+          (fun _ () st₂ ρ₂ ⟨hsub, hagree, hcont'⟩ _ _ _ => by
+            have hret := VerifM.eval_ret hcont'
+            have hwfst₂ : st₂.decls.wf := (VerifM.eval.wf hcont').namesDisjoint
+            apply hΨ _ st₂ ρ₂ (.const (.uninterpreted resVar.name .value)) hret
+            · simp only [Term.wfIn, Const.wfIn]
+              refine ⟨hsub.consts resVar (List.Mem.head _), ?_, ?_⟩
+              · intro τ' hvar
+                exact Signature.wf_no_var_of_const hwfst₂ (hsub.consts resVar (List.Mem.head _)) hvar
+              · intro τ' hc'
+                exact Signature.wf_unique_const hwfst₂ (hsub.consts resVar (List.Mem.head _)) hc'
+            · simp only [Term.eval, Const.denote]
+              have := hagree.2.1 resVar (List.Mem.head _)
+              simpa [Env.lookupConst, Env.updateConst] using this.symm)
+        have hinterp_bi : SpatialContext.interp ρ₁ st₁.owns ⊣⊢
+            SpatialContext.interp (ρ₁.updateConst .value resVar.name v) st₁.owns :=
+          SpatialContext.interp_env_agree (VerifM.eval.wf hcont).ownsWf
+            (agreeOn_update_fresh_const (c := resVar) hfresh_decls)
+        exact (sep_mono hinterp_bi.1 (by
+          iintro HR
+          iexact HR)).trans <| hassume.trans <| Assertion.post_env_agree hwf₁'
+          (by
+            simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using
+              (FiniteSubst.rename_agreeOn (σ := σ₁) (v := ⟨postName, .value⟩) (c := resVar)
+                hσ₁wf.1 hfresh_range rfl))
+          (fun _ _ _ _ _ _ => .rfl))
+  simpa [PredTrans.apply, Φpost] using hpre
+
 
 theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
     (body : VerifM (Term .value))
-    (st : TransState) (ρ : Env) (Φ : Runtime.Val → Prop) (R : Prop) :
+    (st : TransState) (ρ : Env) (Φ : Runtime.Val → iProp) (R : iProp) :
     pt.wfIn (Signature.ofVars σ.dom) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     VerifM.eval (PredTrans.implement σ pt body) st ρ (fun _ _ _ => True) →
-    PredTrans.apply Φ pt (σ.subst.eval ρ) →
-    (∀ st' ρ', st.decls.Subset st'.decls → Env.agreeOn st.decls ρ ρ' →
+    (∀ st' ρ' (Q : iProp),
+      st.decls.Subset st'.decls →
+      Env.agreeOn st.decls ρ ρ' →
       VerifM.eval body st' ρ'
-      (fun result st'' ρ'' => result.wfIn st''.decls → Φ (result.eval ρ'')) → R) →
-    R := by
-  intro hwf hdomwf hσwf heval happly hR
+      (fun result st'' ρ'' =>
+        ∀ (S : iProp),
+        result.wfIn st''.decls →
+        (st''.owns.interp ρ'' ∗ Q ∗ (Φ (result.eval ρ'') -∗ S) ⊢ S)) →
+      st'.owns.interp ρ' ∗ Q ⊢ R) →
+    st.owns.interp ρ ∗ PredTrans.apply Φ pt (σ.subst.eval ρ) ⊢ R := by
+  intro hwf hdomwf hσwf heval hbody
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
-  -- Strengthen with decls_grow to carry subset/agree info into the assume_correct callback
   have hb_grow := VerifM.eval.decls_grow ρ hb
-  -- Choose Φ_post so that pre_post_combine with apply gives R
   let retWf : (String × Assertion Unit) → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  set Φ_post : (String × Assertion Unit) → Env → Prop :=
-    fun ⟨postName, postBody⟩ ρ_log =>
-      (∀ v, Assertion.post (fun () _ => Φ v) postBody (ρ_log.updateConst .value postName v)) → R
+  let OuterQ : (String × Assertion Unit) → Env → iProp :=
+    fun ⟨postName, postBody⟩ ρ' =>
+      BIBase.forall fun v : Runtime.Val =>
+        Assertion.post (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
+  let Φpost : (String × Assertion Unit) → Env → iProp :=
+    fun a ρ' => OuterQ a ρ' -∗ R
   have hpost := Assertion.assume_correct pt σ retWf
-    st ρ _ Φ_post
-    (fun ⟨pN, pB⟩ Δ' ρ₁ ρ₂ hwf_post hagree hΦ =>
-      fun hpost_all => hΦ (fun v => Assertion.post_env_agree hwf_post
-        (Env.agreeOn_symm (Env.agreeOn_declVar hagree))
-        (fun _ _ _ _ _ _ h => h) (hpost_all v)))
+    st ρ _ Φpost emp
+    (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree => by
+      refine wand_intro ?_
+      iintro H
+      icases H with ⟨Hcont, HQ₂⟩
+      iapply Hcont
+      apply forall_intro
+      intro v
+      exact (forall_elim v).trans <|
+        Assertion.post_env_agree hwf_post
+          (Env.agreeOn_symm (Env.agreeOn_declVar hagree))
+          (fun _ _ _ _ _ _ => .rfl))
     hσwf hdomwf hwf hb_grow
-    -- Callback for assume_correct: given continuation eval + subset/agree, produce Φ_post
-    (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ ⟨hdsub_st, hagree_st, hcont⟩ hσ₁wf hσ₁domwf hwf_postBody hpost_all => by
-      -- Decompose continuation: body >>= decl >>= assume >>= prove >>= ret
+    (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ ⟨hdsub_st, hagree_st, hcont⟩ hσ₁wf hσ₁domwf hwf_postBody => by
+      apply BIBase.Entails.trans sep_comm.1
+      apply BIBase.Entails.trans emp_sep.1
       have hcont_body := VerifM.eval_bind _ _ _ _ hcont
-      -- Strengthen with decls_grow to track subset/agree through body
-      have hcont_grow := VerifM.eval.decls_grow ρ₁ hcont_body
-      -- Weaken body postcondition to what we need
-      exact hR st₁ ρ₁ hdsub_st hagree_st <|
-        hcont_grow.mono fun result st_b ρ_b ⟨hdsub_b, hagree_b, hrest⟩ => by
-        -- Given the rest of the continuation succeeds, show result.wfIn → Φ (result.eval)
-        intro hwf_result
-        -- Decompose: decl, assume eq, prove
-        have hb2 := VerifM.eval_bind _ _ _ _ hrest
-        have hdecl := VerifM.eval_decl hb2
-        set resVar := st_b.freshConst (some postName) .value
-        have hfresh_decls_b : resVar.name ∉ st_b.decls.allNames :=
-          fresh_not_mem (addNumbers postName) st_b.decls.allNames (addNumbers_injective _)
-        have hfresh_range_b : resVar.name ∉ σ₁.range.allNames :=
-          fun hmem => hfresh_decls_b (Signature.allNames_subset (Signature.Subset.trans hσ₁wf.2.1 hdsub_b) _ hmem)
-        specialize hdecl (result.eval ρ_b)
-        have hb3 := VerifM.eval_bind _ _ _ _ hdecl
-        -- The eq formula
-        have heq_wf : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).wfIn
-            (st_b.decls.addConst resVar) := by
-          have hwfst_b' : (st_b.decls.addConst resVar).wf :=
-            (TransState.freshConst.wf _ (VerifM.eval.wf hrest)).namesDisjoint
-          refine ⟨?_, Term.wfIn_mono result hwf_result (Signature.Subset.subset_addConst _ _) hwfst_b'⟩
-          · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
-            refine ⟨List.Mem.head _, ?_, ?_⟩
-            · intro τ' hvar
-              exact hfresh_decls_b (Signature.mem_allNames_of_var hvar)
-            · intro τ' hc'
-              exact Signature.wf_unique_const hwfst_b' (List.Mem.head _) hc'
-        have heq_holds : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).eval
-            (ρ_b.updateConst .value resVar.name (result.eval ρ_b)) := by
-          simp only [Formula.eval, Term.eval, Const.denote]
-          simpa [Env.lookupConst, Env.updateConst] using
-            (Term.eval_env_agree hwf_result (agreeOn_update_fresh_const hfresh_decls_b))
-        have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
-        -- Prove σ₂ postBody
-        set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
-        have hσ₂wf : σ₂.wf (st_b.decls.addConst resVar) :=
-          by
-            simpa [σ₂] using
-              (FiniteSubst.rename_wf (σ := σ₁) (v := ⟨postName, .value⟩)
-                (name' := resVar.name) ⟨hσ₁wf.1, Signature.Subset.trans hσ₁wf.2.1 hdsub_b, hσ₁wf.2.2⟩
-                hfresh_range_b)
-        have hσ₂domwf : (Signature.ofVars σ₂.dom).wf := by
-          simpa [σ₂] using
-            (FiniteSubst.rename_dom_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁domwf)
-        have hb4 := VerifM.eval_bind _ _ _ _ hassume
-        have hwf_postBody' : Assertion.wfIn (fun _ _ => True) (Signature.ofVars σ₂.dom) postBody := by
-          simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using hwf_postBody
-        -- From prove_correct: get Assertion.pre on postBody
-        have hpre := Assertion.prove_correct postBody σ₂ (fun _ _ => True)
-          { st_b with decls := st_b.decls.addConst resVar,
-                      asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st_b.asserts }
-          (ρ_b.updateConst .value resVar.name (result.eval ρ_b)) _ (fun () _ => True)
-          (fun _ _ _ _ _ _ h => h)
-          hσ₂wf hσ₂domwf hwf_postBody' hb4 (fun _ () _ _ _ _ _ _ => trivial)
-        -- Transport pre to (σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ_b)
-        have hag_rename := @FiniteSubst.rename_agreeOn σ₁ ⟨postName, .value⟩ resVar
-          ρ_b (result.eval ρ_b) hσ₁wf.1 hfresh_range_b rfl
-        -- Need to go from σ₁.subst.eval ρ_b to σ₁.subst.eval ρ₁
-        have hag_eval := FiniteSubst.eval_agreeOn hσ₁wf.1
-          (Env.agreeOn_mono hσ₁wf.2.1 (Env.agreeOn_symm hagree_b))
-        have hag_eval' : Env.agreeOn (Signature.ofVars σ₂.dom)
-            ((σ₁.subst.eval ρ_b).updateConst .value postName (result.eval ρ_b))
-            ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ_b)) := by
-          apply Env.agreeOn_mono
-            (Δ₁ := Signature.ofVars σ₂.dom)
-            (Δ₂ := Signature.ofVars (⟨postName, .value⟩ :: σ₁.dom))
-            (Signature.Subset.of_vars_subset_ofVars (vars := σ₂.dom) (vars' := ⟨postName, .value⟩ :: σ₁.dom)
-              (fun x hx => by
+      change st₁.owns.interp ρ₁ ⊢ OuterQ (postName, postBody) (σ₁.subst.eval ρ₁) -∗ R
+      refine wand_intro ?_
+      refine hbody st₁ ρ₁ _ hdsub_st hagree_st ?_
+      refine (VerifM.eval.decls_grow ρ₁ hcont_body).mono ?_
+      intro result st₂ ρ₂ ⟨hdsub_body, hagree_body, hrest⟩ S hwf_result
+      have hb2 := VerifM.eval_bind _ _ _ _ hrest
+      have hdecl := VerifM.eval_decl hb2
+      set resVar := st₂.freshConst (some postName) .value
+      have hfresh_decls : resVar.name ∉ st₂.decls.allNames :=
+        fresh_not_mem (addNumbers postName) st₂.decls.allNames (addNumbers_injective _)
+      have hfresh_range : resVar.name ∉ σ₁.range.allNames :=
+        fun hmem => hfresh_decls (Signature.allNames_subset (Signature.Subset.trans hσ₁wf.2.1 hdsub_body) _ hmem)
+      specialize hdecl (result.eval ρ₂)
+      have hb3 := VerifM.eval_bind _ _ _ _ hdecl
+      have heq_wf : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).wfIn
+          (st₂.decls.addConst resVar) := by
+        have hwf' : (st₂.decls.addConst resVar).wf :=
+          (TransState.freshConst.wf _ (VerifM.eval.wf hrest)).namesDisjoint
+        refine ⟨?_, Term.wfIn_mono result hwf_result (Signature.Subset.subset_addConst _ _) hwf'⟩
+        simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+        refine ⟨List.Mem.head _, ?_, ?_⟩
+        · intro τ' hvar
+          exact hfresh_decls (Signature.mem_allNames_of_var hvar)
+        · intro τ' hc'
+          exact Signature.wf_unique_const hwf' (List.Mem.head _) hc'
+      have heq_holds : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).eval
+          (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) := by
+        simp only [Formula.eval, Term.eval, Const.denote]
+        simpa [Env.lookupConst, Env.updateConst] using
+          (Term.eval_env_agree hwf_result (agreeOn_update_fresh_const hfresh_decls))
+      have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
+      set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
+      have hσ₂wf : σ₂.wf (st₂.decls.addConst resVar) := by
+        simpa [σ₂] using
+          (FiniteSubst.rename_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name)
+            ⟨hσ₁wf.1, Signature.Subset.trans hσ₁wf.2.1 hdsub_body, hσ₁wf.2.2⟩ hfresh_range)
+      have hσ₂domwf : (Signature.ofVars σ₂.dom).wf := by
+        simpa [σ₂] using
+          (FiniteSubst.rename_dom_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁domwf)
+      have hb4 := VerifM.eval_bind _ _ _ _ hassume
+      have hwf_postBody' : Assertion.wfIn (fun _ _ => True) (Signature.ofVars σ₂.dom) postBody := by
+        simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using hwf_postBody
+      let st₃ : TransState :=
+        { st₂ with
+          decls := st₂.decls.addConst resVar
+          asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st₂.asserts }
+      have hpre := @Assertion.prove_correct Unit postBody σ₂ (fun _ _ => True)
+        st₃
+        (ρ₂.updateConst .value resVar.name (result.eval ρ₂))
+        _ (fun () _ => Φ (result.eval ρ₂) -∗ S) (Φ (result.eval ρ₂) -∗ S)
+        (fun _ _ _ _ _ _ => .rfl)
+        hσ₂wf hσ₂domwf hwf_postBody' hb4
+        (fun _ () st' ρ' hret _ _ _ => by
+          iintro H
+          icases H with ⟨_, HR⟩
+          iexact HR)
+      have hag_rename := @FiniteSubst.rename_agreeOn σ₁ ⟨postName, .value⟩ resVar
+        ρ₂ (result.eval ρ₂) hσ₁wf.1 hfresh_range rfl
+      have hag_eval := FiniteSubst.eval_agreeOn hσ₁wf.1
+        (Env.agreeOn_mono hσ₁wf.2.1 (Env.agreeOn_symm hagree_body))
+      have hag_eval' : Env.agreeOn (Signature.ofVars σ₂.dom)
+          ((σ₁.subst.eval ρ₂).updateConst .value postName (result.eval ρ₂))
+          ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂)) := by
+        apply Env.agreeOn_mono
+          (Δ₁ := Signature.ofVars σ₂.dom)
+          (Δ₂ := Signature.ofVars (⟨postName, .value⟩ :: σ₁.dom))
+          (Signature.Subset.of_vars_subset_ofVars (vars := σ₂.dom) (vars' := ⟨postName, .value⟩ :: σ₁.dom)
+            (fun x hx => by
               simp [σ₂, FiniteSubst.rename] at hx ⊢
               rcases hx with rfl | ⟨hx, _⟩
               · exact Or.inl rfl
               · exact Or.inr hx))
-          exact Env.agreeOn_update hag_eval
-        have hag_combined : Env.agreeOn (Signature.ofVars σ₂.dom)
-            (σ₂.subst.eval (ρ_b.updateConst .value resVar.name (result.eval ρ_b)))
-            ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ_b)) :=
-          Env.agreeOn_trans hag_rename hag_eval'
-        have hpre' := Assertion.pre_env_agree hwf_postBody'
-          (by
-            simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using hag_combined)
-          (fun _ _ _ _ _ _ h => h) hpre
-        -- Combine with hpost_all via pre_post_combine
-        exact Assertion.pre_post_combine hpre' (hpost_all (result.eval ρ_b))
-          (fun () _ _ hΦ => hΦ))
-  -- Now use pre_post_combine on happly (pre) and hpost (post) to get R
-  exact Assertion.pre_post_combine happly hpost
-    (fun ⟨postName, postBody⟩ _ hpre_all hΦ_post => hΦ_post hpre_all)
+        exact Env.agreeOn_update hag_eval
+      have hpost_transport : Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
+          ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂)) ⊢
+          Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
+            (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
+        exact Assertion.post_env_agree hwf_postBody'
+          (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval'))
+          (fun _ _ _ _ _ _ => .rfl)
+      have howns_agree : st₃.owns.interp ρ₂
+            ⊢
+          st₃.owns.interp (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) := by
+        simpa using
+          (SpatialContext.interp_env_agree (VerifM.eval.wf hrest).ownsWf
+            (agreeOn_update_fresh_const hfresh_decls)).1
+      have hpre_final :
+          st₂.owns.interp ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
+            Assertion.pre (fun () _ => Φ (result.eval ρ₂) -∗ S) postBody
+              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
+        have hinput :
+            st₂.owns.interp ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
+              st₃.owns.interp (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) ∗
+                (Φ (result.eval ρ₂) -∗ S) := by
+          iintro H
+          icases H with ⟨Howns, Hwand⟩
+          isplitl [Howns]
+          · iapply howns_agree
+            iexact Howns
+          · iexact Hwand
+        exact hinput.trans hpre
+      have hpost_final :
+          OuterQ (postName, postBody) (σ₁.subst.eval ρ₁) ⊢
+            Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
+              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
+        exact (forall_elim (result.eval ρ₂)).trans hpost_transport
+      iintro H
+      icases H with ⟨Howns, HQ, Hwand⟩
+      iapply (Assertion.pre_post_combine
+        (ρ := σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))
+        (m := postBody)
+        (Φ := fun () _ => Φ (result.eval ρ₂) -∗ S)
+        (Ψ := fun () _ => Φ (result.eval ρ₂))
+        (R := S)
+        (fun () _ => by
+          iintro H
+          icases H with ⟨Hwand, HΦ⟩
+          iapply Hwand
+          iexact HΦ))
+      isplitl [Howns Hwand]
+      · iapply hpre_final
+        isplitl [Howns]
+        · iexact Howns
+        · iexact Hwand
+      · iapply hpost_final
+        iexact HQ
+      )
+  have hpre : PredTrans.apply Φ pt (σ.subst.eval ρ) = Assertion.pre OuterQ pt (σ.subst.eval ρ) := rfl
+  rw [hpre]
+  exact BIBase.Entails.trans
+    (by
+      iintro H
+      icases H with ⟨Howns, Happ⟩
+      isplitr [Howns]
+      · iexact Happ
+      · iapply hpost
+        isplitl
+        . iexact Howns
+        . iemp_intro)
+    (Assertion.pre_post_combine
+      (ρ := σ.subst.eval ρ)
+      (m := pt)
+      (Φ := OuterQ)
+      (Ψ := Φpost)
+      (R := R)
+      (fun _ _ => by
+        iintro H
+        icases H with ⟨HQ, Hcont⟩
+        iapply Hcont
+        iexact HQ))

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -79,7 +79,7 @@ def PredTrans.implement (σ : FiniteSubst) (pt : PredTrans) (body : VerifM (Term
   let result ← body
   let resVar ← VerifM.decl (some postName) .value
   let σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
-  VerifM.assume (.eq .value (.const (.uninterpreted resVar.name .value)) result)
+  VerifM.assume (.pure (.eq .value (.const (.uninterpreted resVar.name .value)) result))
   let (_, ()) ← Assertion.prove σ₂ postBody
   pure ()
 
@@ -288,7 +288,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         simp only [Formula.eval, Term.eval, Const.denote]
         simpa [Env.lookupConst, Env.updateConst] using
           (Term.eval_env_agree hwf_result (agreeOn_update_fresh_const hfresh_decls))
-      have hassume := VerifM.eval_assume hb3 heq_wf heq_holds
+      have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
       set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
       have hσ₂wf : σ₂.wf (st₂.decls.addConst resVar) := by
         simpa [σ₂] using

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -52,9 +52,10 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def PredTrans.apply (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : Env) : iProp :=
+def PredTrans.apply (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
   Assertion.pre (fun post ρ' =>
-    BIBase.forall fun v : Runtime.Val => Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+    BIBase.forall fun v : Runtime.Val =>
+      Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
   ) m ρ
 
 -- ---------------------------------------------------------------------------
@@ -98,8 +99,8 @@ theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
     h hsub hwf
 
 theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
-    {ρ ρ' : Env} {Δ : Signature}
-    (hwf : pt.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
+    {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : pt.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') :
     PredTrans.apply Φ pt ρ ⊢ PredTrans.apply Φ pt ρ' := by
   unfold PredTrans.apply at ⊢
   apply Assertion.pre_env_agree hwf hagree
@@ -108,7 +109,7 @@ theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
   intro v
   exact (forall_elim v).trans <|
     Assertion.post_env_agree hwf_post
-      (Env.agreeOn_declVar hagree_post)
+      (VerifM.Env.agreeOn_declVar hagree_post)
       (fun _ _ _ _ _ _ => .rfl)
 
 -- ---------------------------------------------------------------------------
@@ -116,38 +117,38 @@ theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
 -- ---------------------------------------------------------------------------
 
 theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
-    (st : TransState) (ρ : Env)
-    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp) R :
+    (st : TransState) (ρ : VerifM.Env)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) R :
     pt.wfIn (Signature.ofVars σ.dom) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     VerifM.eval (PredTrans.call σ pt) st ρ Ψ →
-    (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
-      (st'.owns.interp ρ' ∗ R ⊢ Φ v)) →
-    st.owns.interp ρ ∗ R ⊢ PredTrans.apply Φ pt (σ.subst.eval ρ) := by
+    (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
+      (st'.sl ρ' ∗ R ⊢ Φ v)) →
+    st.sl ρ ∗ R ⊢ PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
   intro hwf hdomwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   let retWf : (String × Assertion Unit) → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let Φpost : (String × Assertion Unit) → Env → iProp :=
+  let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun post ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
-  let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → Env → Prop :=
+  let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → VerifM.Env → Prop :=
     fun r st' ρ' =>
       match r with
       | (σ₁, postName, postBody) => (do
           let resVar ← VerifM.decl (some postName) Srt.value
           let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
           Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
-  have hpre : st.owns.interp ρ ∗ R ⊢ Assertion.pre Φpost pt (σ.subst.eval ρ) := by
+  have hpre : st.sl ρ ∗ R ⊢ Assertion.pre Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
     exact Assertion.prove_correct pt σ retWf st ρ Ψcall Φpost R
       (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree =>
         forall_intro fun v =>
           (forall_elim v).trans <|
             Assertion.post_env_agree hwf_post
-              (Env.agreeOn_declVar hagree)
+              (VerifM.Env.agreeOn_declVar hagree)
               (fun _ _ _ _ _ _ => .rfl))
       hσwf hdomwf hwf hb
       (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ hcont hσ₁wf hσ₁domwf hwf₁ => by
@@ -177,7 +178,7 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
           (ρ₁.updateConst .value resVar.name v)
           (fun a st' ρ' =>
             { st₁ with decls := st₁.decls.addConst resVar }.decls.Subset st'.decls ∧
-              Env.agreeOn { st₁ with decls := st₁.decls.addConst resVar }.decls
+              VerifM.Env.agreeOn { st₁ with decls := st₁.decls.addConst resVar }.decls
                 (ρ₁.updateConst .value resVar.name v) ρ' ∧
               (Pure.pure (Term.const (.uninterpreted resVar.name .value)) : VerifM (Term .value)).eval st' ρ' Ψ)
           (fun () _ => Φ v) R
@@ -196,8 +197,8 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
             · simp only [Term.eval, Const.denote]
               have := hagree.2.1 resVar (List.Mem.head _)
               simpa [Env.lookupConst, Env.updateConst] using this.symm)
-        have hinterp_bi : SpatialContext.interp ρ₁ st₁.owns ⊣⊢
-            SpatialContext.interp (ρ₁.updateConst .value resVar.name v) st₁.owns :=
+        have hinterp_bi :
+            st₁.sl ρ₁ ⊣⊢ st₁.sl (ρ₁.updateConst .value resVar.name v) :=
           SpatialContext.interp_env_agree (VerifM.eval.wf hcont).ownsWf
             (agreeOn_update_fresh_const (c := resVar) hfresh_decls)
         exact (sep_mono hinterp_bi.1 (by
@@ -213,32 +214,32 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
 
 theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
     (body : VerifM (Term .value))
-    (st : TransState) (ρ : Env) (Φ : Runtime.Val → iProp) (R : iProp) :
+    (st : TransState) (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (R : iProp) :
     pt.wfIn (Signature.ofVars σ.dom) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     VerifM.eval (PredTrans.implement σ pt body) st ρ (fun _ _ _ => True) →
     (∀ st' ρ' (Q : iProp),
       st.decls.Subset st'.decls →
-      Env.agreeOn st.decls ρ ρ' →
+      VerifM.Env.agreeOn st.decls ρ ρ' →
       VerifM.eval body st' ρ'
       (fun result st'' ρ'' =>
         ∀ (S : iProp),
         result.wfIn st''.decls →
-        (st''.owns.interp ρ'' ∗ Q ∗ (Φ (result.eval ρ'') -∗ S) ⊢ S)) →
-      st'.owns.interp ρ' ∗ Q ⊢ R) →
-    st.owns.interp ρ ∗ PredTrans.apply Φ pt (σ.subst.eval ρ) ⊢ R := by
+        (st''.sl ρ'' ∗ Q ∗ (Φ (result.eval ρ''.env) -∗ S) ⊢ S)) →
+      st'.sl ρ' ∗ Q ⊢ R) →
+    st.sl ρ ∗ PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ⊢ R := by
   intro hwf hdomwf hσwf heval hbody
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   have hb_grow := VerifM.eval.decls_grow ρ hb
   let retWf : (String × Assertion Unit) → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let OuterQ : (String × Assertion Unit) → Env → iProp :=
+  let OuterQ : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun ⟨postName, postBody⟩ ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
-  let Φpost : (String × Assertion Unit) → Env → iProp :=
+  let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
   have hpost := Assertion.assume_correct pt σ retWf
     st ρ _ Φpost emp
@@ -258,7 +259,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
       apply BIBase.Entails.trans sep_comm.1
       apply BIBase.Entails.trans emp_sep.1
       have hcont_body := VerifM.eval_bind _ _ _ _ hcont
-      change st₁.owns.interp ρ₁ ⊢ OuterQ (postName, postBody) (σ₁.subst.eval ρ₁) -∗ R
+      change st₁.sl ρ₁ ⊢ OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) -∗ R
       refine wand_intro ?_
       refine hbody st₁ ρ₁ _ hdsub_st hagree_st ?_
       refine (VerifM.eval.decls_grow ρ₁ hcont_body).mono ?_
@@ -270,7 +271,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         fresh_not_mem (addNumbers postName) st₂.decls.allNames (addNumbers_injective _)
       have hfresh_range : resVar.name ∉ σ₁.range.allNames :=
         fun hmem => hfresh_decls (Signature.allNames_subset (Signature.Subset.trans hσ₁wf.2.1 hdsub_body) _ hmem)
-      specialize hdecl (result.eval ρ₂)
+      specialize hdecl (result.eval ρ₂.env)
       have hb3 := VerifM.eval_bind _ _ _ _ hdecl
       have heq_wf : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).wfIn
           (st₂.decls.addConst resVar) := by
@@ -284,7 +285,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         · intro τ' hc'
           exact Signature.wf_unique_const hwf' (List.Mem.head _) hc'
       have heq_holds : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).eval
-          (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) := by
+          (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env := by
         simp only [Formula.eval, Term.eval, Const.denote]
         simpa [Env.lookupConst, Env.updateConst] using
           (Term.eval_env_agree hwf_result (agreeOn_update_fresh_const hfresh_decls))
@@ -306,8 +307,8 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
           asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st₂.asserts }
       have hpre := @Assertion.prove_correct Unit postBody σ₂ (fun _ _ => True)
         st₃
-        (ρ₂.updateConst .value resVar.name (result.eval ρ₂))
-        _ (fun () _ => Φ (result.eval ρ₂) -∗ S) (Φ (result.eval ρ₂) -∗ S)
+        (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+        _ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) (Φ (result.eval ρ₂.env) -∗ S)
         (fun _ _ _ _ _ _ => .rfl)
         hσ₂wf hσ₂domwf hwf_postBody' hb4
         (fun _ () st' ρ' hret _ _ _ => by
@@ -315,12 +316,12 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
           icases H with ⟨_, HR⟩
           iexact HR)
       have hag_rename := @FiniteSubst.rename_agreeOn σ₁ ⟨postName, .value⟩ resVar
-        ρ₂ (result.eval ρ₂) hσ₁wf.1 hfresh_range rfl
+        ρ₂.env (result.eval ρ₂.env) hσ₁wf.1 hfresh_range rfl
       have hag_eval := FiniteSubst.eval_agreeOn hσ₁wf.1
         (Env.agreeOn_mono hσ₁wf.2.1 (Env.agreeOn_symm hagree_body))
       have hag_eval' : Env.agreeOn (Signature.ofVars σ₂.dom)
-          ((σ₁.subst.eval ρ₂).updateConst .value postName (result.eval ρ₂))
-          ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂)) := by
+          ((σ₁.subst.eval ρ₂.env).updateConst .value postName (result.eval ρ₂.env))
+          ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env)) := by
         apply Env.agreeOn_mono
           (Δ₁ := Signature.ofVars σ₂.dom)
           (Δ₂ := Signature.ofVars (⟨postName, .value⟩ :: σ₁.dom))
@@ -331,46 +332,52 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
               · exact Or.inl rfl
               · exact Or.inr hx))
         exact Env.agreeOn_update hag_eval
-      have hpost_transport : Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
-          ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂)) ⊢
-          Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
-            (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
+      have hpost_transport : Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+          (VerifM.Env.withEnv ρ₁ ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env))) ⊢
+          Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+            (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
         exact Assertion.post_env_agree hwf_postBody'
-          (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval'))
+          (by
+            simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv]
+              using (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval')))
           (fun _ _ _ _ _ _ => .rfl)
-      have howns_agree : st₃.owns.interp ρ₂
+      have howns_agree : st₃.sl ρ₂
             ⊢
-          st₃.owns.interp (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) := by
+          st₃.sl (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) := by
         simpa using
           (SpatialContext.interp_env_agree (VerifM.eval.wf hrest).ownsWf
             (agreeOn_update_fresh_const hfresh_decls)).1
       have hpre_final :
-          st₂.owns.interp ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
-            Assertion.pre (fun () _ => Φ (result.eval ρ₂) -∗ S) postBody
-              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
+          st₂.sl ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+            Assertion.pre (fun () _ => Φ (result.eval ρ₂.env) -∗ S) postBody
+              (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+                (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
         have hinput :
-            st₂.owns.interp ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
-              st₃.owns.interp (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) ∗
-                (Φ (result.eval ρ₂) -∗ S) := by
+            st₂.sl ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+              st₃.sl (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) ∗
+                (Φ (result.eval ρ₂.env) -∗ S) := by
           iintro H
           icases H with ⟨Howns, Hwand⟩
           isplitl [Howns]
           · iapply howns_agree
-            iexact Howns
+            simp [st₃, TransState.sl]
           · iexact Hwand
         exact hinput.trans hpre
       have hpost_final :
-          OuterQ (postName, postBody) (σ₁.subst.eval ρ₁) ⊢
-            Assertion.post (fun () _ => Φ (result.eval ρ₂)) postBody
-              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))) := by
-        exact (forall_elim (result.eval ρ₂)).trans hpost_transport
+          OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) ⊢
+            Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+              (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+                (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
+        exact (forall_elim (result.eval ρ₂.env)).trans hpost_transport
       iintro H
       icases H with ⟨Howns, HQ, Hwand⟩
       iapply (Assertion.pre_post_combine
-        (ρ := σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))
+        (ρ := VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
+          (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env))
         (m := postBody)
-        (Φ := fun () _ => Φ (result.eval ρ₂) -∗ S)
-        (Ψ := fun () _ => Φ (result.eval ρ₂))
+        (Φ := fun () _ => Φ (result.eval ρ₂.env) -∗ S)
+        (Ψ := fun () _ => Φ (result.eval ρ₂.env))
         (R := S)
         (fun () _ => by
           iintro H
@@ -385,7 +392,9 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
       · iapply hpost_final
         iexact HQ
       )
-  have hpre : PredTrans.apply Φ pt (σ.subst.eval ρ) = Assertion.pre OuterQ pt (σ.subst.eval ρ) := rfl
+  have hpre :
+      PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) =
+      Assertion.pre OuterQ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := rfl
   rw [hpre]
   exact BIBase.Entails.trans
     (by
@@ -393,12 +402,14 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
       icases H with ⟨Howns, Happ⟩
       isplitr [Howns]
       · iexact Happ
-      · iapply hpost
+      · have hpost' : st.sl ρ ∗ emp ⊢ Assertion.post Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+          simpa [VerifM.Env.withEnv] using hpost
+        iapply hpost'
         isplitl
         . iexact Howns
         . iemp_intro)
     (Assertion.pre_post_combine
-      (ρ := σ.subst.eval ρ)
+      (ρ := VerifM.Env.withEnv ρ (σ.subst.eval ρ.env))
       (m := pt)
       (Φ := OuterQ)
       (Ψ := Φpost)

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -1,7 +1,6 @@
 import Mica.TinyML.Typed
 import Mica.TinyML.Untyped
 import Mica.TinyML.Typing
-import Mica.TinyML.WeakestPre
 import Mica.Verifier.Functions
 import Mica.Frontend.SpecParser
 import Mica.Verifier.SpecTranslation
@@ -9,6 +8,7 @@ import Mica.Verifier.PredicateTransformers
 import Mica.Verifier.Specifications
 import Mica.Engine.Driver
 
+open Iris Iris.BI
 open Typed
 
 private def parseSpec (e : Untyped.Expr) : Except String SpecPredicate := do
@@ -117,19 +117,30 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed
     (st : TransState) (ρ : Env)
     {Q : Unit → TransState → Env → Prop}
     (heval : VerifM.eval (ValDecl.checkExpr Θ S d) st ρ Q) :
-    wp (d.body.runtime.subst γ) (fun _ => True) := by
+    st.owns.interp ρ ⊢ wp (d.body.runtime.subst γ) (fun _ => iprop(True)) := by
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
-  exact compile_correct Θ d.body S [] TinyML.TyCtx.empty st ρ γ
+  have hemp : st.owns.interp ρ ⊢ st.owns.interp ρ ∗ emp := by
+    istart
+    iintro Howns
+    isplitl [Howns]
+    · iexact Howns
+    · iemp_intro
+  exact hemp.trans <|
+    compile_correct Θ iprop(emp) d.body S [] TinyML.TyCtx.empty st ρ γ
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
-    (fun _ => True)
+    (fun _ => iprop(True))
     hcompile
     (fun _ _ h => by simp at h)
     (fun _ h => by simp at h)
     (fun _ _ _ h _ => by simp at h)
     hS hSwf
-    (fun _ _ _ _ _ _ _ _ => trivial)
+    (fun _ _ _ _ _ _ _ _ => by
+      istart
+      iintro _
+      ipure_intro
+      trivial)
 
 theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
     (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
@@ -137,7 +148,7 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
     {Q : Spec → TransState → Env → Prop}
     (heval : VerifM.eval (ValDecl.check Θ S d) st ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
-            wp (d.body.runtime.subst γ) (spec.isPrecondFor Θ ·) ∧
+            (st.owns.interp ρ ⊢ wp (d.body.runtime.subst γ) (fun v => ⌜spec.isPrecondFor Θ v⌝)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.spec with
@@ -174,85 +185,91 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
                  VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
-    (st : TransState) (ρ : Env) :
-    VerifM.eval (Program.check Θ S prog) st ρ (fun _ _ _ => True) →
-    pwp ((Typed.Program.runtime prog).subst γ) := by
-  induction prog generalizing S γ st ρ with
+    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty) (ρ : Env) :
+    VerifM.eval (Program.check Θ S prog) TransState.empty ρ (fun _ _ _ => True) →
+    emp ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
+  induction prog generalizing S γ ρ with
   | nil =>
     intro _
-    simp [Typed.Program.runtime, Runtime.Program.subst, pwp]
+    simp [Typed.Program.runtime, Runtime.Program.subst]
   | cons d ds ih =>
     intro heval
-    have hpwp_unfold : pwp ((Typed.Program.runtime (d :: ds)).subst γ) ↔
+    have hpwp_unfold : pwp ((Typed.Program.runtime (d :: ds)).subst γ) ⊣⊢
         wp (d.body.runtime.subst γ) (fun v =>
           pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
-      simp [Typed.Program.runtime, pwp, Typed.ValDecl.runtime,
+      simp [Typed.Program.runtime, Typed.ValDecl.runtime,
         Runtime.Program.subst, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
-    rw [hpwp_unfold]
-    simp only [Program.check] at heval
-    cases hname : d.name.name
-    · cases hspec : d.spec
-      · simp only [hname, hspec] at heval
-        have hbind := VerifM.eval_bind _ _ _ _ heval
-        have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
-        have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-        apply wp.mono _ hwp
-        intro v _
-        simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-        exact ih S γ hS hSwf st ρ (VerifM.eval_ret hcont)
-      · simp only [hname, hspec] at heval
-        obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          ValDecl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
-        apply wp.mono (fun v hprecond => _) hwp
-        intro v hprecond
-        simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-        exact ih S γ hS hSwf st ρ hcont
-    · rename_i n
-      cases hspec : d.spec
-      · simp only [hname, hspec] at heval
-        split at heval
-        · rename_i hfunc
-          obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
-          have hbody_rt : d.body.runtime.subst γ =
-              Runtime.Expr.fix self.runtime (args.map (·.runtime))
-                (body.runtime.subst ((γ.remove' self.runtime).removeAll'
-                  (args.map (·.runtime)))) := by
-            rw [hbody]
-            conv_lhs => unfold Expr.runtime
-            simp only [Runtime.Expr.subst_fix]
-          rw [hbody_rt]
-          apply wp.func
-          simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-          simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-            ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime _ γ)
-            (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
-              simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
-        · have hbind := VerifM.eval_bind _ _ _ _ heval
-          have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf st ρ hbind
+    have hmain : emp ⊢
+        wp (d.body.runtime.subst γ) (fun v =>
+          pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
+      simp only [Program.check] at heval
+      cases hname : d.name.name
+      · cases hspec : d.spec
+        · simp only [hname, hspec] at heval
+          have hbind := VerifM.eval_bind _ _ _ _ heval
+          have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf TransState.empty ρ hbind
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          apply wp.mono _ hwp
-          intro v _
-          simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-          simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-            ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime v γ)
-            (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) st ρ (by
+          refine hwp.trans (wp.mono' ?_)
+          intro v
+          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
+          exact ih S γ hS hSwf ρ (VerifM.eval_ret hcont)
+        · simp only [hname, hspec] at heval
+          obtain ⟨spec, hswf, hwp, hcont⟩ :=
+            ValDecl.check_correct Θ S d γ hS hSwf TransState.empty ρ (VerifM.eval_bind _ _ _ _ heval)
+          refine hwp.trans (wp.mono' ?_)
+          intro v
+          apply pure_elim'
+          intro _
+          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
+          exact ih S γ hS hSwf ρ hcont
+      · rename_i n
+        cases hspec : d.spec
+        · simp only [hname, hspec] at heval
+          split at heval
+          · rename_i hfunc
+            obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
+            have hbody_rt : d.body.runtime.subst γ =
+                Runtime.Expr.fix self.runtime (args.map (·.runtime))
+                  (body.runtime.subst ((γ.remove' self.runtime).removeAll'
+                    (args.map (·.runtime)))) := by
+              rw [hbody]
+              conv_lhs => unfold Expr.runtime
+              simp only [Runtime.Expr.subst_fix]
+            rw [hbody_rt]
+            exact SpatialContext.wp_func <| by
+              simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
               simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-                (VerifM.eval_ret hcont))
-      · simp only [hname, hspec] at heval
-        obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          ValDecl.check_correct Θ S d γ hS hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
-        apply wp.mono (fun v hprecond => _) hwp
-        intro v hprecond
-        simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-        simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-          ih (S.insert' d.name spec) (Runtime.Subst.update' d.name.runtime v γ)
-            (SpecMap.satisfiedBy_insert'_update' hS hprecond) (SpecMap.wfIn_insert' hSwf hswf) st ρ
-            (by
-              simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using hcont)
+                ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime _ γ)
+                (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) ρ (by
+                  simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
+          · have hbind := VerifM.eval_bind _ _ _ _ heval
+            have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf TransState.empty ρ hbind
+            have ⟨_, hcont⟩ := VerifM.eval_seq hbind
+            refine hwp.trans (wp.mono' ?_)
+            intro v
+            simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
+            simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+              ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime v γ)
+              (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) ρ (by
+                simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+                  (VerifM.eval_ret hcont))
+        · simp only [hname, hspec] at heval
+          obtain ⟨spec, hswf, hwp, hcont⟩ :=
+            ValDecl.check_correct Θ S d γ hS hSwf TransState.empty ρ (VerifM.eval_bind _ _ _ _ heval)
+          refine hwp.trans (wp.mono' ?_)
+          intro v
+          apply pure_elim'
+          intro hprecond
+          simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
+          simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
+            ih (S.insert' d.name spec) (Runtime.Subst.update' d.name.runtime v γ)
+              (SpecMap.satisfiedBy_insert'_update' hS hprecond) (SpecMap.wfIn_insert' hSwf hswf) ρ
+              (by
+                simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using hcont)
+    exact hmain.trans hpwp_unfold.2
 
 theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
-  Smt.Strategy.checks (Program.verify p) (pwp (Untyped.Program.runtime p)) := by
+  Smt.Strategy.checks (Program.verify p) (⊢ pwp (Untyped.Program.runtime p)) := by
   simp only [Smt.Strategy.checks, Program.verify, VerifM.strategy]
   intro st' heval
   have h1 := ScopedM.strategy_eval_initial_implies_ScopedM_eval heval
@@ -276,6 +293,6 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
     obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty default hbind
     have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
                        (SpecMap.empty_satisfiedBy _) (SpecMap.empty_wfIn _)
-                       TransState.empty default hcheck
+                        default hcheck
     rw [Runtime.Program.subst_id] at hcorrect
     simpa [hrt] using hcorrect

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -98,8 +98,8 @@ def Program.verify (prog : Untyped.Program Untyped.Expr) : Smt.Strategy Smt.Stra
 /-! ## Correctness -/
 
 theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
-    (st : TransState) (ρ : Env)
-    {Q : (TinyML.TypeEnv × Typed.Program Untyped.Expr) → TransState → Env → Prop}
+    (st : TransState) (ρ : VerifM.Env)
+    {Q : (TinyML.TypeEnv × Typed.Program Untyped.Expr) → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (Program.prepare prog) st ρ Q) :
     ∃ Θ typed, Typed.Program.runtime typed = Untyped.Program.runtime prog ∧ Q (Θ, typed) st ρ := by
   unfold Program.prepare at heval
@@ -114,8 +114,8 @@ theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
     exact VerifM.eval_ret heval
 
 theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : Env)
-    {Q : Unit → TransState → Env → Prop}
+    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env)
+    {Q : Unit → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (ValDecl.checkExpr Θ S d) TransState.empty ρ Q) :
     (S.satisfiedBy Θ γ ⊢ Φ) →
     S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
@@ -148,8 +148,8 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed
     . iexact Hspec
 
 theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : Env)
-    {Q : Spec → TransState → Env → Prop}
+    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env)
+    {Q : Spec → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (ValDecl.check Θ S d) TransState.empty ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
             (S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
@@ -189,7 +189,7 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
                  VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : Env) :
+    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env) :
     VerifM.eval (Program.check Θ S prog) TransState.empty ρ (fun _ _ _ => True) →
     S.satisfiedBy Θ γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ ρ with
@@ -299,7 +299,7 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
   | .error e =>
     cases e <;> simp [ScopedM.eval_ret] at hcont
   | .ok () =>
-    have hholdsFor : TransState.holdsFor TransState.empty default :=
+    have hholdsFor : TransState.holdsFor TransState.empty VerifM.Env.empty :=
       fun φ hφ => by simp [TransState.empty] at hφ
     have hwf : TransState.wf TransState.empty :=
       ⟨fun φ hφ => by simp [TransState.empty] at hφ,
@@ -309,11 +309,11 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
                       (do
                         let (Θ, typed) ← Program.prepare p
                         Program.check Θ ∅ typed)
-                      TransState.empty default ctx_mid hverif hholdsFor hwf
+                      TransState.empty VerifM.Env.empty ctx_mid hverif hholdsFor hwf
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
-    obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty default hbind
+    obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty VerifM.Env.empty hbind
     have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
-                       (SpecMap.empty_wfIn _) default hcheck
+                       (SpecMap.empty_wfIn _) VerifM.Env.empty hcheck
     rw [Runtime.Program.subst_id] at hcorrect
     have hsat : (⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) Runtime.Subst.id) :=
       SpecMap.empty_satisfiedBy _

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -1,6 +1,7 @@
 import Mica.TinyML.Typed
 import Mica.TinyML.Untyped
 import Mica.TinyML.Typing
+import Mica.SeparationLogic.PrimitiveLaws
 import Mica.Verifier.Functions
 import Mica.Frontend.SpecParser
 import Mica.Verifier.SpecTranslation
@@ -113,43 +114,46 @@ theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
     exact VerifM.eval_ret heval
 
 theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
-    (st : TransState) (ρ : Env)
+    (hSwf : S.wfIn Signature.empty) (ρ : Env)
     {Q : Unit → TransState → Env → Prop}
-    (heval : VerifM.eval (ValDecl.checkExpr Θ S d) st ρ Q) :
-    st.owns.interp ρ ⊢ wp (d.body.runtime.subst γ) (fun _ => iprop(True)) := by
+    (heval : VerifM.eval (ValDecl.checkExpr Θ S d) TransState.empty ρ Q) :
+    (S.satisfiedBy Θ γ ⊢ Φ) →
+    S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
+  intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
-  have hemp : st.owns.interp ρ ⊢ st.owns.interp ρ ∗ emp := by
-    istart
-    iintro Howns
-    isplitl [Howns]
-    · iexact Howns
-    · iemp_intro
-  exact hemp.trans <|
-    compile_correct Θ iprop(emp) d.body S [] TinyML.TyCtx.empty st ρ γ
+  have hcomp :=
+    compile_correct Θ iprop(S.satisfiedBy Θ γ) d.body S [] TinyML.TyCtx.empty TransState.empty ρ γ
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
-    (fun _ => iprop(True))
+    (fun _ => Φ)
     hcompile
     (fun _ _ h => by simp at h)
     (fun _ h => by simp at h)
     (fun _ _ _ h _ => by simp at h)
-    hS hSwf
+    hSwf
     (fun _ _ _ _ _ _ _ _ => by
       istart
-      iintro _
-      ipure_intro
-      trivial)
+      iintro ⟨_, Hsat⟩
+      iapply Hent
+      iexact Hsat)
+  refine (BIBase.Entails.trans ?_ hcomp)
+  istart
+  iintro □Hspec
+  isplitl []
+  . simp [TransState.empty]
+    iemp_intro
+  . isplitl []
+    . iexact Hspec
+    . iexact Hspec
 
 theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty)
-    (st : TransState) (ρ : Env)
+    (hSwf : S.wfIn Signature.empty) (ρ : Env)
     {Q : Spec → TransState → Env → Prop}
-    (heval : VerifM.eval (ValDecl.check Θ S d) st ρ Q) :
+    (heval : VerifM.eval (ValDecl.check Θ S d) TransState.empty ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
-            (st.owns.interp ρ ⊢ wp (d.body.runtime.subst γ) (fun v => ⌜spec.isPrecondFor Θ v⌝)) ∧
-            Q spec st ρ := by
+            (S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
+            Q spec TransState.empty ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.spec with
   | none =>
@@ -181,17 +185,18 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
           have h4 := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ h3)
           have hswf : spec.wfIn Signature.empty := Spec.checkWf_ok (by cases u; exact hwf)
           have ⟨hcheckSpec, hpure⟩ := VerifM.eval_seq h4
-          exact ⟨spec, hswf, checkSpec_correct Θ S d.body spec γ hswf hSwf hS st ρ hcheckSpec,
+          exact ⟨spec, hswf, checkSpec_correct Θ S d.body spec γ hswf hSwf ρ hcheckSpec,
                  VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
-    (hS : S.satisfiedBy Θ γ) (hSwf : S.wfIn Signature.empty) (ρ : Env) :
+    (hSwf : S.wfIn Signature.empty) (ρ : Env) :
     VerifM.eval (Program.check Θ S prog) TransState.empty ρ (fun _ _ _ => True) →
-    emp ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
+    S.satisfiedBy Θ γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ ρ with
   | nil =>
     intro _
-    simp [Typed.Program.runtime, Runtime.Program.subst]
+    simp only [Typed.Program.runtime, List.map_nil, Runtime.Program.subst, pwp]
+    exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | cons d ds ih =>
     intro heval
     have hpwp_unfold : pwp ((Typed.Program.runtime (d :: ds)).subst γ) ⊣⊢
@@ -199,74 +204,90 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
           pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
       simp [Typed.Program.runtime, Typed.ValDecl.runtime,
         Runtime.Program.subst, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
-    have hmain : emp ⊢
-        wp (d.body.runtime.subst γ) (fun v =>
-          pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.update' d.name.runtime v γ))) := by
-      simp only [Program.check] at heval
-      cases hname : d.name.name
-      · cases hspec : d.spec
-        · simp only [hname, hspec] at heval
+    refine BIBase.Entails.trans ?_ hpwp_unfold.2
+    simp only [Program.check] at heval
+    cases hname : d.name.name with
+    | none =>
+      -- unnamed: pwp continuation does not depend on `v`
+      have hupd : ∀ v, Runtime.Subst.update' d.name.runtime v γ = γ := by
+        intro v; simp [Binder.runtime_of_name_none hname, Runtime.Subst.update']
+      cases hspec : d.spec with
+      | none =>
+        -- unnamed, no spec
+        simp only [hname, hspec] at heval
+        have hbind := VerifM.eval_bind _ _ _ _ heval
+        have ⟨_, hcont⟩ := VerifM.eval_seq hbind
+        have hih := ih S γ hSwf ρ (VerifM.eval_ret hcont)
+        have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf ρ hbind hih
+        refine hwp.trans (wp.mono' ?_)
+        intro v; rw [hupd v]; exact .rfl
+      | some _ =>
+        -- unnamed, with spec
+        simp only [hname, hspec] at heval
+        obtain ⟨spec, _, hwp, hcont⟩ :=
+          ValDecl.check_correct Θ S d γ hSwf ρ (VerifM.eval_bind _ _ _ _ heval)
+        have hih := ih S γ hSwf ρ hcont
+        refine SpatialContext.wp_strengthen_persistent hwp ?_
+        intro v
+        rw [hupd v]
+        exact wand_intro (sep_elim_l.trans hih)
+    | some n =>
+      have hname_rt : d.name.runtime = .named n := Binder.runtime_of_name_some hname
+      have herase : S.erase' d.name = S.erase n := by simp [SpecMap.erase', hname]
+      have hinsert : ∀ s, S.insert' d.name s = S.insert n s := by
+        intro s; simp [SpecMap.insert', hname]
+      have hupd : ∀ v, Runtime.Subst.update' d.name.runtime v γ = γ.update n v := by
+        intro v; simp [hname_rt, Runtime.Subst.update']
+      cases hspec : d.spec with
+      | none =>
+        simp only [hname, hspec] at heval
+        split at heval
+        · -- named, no spec, function value
+          rename_i hfunc
+          obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
+          have hbody_rt : d.body.runtime.subst γ =
+              Runtime.Expr.fix self.runtime (args.map (·.runtime))
+                (body.runtime.subst ((γ.remove' self.runtime).removeAll'
+                  (args.map (·.runtime)))) := by
+            rw [hbody]; conv_lhs => unfold Expr.runtime
+            simp only [Runtime.Expr.subst_fix]
+          rw [hbody_rt]
+          set fval := Runtime.Val.fix self.runtime (args.map (·.runtime))
+            (body.runtime.subst ((γ.remove' self.runtime).removeAll'
+              (args.map (·.runtime))))
+          apply SpatialContext.wp_func
+          rw [hupd fval]
+          have heval' : VerifM.eval (Program.check Θ (S.erase n) ds) TransState.empty ρ (fun _ _ _ => True) := by
+            convert heval
+          have hih := ih (S.erase n) (γ.update n fval)
+            (SpecMap.wfIn_erase hSwf) ρ heval'
+          exact (SpecMap.satisfiedBy_erase (x := n) (v := fval)).trans hih
+        · -- named, no spec, not a function
           have hbind := VerifM.eval_bind _ _ _ _ heval
-          have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf TransState.empty ρ hbind
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          refine hwp.trans (wp.mono' ?_)
+          have hcont' : VerifM.eval (Program.check Θ (S.erase n) ds) TransState.empty ρ (fun _ _ _ => True) :=
+            VerifM.eval_ret hcont
+          have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf ρ hbind
+            (Φ := iprop(emp)) (by istart; iintro _; iemp_intro)
+          refine SpatialContext.wp_strengthen_persistent hwp ?_
           intro v
-          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-          exact ih S γ hS hSwf ρ (VerifM.eval_ret hcont)
-        · simp only [hname, hspec] at heval
-          obtain ⟨spec, hswf, hwp, hcont⟩ :=
-            ValDecl.check_correct Θ S d γ hS hSwf TransState.empty ρ (VerifM.eval_bind _ _ _ _ heval)
-          refine hwp.trans (wp.mono' ?_)
-          intro v
-          apply pure_elim'
-          intro _
-          simp only [Binder.runtime_of_name_none hname, Runtime.Subst.update']
-          exact ih S γ hS hSwf ρ hcont
-      · rename_i n
-        cases hspec : d.spec
-        · simp only [hname, hspec] at heval
-          split at heval
-          · rename_i hfunc
-            obtain ⟨self, args, retTy, body, hbody⟩ := Expr.isFunc_elim hfunc
-            have hbody_rt : d.body.runtime.subst γ =
-                Runtime.Expr.fix self.runtime (args.map (·.runtime))
-                  (body.runtime.subst ((γ.remove' self.runtime).removeAll'
-                    (args.map (·.runtime)))) := by
-              rw [hbody]
-              conv_lhs => unfold Expr.runtime
-              simp only [Runtime.Expr.subst_fix]
-            rw [hbody_rt]
-            exact SpatialContext.wp_func <| by
-              simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-              simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-                ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime _ γ)
-                (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) ρ (by
-                  simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using heval)
-          · have hbind := VerifM.eval_bind _ _ _ _ heval
-            have hwp := ValDecl.checkExpr_correct Θ S d γ hS hSwf TransState.empty ρ hbind
-            have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-            refine hwp.trans (wp.mono' ?_)
-            intro v
-            simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-            simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-              ih (S.erase' d.name) (Runtime.Subst.update' d.name.runtime v γ)
-              (SpecMap.satisfiedBy_erase' hS) (SpecMap.wfIn_erase' hSwf) ρ (by
-                simpa [SpecMap.erase', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-                  (VerifM.eval_ret hcont))
-        · simp only [hname, hspec] at heval
-          obtain ⟨spec, hswf, hwp, hcont⟩ :=
-            ValDecl.check_correct Θ S d γ hS hSwf TransState.empty ρ (VerifM.eval_bind _ _ _ _ heval)
-          refine hwp.trans (wp.mono' ?_)
-          intro v
-          apply pure_elim'
-          intro hprecond
-          simp only [Binder.runtime_of_name_some hname, Runtime.Subst.update']
-          simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using
-            ih (S.insert' d.name spec) (Runtime.Subst.update' d.name.runtime v γ)
-              (SpecMap.satisfiedBy_insert'_update' hS hprecond) (SpecMap.wfIn_insert' hSwf hswf) ρ
-              (by
-                simpa [SpecMap.insert', hname, Binder.runtime_of_name_some hname, Runtime.Subst.update'] using hcont)
-    exact hmain.trans hpwp_unfold.2
+          rw [hupd v]
+          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) ρ hcont'
+          exact wand_intro (sep_elim_l.trans <|
+            (SpecMap.satisfiedBy_erase (x := n) (v := v)).trans hih)
+      | some _ =>
+        simp only [hname, hspec] at heval
+        obtain ⟨spec, hswf, hwp, hcont⟩ :=
+          ValDecl.check_correct Θ S d γ hSwf ρ (VerifM.eval_bind _ _ _ _ heval)
+        have hcont' : VerifM.eval (Program.check Θ (S.insert n spec) ds) TransState.empty ρ (fun _ _ _ => True) := by
+          convert hcont
+        refine SpatialContext.wp_strengthen_persistent hwp ?_
+        intro v
+        rw [hupd v]
+        have hih := ih (S.insert n spec) (γ.update n v)
+          (SpecMap.wfIn_insert hSwf hswf) ρ hcont'
+        exact wand_intro
+          ((SpecMap.satisfiedBy_insert_update (x := n) (v := v) (spec := spec)).trans hih)
 
 theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
   Smt.Strategy.checks (Program.verify p) (⊢ pwp (Untyped.Program.runtime p)) := by
@@ -292,7 +313,8 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
     obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty default hbind
     have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
-                       (SpecMap.empty_satisfiedBy _) (SpecMap.empty_wfIn _)
-                        default hcheck
+                       (SpecMap.empty_wfIn _) default hcheck
     rw [Runtime.Program.subst_id] at hcorrect
-    simpa [hrt] using hcorrect
+    have hsat : (⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) Runtime.Subst.id) :=
+      SpecMap.empty_satisfiedBy _
+    simpa [hrt] using hsat.trans hcorrect

--- a/Mica/Verifier/SpecTranslation.lean
+++ b/Mica/Verifier/SpecTranslation.lean
@@ -144,6 +144,7 @@ def translatePred (env : Env) : Spec.Pred → M (Σ t, Atom t)
   | .isbool e => do .ok ⟨.bool, .isbool (← checkTerm env .value e)⟩
   | .isinj tag arity e => do
     .ok ⟨.value, .isinj tag arity (← checkTerm env .value e)⟩
+  | .own e => do .ok ⟨.value, .own (← checkTerm env .value e)⟩
 
 -- ---------------------------------------------------------------------------
 -- Assertions

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -48,12 +48,65 @@ def Spec.argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val �
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => Spec.argsEnv (ρ.updateConst .value name v) rest vs
 
-def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : Prop :=
-  ∀ (vs : List Runtime.Val), TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) →
-    ∀ (Φ : Runtime.Val → iProp),
-      PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-        (Spec.argsEnv Env.empty s.args vs) ⊢
-      wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ
+def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : iProp :=
+  iprop(□ ∀ (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
+      ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+          (Spec.argsEnv Env.empty s.args vs) -∗
+        wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
+
+instance : Iris.BI.Persistent (Spec.isPrecondFor Θ f s) := by
+  unfold Spec.isPrecondFor; infer_instance
+
+
+/-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
+    the two differ only by currying the typing hypothesis and the predicate transformer. -/
+theorem Spec.isPrecondFor_fold (Θ : TinyML.TypeEnv) (s : Spec)
+    (f : Runtime.Val) :
+    iprop(□ ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      (⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
+          (Spec.argsEnv Env.empty s.args vs)) -∗
+        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ f := by
+  unfold Spec.isPrecondFor
+  iintro □H
+  imodintro
+  iintro %Φ %vs Htyped Hpred
+  ispecialize H $$ %vs
+  ispecialize H $$ %Φ
+  iapply H
+  isplitl [Htyped]
+  · iexact Htyped
+  · iexact Hpred
+
+/-- Löb-style rule for spec preconditions on `fix`: to prove
+    `s.isPrecondFor Θ (.fix f args e)`, assume it as the recursive hypothesis and
+    prove the `wp` of the body (after the usual fix-substitution). -/
+theorem Spec.isPrecondFor_fix {Θ : TinyML.TypeEnv} {s : Spec}
+    {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
+    {R : iProp}
+    (h : R ⊢ □ (s.isPrecondFor Θ (.fix f args e) -∗
+        ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+          ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
+          PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
+              (Spec.argsEnv Env.empty s.args vs) -∗
+          wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
+    R ⊢ s.isPrecondFor Θ (.fix f args e) := by
+  refine (SpatialContext.wp_fix' (Φ := fun P vs =>
+      iprop(⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
+            (Spec.argsEnv Env.empty s.args vs))) (h.trans ?_)).trans
+    (Spec.isPrecondFor_fold Θ s _)
+  istart
+  iintro □HR
+  imodintro
+  iintro IH %vs %P ⟨%htyped, Hpred⟩
+  ispecialize HR $$ [IH]
+  · iapply (Spec.isPrecondFor_fold Θ s (.fix f args e)); iexact IH
+  ispecialize HR $$ %vs %P
+  iapply HR
+  · ipure_intro; exact htyped
+  · iexact Hpred
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
     context extended with all argument variables. -/
@@ -222,9 +275,39 @@ def Spec.implement (s : Spec) (body : List FOL.Const → VerifM (Term .value)) :
 
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
-def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) : Prop :=
-  ∀ x s, S.lookup x = some s →
-    ∃ f, γ x = some f ∧ s.isPrecondFor Θ f
+def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) : iProp :=
+  iprop(□ (∀ x s, ⌜S.lookup x = some s⌝ -∗ ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor Θ f))
+
+instance : Iris.BI.Persistent (SpecMap.satisfiedBy Θ S γ) := by
+  unfold SpecMap.satisfiedBy; infer_instance
+
+theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp) (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) :
+  (P ⊢ S.satisfiedBy Θ γ) →
+  S.lookup x = some s →
+  (∀ fval, γ x = some fval → s.isPrecondFor Θ fval ∗ P ⊢ Q) →
+  (P ⊢ Q) := by
+  intro hsat hlook hcont
+  simp only [SpecMap.satisfiedBy] at hsat
+  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor Θ fval) ∗ P := by
+    refine (persistent_entails_r hsat).trans ?_
+    istart
+    iintro ⟨□Hall, HP⟩
+    ispecialize Hall $$ %x
+    ispecialize Hall $$ %s
+    isplitl []
+    · iapply Hall
+      ipure_intro
+      exact hlook
+    · iexact HP
+  refine hstep.trans ?_
+  istart
+  iintro ⟨⟨%fval, Hγ, Hpre⟩, HP⟩
+  ipure Hγ
+  iapply (hcont fval Hγ)
+  isplitl [Hpre]
+  · iexact Hpre
+  · iexact HP
+
 
 def SpecMap.wfIn (S : SpecMap) (Δ : Signature) : Prop :=
   ∀ f spec, S.lookup f = some spec → spec.wfIn Δ
@@ -297,27 +380,46 @@ def SpecMap.erase' (S : SpecMap) (b : Typed.Binder) : SpecMap :=
   | none => S
 
 theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy Θ γ) (hγ : γ x = some fval) (hf : spec.isPrecondFor Θ fval) :
-    SpecMap.satisfiedBy Θ (Finmap.insert x spec S) γ := by
-  intro y s' hlookup
+    {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
+    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ fval ⊢ SpecMap.satisfiedBy Θ (Finmap.insert x spec S) γ := by
+  simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
+  iintro ⟨□HS, □Hf⟩
+  imodintro
+  iintro %y %s' %hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup
-    exact ⟨fval, hγ, hf⟩
+    iexists fval
+    isplitr
+    · ipure_intro; exact hγ
+    · iexact Hf
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup
-    exact hS y s' hlookup
+    ispecialize HS $$ %y
+    ispecialize HS $$ %s'
+    ispecialize HS $$ %hlookup
+    iexact HS
 
 theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {x : TinyML.Var} {v : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy Θ γ) (hf : spec.isPrecondFor Θ v) :
-    SpecMap.satisfiedBy Θ (Finmap.insert x spec S) (γ.update x v) := by
-  intro y s' hlookup
+    {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
+    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ v ⊢ SpecMap.satisfiedBy Θ (Finmap.insert x spec S) (γ.update x v) := by
+  simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
+  iintro ⟨□HS, □Hf⟩
+  imodintro
+  iintro %y %s' %hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup
-    exact ⟨v, by simp [Runtime.Subst.update], hf⟩
+    iexists v
+    isplitr
+    · ipure_intro; simp [Runtime.Subst.update]
+    · iexact Hf
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup
-    obtain ⟨f, hγf, hprecond⟩ := hS y s' hlookup
-    exact ⟨f, by simp [Runtime.Subst.update, beq_false_of_ne hyx, hγf], hprecond⟩
+    ispecialize HS $$ %y
+    ispecialize HS $$ %s'
+    ispecialize HS $$ %hlookup
+    icases HS with ⟨%f, %hγf, Hprecond⟩
+    iexists f
+    isplitl [Hprecond]
+    · ipure_intro; simp [Runtime.Subst.update, beq_false_of_ne hyx, hγf]
+    · iexact Hprecond
 
 theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : Signature}
     (hS : S.wfIn Δ) (hs : spec.wfIn Δ) : SpecMap.wfIn (Finmap.insert x spec S) Δ := by
@@ -328,25 +430,22 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
 
 theorem SpecMap.satisfiedBy_insert' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy Θ γ)
-    (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval)
-    (hf : spec.isPrecondFor Θ fval) :
-    SpecMap.satisfiedBy Θ (S.insert' b spec) γ := by
+    (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval) :
+    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ fval ⊢ SpecMap.satisfiedBy Θ (S.insert' b spec) γ := by
   cases b with
   | mk name ty =>
     cases name with
-    | none => exact hS
-    | some x => exact SpecMap.satisfiedBy_insert hS (hγ x ty rfl) hf
+    | none => simp [SpecMap.insert']; iintro ⟨HS, _⟩; iexact HS
+    | some x => exact SpecMap.satisfiedBy_insert (hγ x ty rfl)
 
 theorem SpecMap.satisfiedBy_insert'_update' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {b : Typed.Binder} {v : Runtime.Val} {spec : Spec}
-    (hS : S.satisfiedBy Θ γ) (hf : spec.isPrecondFor Θ v) :
-    SpecMap.satisfiedBy Θ (S.insert' b spec) (Runtime.Subst.update' b.runtime v γ) := by
+    {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
+    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ v ⊢ SpecMap.satisfiedBy Θ (S.insert' b spec) (Runtime.Subst.update' b.runtime v γ) := by
   cases b with
   | mk name _ =>
     cases name with
-    | none => exact hS
-    | some _ => exact SpecMap.satisfiedBy_insert_update hS hf
+    | none => simp [SpecMap.insert', Runtime.Subst.update']; iintro ⟨HS, _⟩; iexact HS
+    | some _ => exact SpecMap.satisfiedBy_insert_update
 
 theorem SpecMap.wfIn_insert' {S : SpecMap} {b : Typed.Binder} {spec : Spec} {Δ : Signature}
     (hS : S.wfIn Δ) (hs : spec.wfIn Δ) : SpecMap.wfIn (S.insert' b spec) Δ := by
@@ -365,9 +464,12 @@ theorem SpecMap.wfIn_erase' {S : SpecMap} {b : Typed.Binder} {Δ : Signature}
     | some _ => exact SpecMap.wfIn_erase hS
 
 theorem SpecMap.satisfiedBy_eraseAll_updateAll' {Θ : TinyML.TypeEnv} {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
-    {vs : List Runtime.Val} (hS : S.satisfiedBy Θ γ) (hlen : keys.length = vs.length) :
-    (SpecMap.eraseAll keys S).satisfiedBy Θ (γ.updateAll' (keys.map Runtime.Binder.named) vs) := by
-  intro y s hlookup
+    {vs : List Runtime.Val} (hlen : keys.length = vs.length) :
+    S.satisfiedBy Θ γ ⊢ (SpecMap.eraseAll keys S).satisfiedBy Θ (γ.updateAll' (keys.map Runtime.Binder.named) vs) := by
+  simp only [SpecMap.satisfiedBy]
+  iintro □HS
+  imodintro
+  iintro %y %s %hlookup
   have hy_notin : y ∉ keys := by
     intro hmem
     have := SpecMap.eraseAll_lookup_none hmem (S := S)
@@ -375,45 +477,70 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAll' {Θ : TinyML.TypeEnv} {keys : Li
   have hγ_eq : (γ.updateAll' (keys.map Runtime.Binder.named) vs) y = γ y := by
     rw [Runtime.Subst.updateAll'_eq _ _ _ _ (by simp; omega)]
     rw [findVal_none_of_not_mem keys vs y (by omega) hy_notin]
-  rw [hγ_eq]
-  apply hS
-  rwa [SpecMap.eraseAll_lookup_of_notin hy_notin] at hlookup
+  have hlookup' : S.lookup y = some s := by rwa [SpecMap.eraseAll_lookup_of_notin hy_notin] at hlookup
+  ispecialize HS $$ %y
+  ispecialize HS $$ %s
+  ispecialize HS $$ %hlookup'
+  icases HS with ⟨%f, %hγf, Hprecond⟩
+  iexists f
+  isplitl [Hprecond]
+  · ipure_intro; rw [hγ_eq]; exact hγf
+  · iexact Hprecond
 
 theorem SpecMap.empty_satisfiedBy (γ : Runtime.Subst) :
-    SpecMap.satisfiedBy Θ (∅ : SpecMap) γ := by
-  intro x s h; simp [Finmap.lookup_empty] at h
+    ⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) γ := by
+  simp only [SpecMap.satisfiedBy]
+  imodintro
+  iintro %x %s %h
+  simp [Finmap.lookup_empty] at h
 
 theorem SpecMap.empty_wfIn (Δ : Signature) :
     SpecMap.wfIn (∅ : SpecMap) Δ := by
   intro f spec h; simp [Finmap.lookup_empty] at h
 
-theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val}
-    (h : S.satisfiedBy Θ γ) : SpecMap.satisfiedBy Θ (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
-  intro y s hlookup
+theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
+    S.satisfiedBy Θ γ ⊢ SpecMap.satisfiedBy Θ (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
+  simp only [SpecMap.satisfiedBy]
+  iintro □HS
+  imodintro
+  iintro %y %s %hlookup
   by_cases hyx : y = x
   · subst hyx; rw [Finmap.lookup_erase] at hlookup; exact absurd hlookup (by simp)
   · rw [Finmap.lookup_erase_ne hyx] at hlookup
-    obtain ⟨fval, hγ, hisPrecond⟩ := h y s hlookup
-    exact ⟨fval, by simp [Runtime.Subst.update, hyx, hγ], hisPrecond⟩
+    ispecialize HS $$ %y
+    ispecialize HS $$ %s
+    ispecialize HS $$ %hlookup
+    icases HS with ⟨%fval, %hγ, Hprecond⟩
+    iexists fval
+    isplitl [Hprecond]
+    · ipure_intro; simp [Runtime.Subst.update, hyx, hγ]
+    · iexact Hprecond
 
 theorem SpecMap.satisfiedBy_erase' {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {b : Typed.Binder} {v : Runtime.Val}
-    (hS : S.satisfiedBy Θ γ) :
-    SpecMap.satisfiedBy Θ (S.erase' b) (Runtime.Subst.update' b.runtime v γ) := by
+    {b : Typed.Binder} {v : Runtime.Val} :
+    S.satisfiedBy Θ γ ⊢ SpecMap.satisfiedBy Θ (S.erase' b) (Runtime.Subst.update' b.runtime v γ) := by
   cases b with
   | mk name _ =>
     cases name with
-    | none => exact hS
-    | some _ => exact SpecMap.satisfiedBy_erase hS
+    | none => simp [SpecMap.erase', Runtime.Subst.update']
+    | some _ => exact SpecMap.satisfiedBy_erase
 
 theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
-    {x : TinyML.Var} {v : Runtime.Val}
-    (h : S.satisfiedBy Θ γ) (hx : S.lookup x = none) :
-    S.satisfiedBy Θ (γ.update x v) := by
-  intro y s hlookup
+    {x : TinyML.Var} {v : Runtime.Val} (hx : S.lookup x = none) :
+    S.satisfiedBy Θ γ ⊢ S.satisfiedBy Θ (γ.update x v) := by
+  simp only [SpecMap.satisfiedBy]
+  iintro □HS
+  imodintro
+  iintro %y %s %hlookup
   have hyx : y ≠ x := by intro heq; subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)
-  obtain ⟨fval, hγ, hisPrecond⟩ := h y s hlookup
-  exact ⟨fval, by simp [Runtime.Subst.update, hyx, hγ], hisPrecond⟩
+  ispecialize HS $$ %y
+  ispecialize HS $$ %s
+  ispecialize HS $$ %hlookup
+  icases HS with ⟨%fval, %hγ, Hprecond⟩
+  iexists fval
+  isplitl [Hprecond]
+  · ipure_intro; simp [Runtime.Subst.update, hyx, hγ]
+  · iexact Hprecond
 
 -- ---------------------------------------------------------------------------
 -- Spec correctness
@@ -622,7 +749,7 @@ theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (s
         have hret := VerifM.eval_ret heval_pure
         iapply (hΨ v st₃ ρ'' t hret (hst₃_decls ▸ htwf) hteval hty)
         isplitl [Howns]
-        · simpa [hst₃_owns] using Howns
+        · simp [hst₃_owns]
         · iexact HR)
     have hcall' : st.owns.interp ρ' ∗ R ⊢
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
@@ -840,7 +967,7 @@ theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL
       iintro H
       icases H with ⟨Howns, Happ⟩
       isplitr [Happ]
-      · iapply (show st.owns.interp ρ' ⊢ st'.owns.interp ρ' by simpa [howns])
+      · iapply (show st.owns.interp ρ' ⊢ st'.owns.interp ρ' by simp [howns])
         iapply (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1
         iexact Howns
       · iapply (PredTrans.apply_env_agree hswf (Env.agreeOn_trans hag_empty (Env.agreeOn_symm hagree)))

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -237,7 +237,7 @@ end
     else VerifM.fatal s!"type mismatch in call to spec"
     let argVar ← VerifM.decl (some name) .value
     let σ' := σ.rename ⟨name, .value⟩ argVar.name
-    VerifM.assume (.eq .value (.const (.uninterpreted argVar.name .value)) sarg)
+    VerifM.assume (.pure (.eq .value (.const (.uninterpreted argVar.name .value)) sarg))
     Spec.declareArgs Θ σ' rest sargs
   | _, _ => VerifM.fatal "wrong number of arguments"
 
@@ -617,7 +617,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
               (fun argVar st' ρ' =>
                 (do
                   VerifM.assume
-                    (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg)
+                    (.pure (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg))
                   Spec.declareArgs Θ (σ.rename ⟨name, .value⟩ argVar.name) rest sargs_rest).eval
                     st' ρ' Ψ) := by
           simpa using
@@ -625,7 +625,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
               (m := VerifM.decl (some name) .value)
               (k := fun argVar => do
                 VerifM.assume
-                  (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg)
+                  (.pure (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg))
                 Spec.declareArgs Θ (σ.rename ⟨name, .value⟩ argVar.name) rest sargs_rest)
               (st := st) (ρ := ρ) hret)
         have hdecl := VerifM.eval_decl hbind'
@@ -658,7 +658,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           simpa [Env.lookupConst, Env.updateConst] using
             (Term.eval_env_agree hsarg_wf (agreeOn_update_fresh_const hfresh_decls))
         have hbind'' := VerifM.eval_bind _ _ _ _ hdecl
-        have hassume := VerifM.eval_assume hbind'' heq_wf heq_holds
+        have hassume := VerifM.eval_assumePure hbind'' heq_wf heq_holds
         set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ)
         have hsargs_rest : ∀ p ∈ sargs_rest, (p : TinyML.Typ × Term .value).2.wfIn
             (st.decls.addConst argVar) := by

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -1,6 +1,5 @@
 import Mica.TinyML.Typed
 import Mica.TinyML.Typing
-import Mica.TinyML.WeakestPre
 import Mica.FOL.Printing
 import Mica.Verifier.Monad
 import Mica.Verifier.Assertions
@@ -8,6 +7,8 @@ import Mica.Verifier.Utils
 import Mica.Verifier.PredicateTransformers
 import Mica.Base.Fresh
 import Mathlib.Data.Finmap
+
+open Iris Iris.BI
 
 /-!
 # Specifications
@@ -49,9 +50,9 @@ def Spec.argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val �
 
 def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : Prop :=
   ∀ (vs : List Runtime.Val), TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) →
-    ∀ (Φ : Runtime.Val → Prop),
-      PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy → Φ r) s.pred
-        (Spec.argsEnv Env.empty s.args vs) →
+    ∀ (Φ : Runtime.Val → iProp),
+      PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+        (Spec.argsEnv Env.empty s.args vs) ⊢
       wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
@@ -452,6 +453,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
     ∃ σ' st' ρ', Ψ σ' st' ρ' ∧
       σ'.wf st'.decls ∧
       (Signature.ofVars σ'.dom).wf ∧
+      st'.owns = st.owns ∧
       @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
       (((Signature.ofVars σ.dom).declVars (Spec.argVars args)).vars ⊆ σ'.dom) ∧
       Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args)) (σ'.subst.eval ρ')
@@ -464,7 +466,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
     | nil =>
       simp [Spec.declareArgs] at heval
       have := VerifM.eval_ret heval
-      exact ⟨σ, st, ρ, this, hσwf, hσdomwf, .nil, fun x hx => hx,
+      exact ⟨σ, st, ρ, this, hσwf, hσdomwf, rfl, .nil, fun x hx => hx,
         by simp [Spec.argVars, Spec.argsEnv]; exact Env.agreeOn_refl⟩
     | cons _ _ =>
       simp [Spec.declareArgs] at heval
@@ -546,11 +548,11 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
             (Env.agreeOn_symm (agreeOn_update_fresh_const hfresh_decls))
         have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
           simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := ⟨name, .value⟩) (name' := argVar.name) hσdomwf)
-        obtain ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf, hsublist, hdom_sub, hagree⟩ :=
+        obtain ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf, howns, hsublist, hdom_sub, hagree⟩ :=
           ih sargs_rest σ' _ ρ₁ Ψ hσ'wf hσ'domwf hsargs_rest hassume
         have hsub_ty' : TinyML.Typ.Sub Θ targ ty := TinyML.Typ.sub_sound hsub_ty
         refine ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf,
-          .cons hsub_ty' hsublist, ?_, ?_⟩
+          howns, .cons hsub_ty' hsublist, ?_, ?_⟩
         · simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
             using hdom_sub
         · have hag_rename := FiniteSubst.rename_agreeOn_declVar
@@ -571,42 +573,63 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
 theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
     (st : TransState) (ρ : Env)
     (Ψ : (TinyML.Typ × Term .value) → TransState → Env → Prop)
-    (Φ : Runtime.Val → Prop) :
+    (Φ : Runtime.Val → iProp) (R : iProp) :
     s.pred.wfIn ((Signature.ofVars σ.dom).declVars (Spec.argVars s.args)) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.call Θ σ s sargs) st ρ Ψ →
     (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
-      TinyML.ValHasType Θ v s.retTy → Φ v) →
+      TinyML.ValHasType Θ v s.retTy → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
     @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
-    PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy → Φ r) s.pred
-      (Spec.argsEnv (σ.subst.eval ρ) s.args (sargs.map fun p => p.2.eval ρ)) := by
+    (st.owns.interp ρ ∗ R ⊢ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+      (Spec.argsEnv (σ.subst.eval ρ) s.args (sargs.map fun p => p.2.eval ρ))) := by
   intro hwf hσdomwf hσwf hsargs heval hΨ
   simp only [Spec.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
-  obtain ⟨σ', st', ρ', hΨ', hσ'wf, hσ'domwf, hsublist, hdom_sub, hagree⟩ :=
-    Spec.declareArgs_correct Θ s.args sargs σ st ρ _ hσwf hσdomwf hsargs hb
+  have hb_grow := VerifM.eval.decls_grow ρ hb
+  obtain ⟨σ', st', ρ', hΨ', hσ'wf, hσ'domwf, howns, hsublist, hdom_sub, hagree⟩ :=
+    Spec.declareArgs_correct Θ s.args sargs σ st ρ _ hσwf hσdomwf hsargs hb_grow
+  obtain ⟨hdsub, hragree, hΨ'⟩ := hΨ'
   constructor
   · exact hsublist
   · have hb2 := VerifM.eval_bind _ _ _ _ hΨ'
-    have hcall := PredTrans.call_correct s.pred σ' st' ρ'
-      _ (fun r => TinyML.ValHasType Θ r s.retTy → Φ r)
-      (PredTrans.wfIn_mono hwf
+    have hwf'' : s.pred.wfIn (Signature.ofVars σ'.dom) := by
+      exact PredTrans.wfIn_mono (Δ := (Signature.ofVars σ.dom).declVars (Spec.argVars s.args))
+        (Δ' := Signature.ofVars σ'.dom) hwf
         ⟨hdom_sub,
           by intro c hc; simp at hc,
           by intro u hu; simp at hu,
           by intro b hb; simp at hb⟩
-        hσ'domwf) hσ'domwf hσ'wf hb2
+        hσ'domwf
+    have hcall := PredTrans.call_correct s.pred σ' st' ρ'
+      _ (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) R
+      hwf'' hσ'domwf hσ'wf hb2
       (fun v st'' ρ'' t hΨ'' htwf hteval => by
-        intro hty
+        apply wand_intro
+        iintro H
+        icases H with ⟨⟨Howns, HR⟩, %hty⟩
         have hbind := VerifM.eval_bind _ _ _ _ hΨ''
-        obtain ⟨st₃, hst₃_decls, heval_pure⟩ := VerifM.eval_assumeAll hbind
+        have hassumeAll :
+            ∃ st₃, st₃.decls = st''.decls ∧ st₃.owns = st''.owns ∧
+              VerifM.eval (Pure.pure (s.retTy, t)) st₃ ρ'' Ψ :=
+          VerifM.eval_assumeAll hbind
           (fun φ hφ => typeConstraints_wfIn htwf φ hφ)
           (fun φ hφ => typeConstraints_hold hteval hty φ hφ)
+        rcases hassumeAll with ⟨st₃, hst₃_decls, hrest⟩
+        have hst₃_owns : st₃.owns = st''.owns := hrest.1
+        have heval_pure : VerifM.eval (Pure.pure (s.retTy, t)) st₃ ρ'' Ψ := hrest.2
         have hret := VerifM.eval_ret heval_pure
-        exact hΨ v st₃ ρ'' t hret (hst₃_decls ▸ htwf) hteval hty)
-    exact PredTrans.apply_env_agree hwf hagree hcall
+        iapply (hΨ v st₃ ρ'' t hret (hst₃_decls ▸ htwf) hteval hty)
+        isplitl [Howns]
+        · simpa [hst₃_owns] using Howns
+        · iexact HR)
+    have hcall' : st.owns.interp ρ' ∗ R ⊢
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+          (σ'.subst.eval ρ') := by
+      simpa [howns] using hcall
+    exact (sep_mono_l (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1).trans <|
+      hcall'.trans <| PredTrans.apply_env_agree hwf hagree
 
 /-- Correctness of `declareImplArgs`: after processing all arguments, the resulting
     substitution is well-formed, all argVars are in decls with sort `.value`,
@@ -624,6 +647,7 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       (Signature.ofVars σ'.dom).wf ∧
       st.decls.Subset st'.decls ∧
       Env.agreeOn st.decls ρ ρ' ∧
+      st'.owns = st.owns ∧
       (((Signature.ofVars σ.dom).declVars (Spec.argVars args)).vars ⊆ σ'.dom) ∧
       Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args)) (σ'.subst.eval ρ')
         (Spec.argsEnv (σ.subst.eval ρ) args vs) ∧
@@ -639,7 +663,7 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       simp [Spec.declareImplArgs] at heval
       have := VerifM.eval_ret heval
       exact ⟨σ, [], st, ρ, this, hσwf, hσdomwf,
-        Signature.Subset.refl _, Env.agreeOn_refl, fun x hx => hx,
+        Signature.Subset.refl _, Env.agreeOn_refl, rfl, fun x hx => hx,
         by simp [Spec.argVars, Spec.argsEnv]; exact Env.agreeOn_refl,
         nofun,
         nofun,
@@ -673,10 +697,22 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       have hvar_eval : (Term.const (.uninterpreted argVar.name .value)).eval ρ₁ = v := by
         simp [ρ₁, Term.eval, Const.denote, Env.updateConst]
       have hassume_bind := VerifM.eval_bind _ _ _ _ hdecl
-      obtain ⟨st₂, hst₂_decls, hdecl₂⟩ := VerifM.eval_assumeAll hassume_bind
+      set σ' := σ.rename ⟨name, .value⟩ argVar.name
+      have hassumeAll :
+          ∃ st₂, st₂.decls = st₁.decls ∧ st₂.owns = st₁.owns ∧
+            VerifM.eval
+              (do
+                let (σ'', vars) ← Spec.declareImplArgs σ' rest
+                pure (σ'', argVar :: vars)) st₂ ρ₁ Ψ :=
+        VerifM.eval_assumeAll hassume_bind
         (fun φ hφ => typeConstraints_wfIn hvar_wf φ hφ)
         (fun φ hφ => typeConstraints_hold hvar_eval hv φ hφ)
-      set σ' := σ.rename ⟨name, .value⟩ argVar.name
+      rcases hassumeAll with ⟨st₂, hst₂_decls, hrest⟩
+      have hst₂_owns : st₂.owns = st₁.owns := hrest.1
+      have hdecl₂ : VerifM.eval
+          (do
+            let (σ'', vars) ← Spec.declareImplArgs σ' rest
+            pure (σ'', argVar :: vars)) st₂ ρ₁ Ψ := hrest.2
       have hσ'wf : σ'.wf st₁.decls := by
         simpa [st₁, σ'] using
           (FiniteSubst.rename_wf (σ := σ) (v := ⟨name, .value⟩) (name' := argVar.name) hσwf hfresh_range)
@@ -685,63 +721,106 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         rw [hst₂_decls]; exact Signature.Subset.subset_addConst _ _
       have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
         simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := ⟨name, .value⟩) (name' := argVar.name) hσdomwf)
-      obtain ⟨σ'', argVars', st', ρ', hΨ, hσ''wf, hσ''domwf, hdsub', hragree', hdom_sub, hagree, hmem_decls,
-        hsorts, hlookups⟩ := ih vs' σ' st₂ ρ₁ _ hσ'wf₂ hσ'domwf hvs_rest hdecl₂
+      have hbind₂ := VerifM.eval_bind _ _ _ _ hdecl₂
+      have hbind₂' : VerifM.eval (Spec.declareImplArgs σ' rest) st₂ ρ₁
+          (fun p st' ρ' => Ψ (p.1, argVar :: p.2) st' ρ') := by
+        apply VerifM.eval.mono hbind₂
+        intro p st' ρ' hp
+        exact VerifM.eval_ret hp
+      have hih :
+          ∃ σ'' argVars' st' ρ', Ψ (σ'', argVar :: argVars') st' ρ' ∧
+            σ''.wf st'.decls ∧
+            (Signature.ofVars σ''.dom).wf ∧
+            st₂.decls.Subset st'.decls ∧
+            Env.agreeOn st₂.decls ρ₁ ρ' ∧
+            st'.owns = st₂.owns ∧
+            (((Signature.ofVars σ'.dom).declVars (Spec.argVars rest)).vars ⊆ σ''.dom) ∧
+            Env.agreeOn ((Signature.ofVars σ'.dom).declVars (Spec.argVars rest)) (σ''.subst.eval ρ')
+              (Spec.argsEnv (σ'.subst.eval ρ₁) rest vs') ∧
+            (∀ v ∈ argVars', v ∈ st'.decls.consts) ∧
+            (∀ v ∈ argVars', v.sort = .value) ∧
+            Terms.Eval ρ' (argVars'.map (fun av => .const (.uninterpreted av.name .value))) vs' :=
+        ih vs' σ' st₂ ρ₁
+          (fun p st' ρ' => Ψ (p.1, argVar :: p.2) st' ρ')
+          hσ'wf₂ hσ'domwf hvs_rest hbind₂'
+      rcases hih with ⟨σ'', argVars', st', ρ', hΨ, hrest⟩
+      rcases hrest with ⟨hσ''wf, hrest⟩
+      rcases hrest with ⟨hσ''domwf, hrest⟩
+      rcases hrest with ⟨hdsub', hrest⟩
+      rcases hrest with ⟨hragree', hrest⟩
+      rcases hrest with ⟨howns, hrest⟩
+      rcases hrest with ⟨hdom_sub, hrest⟩
+      rcases hrest with ⟨hagree, hrest⟩
+      rcases hrest with ⟨hmem_decls, hrest⟩
+      rcases hrest with ⟨hsorts, hlookups⟩
       refine ⟨σ'', argVar :: argVars', st', ρ', hΨ, hσ''wf, hσ''domwf,
-        Signature.Subset.trans hst_st₂ hdsub', ?_, ?_, ?_, ?_, ?_, ?_⟩
-      -- ρ.agreeOn st.decls ρ'
-      · have hst_st₂_sig : st.decls.Subset st₂.decls :=
-          hst₂_decls ▸ Signature.Subset.subset_addConst st.decls argVar
-        exact Env.agreeOn_trans (agreeOn_update_fresh_const hfresh_decls)
+        Signature.Subset.trans hst_st₂ hdsub', ?_⟩
+      have hst_st₂_sig : st.decls.Subset st₂.decls :=
+        hst₂_decls ▸ Signature.Subset.subset_addConst st.decls argVar
+      have hragree_final : Env.agreeOn st.decls ρ ρ' :=
+        Env.agreeOn_trans (agreeOn_update_fresh_const hfresh_decls)
           (Env.agreeOn_mono hst_st₂_sig hragree')
-      -- dom inclusion
-      · simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
+      have howns_final : st'.owns = st.owns := by
+        calc
+          st'.owns = st₂.owns := howns
+          _ = st₁.owns := hst₂_owns
+          _ = st.owns := rfl
+      have hdom_sub_final :
+          (((Signature.ofVars σ.dom).declVars (Spec.argVars ((name, ty) :: rest))).vars ⊆ σ''.dom) := by
+        simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
           using hdom_sub
-      -- env agree
-      · have hag_rename := FiniteSubst.rename_agreeOn_declVar
-            (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ) (u := v)
-            hσwf hfresh_decls rfl
-        have hag_env := Spec.argsEnv_agreeOn hag_rename rest vs' (by
-            have := hvs_rest.length_eq
-            simp [List.length_map] at this; omega)
+      have hag_rename := FiniteSubst.rename_agreeOn_declVar
+          (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ) (u := v)
+          hσwf hfresh_decls rfl
+      have hag_env := Spec.argsEnv_agreeOn hag_rename rest vs' (by
+          have := hvs_rest.length_eq
+          simp [List.length_map] at this; omega)
+      have hagree_final :
+          Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars ((name, ty) :: rest))) (σ''.subst.eval ρ')
+            (Spec.argsEnv (σ.subst.eval ρ) ((name, ty) :: rest) (v :: vs')) := by
         simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar] using
           (Env.agreeOn_trans hagree hag_env)
-      -- argVars all in decls.consts
-      · intro w hw
+      have hmem_final : ∀ w ∈ argVar :: argVars', w ∈ st'.decls.consts := by
+        intro w hw
         cases List.mem_cons.mp hw with
         | inl h => subst h; exact hdsub'.consts argVar (hst₂_decls ▸ List.mem_cons_self ..)
         | inr h => exact hmem_decls w h
-      -- sorts
-      · intro w hw
+      have hsorts_final : ∀ w ∈ argVar :: argVars', w.sort = .value := by
+        intro w hw
         cases List.mem_cons.mp hw with
         | inl h => subst h; rfl
         | inr h => exact hsorts w h
-      -- lookups
-      · constructor
+      have hlookups_final :
+          Terms.Eval ρ' ((argVar :: argVars').map (fun av => .const (.uninterpreted av.name .value))) (v :: vs') := by
+        constructor
         · have h1 := hragree'.2.1 argVar (hst₂_decls ▸ List.mem_cons_self ..)
           have h1' : Term.eval ρ' (Term.const (.uninterpreted argVar.name .value)) =
               Term.eval ρ₁ (Term.const (.uninterpreted argVar.name .value)) := by
             simpa [Term.eval, Const.denote, Env.lookupConst] using h1.symm
           exact h1'.trans hvar_eval
         · exact hlookups
+      exact ⟨hragree_final, howns_final, hdom_sub_final, hagree_final, hmem_final, hsorts_final, hlookups_final⟩
 
 theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
-    (st : TransState) (ρ : Env) (vs : List Runtime.Val) (Φ : Runtime.Val → Prop) (R : Prop) :
+    (st : TransState) (ρ : Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
     s.wfIn Signature.empty →
     TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) →
     VerifM.eval (Spec.implement s body) st ρ (fun _ _ _ => True) →
-    PredTrans.apply Φ s.pred (Spec.argsEnv Env.empty s.args vs) →
-    (∀ argVars st' ρ',
+    (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : Env) (Q : iProp),
       (∀ v ∈ argVars, v ∈ st'.decls.consts) →
       (∀ v ∈ argVars, v.sort = .value) →
       List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs →
       VerifM.eval (body argVars) st' ρ'
-        (fun result st'' ρ'' => result.wfIn st''.decls → Φ (result.eval ρ'')) → R) →
-    R := by
-  intro hswf hvs heval happly hR
+        (fun result st'' ρ'' =>
+          ∀ (S : iProp), result.wfIn st''.decls →
+            st''.owns.interp ρ'' ∗ Q ∗ ((⌜TinyML.ValHasType Θ (result.eval ρ'') s.retTy⌝ -∗ Φ (result.eval ρ'')) -∗ S) ⊢ S) →
+      st'.owns.interp ρ' ∗ Q ⊢ R) →
+    st.owns.interp ρ ∗ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+      (Spec.argsEnv Env.empty s.args vs) ⊢ R := by
+  intro hswf hvs heval hR
   simp only [Spec.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
-  obtain ⟨σ', argVars, st', ρ', hΨ, hσ'wf, hσ'domwf, hdsub, hragree, hdom_sub, hagree,
+  obtain ⟨σ', argVars, st', ρ', hΨ, hσ'wf, hσ'domwf, hdsub, hragree, howns, hdom_sub, hagree,
     hmem_decls, hsorts, hlookups⟩ :=
     Spec.declareImplArgs_correct Θ s.args vs FiniteSubst.id st ρ _ (FiniteSubst.id_wf st.decls)
       (by simpa [Signature.ofVars] using Signature.wf_empty) hvs hb
@@ -752,45 +831,57 @@ theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL
     Spec.argsEnv_agreeOn (Δ := Signature.empty) (ρ₁ := Env.empty) (ρ₂ := FiniteSubst.id.subst.eval ρ)
       ⟨nofun, nofun, nofun, nofun⟩ s.args vs
       (by have := hvs.length_eq; simp [List.length_map] at this; omega)
-  have happly' : PredTrans.apply Φ s.pred (σ'.subst.eval ρ') :=
-    PredTrans.apply_env_agree hswf
-      (Env.agreeOn_trans hag_empty (Env.agreeOn_symm hagree)) happly
-  -- hΨ is already `(PredTrans.implement σ' s.pred (body argVars)).eval st' ρ' ...`
-  apply PredTrans.implement_correct s.pred σ' (body argVars) st' ρ' Φ R
-    (PredTrans.wfIn_mono hswf
-      ⟨hdom_sub,
-        by
-          intro c hc
-          change c ∈ ((Signature.ofVars ([] : List Var)).declVars (Spec.argVars s.args)).consts at hc
-          simp at hc,
-        by
-          intro u hu
-          change u ∈ ((Signature.ofVars ([] : List Var)).declVars (Spec.argVars s.args)).unary at hu
-          simp at hu,
-        by
-          intro b hb
-          change b ∈ ((Signature.ofVars ([] : List Var)).declVars (Spec.argVars s.args)).binary at hb
-          simp at hb⟩
-      hσ'domwf) hσ'domwf hσ'wf hΨ happly'
-  -- Callback
-  intro st'' ρ'' hdsub' hragree' hbody_eval
-  apply hR argVars st'' ρ''
-  · intro v hv; exact hdsub'.consts v (hmem_decls v hv)
-  · exact hsorts
-  · apply Terms.Eval.lookup_const
-    apply Terms.Eval.env_agree (ρ := ρ')
-    · intro t ht; obtain ⟨av, hav, rfl⟩ := List.mem_map.mp ht
-      simp only [Term.wfIn, Const.wfIn]
-      cases av with
-      | mk name sort =>
-        have hsort : sort = .value := hsorts ⟨name, sort⟩ hav
-        subst hsort
-        have hwfst' : st'.decls.wf := (VerifM.eval.wf hΨ).namesDisjoint
-        refine ⟨hmem_decls ⟨name, .value⟩ hav, ?_, ?_⟩
-        · intro τ' hvar
-          exact Signature.wf_no_var_of_const hwfst' (hmem_decls ⟨name, .value⟩ hav) hvar
-        · intro τ' hc'
-          exact Signature.wf_unique_const hwfst' (hmem_decls ⟨name, .value⟩ hav) hc'
-    · exact hragree'
-    · exact hlookups
-  · exact hbody_eval
+  refine (show st.owns.interp ρ ∗
+      PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+        (Spec.argsEnv Env.empty s.args vs) ⊢
+      st'.owns.interp ρ' ∗
+        PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+          (σ'.subst.eval ρ') from by
+      iintro H
+      icases H with ⟨Howns, Happ⟩
+      isplitr [Happ]
+      · iapply (show st.owns.interp ρ' ⊢ st'.owns.interp ρ' by simpa [howns])
+        iapply (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1
+        iexact Howns
+      · iapply (PredTrans.apply_env_agree hswf (Env.agreeOn_trans hag_empty (Env.agreeOn_symm hagree)))
+        iexact Happ).trans
+    (PredTrans.implement_correct s.pred σ' (body argVars) st' ρ'
+      (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) R
+      (PredTrans.wfIn_mono hswf
+        ⟨hdom_sub,
+          by
+            intro c hc
+            change c ∈ ((Signature.ofVars ([] : List Var)).declVars (Spec.argVars s.args)).consts at hc
+            simp at hc,
+          by
+            intro u hu
+            change u ∈ ((Signature.ofVars ([] : List Var)).declVars (Spec.argVars s.args)).unary at hu
+            simp at hu,
+          by
+            intro b hb
+            change b ∈ ((Signature.ofVars ([] : List Var)).declVars (Spec.argVars s.args)).binary at hb
+            simp at hb⟩
+        hσ'domwf) hσ'domwf hσ'wf hΨ
+        (fun st'' ρ'' Q hdsub' hragree' hbody_eval => by
+          apply hR argVars st'' ρ'' Q
+          · intro v hv
+            exact hdsub'.consts v (hmem_decls v hv)
+          · exact hsorts
+          · apply Terms.Eval.lookup_const
+            apply Terms.Eval.env_agree (ρ := ρ')
+            · intro t ht
+              obtain ⟨av, hav, rfl⟩ := List.mem_map.mp ht
+              simp only [Term.wfIn, Const.wfIn]
+              cases av with
+              | mk name sort =>
+                have hsort : sort = .value := hsorts ⟨name, sort⟩ hav
+                subst hsort
+                have hwfst' : st'.decls.wf := (VerifM.eval.wf hΨ).namesDisjoint
+                refine ⟨hmem_decls ⟨name, .value⟩ hav, ?_, ?_⟩
+                · intro τ' hvar
+                  exact Signature.wf_no_var_of_const hwfst' (hmem_decls ⟨name, .value⟩ hav) hvar
+                · intro τ' hc'
+                  exact Signature.wf_unique_const hwfst' (hmem_decls ⟨name, .value⟩ hav) hc'
+            · exact hragree'
+            · exact hlookups
+          · exact hbody_eval))

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -44,7 +44,7 @@ def Spec.argVars (args : List (String × TinyML.Typ)) : List Var :=
 
 /-- Build an environment binding each argument name to its value, left-to-right.
     Later arguments shadow earlier ones with the same name. -/
-def Spec.argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val → Env
+def Spec.argsEnv (ρ : VerifM.Env) : List (String × TinyML.Typ) → List Runtime.Val → VerifM.Env
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => Spec.argsEnv (ρ.updateConst .value name v) rest vs
 
@@ -52,7 +52,7 @@ def Spec.isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : iProp
   iprop(□ ∀ (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-          (Spec.argsEnv Env.empty s.args vs) -∗
+          (Spec.argsEnv VerifM.Env.empty s.args vs) -∗
         wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
 instance : Iris.BI.Persistent (Spec.isPrecondFor Θ f s) := by
@@ -66,7 +66,7 @@ theorem Spec.isPrecondFor_fold (Θ : TinyML.TypeEnv) (s : Spec)
     iprop(□ ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
       (⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-          (Spec.argsEnv Env.empty s.args vs)) -∗
+          (Spec.argsEnv VerifM.Env.empty s.args vs)) -∗
         wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ f := by
   unfold Spec.isPrecondFor
   iintro □H
@@ -89,13 +89,13 @@ theorem Spec.isPrecondFor_fix {Θ : TinyML.TypeEnv} {s : Spec}
         ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           ⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ -∗
           PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-              (Spec.argsEnv Env.empty s.args vs) -∗
+              (Spec.argsEnv VerifM.Env.empty s.args vs) -∗
           wp (e.subst ((Runtime.Subst.id.update' f (.fix f args e)).updateAll' args vs)) P)) :
     R ⊢ s.isPrecondFor Θ (.fix f args e) := by
   refine (SpatialContext.wp_fix' (Φ := fun P vs =>
       iprop(⌜TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd)⌝ ∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ P r) s.pred
-            (Spec.argsEnv Env.empty s.args vs))) (h.trans ?_)).trans
+            (Spec.argsEnv VerifM.Env.empty s.args vs))) (h.trans ?_)).trans
     (Spec.isPrecondFor_fold Θ s _)
   istart
   iintro □HR
@@ -186,9 +186,9 @@ end
 
 mutual
   /-- If `ValHasType v ty` and `t.eval ρ = v`, then all formulas in `typeConstraints ty t` hold. -/
-  theorem typeConstraints_hold {ty : TinyML.Typ} {t : Term .value} {ρ : Env}
-      {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ = v) (hty : TinyML.ValHasType Θ v ty) :
-      ∀ φ ∈ typeConstraints ty t, φ.eval ρ := by
+  theorem typeConstraints_hold {ty : TinyML.Typ} {t : Term .value} {ρ : VerifM.Env}
+      {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ.env = v) (hty : TinyML.ValHasType Θ v ty) :
+      ∀ φ ∈ typeConstraints ty t, φ.eval ρ.env := by
     cases hty with
     | int n =>
       intro φ hφ; simp [typeConstraints] at hφ; subst hφ
@@ -208,9 +208,9 @@ mutual
     | any => simp [typeConstraints]
     | _ => simp [typeConstraints]
 
-  theorem typeConstraintsList_hold {ts : List TinyML.Typ} {tl : Term .vallist} {ρ : Env}
-      {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} (htl : tl.eval ρ = vs) (hty : TinyML.ValsHaveTypes Θ vs ts) :
-      ∀ φ ∈ typeConstraints.typeConstraintsList ts tl, φ.eval ρ := by
+  theorem typeConstraintsList_hold {ts : List TinyML.Typ} {tl : Term .vallist} {ρ : VerifM.Env}
+      {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} (htl : tl.eval ρ.env = vs) (hty : TinyML.ValsHaveTypes Θ vs ts) :
+      ∀ φ ∈ typeConstraints.typeConstraintsList ts tl, φ.eval ρ.env := by
     cases hty with
     | nil => simp [typeConstraints.typeConstraintsList]
     | cons hv hvs =>
@@ -546,13 +546,13 @@ theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {S : SpecMap
 -- Spec correctness
 -- ---------------------------------------------------------------------------
 
-/-- `argsEnv` preserves `agreeOn`: if two base envs agree on `Δ`,
+/-- `argsEnv` preserves `agreeOn`: if two envs agree on `Δ`,
     then after applying the same updates, they agree on `argVars args ++ Δ`. -/
-theorem Spec.argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : Env}
-    (h : Env.agreeOn Δ ρ₁ ρ₂) :
+theorem Spec.argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : VerifM.Env}
+    (h : VerifM.Env.agreeOn Δ ρ₁ ρ₂) :
     ∀ (args : List (String × TinyML.Typ)) (vals : List Runtime.Val),
     args.length ≤ vals.length →
-    Env.agreeOn (Δ.declVars (Spec.argVars args))
+    VerifM.Env.agreeOn (Δ.declVars (Spec.argVars args))
       (Spec.argsEnv ρ₁ args vals) (Spec.argsEnv ρ₂ args vals) := by
   intro args
   induction args generalizing Δ ρ₁ ρ₂ with
@@ -565,14 +565,14 @@ theorem Spec.argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : Env}
     | cons v vs =>
       simp only [Spec.argsEnv, Spec.argVars, List.map]
       simpa [Signature.declVars] using
-        ih (Env.agreeOn_declVar h) vs (by simp [List.length] at hlen ⊢; omega)
+        ih (VerifM.Env.agreeOn_declVar h) vs (by simp [List.length] at hlen ⊢; omega)
 
 /-- Correctness of `declareArgs`: after processing all arguments, the resulting
     substitution is well-formed, types match, and the env agrees with `argsEnv`. -/
 theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
     ∀ (args : List (String × TinyML.Typ)) (sargs : List (TinyML.Typ × Term .value))
-      (σ : FiniteSubst) (st : TransState) (ρ : Env)
-      (Ψ : FiniteSubst → TransState → Env → Prop),
+      (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
+      (Ψ : FiniteSubst → TransState → VerifM.Env → Prop),
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
@@ -583,8 +583,10 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
       st'.owns = st.owns ∧
       @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
       (((Signature.ofVars σ.dom).declVars (Spec.argVars args)).vars ⊆ σ'.dom) ∧
-      Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args)) (σ'.subst.eval ρ')
-        (Spec.argsEnv (σ.subst.eval ρ) args (sargs.map fun p => p.2.eval ρ)) := by
+      VerifM.Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args))
+        (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env))
+        (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) args
+          (sargs.map fun p => p.2.eval ρ.env)) := by
   intro args
   induction args with
   | nil =>
@@ -594,7 +596,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
       simp [Spec.declareArgs] at heval
       have := VerifM.eval_ret heval
       exact ⟨σ, st, ρ, this, hσwf, hσdomwf, rfl, .nil, fun x hx => hx,
-        by simp [Spec.argVars, Spec.argsEnv]; exact Env.agreeOn_refl⟩
+        by simp [Spec.argVars, Spec.argsEnv]; exact VerifM.Env.agreeOn_refl⟩
     | cons _ _ =>
       simp [Spec.declareArgs] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -634,7 +636,7 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
           fresh_not_mem (addNumbers name) st.decls.allNames (addNumbers_injective _)
         have hfresh_range : argVar.name ∉ σ.range.allNames :=
           fun h => hfresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-        specialize hdecl (sarg.eval ρ)
+        specialize hdecl (sarg.eval ρ.env)
         set σ' := σ.rename ⟨name, .value⟩ argVar.name
         have hσ'wf : σ'.wf (st.decls.addConst argVar) := by
           simpa [σ'] using
@@ -653,21 +655,21 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
               exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
           · exact (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
         have heq_holds : (Formula.eq Srt.value (Term.const (.uninterpreted argVar.name .value)) sarg).eval
-            (ρ.updateConst .value argVar.name (sarg.eval ρ)) := by
+            (ρ.updateConst .value argVar.name (sarg.eval ρ.env)).env := by
           simp only [Formula.eval, Term.eval, Const.denote]
           simpa [Env.lookupConst, Env.updateConst] using
             (Term.eval_env_agree hsarg_wf (agreeOn_update_fresh_const hfresh_decls))
         have hbind'' := VerifM.eval_bind _ _ _ _ hdecl
         have hassume := VerifM.eval_assumePure hbind'' heq_wf heq_holds
-        set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ)
+        set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ.env)
         have hsargs_rest : ∀ p ∈ sargs_rest, (p : TinyML.Typ × Term .value).2.wfIn
             (st.decls.addConst argVar) := by
           intro p hp
           exact Term.wfIn_mono _ (hsargs p (List.mem_cons_of_mem _ hp))
             (Signature.Subset.subset_addConst _ _)
             ((TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint)
-        have hsargs_eval : sargs_rest.map (fun p => p.2.eval ρ₁) =
-            sargs_rest.map (fun p => p.2.eval ρ) := by
+        have hsargs_eval : sargs_rest.map (fun p => p.2.eval ρ₁.env) =
+            sargs_rest.map (fun p => p.2.eval ρ.env) := by
           apply List.map_congr_left
           intro p hp
           exact Term.eval_env_agree
@@ -683,34 +685,40 @@ theorem Spec.declareArgs_correct (Θ : TinyML.TypeEnv) :
         · simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
             using hdom_sub
         · have hag_rename := FiniteSubst.rename_agreeOn_declVar
-            (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ) (u := sarg.eval ρ)
+            (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ.env) (u := sarg.eval ρ.env)
             hσwf hfresh_decls rfl
           have hlen : rest.length ≤ sargs_rest.length := by
             have := TinyML.Typ.SubList.length_eq hsublist
             simp [List.length_map] at this; omega
-          have hag_env := Spec.argsEnv_agreeOn hag_rename rest
-            (sargs_rest.map fun p => p.2.eval ρ) (by simp [List.length_map]; omega)
+          have hag_env := Spec.argsEnv_agreeOn
+            (ρ₁ := VerifM.Env.withEnv ρ (σ'.subst.eval ρ₁.env))
+            (ρ₂ := VerifM.Env.withEnv ρ ((σ.subst.eval ρ.env).updateConst .value name (sarg.eval ρ.env)))
+            (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', FiniteSubst.rename]
+              using hag_rename)
+            rest (sargs_rest.map fun p => p.2.eval ρ.env) (by simp [List.length_map]; omega)
           rw [hsargs_eval] at hagree
-          simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar] using
-            (Env.agreeOn_trans hagree hag_env)
+          simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars,
+            Signature.declVar, VerifM.Env.withEnv, VerifM.Env.agreeOn] using
+            (VerifM.Env.agreeOn_trans hagree hag_env)
       · simp [hsub_ty] at heval
         have hb := VerifM.eval_bind _ _ _ _ heval
         exact (VerifM.eval_fatal hb).elim
 
 theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
-    (st : TransState) (ρ : Env)
-    (Ψ : (TinyML.Typ × Term .value) → TransState → Env → Prop)
+    (st : TransState) (ρ : VerifM.Env)
+    (Ψ : (TinyML.Typ × Term .value) → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp) (R : iProp) :
     s.pred.wfIn ((Signature.ofVars σ.dom).declVars (Spec.argVars s.args)) →
     (Signature.ofVars σ.dom).wf →
     σ.wf st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.call Θ σ s sargs) st ρ Ψ →
-    (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
-      TinyML.ValHasType Θ v s.retTy → st'.owns.interp ρ' ∗ R ⊢ Φ v) →
+    (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
+      TinyML.ValHasType Θ v s.retTy → st'.sl ρ' ∗ R ⊢ Φ v) →
     @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
-    (st.owns.interp ρ ∗ R ⊢ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-      (Spec.argsEnv (σ.subst.eval ρ) s.args (sargs.map fun p => p.2.eval ρ))) := by
+    (st.sl ρ ∗ R ⊢ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+      (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) s.args
+        (sargs.map fun p => p.2.eval ρ.env))) := by
   intro hwf hσdomwf hσwf hsargs heval hΨ
   simp only [Spec.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
@@ -751,9 +759,9 @@ theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (s
         isplitl [Howns]
         · simp [hst₃_owns]
         · iexact HR)
-    have hcall' : st.owns.interp ρ' ∗ R ⊢
+    have hcall' : st.sl ρ' ∗ R ⊢
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-          (σ'.subst.eval ρ') := by
+          (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) := by
       simpa [howns] using hcall
     exact (sep_mono_l (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1).trans <|
       hcall'.trans <| PredTrans.apply_env_agree hwf hagree
@@ -763,8 +771,8 @@ theorem Spec.call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (s
     and the env agrees with `argsEnv`. -/
 theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
     ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
-      (σ : FiniteSubst) (st : TransState) (ρ : Env)
-      (Ψ : (FiniteSubst × List FOL.Const) → TransState → Env → Prop),
+      (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
+      (Ψ : (FiniteSubst × List FOL.Const) → TransState → VerifM.Env → Prop),
     σ.wf st.decls →
     (Signature.ofVars σ.dom).wf →
     TinyML.ValsHaveTypes Θ vs (args.map Prod.snd) →
@@ -773,14 +781,15 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       σ'.wf st'.decls ∧
       (Signature.ofVars σ'.dom).wf ∧
       st.decls.Subset st'.decls ∧
-      Env.agreeOn st.decls ρ ρ' ∧
+      VerifM.Env.agreeOn st.decls ρ ρ' ∧
       st'.owns = st.owns ∧
       (((Signature.ofVars σ.dom).declVars (Spec.argVars args)).vars ⊆ σ'.dom) ∧
-      Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args)) (σ'.subst.eval ρ')
-        (Spec.argsEnv (σ.subst.eval ρ) args vs) ∧
+      VerifM.Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args))
+        (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env))
+        (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) args vs) ∧
       (∀ v ∈ argVars, v ∈ st'.decls.consts) ∧
       (∀ v ∈ argVars, v.sort = .value) ∧
-      Terms.Eval ρ' (argVars.map (fun av => .const (.uninterpreted av.name .value))) vs := by
+      Terms.Eval ρ'.env (argVars.map (fun av => .const (.uninterpreted av.name .value))) vs := by
   intro args
   induction args with
   | nil =>
@@ -790,8 +799,8 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       simp [Spec.declareImplArgs] at heval
       have := VerifM.eval_ret heval
       exact ⟨σ, [], st, ρ, this, hσwf, hσdomwf,
-        Signature.Subset.refl _, Env.agreeOn_refl, rfl, fun x hx => hx,
-        by simp [Spec.argVars, Spec.argsEnv]; exact Env.agreeOn_refl,
+        Signature.Subset.refl _, VerifM.Env.agreeOn_refl, rfl, fun x hx => hx,
+        by simp [Spec.argVars, Spec.argsEnv]; exact VerifM.Env.agreeOn_refl,
         nofun,
         nofun,
         .nil⟩
@@ -821,7 +830,7 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
           exact hfresh_decls (Signature.mem_allNames_of_var hvar)
         · intro τ' hc'
           exact Signature.wf_unique_const hwfst₁ (List.Mem.head _) hc'
-      have hvar_eval : (Term.const (.uninterpreted argVar.name .value)).eval ρ₁ = v := by
+      have hvar_eval : (Term.const (.uninterpreted argVar.name .value)).eval ρ₁.env = v := by
         simp [ρ₁, Term.eval, Const.denote, Env.updateConst]
       have hassume_bind := VerifM.eval_bind _ _ _ _ hdecl
       set σ' := σ.rename ⟨name, .value⟩ argVar.name
@@ -859,14 +868,15 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
             σ''.wf st'.decls ∧
             (Signature.ofVars σ''.dom).wf ∧
             st₂.decls.Subset st'.decls ∧
-            Env.agreeOn st₂.decls ρ₁ ρ' ∧
+            VerifM.Env.agreeOn st₂.decls ρ₁ ρ' ∧
             st'.owns = st₂.owns ∧
             (((Signature.ofVars σ'.dom).declVars (Spec.argVars rest)).vars ⊆ σ''.dom) ∧
-            Env.agreeOn ((Signature.ofVars σ'.dom).declVars (Spec.argVars rest)) (σ''.subst.eval ρ')
-              (Spec.argsEnv (σ'.subst.eval ρ₁) rest vs') ∧
+            VerifM.Env.agreeOn ((Signature.ofVars σ'.dom).declVars (Spec.argVars rest))
+              (VerifM.Env.withEnv ρ' (σ''.subst.eval ρ'.env))
+              (Spec.argsEnv (VerifM.Env.withEnv ρ₁ (σ'.subst.eval ρ₁.env)) rest vs') ∧
             (∀ v ∈ argVars', v ∈ st'.decls.consts) ∧
             (∀ v ∈ argVars', v.sort = .value) ∧
-            Terms.Eval ρ' (argVars'.map (fun av => .const (.uninterpreted av.name .value))) vs' :=
+            Terms.Eval ρ'.env (argVars'.map (fun av => .const (.uninterpreted av.name .value))) vs' :=
         ih vs' σ' st₂ ρ₁
           (fun p st' ρ' => Ψ (p.1, argVar :: p.2) st' ρ')
           hσ'wf₂ hσ'domwf hvs_rest hbind₂'
@@ -884,9 +894,9 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         Signature.Subset.trans hst_st₂ hdsub', ?_⟩
       have hst_st₂_sig : st.decls.Subset st₂.decls :=
         hst₂_decls ▸ Signature.Subset.subset_addConst st.decls argVar
-      have hragree_final : Env.agreeOn st.decls ρ ρ' :=
-        Env.agreeOn_trans (agreeOn_update_fresh_const hfresh_decls)
-          (Env.agreeOn_mono hst_st₂_sig hragree')
+      have hragree_final : VerifM.Env.agreeOn st.decls ρ ρ' :=
+        VerifM.Env.agreeOn_trans (VerifM.Env.agreeOn_update_fresh (ρ := ρ) (c := argVar) (u := v) hfresh_decls)
+          (VerifM.Env.agreeOn_mono hst_st₂_sig hragree')
       have howns_final : st'.owns = st.owns := by
         calc
           st'.owns = st₂.owns := howns
@@ -897,16 +907,22 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars, Signature.declVars, Signature.declVar]
           using hdom_sub
       have hag_rename := FiniteSubst.rename_agreeOn_declVar
-          (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ) (u := v)
+          (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar) (ρ := ρ.env) (u := v)
           hσwf hfresh_decls rfl
-      have hag_env := Spec.argsEnv_agreeOn hag_rename rest vs' (by
+      have hag_env := Spec.argsEnv_agreeOn
+          (ρ₁ := VerifM.Env.withEnv ρ₁ (σ'.subst.eval ρ₁.env))
+          (ρ₂ := VerifM.Env.withEnv ρ ((σ.subst.eval ρ.env).updateConst .value name v))
+          (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', FiniteSubst.rename] using hag_rename)
+          rest vs' (by
           have := hvs_rest.length_eq
           simp [List.length_map] at this; omega)
       have hagree_final :
-          Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars ((name, ty) :: rest))) (σ''.subst.eval ρ')
-            (Spec.argsEnv (σ.subst.eval ρ) ((name, ty) :: rest) (v :: vs')) := by
-        simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar] using
-          (Env.agreeOn_trans hagree hag_env)
+          VerifM.Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars ((name, ty) :: rest)))
+            (VerifM.Env.withEnv ρ' (σ''.subst.eval ρ'.env))
+            (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ((name, ty) :: rest) (v :: vs')) := by
+        simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars, Signature.declVar,
+          VerifM.Env.withEnv, VerifM.Env.agreeOn] using
+          (VerifM.Env.agreeOn_trans hagree hag_env)
       have hmem_final : ∀ w ∈ argVar :: argVars', w ∈ st'.decls.consts := by
         intro w hw
         cases List.mem_cons.mp hw with
@@ -918,32 +934,32 @@ theorem Spec.declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         | inl h => subst h; rfl
         | inr h => exact hsorts w h
       have hlookups_final :
-          Terms.Eval ρ' ((argVar :: argVars').map (fun av => .const (.uninterpreted av.name .value))) (v :: vs') := by
+          Terms.Eval ρ'.env ((argVar :: argVars').map (fun av => .const (.uninterpreted av.name .value))) (v :: vs') := by
         constructor
         · have h1 := hragree'.2.1 argVar (hst₂_decls ▸ List.mem_cons_self ..)
-          have h1' : Term.eval ρ' (Term.const (.uninterpreted argVar.name .value)) =
-              Term.eval ρ₁ (Term.const (.uninterpreted argVar.name .value)) := by
+          have h1' : Term.eval ρ'.env (Term.const (.uninterpreted argVar.name .value)) =
+              Term.eval ρ₁.env (Term.const (.uninterpreted argVar.name .value)) := by
             simpa [Term.eval, Const.denote, Env.lookupConst] using h1.symm
           exact h1'.trans hvar_eval
         · exact hlookups
       exact ⟨hragree_final, howns_final, hdom_sub_final, hagree_final, hmem_final, hsorts_final, hlookups_final⟩
 
 theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
-    (st : TransState) (ρ : Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
+    (st : TransState) (ρ : VerifM.Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
     s.wfIn Signature.empty →
     TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) →
     VerifM.eval (Spec.implement s body) st ρ (fun _ _ _ => True) →
-    (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : Env) (Q : iProp),
+    (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : VerifM.Env) (Q : iProp),
       (∀ v ∈ argVars, v ∈ st'.decls.consts) →
       (∀ v ∈ argVars, v.sort = .value) →
-      List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs →
+      List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs →
       VerifM.eval (body argVars) st' ρ'
         (fun result st'' ρ'' =>
           ∀ (S : iProp), result.wfIn st''.decls →
-            st''.owns.interp ρ'' ∗ Q ∗ ((⌜TinyML.ValHasType Θ (result.eval ρ'') s.retTy⌝ -∗ Φ (result.eval ρ'')) -∗ S) ⊢ S) →
-      st'.owns.interp ρ' ∗ Q ⊢ R) →
-    st.owns.interp ρ ∗ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-      (Spec.argsEnv Env.empty s.args vs) ⊢ R := by
+            st''.sl ρ'' ∗ Q ∗ ((⌜TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy⌝ -∗ Φ (result.eval ρ''.env)) -∗ S) ⊢ S) →
+      st'.sl ρ' ∗ Q ⊢ R) →
+    st.sl ρ ∗ PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
+      (Spec.argsEnv VerifM.Env.empty s.args vs) ⊢ R := by
   intro hswf hvs heval hR
   simp only [Spec.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
@@ -952,25 +968,29 @@ theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL
     Spec.declareImplArgs_correct Θ s.args vs FiniteSubst.id st ρ _ (FiniteSubst.id_wf st.decls)
       (by simpa [Signature.ofVars] using Signature.wf_empty) hvs hb
   -- Transport apply from argsEnv Env.empty to σ'.subst.eval ρ'
-  have hag_empty : Env.agreeOn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars s.args))
-      (Spec.argsEnv Env.empty s.args vs)
-      (Spec.argsEnv (FiniteSubst.id.subst.eval ρ) s.args vs) :=
-    Spec.argsEnv_agreeOn (Δ := Signature.empty) (ρ₁ := Env.empty) (ρ₂ := FiniteSubst.id.subst.eval ρ)
-      ⟨nofun, nofun, nofun, nofun⟩ s.args vs
+  have hag_empty : VerifM.Env.agreeOn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars s.args))
+      (Spec.argsEnv VerifM.Env.empty s.args vs)
+      (Spec.argsEnv (VerifM.Env.withEnv ρ (FiniteSubst.id.subst.eval ρ.env)) s.args vs) :=
+    Spec.argsEnv_agreeOn (Δ := Signature.empty)
+      (ρ₁ := VerifM.Env.empty)
+      (ρ₂ := VerifM.Env.withEnv ρ (FiniteSubst.id.subst.eval ρ.env))
+      (by exact ⟨nofun, nofun, nofun, nofun⟩) s.args vs
       (by have := hvs.length_eq; simp [List.length_map] at this; omega)
-  refine (show st.owns.interp ρ ∗
+  refine (show st.sl ρ ∗
       PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-        (Spec.argsEnv Env.empty s.args vs) ⊢
-      st'.owns.interp ρ' ∗
+        (Spec.argsEnv VerifM.Env.empty s.args vs) ⊢
+      st'.sl ρ' ∗
         PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) s.pred
-          (σ'.subst.eval ρ') from by
+          (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) from by
       iintro H
       icases H with ⟨Howns, Happ⟩
       isplitr [Happ]
-      · iapply (show st.owns.interp ρ' ⊢ st'.owns.interp ρ' by simp [howns])
-        iapply (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1
+      · iapply (show st.sl ρ' ⊢ st'.sl ρ' by simp [howns, TransState.sl])
+        iapply (show st.sl ρ ⊢ st.sl ρ' by
+          simpa [TransState.sl] using
+            (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1)
         iexact Howns
-      · iapply (PredTrans.apply_env_agree hswf (Env.agreeOn_trans hag_empty (Env.agreeOn_symm hagree)))
+      · iapply (PredTrans.apply_env_agree hswf (VerifM.Env.agreeOn_trans hag_empty (VerifM.Env.agreeOn_symm hagree)))
         iexact Happ).trans
     (PredTrans.implement_correct s.pred σ' (body argVars) st' ρ'
       (fun r => ⌜TinyML.ValHasType Θ r s.retTy⌝ -∗ Φ r) R
@@ -995,7 +1015,7 @@ theorem Spec.implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL
             exact hdsub'.consts v (hmem_decls v hv)
           · exact hsorts
           · apply Terms.Eval.lookup_const
-            apply Terms.Eval.env_agree (ρ := ρ')
+            apply Terms.Eval.env_agree (ρ := ρ'.env)
             · intro t ht
               obtain ⟨av, hav, rfl⟩ := List.mem_map.mp ht
               simp only [Term.wfIn, Const.wfIn]


### PR DESCRIPTION
This PR adds basic separation logic support to Mica. It consists of a sequence of previous PRs. Together, they are now enough to verify simple examples using integer references, and internally all of the correctness statements have been changed to work with Iris entailments.