### PR TITLE
Refactor expressions proof

### DIFF
--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -286,8 +286,6 @@ mutual
       pure (se :: rest)
 end
 
-
-
 /-! ### Helper lemmas -/
 
 theorem compileBranches_spec (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -339,6 +337,7 @@ theorem SpecMap.satisfiedBy_weaken {A R : iProp}
 
 /-! ### Correctness -/
 
+/-! #### Correctness Statements -/
 
 def correctExpr (e : Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
@@ -405,845 +404,896 @@ def correctExprs (es : List Expr) : Prop :=
       TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
     st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ
 
+/-! #### Correctness Compatibility Lemmas -/
 
-mutual
-
-theorem compile_correct  (e : Expr) : correctExpr e := by
-  intro Θ R S B Γ st ρ γ Ψ Φ
-  intro heval hagree hbwf hts hSwf hpost
-  cases e with
-  | const c =>
-    cases c with
-    | int n =>
-      simp only [compile] at heval
-      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
-      obtain heval := VerifM.eval_ret heval
-      simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost (.int n) ρ st _ heval
-        (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
-        (by simp [Term.eval, UnOp.eval, Const.denote])
-        (.int n)
-    | bool b =>
-      simp only [compile] at heval
-      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
-      obtain heval := VerifM.eval_ret heval
-      simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost (.bool b) ρ st _ heval
-        (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
-        (by simp [Term.eval, UnOp.eval, Const.denote])
-        (.bool b)
-    | unit =>
-      simp only [compile] at heval
-      simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
-      obtain heval := VerifM.eval_ret heval
-      simp only [Expr.ty, Const.ty] at hpost
-      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost .unit ρ st _ heval
-        (by simp [Term.wfIn, Const.wfIn])
-        (by simp [Term.eval])
-        .unit
-  | var x vty =>
+theorem compileConst_correct (c : TinyML.Const) :
+    correctExpr (.const c) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval _hagree _hbwf _hts _hSwf hpost
+  cases c with
+  | int n =>
     simp only [compile] at heval
-    obtain ⟨x', hbind, heval⟩ := VerifM.eval_bind_expectSome heval
-    by_cases hcheck : (Γ x |>.getD .value) = vty
-    · obtain ⟨_, hcont⟩ := VerifM.eval_bind_expectEq heval
-      unfold Expr.runtime; simp only [Runtime.Expr.subst]
-      obtain ⟨hsort, hγ⟩ := hagree x x' hbind
-      rw [hγ]; simp
-      have hmem : (x, x') ∈ B := by
-        obtain ⟨l₁, l₂, heq, _⟩ := List.lookup_eq_some_iff.mp hbind
-        rw [heq]; simp
-      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
-      obtain heval := VerifM.eval_ret hcont
-      have hwfv : (Term.const (.uninterpreted x'.name .value)).wfIn st.decls := by
-        simp only [Term.wfIn, Const.wfIn]
-        have h := hbwf _ hmem
-        cases x' with
-        | mk n s =>
-          simp only at hsort
-          subst hsort
-          refine ⟨h, ?_, ?_⟩
-          · intro τ' hvar
-            exact Signature.wf_no_var_of_const hwfst h hvar
-          · intro τ' hc'
-            exact Signature.wf_unique_const hwfst h hc'
-      simp only [Expr.ty] at hpost
-      have htyping : TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty := by
-        rw [← hcheck]
-        cases hΓ : Γ x with
-        | none => exact .any
-        | some t =>
-          obtain ⟨w, hw, hwt⟩ := hts x x' t hbind hΓ
-          rw [hγ] at hw
-          exact (Option.some.inj hw) ▸ hwt
-      exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <|
-        hpost _ ρ st _ heval hwfv (by simp [Term.eval, Const.denote]) htyping
-    · exact False.elim (hcheck (VerifM.eval_bind_expectEq heval).1)
-  | inj tag arity payload =>
-    unfold Expr.runtime; simp only [Runtime.Expr.subst]
+    simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
+    obtain heval := VerifM.eval_ret heval
+    simp only [Expr.ty, Const.ty] at hpost
+    exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost (.int n) ρ st _ heval
+      (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
+      (by simp [Term.eval, UnOp.eval, Const.denote])
+      (.int n)
+  | bool b =>
     simp only [compile] at heval
-    by_cases htag : tag ≥ arity
-    · simp [htag] at heval; exact (VerifM.eval_fatal heval).elim
-    · push_neg at htag
-      simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
-      have heval_p : (compile Θ S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine SpatialContext.wp_bind_inj <| compile_correct payload Θ R S B Γ st ρ γ _ _
-        (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hSwf ?_
-      intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p htype_p
-      obtain ⟨hdecls_p, hagreeOn_p, hΨ_p⟩ := hΨ_p
-      obtain hΨ_p := VerifM.eval_ret hΨ_p
-      simp only [Expr.ty] at hpost
-      refine SpatialContext.wp_inj <| hpost (.inj tag arity v_p) ρ_p st_p _ hΨ_p
-          (by simp only [Term.wfIn]; exact ⟨trivial, hse_wf_p⟩)
-          (by simp [Term.eval, UnOp.eval, heval_se_p])
-          (by
-            let ts := (List.replicate arity TinyML.Typ.empty).set tag payload.ty
-            have hlen_ts : ts.length = arity := by simp [ts]
-            have : TinyML.ValHasType Θ (.inj tag ts.length v_p) (.sum ts) :=
-              .inj (ts := ts) (by simp [ts, htag]) htype_p
-            rwa [hlen_ts] at this)
-  | cast e ty =>
-    simp only [Expr.ty] at hpost
+    simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
+    obtain heval := VerifM.eval_ret heval
+    simp only [Expr.ty, Const.ty] at hpost
+    exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost (.bool b) ρ st _ heval
+      (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
+      (by simp [Term.eval, UnOp.eval, Const.denote])
+      (.bool b)
+  | unit =>
     simp only [compile] at heval
-    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    simp [Expr.runtime]
-    refine compile_correct e Θ R S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
-    intro v ρ' st' se hΨ hse_wf heval_se htype_v
-    obtain ⟨_, _, hΨ⟩ := hΨ
-    cases hsub : TinyML.Typ.sub Θ e.ty ty
-    · simp [hsub] at hΨ
-      exact (VerifM.eval_fatal hΨ).elim
-    · simp [hsub] at hΨ
-      obtain hΨ := VerifM.eval_ret hΨ
-      have hsub' : TinyML.Typ.Sub Θ e.ty ty := TinyML.Typ.sub_sound hsub
-      exact hpost v ρ' st' se hΨ hse_wf heval_se (TinyML.ValHasType_sub htype_v hsub')
-  | assert e =>
-    unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    simp only [compile] at heval
-    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_assert <| compile_correct e Θ R S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
-    intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _
-    obtain ⟨_, _, hΨ_e⟩ := hΨ_e
-    let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
-    have hwf_φ : φ.wfIn st₁.decls := by
-      simpa [φ, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using hse_wf
-    have heval_assert : (VerifM.assert φ).eval st₁ ρ_e _ := VerifM.eval_bind _ _ _ _ hΨ_e
-    obtain ⟨hφ, hcont⟩ := VerifM.eval_assert heval_assert hwf_φ
-    have hΨ_pure := VerifM.eval_ret hcont
-    have hvtrue : v_e = .bool true := by
-      simp only [φ, Formula.eval, Term.eval, UnOp.eval, Const.denote] at hφ
-      rw [heval_se] at hφ
-      cases v_e <;> simp_all
-    simp only [Expr.ty] at hpost
-    subst hvtrue
-    exact SpatialContext.wp_assert <| hpost .unit ρ_e st₁ (Term.const .unit) hΨ_pure
-      trivial
+    simp only [Expr.runtime, TinyML.Const.runtime, Runtime.Expr.subst_val]
+    obtain heval := VerifM.eval_ret heval
+    simp only [Expr.ty, Const.ty] at hpost
+    exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hpost .unit ρ st _ heval
+      (by simp [Term.wfIn, Const.wfIn])
       (by simp [Term.eval])
       .unit
-  | fix _ _ _ _ =>
-    simp only [compile] at heval
-    exact (VerifM.eval_fatal heval).elim
-  | ref e =>
+
+theorem compileVar_correct (x : String) (vty : TinyML.Typ) :
+    correctExpr (.var x vty) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts _hSwf hpost
+  simp only [compile] at heval
+  obtain ⟨x', hbind, heval⟩ := VerifM.eval_bind_expectSome heval
+  by_cases hcheck : (Γ x |>.getD .value) = vty
+  · obtain ⟨_, hcont⟩ := VerifM.eval_bind_expectEq heval
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    simp only [compile] at heval
+    obtain ⟨hsort, hγ⟩ := hagree x x' hbind
+    rw [hγ]; simp
+    have hmem : (x, x') ∈ B := by
+      obtain ⟨l₁, l₂, heq, _⟩ := List.lookup_eq_some_iff.mp hbind
+      rw [heq]; simp
+    have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+    obtain heval := VerifM.eval_ret hcont
+    have hwfv : (Term.const (.uninterpreted x'.name .value)).wfIn st.decls := by
+      simp only [Term.wfIn, Const.wfIn]
+      have h := hbwf _ hmem
+      cases x' with
+      | mk n s =>
+        simp only at hsort
+        subst hsort
+        refine ⟨h, ?_, ?_⟩
+        · intro τ' hvar
+          exact Signature.wf_no_var_of_const hwfst h hvar
+        · intro τ' hc'
+          exact Signature.wf_unique_const hwfst h hc'
     simp only [Expr.ty] at hpost
+    have htyping : TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty := by
+      rw [← hcheck]
+      cases hΓ : Γ x with
+      | none => exact .any
+      | some t =>
+        obtain ⟨w, hw, hwt⟩ := hts x x' t hbind hΓ
+        rw [hγ] at hw
+        exact (Option.some.inj hw) ▸ hwt
+    exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <|
+      hpost _ ρ st _ heval hwfv (by simp [Term.eval, Const.denote]) htyping
+  · exact False.elim (hcheck (VerifM.eval_bind_expectEq heval).1)
+
+theorem compileInj_correct (tag arity : Nat) (payload : Expr)
+    (ihPayload : correctExpr payload) :
+    correctExpr (.inj tag arity payload) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  unfold Expr.runtime; simp only [Runtime.Expr.subst]
+  simp only [compile] at heval
+  by_cases htag : tag ≥ arity
+  · simp [htag] at heval; exact (VerifM.eval_fatal heval).elim
+  · push_neg at htag
+    simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
+    have heval_p : (compile Θ S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_inj <| ihPayload Θ R S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hSwf ?_
+    intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p htype_p
+    obtain ⟨hdecls_p, hagreeOn_p, hΨ_p⟩ := hΨ_p
+    obtain hΨ_p := VerifM.eval_ret hΨ_p
+    simp only [Expr.ty] at hpost
+    refine SpatialContext.wp_inj <| hpost (.inj tag arity v_p) ρ_p st_p _ hΨ_p
+        (by simp only [Term.wfIn]; exact ⟨trivial, hse_wf_p⟩)
+        (by simp [Term.eval, UnOp.eval, heval_se_p])
+        (by
+          let ts := (List.replicate arity TinyML.Typ.empty).set tag payload.ty
+          have hlen_ts : ts.length = arity := by simp [ts]
+          have : TinyML.ValHasType Θ (.inj tag ts.length v_p) (.sum ts) :=
+            .inj (ts := ts) (by simp [ts, htag]) htype_p
+          rwa [hlen_ts] at this)
+
+theorem compileCast_correct (e : Expr) (ty : TinyML.Typ)
+    (ih : correctExpr e) :
+    correctExpr (.cast e ty) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  simp only [Expr.ty] at hpost
+  simp only [compile] at heval
+  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  simp [Expr.runtime]
+  refine ih Θ R S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+  intro v ρ' st' se hΨ hse_wf heval_se htype_v
+  obtain ⟨_, _, hΨ⟩ := hΨ
+  cases hsub : TinyML.Typ.sub Θ e.ty ty
+  · simp [hsub] at hΨ
+    exact (VerifM.eval_fatal hΨ).elim
+  · simp [hsub] at hΨ
+    obtain hΨ := VerifM.eval_ret hΨ
+    have hsub' : TinyML.Typ.Sub Θ e.ty ty := TinyML.Typ.sub_sound hsub
+    exact hpost v ρ' st' se hΨ hse_wf heval_se (TinyML.ValHasType_sub htype_v hsub')
+
+theorem compileAssert_correct (e : Expr)
+    (ih : correctExpr e) :
+    correctExpr (.assert e) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  unfold Expr.runtime; simp only [Runtime.Expr.subst]
+  simp only [compile] at heval
+  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_assert <| ih Θ R S B Γ st ρ γ _ _
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+  intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _
+  obtain ⟨_, _, hΨ_e⟩ := hΨ_e
+  let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
+  have hwf_φ : φ.wfIn st₁.decls := by
+    simpa [φ, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using hse_wf
+  have heval_assert : (VerifM.assert φ).eval st₁ ρ_e _ := VerifM.eval_bind _ _ _ _ hΨ_e
+  obtain ⟨hφ, hcont⟩ := VerifM.eval_assert heval_assert hwf_φ
+  have hΨ_pure := VerifM.eval_ret hcont
+  have hvtrue : v_e = .bool true := by
+    simp only [φ, Formula.eval, Term.eval, UnOp.eval, Const.denote] at hφ
+    rw [heval_se] at hφ
+    cases v_e <;> simp_all
+  simp only [Expr.ty] at hpost
+  subst hvtrue
+  exact SpatialContext.wp_assert <| hpost .unit ρ_e st₁ (Term.const .unit) hΨ_pure
+    trivial
+    (by simp [Term.eval])
+    .unit
+
+theorem compileFix_correct (self : Binder) (args : List Binder) (retTy : TinyML.Typ) (body : Expr) :
+    correctExpr (.fix self args retTy body) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval _hagree _hbwf _hts _hSwf _hpost
+  simp only [compile] at heval
+  exact (VerifM.eval_fatal heval).elim
+
+theorem compileRef_correct (e : Expr)
+    (ih : correctExpr e) :
+    correctExpr (.ref e) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  unfold Expr.runtime; simp only [Runtime.Expr.subst]
+  simp only [compile] at heval
+  simp only [Expr.ty] at hpost
+  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_ref <| ih Θ R S B Γ st ρ γ _ _
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+  intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
+  obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
+  have hwf_st₁ := VerifM.eval.wf hΨ_e
+  set c : FOL.Const := st₁.freshConst none .value
+  have hfresh : c.name ∉ st₁.decls.allNames :=
+    fresh_not_mem _ _ (addNumbers_injective _)
+  have hwf_addConst : TransState.wf { st₁ with decls := st₁.decls.addConst c } :=
+    TransState.freshConst.wf _ hwf_st₁
+  refine SpatialContext.wp_ref (ctx := st₁.owns) (Δ := st₁.decls) (vt := se)
+    (name := c.name)
+    (newctx := .pointsTo (.const (.uninterpreted c.name .value)) se :: st₁.owns)
+    hwf_st₁.ownsWf hse_wf heval_se hfresh rfl ?_
+  intro loc
+  have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
+  have hdecl := VerifM.eval_decl hdecl_eval (.loc loc)
+  have hassume_eval := VerifM.eval_bind _ _ _ _ hdecl
+  set ρ_e' : VerifM.Env := ρ_e.updateConst .value c.name (.loc loc)
+  set st₂ : TransState := { st₁ with decls := st₁.decls.addConst c }
+  have hc_wf : (Term.const (.uninterpreted c.name .value)).wfIn st₂.decls := by
+    simp only [Term.wfIn, Const.wfIn]
+    refine ⟨List.Mem.head _, ?_, ?_⟩
+    · intro τ' hvar
+      exact Signature.wf_no_var_of_const hwf_addConst.namesDisjoint
+        (List.Mem.head _) hvar
+    · intro τ' hc'
+      exact Signature.wf_unique_const hwf_addConst.namesDisjoint (List.Mem.head _) hc'
+  have hse_wf_st₂ : se.wfIn st₂.decls :=
+    Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _) hwf_addConst.namesDisjoint
+  have hatom_wf : SpatialAtom.wfIn
+      (.pointsTo (.const (.uninterpreted c.name .value)) se) st₂.decls :=
+    ⟨hc_wf, hse_wf_st₂⟩
+  have hassume_res := VerifM.eval_assumeSpatial hassume_eval hatom_wf
+  have hret := VerifM.eval_ret hassume_res
+  have hval_eval : Term.eval ρ_e'.env (Term.const (.uninterpreted c.name .value)) = .loc loc := by
+    simp [Term.eval, Const.denote, ρ_e', VerifM.Env.updateConst, Env.updateConst]
+  have hty : TinyML.ValHasType Θ (Runtime.Val.loc loc) (TinyML.Typ.ref e.ty) := by
+    exact TinyML.ValHasType.ref loc e.ty
+  exact hpost (.loc loc) ρ_e' _ _ hret hc_wf hval_eval hty
+
+theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
+    (ih : correctExpr e) :
+    correctExpr (.deref e ty) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  unfold Expr.runtime; simp only [Runtime.Expr.subst]
+  simp only [compile] at heval
+  simp only [Expr.ty] at hpost
+  obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
+  cases hty : ty with
+  | int =>
+    simp [hty] at heval hpost
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_ref <| compile_correct e Θ R S B Γ st ρ γ _ _
+    refine SpatialContext.wp_bind_deref <| ih Θ R S B Γ st ρ γ _ _
       (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
     obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
-    have hwf_st₁ := VerifM.eval.wf hΨ_e
-    set c : FOL.Const := st₁.freshConst none .value
-    have hfresh : c.name ∉ st₁.decls.allNames :=
-      fresh_not_mem _ _ (addNumbers_injective _)
-    have hwf_addConst : TransState.wf { st₁ with decls := st₁.decls.addConst c } :=
-      TransState.freshConst.wf _ hwf_st₁
-    refine SpatialContext.wp_ref (ctx := st₁.owns) (Δ := st₁.decls) (vt := se)
-      (name := c.name)
-      (newctx := .pointsTo (.const (.uninterpreted c.name .value)) se :: st₁.owns)
-      hwf_st₁.ownsWf hse_wf heval_se hfresh rfl ?_
-    intro loc
-    have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
-    have hdecl := VerifM.eval_decl hdecl_eval (.loc loc)
-    have hassume_eval := VerifM.eval_bind _ _ _ _ hdecl
-    set ρ_e' : VerifM.Env := ρ_e.updateConst .value c.name (.loc loc)
-    set st₂ : TransState := { st₁ with decls := st₁.decls.addConst c }
-    have hc_wf : (Term.const (.uninterpreted c.name .value)).wfIn st₂.decls := by
-      simp only [Term.wfIn, Const.wfIn]
-      refine ⟨List.Mem.head _, ?_, ?_⟩
-      · intro τ' hvar
-        exact Signature.wf_no_var_of_const hwf_addConst.namesDisjoint
-          (List.Mem.head _) hvar
-      · intro τ' hc'
-        exact Signature.wf_unique_const hwf_addConst.namesDisjoint (List.Mem.head _) hc'
-    have hse_wf_st₂ : se.wfIn st₂.decls :=
-      Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _) hwf_addConst.namesDisjoint
-    have hatom_wf : SpatialAtom.wfIn
-        (.pointsTo (.const (.uninterpreted c.name .value)) se) st₂.decls :=
-      ⟨hc_wf, hse_wf_st₂⟩
-    have hassume_res := VerifM.eval_assumeSpatial hassume_eval hatom_wf
-    have hret := VerifM.eval_ret hassume_res
-    have hval_eval : Term.eval ρ_e'.env (Term.const (.uninterpreted c.name .value)) = .loc loc := by
-      simp [Term.eval, Const.denote, ρ_e', VerifM.Env.updateConst, Env.updateConst]
-    have hty : TinyML.ValHasType Θ (Runtime.Val.loc loc) (TinyML.Typ.ref e.ty) := by
-      exact TinyML.ValHasType.ref loc e.ty
-    exact hpost (.loc loc) ρ_e' _ _ hret hc_wf hval_eval hty
-  | deref e ty =>
-    unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    simp only [compile] at heval
-    simp only [Expr.ty] at hpost
-    obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
-    cases hty : ty with
-    | int =>
-      simp [hty] at heval hpost
-      have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine SpatialContext.wp_bind_deref <| compile_correct e Θ R S B Γ st ρ γ _ _
-        (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
-      intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
-      obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
-      have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_e
-      refine VerifM.eval_resolve (pred := .own se) (R := R)
-        (Φ := wp (.deref (.val v_e)) Φ) hres_bind hse_wf ?_ ?_
-      · intro st' hQ _
-        exact (VerifM.eval_failed hQ).elim
-      · intro v st' hQ hdecls hvwf
-        have hassert_bind := VerifM.eval_bind _ _ _ _ hQ
-        have hse_wf_st' : se.wfIn st'.decls := hdecls ▸ hse_wf
-        have hv_wf_st' : v.wfIn st'.decls := hdecls ▸ hvwf
-        have hassert_wf : (Formula.unpred .isInt v).wfIn st'.decls := hv_wf_st'
-        have ⟨hv_int, hQ⟩ := VerifM.eval_assert hassert_bind hassert_wf
-        have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
-        have hatom_wf : SpatialAtom.wfIn (.pointsTo se v) st'.decls :=
-          ⟨hse_wf_st', hv_wf_st'⟩
-        have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
-        have hret := VerifM.eval_ret hassume_res
-        have hv_wf_final : v.wfIn (TransState.addItem st' (.spatial (.pointsTo se v))).decls := by
-          simpa [TransState.addItem] using hv_wf_st'
-        have htype : TinyML.ValHasType Θ (v.eval ρ_e.env) .int := by
-          cases hv : v.eval ρ_e.env with
-          | int n => exact TinyML.ValHasType.int n
-          | bool _ | unit | inj _ _ _ | loc _ | fix _ _ _ | tuple _ =>
-              simp [Formula.eval, hv] at hv_int
-        let st'' := TransState.addItem st' (.spatial (.pointsTo se v))
-        have hgoal : st''.sl ρ_e ∗ R ⊢ Φ (v.eval ρ_e.env) :=
-          hpost (v.eval ρ_e.env) ρ_e st'' _ hret hv_wf_final rfl htype
-        simp only [Atom.eval]
-        istart
-        iintro H
-        icases H with ⟨Hex, Hrest, HR⟩
-        icases Hex with ⟨%loc, Hpt'⟩
-        icases Hpt' with ⟨%Hloc, Hpt⟩
-        have hv_e : v_e = .loc loc := heval_se.symm.trans Hloc
-        subst hv_e
-        have hptIntro : loc ↦ v.eval ρ_e.env ⊢ SpatialAtom.interp ρ_e.env (.pointsTo se v) := by
-          simpa [Hloc] using
-            (SpatialAtom.interp_pointsTo (ρ := ρ_e.env) (lt := se) (vt := v) (loc := loc) Hloc).2
-        have hctx : (loc ↦ v.eval ρ_e.env) ∗ SpatialContext.interp ρ_e.env st'.owns ∗ R ⊢ Φ (v.eval ρ_e.env) := by
-          have hcons : (loc ↦ v.eval ρ_e.env) ∗ SpatialContext.interp ρ_e.env st'.owns ⊢ st''.sl ρ_e := by
-            simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hptIntro)
-          exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
-        iapply (wp.deref (l := loc) (v := v.eval ρ_e.env))
-        isplitl [Hpt]
-        · iexact Hpt
-        · iintro Hpt
-          iapply hctx
-          isplitl [Hpt]
-          · iexact Hpt
-          · isplitl [Hrest]
-            · simp [TransState.sl]
-            · iexact HR
-    | bool | unit | arrow _ _ | ref _ | sum _ | empty | value | tuple _ | tvar _ | named _ _ =>
-      simp [hty] at heval
-      exact (VerifM.eval_fatal heval).elim
-  | store loc val =>
-    unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    simp only [compile] at heval
-    simp only [Expr.ty] at hpost
-    obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
-    have heval_v : (compile Θ S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_store <| (SpecMap.satisfiedBy_dup.trans <|
-      compile_correct val Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
-        (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hts hSwf ?_)
-    intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv htyv
-    obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
-    have hagree_v : B.agreeOnLinked ρ_v.env γ :=
-      Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
-    have hbwf_v : B.wf st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
-    have heval_l : (compile Θ S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
-    refine compile_correct loc Θ R S B Γ st₁ ρ_v γ _ _
-      (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hts hSwf ?_
-    intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
-    obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
-    have hsv_ρ_l : sv.eval ρ_l.env = v_v := by
-      rw [Term.eval_env_agree hsv_wf (Env.agreeOn_symm hagreeOn_l)]
-      exact heval_sv
-    have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_l
-    refine VerifM.eval_resolve (pred := .own sl) (R := R)
-      (Φ := wp (.store (.val v_l) (.val v_v)) Φ) hres_bind hsl_wf ?_ ?_
+    have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_e
+    refine VerifM.eval_resolve (pred := .own se) (R := R)
+      (Φ := wp (.deref (.val v_e)) Φ) hres_bind hse_wf ?_ ?_
     · intro st' hQ _
       exact (VerifM.eval_failed hQ).elim
-    · intro old st' hQ hdecls hold_wf
+    · intro v st' hQ hdecls hvwf
+      have hassert_bind := VerifM.eval_bind _ _ _ _ hQ
+      have hse_wf_st' : se.wfIn st'.decls := hdecls ▸ hse_wf
+      have hv_wf_st' : v.wfIn st'.decls := hdecls ▸ hvwf
+      have hassert_wf : (Formula.unpred .isInt v).wfIn st'.decls := hv_wf_st'
+      have ⟨hv_int, hQ⟩ := VerifM.eval_assert hassert_bind hassert_wf
       have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
-      have hsl_wf_st' : sl.wfIn st'.decls := hdecls ▸ hsl_wf
-      have hsv_wf_st₂ : sv.wfIn st₂.decls :=
-        Term.wfIn_mono sv hsv_wf hdecls_l (VerifM.eval.wf hΨ_l).namesDisjoint
-      have hsv_wf_st' : sv.wfIn st'.decls := hdecls ▸ hsv_wf_st₂
-      have hatom_wf : SpatialAtom.wfIn (.pointsTo sl sv) st'.decls :=
-        ⟨hsl_wf_st', hsv_wf_st'⟩
+      have hatom_wf : SpatialAtom.wfIn (.pointsTo se v) st'.decls :=
+        ⟨hse_wf_st', hv_wf_st'⟩
       have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
       have hret := VerifM.eval_ret hassume_res
-      have hunit_wf : (Term.const .unit).wfIn
-          (TransState.addItem st' (.spatial (.pointsTo sl sv))).decls := by
-        simp [Term.wfIn, Const.wfIn]
-      let st'' := TransState.addItem st' (.spatial (.pointsTo sl sv))
-      have hgoal : st''.sl ρ_l ∗ R ⊢ Φ .unit :=
-        hpost .unit ρ_l st'' _ hret hunit_wf (by simp [Term.eval]) (.unit)
+      have hv_wf_final : v.wfIn (TransState.addItem st' (.spatial (.pointsTo se v))).decls := by
+        simpa [TransState.addItem] using hv_wf_st'
+      have htype : TinyML.ValHasType Θ (v.eval ρ_e.env) .int := by
+        cases hv : v.eval ρ_e.env with
+        | int n => exact TinyML.ValHasType.int n
+        | bool _ | unit | inj _ _ _ | loc _ | fix _ _ _ | tuple _ =>
+            simp [Formula.eval, hv] at hv_int
+      let st'' := TransState.addItem st' (.spatial (.pointsTo se v))
+      have hgoal : st''.sl ρ_e ∗ R ⊢ Φ (v.eval ρ_e.env) :=
+        hpost (v.eval ρ_e.env) ρ_e st'' _ hret hv_wf_final rfl htype
       simp only [Atom.eval]
       istart
       iintro H
       icases H with ⟨Hex, Hrest, HR⟩
-      icases Hex with ⟨%loc, Hold'⟩
-      icases Hold' with ⟨%Hloc, Hold⟩
-      have hv_l : v_l = .loc loc := heval_sl.symm.trans Hloc
-      subst hv_l
-      have hnewIntro : loc ↦ v_v ⊢ SpatialAtom.interp ρ_l.env (.pointsTo sl sv) := by
-        simpa [Hloc, hsv_ρ_l] using
-          (SpatialAtom.interp_pointsTo (ρ := ρ_l.env) (lt := sl) (vt := sv) (loc := loc) Hloc).2
-      have hctx : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l.env st'.owns ∗ R ⊢ Φ .unit := by
-        have hcons : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l.env st'.owns ⊢ st''.sl ρ_l := by
-          simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hnewIntro)
+      icases Hex with ⟨%loc, Hpt'⟩
+      icases Hpt' with ⟨%Hloc, Hpt⟩
+      have hv_e : v_e = .loc loc := heval_se.symm.trans Hloc
+      subst hv_e
+      have hptIntro : loc ↦ v.eval ρ_e.env ⊢ SpatialAtom.interp ρ_e.env (.pointsTo se v) := by
+        simpa [Hloc] using
+          (SpatialAtom.interp_pointsTo (ρ := ρ_e.env) (lt := se) (vt := v) (loc := loc) Hloc).2
+      have hctx : (loc ↦ v.eval ρ_e.env) ∗ SpatialContext.interp ρ_e.env st'.owns ∗ R ⊢ Φ (v.eval ρ_e.env) := by
+        have hcons : (loc ↦ v.eval ρ_e.env) ∗ SpatialContext.interp ρ_e.env st'.owns ⊢ st''.sl ρ_e := by
+          simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hptIntro)
         exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
-      iapply (wp.store (l := loc) (old := old.eval ρ_l.env) (v := v_v))
-      isplitl [Hold]
-      · iexact Hold
-      · iintro Hnew
+      iapply (wp.deref (l := loc) (v := v.eval ρ_e.env))
+      isplitl [Hpt]
+      · iexact Hpt
+      · iintro Hpt
         iapply hctx
-        isplitl [Hnew]
-        · iexact Hnew
+        isplitl [Hpt]
+        · iexact Hpt
         · isplitl [Hrest]
           · simp [TransState.sl]
           · iexact HR
-  | unop op e uty =>
-    unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    simp only [compile] at heval
-    have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_unop <| compile_correct e Θ R S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
-    intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se htype_e
-    obtain ⟨_, _, hΨ_e⟩ := hΨ_e
-    obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
-    obtain ⟨hty_eq, hΨ_e⟩ := VerifM.eval_bind_expectEq hΨ_e
-    obtain ⟨t, hcompUnop, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
-    obtain hΨ_e := VerifM.eval_ret hΨ_e
-    obtain ⟨w, heval_op, hwt⟩ := evalUnOp_typed htypeOf htype_e
-    have ht_eval : t.eval ρ_e.env = w :=
-      compileUnop_eval heval_se heval_op hcompUnop
-    simp only [Expr.ty] at hpost
-    exact SpatialContext.wp_unop
-      (hpost w ρ_e st₁ t hΨ_e
-        (compileUnop_wfIn hse_wf hcompUnop) ht_eval (hty_eq ▸ hwt))
+  | bool | unit | arrow _ _ | ref _ | sum _ | empty | value | tuple _ | tvar _ | named _ _ =>
+    simp [hty] at heval
+    exact (VerifM.eval_fatal heval).elim
+
+theorem compileStore_correct (loc val : Expr)
+    (ihVal : correctExpr val) (ihLoc : correctExpr loc) :
+    correctExpr (.store loc val) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  unfold Expr.runtime; simp only [Runtime.Expr.subst]
+  simp only [compile] at heval
+  simp only [Expr.ty] at hpost
+  obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
+  have heval_v : (compile Θ S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_store <| (SpecMap.satisfiedBy_dup.trans <|
+    ihVal Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hts hSwf ?_)
+  intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv htyv
+  obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
+  have hagree_v : B.agreeOnLinked ρ_v.env γ :=
+    Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
+  have hbwf_v : B.wf st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
+  have heval_l : (compile Θ S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
+  refine ihLoc Θ R S B Γ st₁ ρ_v γ _ _
+    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hts hSwf ?_
+  intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
+  obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
+  have hsv_ρ_l : sv.eval ρ_l.env = v_v := by
+    rw [Term.eval_env_agree hsv_wf (Env.agreeOn_symm hagreeOn_l)]
+    exact heval_sv
+  have hres_bind := VerifM.eval_bind _ _ _ _ hΨ_l
+  refine VerifM.eval_resolve (pred := .own sl) (R := R)
+    (Φ := wp (.store (.val v_l) (.val v_v)) Φ) hres_bind hsl_wf ?_ ?_
+  · intro st' hQ _
+    exact (VerifM.eval_failed hQ).elim
+  · intro old st' hQ hdecls hold_wf
+    have hassume_bind := VerifM.eval_bind _ _ _ _ hQ
+    have hsl_wf_st' : sl.wfIn st'.decls := hdecls ▸ hsl_wf
+    have hsv_wf_st₂ : sv.wfIn st₂.decls :=
+      Term.wfIn_mono sv hsv_wf hdecls_l (VerifM.eval.wf hΨ_l).namesDisjoint
+    have hsv_wf_st' : sv.wfIn st'.decls := hdecls ▸ hsv_wf_st₂
+    have hatom_wf : SpatialAtom.wfIn (.pointsTo sl sv) st'.decls :=
+      ⟨hsl_wf_st', hsv_wf_st'⟩
+    have hassume_res := VerifM.eval_assumeSpatial hassume_bind hatom_wf
+    have hret := VerifM.eval_ret hassume_res
+    have hunit_wf : (Term.const .unit).wfIn
+        (TransState.addItem st' (.spatial (.pointsTo sl sv))).decls := by
+      simp [Term.wfIn, Const.wfIn]
+    let st'' := TransState.addItem st' (.spatial (.pointsTo sl sv))
+    have hgoal : st''.sl ρ_l ∗ R ⊢ Φ .unit :=
+      hpost .unit ρ_l st'' _ hret hunit_wf (by simp [Term.eval]) (.unit)
+    simp only [Atom.eval]
+    istart
+    iintro H
+    icases H with ⟨Hex, Hrest, HR⟩
+    icases Hex with ⟨%loc, Hold'⟩
+    icases Hold' with ⟨%Hloc, Hold⟩
+    have hv_l : v_l = .loc loc := heval_sl.symm.trans Hloc
+    subst hv_l
+    have hnewIntro : loc ↦ v_v ⊢ SpatialAtom.interp ρ_l.env (.pointsTo sl sv) := by
+      simpa [Hloc, hsv_ρ_l] using
+        (SpatialAtom.interp_pointsTo (ρ := ρ_l.env) (lt := sl) (vt := sv) (loc := loc) Hloc).2
+    have hctx : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l.env st'.owns ∗ R ⊢ Φ .unit := by
+      have hcons : (loc ↦ v_v) ∗ SpatialContext.interp ρ_l.env st'.owns ⊢ st''.sl ρ_l := by
+        simpa [st'', TransState.addItem, SpatialContext.interp] using (sep_mono_l hnewIntro)
+      exact sep_assoc.2.trans ((sep_mono_l hcons).trans hgoal)
+    iapply (wp.store (l := loc) (old := old.eval ρ_l.env) (v := v_v))
+    isplitl [Hold]
+    · iexact Hold
+    · iintro Hnew
+      iapply hctx
+      isplitl [Hnew]
+      · iexact Hnew
+      · isplitl [Hrest]
+        · simp [TransState.sl]
+        · iexact HR
+
+theorem compileUnop_correct (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
+    (ih : correctExpr e) :
+    correctExpr (.unop op e uty) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  unfold Expr.runtime; simp only [Runtime.Expr.subst]
+  simp only [compile] at heval
+  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_unop <| ih Θ R S B Γ st ρ γ _ _
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+  intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se htype_e
+  obtain ⟨_, _, hΨ_e⟩ := hΨ_e
+  obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
+  obtain ⟨hty_eq, hΨ_e⟩ := VerifM.eval_bind_expectEq hΨ_e
+  obtain ⟨t, hcompUnop, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
+  obtain hΨ_e := VerifM.eval_ret hΨ_e
+  obtain ⟨w, heval_op, hwt⟩ := evalUnOp_typed htypeOf htype_e
+  have ht_eval : t.eval ρ_e.env = w :=
+    compileUnop_eval heval_se heval_op hcompUnop
+  simp only [Expr.ty] at hpost
+  exact SpatialContext.wp_unop
+    (hpost w ρ_e st₁ t hΨ_e
+      (compileUnop_wfIn hse_wf hcompUnop) ht_eval (hty_eq ▸ hwt))
+    heval_op
+
+theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
+    (ihR : correctExpr r) (ihL : correctExpr l) :
+    correctExpr (.binop op l r bty) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  unfold Expr.runtime; simp only [Runtime.Expr.subst]
+  simp only [compile] at heval
+  have heval_r : (compile Θ S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_binop <| (SpecMap.satisfiedBy_dup).trans <|
+    ihR Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
+    (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hSwf ?_
+  intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr htyr
+  obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
+  have hagree_r : B.agreeOnLinked ρ_r.env γ :=
+    Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
+  have hbwf_r : B.wf st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
+  have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
+  refine ihL Θ R S B Γ st₁ ρ_r γ _ _
+    (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hts hSwf ?_
+  intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
+  obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
+  obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
+  obtain ⟨hty_eq, hΨ_l'⟩ := VerifM.eval_bind_expectEq hΨ_l
+  simp only [Expr.ty] at hpost
+  have hsr_ρ_l : sr.eval ρ_l.env = vr := by
+    rw [Term.eval_env_agree hsr_wf (Env.agreeOn_symm hagreeOn_l)]; exact heval_sr
+  by_cases hdivmod : op = .div ∨ op = .mod
+  · have hΨ_div :
+          (do
+            let i t := Term.unop UnOp.toInt t
+            let fol_op := if op == TinyML.BinOp.div then BinOp.div else BinOp.mod
+            VerifM.assert (.not (.eq .int (i sr) (.const (.i 0))))
+            pure (Term.unop .ofInt (Term.binop fol_op (i sl) (i sr)))).eval st₂ ρ_l Ψ := by
+      simpa [hdivmod] using hΨ_l'
+    rcases hdivmod with hdiv | hmod
+    · subst hdiv
+      have hlty : l.ty = .int := by
+        revert htypeOf; cases l.ty <;> simp [TinyML.BinOp.typeOf]
+      have hrty : r.ty = .int := by
+        revert htypeOf; cases r.ty <;> simp [TinyML.BinOp.typeOf, hlty]
+      rw [hlty] at htyl; rw [hrty] at htyr
+      cases htyl with
+      | int a =>
+        cases htyr with
+        | int b =>
+          have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
+            simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
+              (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
+          have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
+          have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
+          simp [Formula.eval, Term.eval, Const.denote] at hne_zero
+          rw [hsr_ρ_l] at hne_zero
+          simp at hne_zero
+          obtain hΨ_post := VerifM.eval_ret hΨ_post
+          have hty_int : ty = .int := by
+            rw [hlty, hrty] at htypeOf
+            simpa [TinyML.BinOp.typeOf] using htypeOf.symm
+          have hbty : bty = .int := hty_eq.symm.trans hty_int
+          have hwf_sr_l : sr.wfIn st₂.decls :=
+            Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
+          have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
+            simpa [Term.wfIn, BinOp.wfIn, UnOp.wfIn] using And.intro hsl_wf hwf_sr_l
+          have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
+            simpa using hΨ_post
+          exact SpatialContext.wp_binop
+            (hpost (.int (a / b)) ρ_l st₂ _ hΨ_post' hwf_bin
+              (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l])
+              (hbty ▸ .int _))
+            (by simp [TinyML.evalBinOp, hne_zero])
+    · subst hmod
+      have hlty : l.ty = .int := by
+        revert htypeOf; cases l.ty <;> simp [TinyML.BinOp.typeOf]
+      have hrty : r.ty = .int := by
+        revert htypeOf; cases r.ty <;> simp [TinyML.BinOp.typeOf, hlty]
+      rw [hlty] at htyl; rw [hrty] at htyr
+      cases htyl with
+      | int a =>
+        cases htyr with
+        | int b =>
+          have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
+            simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
+              (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
+          have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
+          have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
+          simp [Formula.eval, Term.eval, Const.denote] at hne_zero
+          rw [hsr_ρ_l] at hne_zero
+          simp at hne_zero
+          obtain hΨ_post := VerifM.eval_ret hΨ_post
+          have hty_int : ty = .int := by
+            rw [hlty, hrty] at htypeOf
+            simpa [TinyML.BinOp.typeOf] using htypeOf.symm
+          have hbty : bty = .int := hty_eq.symm.trans hty_int
+          have hwf_sr_l : sr.wfIn st₂.decls :=
+            Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
+          have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
+            simpa [Term.wfIn, BinOp.wfIn, UnOp.wfIn] using And.intro hsl_wf hwf_sr_l
+          have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
+            simpa using hΨ_post
+          exact SpatialContext.wp_binop
+            (hpost (.int (a % b)) ρ_l st₂ _ hΨ_post' hwf_bin
+              (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l])
+              (hbty ▸ .int _))
+            (by simp [TinyML.evalBinOp, hne_zero])
+  · have hndivmod : ¬(op = TinyML.BinOp.div ∨ op = TinyML.BinOp.mod) := hdivmod
+    have hΨ_ndiv :
+          (do
+            let t ← VerifM.expectSome
+              s!"unsupported binary operator: {repr op}"
+              (compileOp op sl sr)
+            pure t).eval st₂ ρ_l Ψ := by
+      simpa [hndivmod] using hΨ_l'
+    obtain ⟨t, hcompOp, hΨ_ndiv⟩ := VerifM.eval_bind_expectSome hΨ_ndiv
+    have hwfst₂ : st₂.decls.wf := (VerifM.eval.wf hΨ_ndiv).namesDisjoint
+    obtain hΨ_ndiv := VerifM.eval_ret hΨ_ndiv
+    have hdiv : op ≠ .div := fun h => hndivmod (Or.inl h)
+    have hmod : op ≠ .mod := fun h => hndivmod (Or.inr h)
+    obtain ⟨w, heval_op, hwt⟩ := evalBinOp_typed hdiv hmod htypeOf htyl htyr
+    have hwf_sr_l : sr.wfIn st₂.decls :=
+      Term.wfIn_mono sr hsr_wf hdecls_l hwfst₂
+    have ht_eval : t.eval ρ_l.env = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
+    exact SpatialContext.wp_binop
+      (hpost w ρ_l st₂ t hΨ_ndiv
+        (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval (hty_eq ▸ hwt))
       heval_op
-  | binop op l r bty =>
-    unfold Expr.runtime; simp only [Runtime.Expr.subst]
-    simp only [compile] at heval
-    -- compile processes r first (matching runtime r-first evaluation order)
-    have heval_r : (compile Θ S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_binop <| (SpecMap.satisfiedBy_dup).trans <|
-      compile_correct r Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hSwf ?_
-    intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr htyr
-    obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
-    have hagree_r : B.agreeOnLinked ρ_r.env γ :=
-      Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
-    have hbwf_r : B.wf st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
-    have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
-    refine compile_correct l Θ R S B Γ st₁ ρ_r γ _ _
-      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hts hSwf ?_
-    intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
-    obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
-    obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
-    obtain ⟨hty_eq, hΨ_l'⟩ := VerifM.eval_bind_expectEq hΨ_l
-    simp only [Expr.ty] at hpost
-    -- transport sr's eval to the final env ρ_l
-    have hsr_ρ_l : sr.eval ρ_l.env = vr := by
-      rw [Term.eval_env_agree hsr_wf (Env.agreeOn_symm hagreeOn_l)]; exact heval_sr
-    /- Split on whether op is division -/
-    by_cases hdivmod : op = .div ∨ op = .mod
-    · -- Division or modulo: both have the non-zero divisor assertion
-      have hΨ_div :
-            (do
-              let i t := Term.unop UnOp.toInt t
-              let fol_op := if op == TinyML.BinOp.div then BinOp.div else BinOp.mod
-              VerifM.assert (.not (.eq .int (i sr) (.const (.i 0))))
-              pure (Term.unop .ofInt (Term.binop fol_op (i sl) (i sr)))).eval st₂ ρ_l Ψ := by
-        simpa [hdivmod] using hΨ_l'
-      rcases hdivmod with hdiv | hmod
-      · subst hdiv
-        have hlty : l.ty = .int := by
-          revert htypeOf; cases l.ty <;> simp [TinyML.BinOp.typeOf]
-        have hrty : r.ty = .int := by
-          revert htypeOf; cases r.ty <;> simp [TinyML.BinOp.typeOf, hlty]
-        rw [hlty] at htyl; rw [hrty] at htyr
-        cases htyl with
-        | int a =>
-          cases htyr with
-          | int b =>
-            have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
-              simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
-                (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
-            have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
-            have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
-            simp [Formula.eval, Term.eval, Const.denote] at hne_zero
-            rw [hsr_ρ_l] at hne_zero
-            simp at hne_zero
-            obtain hΨ_post := VerifM.eval_ret hΨ_post
-            have hty_int : ty = .int := by
-              rw [hlty, hrty] at htypeOf
-              simpa [TinyML.BinOp.typeOf] using htypeOf.symm
-            have hbty : bty = .int := hty_eq.symm.trans hty_int
-            have hwf_sr_l : sr.wfIn st₂.decls :=
-              Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
-            have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
-              simpa [Term.wfIn, BinOp.wfIn, UnOp.wfIn] using And.intro hsl_wf hwf_sr_l
-            have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
-              simpa using hΨ_post
-            exact SpatialContext.wp_binop
-              (hpost (.int (a / b)) ρ_l st₂ _ hΨ_post' hwf_bin
-                (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l])
-                (hbty ▸ .int _))
-              (by simp [TinyML.evalBinOp, hne_zero])
-      · subst hmod
-        have hlty : l.ty = .int := by
-          revert htypeOf; cases l.ty <;> simp [TinyML.BinOp.typeOf]
-        have hrty : r.ty = .int := by
-          revert htypeOf; cases r.ty <;> simp [TinyML.BinOp.typeOf, hlty]
-        rw [hlty] at htyl; rw [hrty] at htyr
-        cases htyl with
-        | int a =>
-          cases htyr with
-          | int b =>
-            have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
-              simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
-                (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
-            have heval_assert := VerifM.eval_bind _ _ _ _ hΨ_div
-            have ⟨hne_zero, hΨ_post⟩ := VerifM.eval_assert heval_assert hassert_wf
-            simp [Formula.eval, Term.eval, Const.denote] at hne_zero
-            rw [hsr_ρ_l] at hne_zero
-            simp at hne_zero
-            obtain hΨ_post := VerifM.eval_ret hΨ_post
-            have hty_int : ty = .int := by
-              rw [hlty, hrty] at htypeOf
-              simpa [TinyML.BinOp.typeOf] using htypeOf.symm
-            have hbty : bty = .int := hty_eq.symm.trans hty_int
-            have hwf_sr_l : sr.wfIn st₂.decls :=
-              Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
-            have hwf_bin : (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))).wfIn st₂.decls := by
-              simpa [Term.wfIn, BinOp.wfIn, UnOp.wfIn] using And.intro hsl_wf hwf_sr_l
-            have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
-              simpa using hΨ_post
-            exact SpatialContext.wp_binop
-              (hpost (.int (a % b)) ρ_l st₂ _ hΨ_post' hwf_bin
-                (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l])
-                (hbty ▸ .int _))
-              (by simp [TinyML.evalBinOp, hne_zero])
-    · have hndivmod : ¬(op = TinyML.BinOp.div ∨ op = TinyML.BinOp.mod) := hdivmod
-      have hΨ_ndiv :
-            (do
-              let t ← VerifM.expectSome
-                s!"unsupported binary operator: {repr op}"
-                (compileOp op sl sr)
-              pure t).eval st₂ ρ_l Ψ := by
-        simpa [hndivmod] using hΨ_l'
-      obtain ⟨t, hcompOp, hΨ_ndiv⟩ := VerifM.eval_bind_expectSome hΨ_ndiv
-      have hwfst₂ : st₂.decls.wf := (VerifM.eval.wf hΨ_ndiv).namesDisjoint
-      obtain hΨ_ndiv := VerifM.eval_ret hΨ_ndiv
-      have hdiv : op ≠ .div := fun h => hndivmod (Or.inl h)
-      have hmod : op ≠ .mod := fun h => hndivmod (Or.inr h)
-      obtain ⟨w, heval_op, hwt⟩ := evalBinOp_typed hdiv hmod htypeOf htyl htyr
-      have hwf_sr_l : sr.wfIn st₂.decls :=
-        Term.wfIn_mono sr hsr_wf hdecls_l hwfst₂
-      have ht_eval : t.eval ρ_l.env = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
-      exact SpatialContext.wp_binop
-        (hpost w ρ_l st₂ t hΨ_ndiv
-          (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval (hty_eq ▸ hwt))
-        heval_op
-  | letIn b e body =>
-    simp only [compile] at heval
-    simp only [Expr.ty] at hpost
-    unfold Expr.runtime
-    simp only [Runtime.Expr.letIn_subst]
-    have heval_e_outer : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine (SpecMap.satisfiedBy_dup.trans <| compile_correct e Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hSwf ?_).trans wp.letIn
-    intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e htyping_e
-    obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
-    have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
-    have hbwf_e : B.wf st₁.decls := fun p hp => hdecls_e.consts _ (hbwf p hp)
-    obtain ⟨_, hΨ_e⟩ := VerifM.eval_bind_expectEq hΨ_e
-    cases hname : b.name with
-    | none =>
-      simp [hname] at hΨ_e
-      have hbody := compile_correct body Θ R S B Γ st₁ ρ_e γ _ _
-        (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hSwf
-        (fun v ρ' st' se hΨ hs hw ht =>
-          let ⟨_, _, hΨ'⟩ := hΨ
-          hpost v ρ' st' se hΨ' hs hw ht)
-      have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ Runtime.Binder.none v_e
-      have hbody' : st₁.sl ρ_e ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp
+
+theorem compileLetIn_correct (b : Binder) (e body : Expr)
+    (ihE : correctExpr e) (ihBody : correctExpr body) :
+    correctExpr (.letIn b e body) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  simp only [compile] at heval
+  simp only [Expr.ty] at hpost
+  unfold Expr.runtime
+  simp only [Runtime.Expr.letIn_subst]
+  have heval_e_outer : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine (SpecMap.satisfiedBy_dup.trans <| ihE Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
+    (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hSwf ?_).trans wp.letIn
+  intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e htyping_e
+  obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
+  have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
+  have hbwf_e : B.wf st₁.decls := fun p hp => hdecls_e.consts _ (hbwf p hp)
+  obtain ⟨_, hΨ_e⟩ := VerifM.eval_bind_expectEq hΨ_e
+  cases hname : b.name with
+  | none =>
+    simp [hname] at hΨ_e
+    have hbody := ihBody Θ R S B Γ st₁ ρ_e γ _ _
+      (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hSwf
+      (fun v ρ' st' se hΨ hs hw ht =>
+        let ⟨_, _, hΨ'⟩ := hΨ
+        hpost v ρ' st' se hΨ' hs hw ht)
+    have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ Runtime.Binder.none v_e
+    have hbody' : st₁.sl ρ_e ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp
+          (Runtime.Expr.subst
+            (Runtime.Subst.update' Runtime.Binder.none v_e Runtime.Subst.id)
+            (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
+          Φ :=
+      hsubst.symm ▸ hbody
+    rw [Binder.runtime_of_name_none hname]
+    simpa [Runtime.Subst.update'] using hbody'
+  | some x =>
+    simp [hname] at hΨ_e
+    set base := x
+    set x' := fresh (addNumbers base) st₁.decls.allNames
+    set v : FOL.Const := ⟨x', .value⟩
+    have _hvty : v.sort = .value := rfl
+    have hfresh : v.name ∉ st₁.decls.allNames :=
+      fresh_not_mem _ _ (addNumbers_injective _)
+    set st₂ : TransState :=
+      { decls := st₁.decls.addConst v,
+        asserts := (Formula.eq .value (.const (.uninterpreted v.name .value)) se) :: st₁.asserts,
+        owns := st₁.owns }
+    set ρ_body := ρ_e.updateConst .value v.name v_e
+    set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
+    suffices st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp (body.runtime.subst γ_body) Φ by
+      have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ (.named x) v_e
+      have hbody' : st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp
             (Runtime.Expr.subst
-              (Runtime.Subst.update' Runtime.Binder.none v_e Runtime.Subst.id)
-              (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
+              (Runtime.Subst.update' (.named x) v_e Runtime.Subst.id)
+              (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
             Φ :=
-        hsubst.symm ▸ hbody
-      rw [Binder.runtime_of_name_none hname]
-      simpa [Runtime.Subst.update'] using hbody'
-    | some x =>
-      simp [hname] at hΨ_e
-      set base := x
-      set x' := fresh (addNumbers base) st₁.decls.allNames
-      set v : FOL.Const := ⟨x', .value⟩
-      have _hvty : v.sort = .value := rfl
-      have hfresh : v.name ∉ st₁.decls.allNames :=
-        fresh_not_mem _ _ (addNumbers_injective _)
-      set st₂ : TransState :=
-        { decls := st₁.decls.addConst v,
-          asserts := (Formula.eq .value (.const (.uninterpreted v.name .value)) se) :: st₁.asserts,
-          owns := st₁.owns }
-      set ρ_body := ρ_e.updateConst .value v.name v_e
-      set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
-      suffices st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp (body.runtime.subst γ_body) Φ by
-        have hsubst := Runtime.Expr.subst_remove'_update' body.runtime γ (.named x) v_e
-        have hbody' : st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) ⊢ wp
-              (Runtime.Expr.subst
-                (Runtime.Subst.update' (.named x) v_e Runtime.Subst.id)
-                (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
-              Φ :=
-          hsubst.symm ▸ this
-        have hinterp_eq : SpatialContext.interp ρ_e.env st₁.owns ⊢ SpatialContext.interp ρ_body.env st₁.owns :=
-          (SpatialContext.interp_env_agree (VerifM.eval.wf hΨ_e).ownsWf
-            (agreeOn_update_fresh_const hfresh)).1
-        rw [Binder.runtime_of_name_some hname]
-        have hsat :
-            st₂.sl ρ_body ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
-              st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) := by
-          exact SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase
-        exact (sep_mono_l hinterp_eq).trans <|
-          hsat.trans <|
-          by simpa [st₂, γ_body, base, Runtime.Subst.update', Runtime.Subst.update, Runtime.Subst.id]
-            using hbody'
-      have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
-        agreeOn_update_fresh_const hfresh
-      have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
-        have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
-        have hdecl := VerifM.eval_decl hdecl_eval
-        have h := hdecl v_e
-        obtain h := VerifM.eval_bind _ _ _ _ h
-        obtain h := VerifM.eval_assumePure h
-        apply h
-        · simp only [Formula.wfIn, Term.wfIn, Const.wfIn]
-          refine ⟨?_, Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _)
-            (TransState.freshConst.wf _ (VerifM.eval.wf hdecl_eval)).namesDisjoint⟩
-          refine ⟨List.mem_cons_self .., ?_, ?_⟩
-          · intro τ' hvar
-            exact Signature.wf_no_var_of_const
-              (TransState.freshConst.wf _ (VerifM.eval.wf hdecl_eval)).namesDisjoint
-              (List.mem_cons_self ..) hvar
-          · intro τ' hc'
-            exact Signature.wf_unique_const
-              (TransState.freshConst.wf _ (VerifM.eval.wf hdecl_eval)).namesDisjoint
-              (List.mem_cons_self ..) hc'
-        · simp only [Formula.eval, Term.eval, Const.denote]
-          have : v_e = Term.eval ρ_body.env se := by
-            rw [Term.eval_env_agree hse_wf (Env.agreeOn_symm hagreeOn_body_e)]
-            exact heval_e.symm
-          simpa [ρ_body, Env.updateConst] using this
-      have hbwf₂ : Bindings.wf ((x, v) :: B) st₂.decls := Bindings.wf_cons hbwf_e
-      have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ_body.env ρ.env := by
-        constructor
-        · intro y hy
-          cases hy
-        · constructor
-          · intro y' hy'
-            obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hy'
-            exact ((hagreeOn_e.2.1 p.2 (hbwf p hp)).trans
-              (hagreeOn_body_e.2.1 p.2 (hbwf_e p hp))).symm
-          · constructor <;> intro z hz <;> cases hz
-      have hρ_body_lookup : ρ_body.env.consts .value v.name = v_e := by
-        simp [ρ_body, VerifM.Env.updateConst, Env.updateConst]
-      have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body.env γ_body := by
-        have h := Bindings.agreeOnLinked_cons (x := x) (γ := γ) hagree hρ_agree (hvty := (rfl : v.sort = .value))
-        rwa [hρ_body_lookup] at h
-      have hts_body : Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body :=
-        Bindings.typedSubst_cons hts htyping_e
-      refine compile_correct body Θ R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
-        (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ hts_body
-        (SpecMap.wfIn_erase hSwf) ?_
-      intro v' ρ' st' se' hΨ hs hw ht
-      obtain ⟨_, _, hΨ'⟩ := hΨ
-      exact hpost v' ρ' st' se' hΨ' hs hw ht
-  | ifThenElse cond thn els ty =>
-    simp only [Expr.ty] at hpost
-    unfold Expr.runtime
-    simp only [Runtime.Expr.subst]
+        hsubst.symm ▸ this
+      have hinterp_eq : SpatialContext.interp ρ_e.env st₁.owns ⊢ SpatialContext.interp ρ_body.env st₁.owns :=
+        (SpatialContext.interp_env_agree (VerifM.eval.wf hΨ_e).ownsWf
+          (agreeOn_update_fresh_const hfresh)).1
+      rw [Binder.runtime_of_name_some hname]
+      have hsat :
+          st₂.sl ρ_body ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+            st₂.sl ρ_body ∗ (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗ R) := by
+        exact SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase
+      exact (sep_mono_l hinterp_eq).trans <|
+        hsat.trans <|
+        by simpa [st₂, γ_body, base, Runtime.Subst.update', Runtime.Subst.update, Runtime.Subst.id]
+          using hbody'
+    have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
+      agreeOn_update_fresh_const hfresh
+    have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
+      have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
+      have hdecl := VerifM.eval_decl hdecl_eval
+      have h := hdecl v_e
+      obtain h := VerifM.eval_bind _ _ _ _ h
+      obtain h := VerifM.eval_assumePure h
+      apply h
+      · simp only [Formula.wfIn, Term.wfIn, Const.wfIn]
+        refine ⟨?_, Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _)
+          (TransState.freshConst.wf _ (VerifM.eval.wf hdecl_eval)).namesDisjoint⟩
+        refine ⟨List.mem_cons_self .., ?_, ?_⟩
+        · intro τ' hvar
+          exact Signature.wf_no_var_of_const
+            (TransState.freshConst.wf _ (VerifM.eval.wf hdecl_eval)).namesDisjoint
+            (List.mem_cons_self ..) hvar
+        · intro τ' hc'
+          exact Signature.wf_unique_const
+            (TransState.freshConst.wf _ (VerifM.eval.wf hdecl_eval)).namesDisjoint
+            (List.mem_cons_self ..) hc'
+      · simp only [Formula.eval, Term.eval, Const.denote]
+        have : v_e = Term.eval ρ_body.env se := by
+          rw [Term.eval_env_agree hse_wf (Env.agreeOn_symm hagreeOn_body_e)]
+          exact heval_e.symm
+        simpa [ρ_body, Env.updateConst] using this
+    have hbwf₂ : Bindings.wf ((x, v) :: B) st₂.decls := Bindings.wf_cons hbwf_e
+    have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ_body.env ρ.env := by
+      constructor
+      · intro y hy
+        cases hy
+      · constructor
+        · intro y' hy'
+          obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hy'
+          exact ((hagreeOn_e.2.1 p.2 (hbwf p hp)).trans
+            (hagreeOn_body_e.2.1 p.2 (hbwf_e p hp))).symm
+        · constructor <;> intro z hz <;> cases hz
+    have hρ_body_lookup : ρ_body.env.consts .value v.name = v_e := by
+      simp [ρ_body, VerifM.Env.updateConst, Env.updateConst]
+    have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body.env γ_body := by
+      have h := Bindings.agreeOnLinked_cons (x := x) (γ := γ) hagree hρ_agree (hvty := (rfl : v.sort = .value))
+      rwa [hρ_body_lookup] at h
+    have hts_body : Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body :=
+      Bindings.typedSubst_cons hts htyping_e
+    refine ihBody Θ R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
+      (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ hts_body
+      (SpecMap.wfIn_erase hSwf) ?_
+    intro v' ρ' st' se' hΨ hs hw ht
+    obtain ⟨_, _, hΨ'⟩ := hΨ
+    exact hpost v' ρ' st' se' hΨ' hs hw ht
+
+theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
+    (ihCond : correctExpr cond) (ihThn : correctExpr thn) (ihEls : correctExpr els) :
+    correctExpr (.ifThenElse cond thn els ty) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  simp only [Expr.ty] at hpost
+  unfold Expr.runtime
+  simp only [Runtime.Expr.subst]
+  simp only [compile] at heval
+  have heval_cond : (compile Θ S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_if <| SpecMap.satisfiedBy_dup.trans <|
+    ihCond Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
+    (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hSwf ?_
+  intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c htypc
+  obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
+  have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
+  have hbwf_c : B.wf st₁.decls := fun p hp => hdecls_c.consts _ (hbwf p hp)
+  obtain ⟨hcond_bool, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
+  obtain ⟨hthn_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
+  obtain ⟨hels_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
+  have heval_branches : (VerifM.all [true, false]).eval st₁ ρ_c _ := VerifM.eval_bind _ _ _ _ hΨ_c
+  have hall := VerifM.eval_all heval_branches
+  have htrue := hall true (by simp)
+  have hfalse := hall false (by simp)
+  have hwf_ne : (Formula.not (Formula.eq .value sc (.unop .ofBool (.const (.b false))))).wfIn st₁.decls := by
+    simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
+  have hwf_eq : (Formula.eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))).wfIn st₁.decls := by
+    simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
+  have htrue_cont := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ htrue)
+  have hfalse_cont := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ hfalse)
+  let φ_eq : Formula := .eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))
+  let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
+  let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
+  by_cases hvc_false : v_c = .bool false
+  · subst hvc_false
+    have heval_els : (compile Θ S B Γ els).eval st_els ρ_c Ψ :=
+      hfalse_cont hwf_eq (by
+        simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
+        exact heval_c)
+    exact SpatialContext.wp_if_false <| ihEls Θ R S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hSwf
+      (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hels_ty ▸ ht))
+  · have hvc_true : v_c = .bool true := by
+      rw [hcond_bool] at htypc
+      cases htypc with
+      | bool b => cases b with
+        | false => exact absurd rfl hvc_false
+        | true  => rfl
+    subst hvc_true
+    have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by rw [heval_c]; simp
+    have heval_thn : (compile Θ S B Γ thn).eval st_thn ρ_c Ψ :=
+      htrue_cont hwf_ne (by
+        simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
+        exact heval_ne)
+    exact SpatialContext.wp_if_true <| ihThn Θ R S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hSwf
+      (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hthn_ty ▸ ht))
+
+theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
+    (ihArgs : correctExprs args) :
+    correctExpr (.app fn args aty) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  simp only [Expr.ty] at hpost
+  unfold Expr.runtime
+  simp only [Runtime.Expr.subst, List.map_map]
+  cases fn with
+  | var f fty =>
     simp only [compile] at heval
-    have heval_cond : (compile Θ S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_if <| SpecMap.satisfiedBy_dup.trans <|
-      compile_correct cond Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hSwf ?_
-    intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c htypc
-    obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
-    have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
-    have hbwf_c : B.wf st₁.decls := fun p hp => hdecls_c.consts _ (hbwf p hp)
-    obtain ⟨hcond_bool, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
-    obtain ⟨hthn_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
-    obtain ⟨hels_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
-    have heval_branches : (VerifM.all [true, false]).eval st₁ ρ_c _ := VerifM.eval_bind _ _ _ _ hΨ_c
-    have hall := VerifM.eval_all heval_branches
-    have htrue := hall true (by simp)
-    have hfalse := hall false (by simp)
-    have hwf_ne : (Formula.not (Formula.eq .value sc (.unop .ofBool (.const (.b false))))).wfIn st₁.decls := by
-      simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
-    have hwf_eq : (Formula.eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))).wfIn st₁.decls := by
-      simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]; exact hsc_wf
-    have htrue_cont := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ htrue)
-    have hfalse_cont := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ hfalse)
-    let φ_eq : Formula := .eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))
-    let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
-    let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
-    by_cases hvc_false : v_c = .bool false
-    · subst hvc_false
-      have heval_els : (compile Θ S B Γ els).eval st_els ρ_c Ψ :=
-        hfalse_cont hwf_eq (by
-          simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
-          exact heval_c)
-      exact SpatialContext.wp_if_false <| compile_correct els Θ R S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hSwf
-        (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hels_ty ▸ ht))
-    · have hvc_true : v_c = .bool true := by
-        rw [hcond_bool] at htypc
-        cases htypc with
-        | bool b => cases b with
-          | false => exact absurd rfl hvc_false
-          | true  => rfl
-      subst hvc_true
-      have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by rw [heval_c]; simp
-      have heval_thn : (compile Θ S B Γ thn).eval st_thn ρ_c Ψ :=
-        htrue_cont hwf_ne (by
-          simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
-          exact heval_ne)
-      exact SpatialContext.wp_if_true <| compile_correct thn Θ R S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hSwf
-        (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hthn_ty ▸ ht))
-  | app fn args aty =>
-    simp only [Expr.ty] at hpost
-    unfold Expr.runtime
-    simp only [Runtime.Expr.subst, List.map_map]
-    cases fn with
-    | var f fty =>
-      simp only [compile] at heval
-      obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
-      have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine SpecMap.project (P := st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R)) Θ S γ ?_ hlookup ?_
-      · istart
-        iintro ⟨_, □HS, _⟩
-        iexact HS
-      · intro fval hγf
-        simp [Expr.runtime, Runtime.Expr.subst, hγf]
-        refine SpatialContext.wp_bind_app ?_
-        have hctx :
-            spec.isPrecondFor Θ fval ∗ (st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
-              st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
-          istart
-          iintro ⟨□Hspec, Howns, □HS, HR⟩
-          isplitl [Howns]
-          · iexact Howns
+    obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
+    have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpecMap.project (P := st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R)) Θ S γ ?_ hlookup ?_
+    · istart
+      iintro ⟨_, □HS, _⟩
+      iexact HS
+    · intro fval hγf
+      simp [Expr.runtime, Runtime.Expr.subst, hγf]
+      refine SpatialContext.wp_bind_app ?_
+      have hctx :
+          spec.isPrecondFor Θ fval ∗ (st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
+            st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
+        istart
+        iintro ⟨□Hspec, Howns, □HS, HR⟩
+        isplitl [Howns]
+        · iexact Howns
+        · isplitl []
+          · iexact HS
           · isplitl []
-            · iexact HS
-            · isplitl []
-              · iexact Hspec
-              · iexact HR
-        refine hctx.trans <| compileExprs_correct args Θ (spec.isPrecondFor Θ fval ∗ R) S B Γ st ρ γ _ _
-          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hSwf ?_
-        intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
-        obtain ⟨_, _, hΨ_args⟩ := hΨ_args
-        let typedArgs := (args.map Expr.ty).zip sargs
-        have hlen_sargs : sargs.length = vs.length := by
-          simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
-        have hlen_typed : (args.map Expr.ty).length = sargs.length := by
-          calc
-            (args.map Expr.ty).length = vs.length := by simpa using htyping_args.length_eq.symm
-            _ = sargs.length := hlen_sargs.symm
-        obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-        obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-        have hwf_pred : spec.pred.wfIn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars spec.args)) := by
-          simpa [Spec.wfIn, FiniteSubst.id, Signature.empty, Signature.ofVars] using hSwf f spec hlookup
-        have hid_wf : FiniteSubst.id.wf st_args.decls := FiniteSubst.id_wf st_args.decls
-        have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
-          intro p hp
-          have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
-          exact hsargs_wf _ hp''
-        have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
-            (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
-        have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
-          (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
-          hwf_pred
-          (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
-          hid_wf htypedArgs_wf hcall_eval
-          (fun v st' ρ' t hΨ hwf heval hty =>
-            hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval (hret_eq ▸ hty))
-        obtain ⟨hsub_ty, happly⟩ := hcall
-        have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
-          simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
-        have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
-          TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
-        have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args.env) = vs := by
-          have hsnd :
-              List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
-            simpa using
-              (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
-                (Nat.le_of_eq hlen_typed.symm))
-          calc
-            typedArgs.map (fun p => p.2.eval ρ_args.env)
-                = sargs.map (fun t => t.eval ρ_args.env) := by
-                    simpa [typedArgs, List.map_map] using
-                      congrArg (List.map (fun t => t.eval ρ_args.env)) hsnd
-            _ = vs := Terms.Eval.map_eval heval_sargs
-        have happly' :
-            st_args.sl ρ_args ∗ R ⊢
-              PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
-                (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
-          rw [heval_sargs_map] at happly
-          exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
-            Spec.argsEnv_agreeOn (Δ := Signature.empty)
-              (ρ₁ := VerifM.Env.withEnv ρ_args (FiniteSubst.id.subst.eval ρ_args.env))
-              (ρ₂ := VerifM.Env.empty)
-              (by exact ⟨nofun, nofun, nofun, nofun⟩) spec.args vs
-              (by have := htyped.length_eq; simp [List.length_map] at this; omega)
-        have happly'' :
+            · iexact Hspec
+            · iexact HR
+      refine hctx.trans <| ihArgs Θ (spec.isPrecondFor Θ fval ∗ R) S B Γ st ρ γ _ _
+        (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hSwf ?_
+      intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
+      obtain ⟨_, _, hΨ_args⟩ := hΨ_args
+      let typedArgs := (args.map Expr.ty).zip sargs
+      have hlen_sargs : sargs.length = vs.length := by
+        simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
+      have hlen_typed : (args.map Expr.ty).length = sargs.length := by
+        calc
+          (args.map Expr.ty).length = vs.length := by simpa using htyping_args.length_eq.symm
+          _ = sargs.length := hlen_sargs.symm
+      obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
+      obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
+      have hwf_pred : spec.pred.wfIn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars spec.args)) := by
+        simpa [Spec.wfIn, FiniteSubst.id, Signature.empty, Signature.ofVars] using hSwf f spec hlookup
+      have hid_wf : FiniteSubst.id.wf st_args.decls := FiniteSubst.id_wf st_args.decls
+      have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
+        intro p hp
+        have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
+        exact hsargs_wf _ hp''
+      have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
+          (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
+      have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
+        (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
+        hwf_pred
+        (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
+        hid_wf htypedArgs_wf hcall_eval
+        (fun v st' ρ' t hΨ hwf heval hty =>
+          hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval (hret_eq ▸ hty))
+      obtain ⟨hsub_ty, happly⟩ := hcall
+      have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
+        simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
+      have htyped : TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) :=
+        TinyML.ValsHaveTypes_sub htyping_args hsub_ty'
+      have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args.env) = vs := by
+        have hsnd :
+            List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
+          simpa using
+            (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
+              (Nat.le_of_eq hlen_typed.symm))
+        calc
+          typedArgs.map (fun p => p.2.eval ρ_args.env)
+              = sargs.map (fun t => t.eval ρ_args.env) := by
+                  simpa [typedArgs, List.map_map] using
+                    congrArg (List.map (fun t => t.eval ρ_args.env)) hsnd
+          _ = vs := Terms.Eval.map_eval heval_sargs
+      have happly' :
+          st_args.sl ρ_args ∗ R ⊢
+            PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
+              (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
+        rw [heval_sargs_map] at happly
+        exact happly.trans <| PredTrans.apply_env_agree hwf_pred <|
+          Spec.argsEnv_agreeOn (Δ := Signature.empty)
+            (ρ₁ := VerifM.Env.withEnv ρ_args (FiniteSubst.id.subst.eval ρ_args.env))
+            (ρ₂ := VerifM.Env.empty)
+            (by exact ⟨nofun, nofun, nofun, nofun⟩) spec.args vs
+            (by have := htyped.length_eq; simp [List.length_map] at this; omega)
+      have happly'' :
+          st_args.sl ρ_args ∗
+              (S.satisfiedBy Θ γ ∗ R) ⊢
+            PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
+              (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
+        have hdrop :
             st_args.sl ρ_args ∗
                 (S.satisfiedBy Θ γ ∗ R) ⊢
-              PredTrans.apply (fun r => ⌜TinyML.ValHasType Θ r spec.retTy⌝ -∗ Φ r) spec.pred
-                (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
-          have hdrop :
-              st_args.sl ρ_args ∗
-                  (S.satisfiedBy Θ γ ∗ R) ⊢
-                st_args.sl ρ_args ∗ R := by
-            simpa [sep_assoc] using
-              (SpecMap.satisfiedBy_drop
-                (A := st_args.sl ρ_args)
-                (Θ := Θ) (S := S) (γ := γ)
-                (R := R))
-          exact hdrop.trans happly'
-        refine SpatialContext.wp_val ?_
-        unfold Spec.isPrecondFor
-        istart
-        iintro ⟨Howns, □HS, □Hspec, HR⟩
-        ispecialize Hspec $$ %Φ
-        ispecialize Hspec $$ %vs
-        iapply Hspec
-        · ipure_intro
-          exact htyped
-        · iapply happly''
-          isplitl [Howns]
-          · iexact Howns
-          · isplitl []
-            · iexact HS
-            · iexact HR
-    | _ =>
-      simp only [compile] at heval
-      exact (VerifM.eval_fatal heval).elim
-  | tuple es =>
-    simp only [Expr.ty] at hpost
-    unfold Expr.runtime
-    simp only [Runtime.Expr.subst, List.map_map]
+              st_args.sl ρ_args ∗ R := by
+          simpa [sep_assoc] using
+            (SpecMap.satisfiedBy_drop
+              (A := st_args.sl ρ_args)
+              (Θ := Θ) (S := S) (γ := γ)
+              (R := R))
+        exact hdrop.trans happly'
+      refine SpatialContext.wp_val ?_
+      unfold Spec.isPrecondFor
+      istart
+      iintro ⟨Howns, □HS, □Hspec, HR⟩
+      ispecialize Hspec $$ %Φ
+      ispecialize Hspec $$ %vs
+      iapply Hspec
+      · ipure_intro
+        exact htyped
+      · iapply happly''
+        isplitl [Howns]
+        · iexact Howns
+        · isplitl []
+          · iexact HS
+          · iexact HR
+  | _ =>
     simp only [compile] at heval
-    have heval_es : (compileExprs Θ S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_tuple <| compileExprs_correct es Θ R S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hSwf ?_
-    intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
-    obtain ⟨_, _, hΨ⟩ := hΨ
-    obtain hΨ := VerifM.eval_ret hΨ
-    have heval_tuple : (Term.unop .ofValList (Terms.toValList terms)).eval ρ'.env = Runtime.Val.tuple vs := by
-      simp [Term.eval, UnOp.eval, Terms.toValList_eval heval_terms]
-    have hwf_tuple : (Term.unop UnOp.ofValList (Terms.toValList terms)).wfIn st'.decls := by
-      simp only [Term.wfIn]
-      exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
-    exact SpecMap.satisfiedBy_drop.trans <| SpatialContext.wp_tuple <|
-      hpost (Runtime.Val.tuple vs) ρ' st' (.unop .ofValList (Terms.toValList terms))
-        hΨ hwf_tuple heval_tuple (.tuple htyping)
-  | match_ scrut branches ty =>
-    simp only [Expr.ty] at hpost
-    unfold Expr.runtime
-    simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
-    simp only [compile] at heval
-    have heval_scrut : (compile Θ S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_match <| SpecMap.satisfiedBy_dup.trans <|
-      compile_correct scrut Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
-        (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hSwf ?_
-    intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se htype_scrut
-    obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
-    cases hscrut_ty : scrut.ty with
-    | unit | bool | int | arrow _ _ | ref _ | empty | value | tuple _ | tvar _ | named _ _ =>
-      simp only [hscrut_ty] at hΨ_scrut
-      exact (VerifM.eval_fatal hΨ_scrut).elim
-    | sum ts =>
-      simp [hscrut_ty] at hΨ_scrut htype_scrut
-      by_cases hlen : ts.length ≠ branches.length
-      · simp [hlen] at hΨ_scrut
-        exact (VerifM.eval_fatal hΨ_scrut).elim
-      · push_neg at hlen
-        by_cases htys : ∀ br ∈ branches, br.2.ty = ty
-        · have hΨ_scrut' :
-              (do
-                let i ← VerifM.all (List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length)
-                match (compileBranches Θ S B Γ se_scrut ts branches 0)[i]? with
-                | some m => m
-                | none => VerifM.fatal "match branch index out of range").eval st_scrut ρ_scrut Ψ := by
-            simpa [if_pos hlen, if_pos htys] using hΨ_scrut
-          have hcb := compileBranches_spec Θ S B Γ se_scrut ts branches 0
-          have hactions_len := hcb.1
-          have heval_all := VerifM.eval_bind _ _ _ _ hΨ_scrut'
-          have hall := VerifM.eval_all heval_all
-          cases htype_scrut with
-          | inj ht_tag htype_payload =>
-            rename_i tag ty_payload v_payload
-            have htag_bound : tag < ts.length := by
-              exact (List.getElem?_eq_some_iff.mp ht_tag).1
-            have htag_branches : tag < branches.length := hlen ▸ htag_bound
-            have htag_range : tag ∈ List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length := by
-              rw [hactions_len]
-              exact List.mem_range.mpr htag_branches
-            have heval_tag := hall tag htag_range
-            have hcb_get := hcb.2 tag htag_branches
-            simp [hcb_get, show branches[tag]? = some branches[tag] from
-              List.getElem?_eq_some_iff.mpr ⟨htag_branches, rfl⟩] at heval_tag
-            have hty_eq : ts[tag]?.getD .value = ty_payload := by
-              simp [ht_tag]
-            rw [hty_eq] at heval_tag
-            have hagree_scrut := Bindings.agreeOnLinked_env_agree hagree hagreeOn_scrut hbwf
-            have hbwf_scrut : B.wf st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
-            have hbranch_wp := compileBranches_correct branches Θ R S B Γ se_scrut ts.length ts 0
-              st_scrut ρ_scrut γ Ψ Φ
-              hagree_scrut hbwf_scrut hts hSwf hse_wf
-              (fun j hj v ρ' st' se hΨ hse_wf hse_eval htyped =>
-                SpecMap.satisfiedBy_drop.trans <| hpost v ρ' st' se hΨ hse_wf hse_eval
-                  ((htys (branches[j]) (List.getElem_mem _)) ▸ htyped))
-              tag htag_branches (by simpa [Nat.zero_add, hty_eq] using heval_tag)
-            have hsc_eval : se_scrut.eval ρ_scrut.env = Runtime.Val.inj tag ts.length v_payload :=
-              heval_se
-            have hpayload_ty : TinyML.ValHasType Θ v_payload (ts[tag]?.getD .value) := by
-              simpa [hty_eq] using htype_payload
-            have hbranch := hbranch_wp v_payload ((Nat.zero_add tag).symm ▸ hsc_eval)
-              ((Nat.zero_add tag).symm ▸ hpayload_ty)
-            exact SpatialContext.wp_match
-              (by simpa [Nat.zero_add] using hbranch)
-              (by simp [htag_branches])
-        · have hΨ_bad : (VerifM.fatal "match branch type annotation mismatch").eval st_scrut ρ_scrut Ψ := by
-            simpa [if_pos hlen, if_neg htys] using hΨ_scrut
-          exact (VerifM.eval_fatal hΨ_bad).elim
+    exact (VerifM.eval_fatal heval).elim
 
-theorem compileBranch_correct (branch : Binder × Expr) : correctBranch branch := by
-  intro Θ R S B Γ sc n i ty_i st ρ γ Ψ Φ
-  intro heval hagree hbwf hts hSwf hsc_wf hpost payload hsc_eval htype_payload
-  obtain ⟨binder, body⟩ := branch
+theorem compileTuple_correct (es : List Expr)
+    (ihEs : correctExprs es) :
+    correctExpr (.tuple es) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  simp only [Expr.ty] at hpost
+  unfold Expr.runtime
+  simp only [Runtime.Expr.subst, List.map_map]
+  simp only [compile] at heval
+  have heval_es : (compileExprs Θ S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_tuple <| ihEs Θ R S B Γ st ρ γ _ _
+    (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hSwf ?_
+  intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
+  obtain ⟨_, _, hΨ⟩ := hΨ
+  obtain hΨ := VerifM.eval_ret hΨ
+  have heval_tuple : (Term.unop .ofValList (Terms.toValList terms)).eval ρ'.env = Runtime.Val.tuple vs := by
+    simp [Term.eval, UnOp.eval, Terms.toValList_eval heval_terms]
+  have hwf_tuple : (Term.unop UnOp.ofValList (Terms.toValList terms)).wfIn st'.decls := by
+    simp only [Term.wfIn]
+    exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
+  exact SpecMap.satisfiedBy_drop.trans <| SpatialContext.wp_tuple <|
+    hpost (Runtime.Val.tuple vs) ρ' st' (.unop .ofValList (Terms.toValList terms))
+      hΨ hwf_tuple heval_tuple (.tuple htyping)
+
+theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (ty : TinyML.Typ)
+    (ihScrut : correctExpr scrut) (ihBranches : correctBranches branches) :
+    correctExpr (.match_ scrut branches ty) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  simp only [Expr.ty] at hpost
+  unfold Expr.runtime
+  simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
+  simp only [compile] at heval
+  have heval_scrut : (compile Θ S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_match <| SpecMap.satisfiedBy_dup.trans <|
+    ihScrut Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hSwf ?_
+  intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se htype_scrut
+  obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
+  cases hscrut_ty : scrut.ty with
+  | unit | bool | int | arrow _ _ | ref _ | empty | value | tuple _ | tvar _ | named _ _ =>
+    simp only [hscrut_ty] at hΨ_scrut
+    exact (VerifM.eval_fatal hΨ_scrut).elim
+  | sum ts =>
+    simp [hscrut_ty] at hΨ_scrut htype_scrut
+    by_cases hlen : ts.length ≠ branches.length
+    · simp [hlen] at hΨ_scrut
+      exact (VerifM.eval_fatal hΨ_scrut).elim
+    · push_neg at hlen
+      by_cases htys : ∀ br ∈ branches, br.2.ty = ty
+      · have hΨ_scrut' :
+            (do
+              let i ← VerifM.all (List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length)
+              match (compileBranches Θ S B Γ se_scrut ts branches 0)[i]? with
+              | some m => m
+              | none => VerifM.fatal "match branch index out of range").eval st_scrut ρ_scrut Ψ := by
+          simpa [if_pos hlen, if_pos htys] using hΨ_scrut
+        have hcb := compileBranches_spec Θ S B Γ se_scrut ts branches 0
+        have hactions_len := hcb.1
+        have heval_all := VerifM.eval_bind _ _ _ _ hΨ_scrut'
+        have hall := VerifM.eval_all heval_all
+        cases htype_scrut with
+        | inj ht_tag htype_payload =>
+          rename_i tag ty_payload v_payload
+          have htag_bound : tag < ts.length := by
+            exact (List.getElem?_eq_some_iff.mp ht_tag).1
+          have htag_branches : tag < branches.length := hlen ▸ htag_bound
+          have htag_range : tag ∈ List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length := by
+            rw [hactions_len]
+            exact List.mem_range.mpr htag_branches
+          have heval_tag := hall tag htag_range
+          have hcb_get := hcb.2 tag htag_branches
+          simp [hcb_get, show branches[tag]? = some branches[tag] from
+            List.getElem?_eq_some_iff.mpr ⟨htag_branches, rfl⟩] at heval_tag
+          have hty_eq : ts[tag]?.getD .value = ty_payload := by
+            simp [ht_tag]
+          rw [hty_eq] at heval_tag
+          have hagree_scrut := Bindings.agreeOnLinked_env_agree hagree hagreeOn_scrut hbwf
+          have hbwf_scrut : B.wf st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
+          have hbranch_wp := ihBranches Θ R S B Γ se_scrut ts.length ts 0
+            st_scrut ρ_scrut γ Ψ Φ
+            hagree_scrut hbwf_scrut hts hSwf hse_wf
+            (fun j hj v ρ' st' se hΨ hse_wf hse_eval htyped =>
+              SpecMap.satisfiedBy_drop.trans <| hpost v ρ' st' se hΨ hse_wf hse_eval
+                ((htys (branches[j]) (List.getElem_mem _)) ▸ htyped))
+            tag htag_branches (by simpa [Nat.zero_add, hty_eq] using heval_tag)
+          have hsc_eval : se_scrut.eval ρ_scrut.env = Runtime.Val.inj tag ts.length v_payload :=
+            heval_se
+          have hpayload_ty : TinyML.ValHasType Θ v_payload (ts[tag]?.getD .value) := by
+            simpa [hty_eq] using htype_payload
+          have hbranch := hbranch_wp v_payload ((Nat.zero_add tag).symm ▸ hsc_eval)
+            ((Nat.zero_add tag).symm ▸ hpayload_ty)
+          exact SpatialContext.wp_match
+            (by simpa [Nat.zero_add] using hbranch)
+            (by simp [htag_branches])
+      · have hΨ_bad : (VerifM.fatal "match branch type annotation mismatch").eval st_scrut ρ_scrut Ψ := by
+          simpa [if_pos hlen, if_neg htys] using hΨ_scrut
+        exact (VerifM.eval_fatal hΨ_bad).elim
+
+theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
+    (ihBody : correctExpr body) :
+    correctBranch (binder, body) := by
+  intro Θ R S B Γ sc n i ty_i st ρ γ Ψ Φ heval hagree hbwf hts hSwf hsc_wf hpost payload hsc_eval htype_payload
   simp only [compileBranch] at heval
   by_cases hty : binder.ty = ty_i
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
@@ -1326,7 +1376,7 @@ theorem compileBranch_correct (branch : Binder × Expr) : correctBranch branch :
       simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left]
       exact (sep_mono_l hinterp_eq).trans <| SpecMap.satisfiedBy_dup.trans <| (hst₂_owns_eq ▸
         by simpa [Runtime.Subst.update] using
-          compile_correct body Θ (S.satisfiedBy Θ γ ∗ R) S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
+          ihBody Θ (S.satisfiedBy Θ γ ∗ R) S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
             heval_body'' hagree₁ hbwf₁ hts₁ hSwf
             (fun v ρ' st' se hΨ hs hw ht =>
               by simpa [hty] using hpost v ρ' st' se hΨ hs hw ht))
@@ -1365,7 +1415,7 @@ theorem compileBranch_correct (branch : Binder × Expr) : correctBranch branch :
       exact (sep_mono_l hinterp_eq).trans <| SpecMap.satisfiedBy_dup.trans <|
         (SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase).trans <| by
           simpa [hst₂_owns_eq, Runtime.Subst.update] using
-          compile_correct body Θ (S.satisfiedBy Θ γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
+          ihBody Θ (S.satisfiedBy Θ γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
             (Runtime.Subst.update γ x payload) Ψ Φ heval_body'' hagree₁ hbwf₂ hts₁
             (SpecMap.wfIn_erase hSwf)
             (fun v ρ' st' se hΨ hs hw ht =>
@@ -1373,72 +1423,126 @@ theorem compileBranch_correct (branch : Binder × Expr) : correctBranch branch :
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
     exact False.elim (hty (VerifM.eval_expectEq hexpect).1)
 
+theorem compileBranchesCons_correct (b : Binder × Expr) (bs : List (Binder × Expr))
+    (ihHead : correctBranch b) (ihTail : correctBranches bs) :
+    correctBranches (b :: bs) := by
+  intro Θ R S B Γ sc n ts idx st ρ γ Ψ Φ hagree hbwf hts hSwf hsc_wf hpost j hj
+  cases j with
+  | zero =>
+    simp only [Nat.add_zero, List.getElem_cons_zero]
+    intro heval
+    exact ihHead Θ R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
+      heval hagree hbwf hts hSwf hsc_wf (by simpa using hpost 0 hj)
+  | succ k =>
+    have hk : k < bs.length := by simp at hj; omega
+    have hidx : idx + (k + 1) = (idx + 1) + k := by omega
+    simp only [hidx, List.getElem_cons_succ]
+    exact ihTail Θ R S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
+      hagree hbwf hts hSwf hsc_wf
+      (by
+        intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
+        simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
+      k hk
+
+theorem compileExprsCons_correct (e : Expr) (rest : List Expr)
+    (ihE : correctExpr e) (ihRest : correctExprs rest) :
+    correctExprs (e :: rest) := by
+  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
+  simp only [compileExprs] at heval
+  simp only [List.map, wps_cons]
+  have heval_rest : (compileExprs Θ S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpecMap.satisfiedBy_dup.trans <|
+    ihRest Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
+      (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hSwf ?_
+  intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
+  obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
+  have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
+    Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
+  have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
+  have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
+  refine ihE Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st_vs ρ_vs γ _ _
+    (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hSwf ?_
+  intro v ρ' st' se hΨ_e hse_wf heval_se htyping_e
+  obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
+  have hwfst' : st'.decls.wf := (VerifM.eval.wf hΨ_e).namesDisjoint
+  obtain hΨ_e := VerifM.eval_ret hΨ_e
+  have hwf_cons : ∀ t ∈ se :: rest_terms, t.wfIn st'.decls := by
+    intro t ht
+    simp only [List.mem_cons] at ht
+    rcases ht with rfl | ht
+    · exact hse_wf
+    · exact Term.wfIn_mono _ (hwf_rest t ht) hdecls_e hwfst'
+  have heval_cons : Terms.Eval ρ'.env (se :: rest_terms) (v :: vs) :=
+    Terms.Eval.cons heval_se
+      (Terms.Eval.env_agree
+        (fun t ht => hwf_rest t ht)
+        hagreeOn_e
+        heval_rest)
+  exact hpost (v :: vs) ρ' st' (se :: rest_terms) hΨ_e hwf_cons heval_cons (.cons htyping_e htyping_vs)
+
+
+/-! #### Correctness Theorem -/
+
+mutual
+theorem compile_correct_core (e : Expr) : correctExpr e := by
+  cases e with
+  | const c =>
+    simpa using compileConst_correct c
+  | var x vty =>
+    simpa using compileVar_correct x vty
+  | inj tag arity payload =>
+    simpa using compileInj_correct tag arity payload (compile_correct_core payload)
+  | cast e ty =>
+    simpa using compileCast_correct e ty (compile_correct_core e)
+  | assert e =>
+    simpa using compileAssert_correct e (compile_correct_core e)
+  | fix self args retTy body =>
+    simpa using compileFix_correct self args retTy body
+  | ref e =>
+    simpa using compileRef_correct e (compile_correct_core e)
+  | deref e ty =>
+    simpa using compileDeref_correct e ty (compile_correct_core e)
+  | store loc val =>
+    simpa using compileStore_correct loc val (compile_correct_core val) (compile_correct_core loc)
+  | unop op e uty =>
+    simpa using compileUnop_correct op e uty (compile_correct_core e)
+  | binop op l r bty =>
+    simpa using compileBinop_correct op l r bty (compile_correct_core r) (compile_correct_core l)
+  | letIn b e body =>
+    simpa using compileLetIn_correct b e body (compile_correct_core e) (compile_correct_core body)
+  | ifThenElse cond thn els ty =>
+    simpa using compileIfThenElse_correct cond thn els ty
+      (compile_correct_core cond) (compile_correct_core thn) (compile_correct_core els)
+  | app fn args aty =>
+    simpa using compileApp_correct fn args aty (compileExprs_correct args)
+  | tuple es =>
+    simpa using compileTuple_correct es (compileExprs_correct es)
+  | match_ scrut branches ty =>
+    simpa using compileMatch_correct scrut branches ty
+      (compile_correct_core scrut) (compileBranches_correct branches)
+
+theorem compileBranch_correct (branch : Binder × Expr) : correctBranch branch := by
+  obtain ⟨binder, body⟩ := branch
+  simpa using compileSingleBranch_correct binder body (compile_correct_core body)
+
 theorem compileBranches_correct (branches : List (Binder × Expr)) : correctBranches branches := by
-  intro Θ R S B Γ sc n ts idx st ρ γ Ψ Φ
-  intro hagree hbwf hts hSwf hsc_wf hpost
   match branches with
   | [] =>
-    intro j hj
+    intro Θ R S B Γ sc n ts idx st ρ γ Ψ Φ hagree hbwf hts hSwf hsc_wf hpost j hj
     exact absurd hj (Nat.not_lt_zero _)
   | b :: bs =>
-    intro j hj
-    cases j with
-    | zero =>
-      simp only [Nat.add_zero, List.getElem_cons_zero]
-      intro heval
-      exact compileBranch_correct b Θ R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
-        heval hagree hbwf hts hSwf hsc_wf (by simpa using hpost 0 hj)
-    | succ k =>
-      have hk : k < bs.length := by simp at hj; omega
-      have hidx : idx + (k + 1) = (idx + 1) + k := by omega
-      simp only [hidx, List.getElem_cons_succ]
-      exact compileBranches_correct bs Θ R S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
-        hagree hbwf hts hSwf hsc_wf
-        (by
-          intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
-          simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
-        k hk
+    simpa using compileBranchesCons_correct b bs
+      (compileBranch_correct b) (compileBranches_correct bs)
 
 theorem compileExprs_correct (es : List Expr) : correctExprs es := by
-  intro Θ R S B Γ st ρ γ Ψ Φ
-  intro heval hagree hbwf hts hSwf hpost
   match es with
   | [] =>
+    intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hts hSwf hpost
     simp only [compileExprs] at heval
     simp only [List.map, wps]
     obtain heval := VerifM.eval_ret heval
     exact hpost [] ρ st [] heval (by simp) .nil .nil
   | e :: rest =>
-    simp only [compileExprs] at heval
-    simp only [List.map, wps_cons]
-    have heval_rest : (compileExprs Θ S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpecMap.satisfiedBy_dup.trans <|
-      compileExprs_correct rest Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
-        (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hSwf ?_
-    intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
-    obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
-    have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
-      Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
-    have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
-    have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
-    refine compile_correct e Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st_vs ρ_vs γ _ _
-      (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hSwf ?_
-    intro v ρ' st' se hΨ_e hse_wf heval_se htyping_e
-    obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
-    have hwfst' : st'.decls.wf := (VerifM.eval.wf hΨ_e).namesDisjoint
-    obtain hΨ_e := VerifM.eval_ret hΨ_e
-    have hwf_cons : ∀ t ∈ se :: rest_terms, t.wfIn st'.decls := by
-      intro t ht
-      simp only [List.mem_cons] at ht
-      rcases ht with rfl | ht
-      · exact hse_wf
-      · exact Term.wfIn_mono _ (hwf_rest t ht) hdecls_e hwfst'
-    have heval_cons : Terms.Eval ρ'.env (se :: rest_terms) (v :: vs) :=
-      Terms.Eval.cons heval_se
-        (Terms.Eval.env_agree
-          (fun t ht => hwf_rest t ht)
-          hagreeOn_e
-          heval_rest)
-    exact hpost (v :: vs) ρ' st' (se :: rest_terms) hΨ_e hwf_cons heval_cons (.cons htyping_e htyping_vs)
-
+    simpa using compileExprsCons_correct e rest
+      (compile_correct_core e) (compileExprs_correct rest)
 end

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -339,10 +339,10 @@ theorem SpecMap.satisfiedBy_weaken {A R : iProp}
 
 /-! ### Correctness -/
 
-mutual
 
-theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) :
+def correctExpr (e : Expr) : Prop :=
+  ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+  (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
     VerifM.eval (compile Θ S B Γ e) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wf st.decls →
@@ -350,7 +350,66 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     S.wfIn Signature.empty →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
       TinyML.ValHasType Θ v e.ty → st'.sl ρ' ∗ R ⊢ Φ v) →
-    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ := by
+    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ
+
+def correctBranch (branch : Binder × Expr) : Prop :=
+  ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
+    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop)
+    (Φ : Runtime.Val → iProp),
+    VerifM.eval (compileBranch Θ S B Γ sc n i ty_i branch) st ρ Ψ →
+    B.agreeOnLinked ρ.env γ →
+    B.wf st.decls →
+    B.typedSubst Θ Γ γ →
+    S.wfIn Signature.empty →
+    sc.wfIn st.decls →
+    (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
+      se.eval ρ'.env = v → TinyML.ValHasType Θ v branch.2.ty → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+    ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
+      TinyML.ValHasType Θ payload ty_i →
+      st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
+
+def correctBranches (branches : List (Binder × Expr)) : Prop :=
+  ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (sc : Term .value) (n : Nat) (ts : List TinyML.Typ) (idx : Nat)
+    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : Term .value → TransState → VerifM.Env → Prop)
+    (Φ : Runtime.Val → iProp),
+    B.agreeOnLinked ρ.env γ →
+    B.wf st.decls →
+    B.typedSubst Θ Γ γ →
+    S.wfIn Signature.empty →
+    sc.wfIn st.decls →
+    (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
+      se.eval ρ'.env = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+    ∀ (j : Nat) (hj : j < branches.length),
+      VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
+      ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
+        TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
+        st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
+
+def correctExprs (es : List Expr) : Prop :=
+  ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Ψ : List (Term .value) → TransState → VerifM.Env → Prop)
+    (Φ : List Runtime.Val → iProp),
+    VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
+    B.agreeOnLinked ρ.env γ →
+    B.wf st.decls →
+    B.typedSubst Θ Γ γ →
+    S.wfIn Signature.empty →
+    (∀ vs ρ' st' terms, Ψ terms st' ρ' →
+      (∀ t ∈ terms, t.wfIn st'.decls) →
+      Terms.Eval ρ'.env terms vs →
+      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
+    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ
+
+
+mutual
+
+theorem compile_correct  (e : Expr) : correctExpr e := by
+  intro Θ R S B Γ st ρ γ Ψ Φ
   intro heval hagree hbwf hts hSwf hpost
   cases e with
   | const c =>
@@ -427,7 +486,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     · push_neg at htag
       simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
       have heval_p : (compile Θ S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine SpatialContext.wp_bind_inj <| compile_correct Θ R payload S B Γ st ρ γ _ _
+      refine SpatialContext.wp_bind_inj <| compile_correct payload Θ R S B Γ st ρ γ _ _
         (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hts hSwf ?_
       intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p htype_p
       obtain ⟨hdecls_p, hagreeOn_p, hΨ_p⟩ := hΨ_p
@@ -447,7 +506,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     simp [Expr.runtime]
-    refine compile_correct Θ R e S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
+    refine compile_correct e Θ R S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v ρ' st' se hΨ hse_wf heval_se htype_v
     obtain ⟨_, _, hΨ⟩ := hΨ
     cases hsub : TinyML.Typ.sub Θ e.ty ty
@@ -461,7 +520,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_assert <| compile_correct Θ R e S B Γ st ρ γ _ _
+    refine SpatialContext.wp_bind_assert <| compile_correct e Θ R S B Γ st ρ γ _ _
       (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
@@ -489,7 +548,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     simp only [Expr.ty] at hpost
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_ref <| compile_correct Θ R e S B Γ st ρ γ _ _
+    refine SpatialContext.wp_bind_ref <| compile_correct e Θ R S B Γ st ρ γ _ _
       (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
     obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -538,7 +597,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     | int =>
       simp [hty] at heval hpost
       have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-      refine SpatialContext.wp_bind_deref <| compile_correct Θ R e S B Γ st ρ γ _ _
+      refine SpatialContext.wp_bind_deref <| compile_correct e Θ R S B Γ st ρ γ _ _
         (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
       intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se _htype_e
       obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -603,7 +662,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     obtain ⟨_hannot, heval⟩ := VerifM.eval_bind_expectEq heval
     have heval_v : (compile Θ S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_store <| (SpecMap.satisfiedBy_dup.trans <|
-      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) val S B Γ st ρ γ _ _
+      compile_correct val Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
         (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hts hSwf ?_)
     intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv htyv
     obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
@@ -611,7 +670,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
     have hbwf_v : B.wf st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
     have heval_l : (compile Θ S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
-    refine compile_correct Θ R loc S B Γ st₁ ρ_v γ _ _
+    refine compile_correct loc Θ R S B Γ st₁ ρ_v γ _ _
       (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hts hSwf ?_
     intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
     obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
@@ -668,7 +727,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     unfold Expr.runtime; simp only [Runtime.Expr.subst]
     simp only [compile] at heval
     have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_unop <| compile_correct Θ R e S B Γ st ρ γ _ _
+    refine SpatialContext.wp_bind_unop <| compile_correct e Θ R S B Γ st ρ γ _ _
       (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hts hSwf ?_
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se htype_e
     obtain ⟨_, _, hΨ_e⟩ := hΨ_e
@@ -690,7 +749,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     -- compile processes r first (matching runtime r-first evaluation order)
     have heval_r : (compile Θ S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_binop <| (SpecMap.satisfiedBy_dup).trans <|
-      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) r S B Γ st ρ γ _ _
+      compile_correct r Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
       (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hts hSwf ?_
     intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr htyr
     obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
@@ -698,7 +757,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
     have hbwf_r : B.wf st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
     have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
-    refine compile_correct Θ R l S B Γ st₁ ρ_r γ _ _
+    refine compile_correct l Θ R S B Γ st₁ ρ_r γ _ _
       (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hts hSwf ?_
     intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl htyl
     obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
@@ -814,7 +873,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     unfold Expr.runtime
     simp only [Runtime.Expr.letIn_subst]
     have heval_e_outer : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine (SpecMap.satisfiedBy_dup.trans <| compile_correct Θ (S.satisfiedBy Θ γ ∗ R) e S B Γ st ρ γ _ _
+    refine (SpecMap.satisfiedBy_dup.trans <| compile_correct e Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
       (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hts hSwf ?_).trans wp.letIn
     intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -824,7 +883,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     cases hname : b.name with
     | none =>
       simp [hname] at hΨ_e
-      have hbody := compile_correct Θ R body S B Γ st₁ ρ_e γ _ _
+      have hbody := compile_correct body Θ R S B Γ st₁ ρ_e γ _ _
         (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hts hSwf
         (fun v ρ' st' se hΨ hs hw ht =>
           let ⟨_, _, hΨ'⟩ := hΨ
@@ -916,7 +975,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         rwa [hρ_body_lookup] at h
       have hts_body : Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body :=
         Bindings.typedSubst_cons hts htyping_e
-      refine compile_correct Θ R body (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
+      refine compile_correct body Θ R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
         (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ hts_body
         (SpecMap.wfIn_erase hSwf) ?_
       intro v' ρ' st' se' hΨ hs hw ht
@@ -929,7 +988,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_cond : (compile Θ S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_if <| SpecMap.satisfiedBy_dup.trans <|
-      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) cond S B Γ st ρ γ _ _
+      compile_correct cond Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
       (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hts hSwf ?_
     intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c htypc
     obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
@@ -957,7 +1016,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         hfalse_cont hwf_eq (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_c)
-      exact SpatialContext.wp_if_false <| compile_correct Θ R els S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hSwf
+      exact SpatialContext.wp_if_false <| compile_correct els Θ R S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hts hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hels_ty ▸ ht))
     · have hvc_true : v_c = .bool true := by
         rw [hcond_bool] at htypc
@@ -971,7 +1030,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
         htrue_cont hwf_ne (by
           simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
           exact heval_ne)
-      exact SpatialContext.wp_if_true <| compile_correct Θ R thn S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hSwf
+      exact SpatialContext.wp_if_true <| compile_correct thn Θ R S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hts hSwf
         (fun v ρ' st' se hΨ hs hw ht => hpost v ρ' st' se hΨ hs hw (hthn_ty ▸ ht))
   | app fn args aty =>
     simp only [Expr.ty] at hpost
@@ -1001,7 +1060,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             · isplitl []
               · iexact Hspec
               · iexact HR
-        refine hctx.trans <| compileExprs_correct Θ (spec.isPrecondFor Θ fval ∗ R) args S B Γ st ρ γ _ _
+        refine hctx.trans <| compileExprs_correct args Θ (spec.isPrecondFor Θ fval ∗ R) S B Γ st ρ γ _ _
           (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hts hSwf ?_
         intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs htyping_args
         obtain ⟨_, _, hΨ_args⟩ := hΨ_args
@@ -1097,7 +1156,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [Runtime.Expr.subst, List.map_map]
     simp only [compile] at heval
     have heval_es : (compileExprs Θ S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_tuple <| compileExprs_correct Θ R es S B Γ st ρ γ _ _
+    refine SpatialContext.wp_bind_tuple <| compileExprs_correct es Θ R S B Γ st ρ γ _ _
       (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hts hSwf ?_
     intro vs ρ' st' terms hΨ hwf_terms heval_terms htyping
     obtain ⟨_, _, hΨ⟩ := hΨ
@@ -1117,7 +1176,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
     simp only [compile] at heval
     have heval_scrut : (compile Θ S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_match <| SpecMap.satisfiedBy_dup.trans <|
-      compile_correct Θ (S.satisfiedBy Θ γ ∗ R) scrut S B Γ st ρ γ _ _
+      compile_correct scrut Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
         (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hts hSwf ?_
     intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se htype_scrut
     obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
@@ -1161,7 +1220,7 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             rw [hty_eq] at heval_tag
             have hagree_scrut := Bindings.agreeOnLinked_env_agree hagree hagreeOn_scrut hbwf
             have hbwf_scrut : B.wf st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
-            have hbranch_wp := compileBranches_correct Θ R branches S B Γ se_scrut ts.length ts 0
+            have hbranch_wp := compileBranches_correct branches Θ R S B Γ se_scrut ts.length ts 0
               st_scrut ρ_scrut γ Ψ Φ
               hagree_scrut hbwf_scrut hts hSwf hse_wf
               (fun j hj v ρ' st' se hΨ hse_wf hse_eval htyped =>
@@ -1181,22 +1240,8 @@ theorem compile_correct (Θ : TinyML.TypeEnv) (R : iProp) (e : Expr) (S : SpecMa
             simpa [if_pos hlen, if_neg htys] using hΨ_scrut
           exact (VerifM.eval_fatal hΨ_bad).elim
 
-theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder × Expr) (S : SpecMap) (B : Bindings)
-    (Γ : TinyML.TyCtx) (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → VerifM.Env → Prop)
-    (Φ : Runtime.Val → iProp) :
-    VerifM.eval (compileBranch Θ S B Γ sc n i ty_i branch) st ρ Ψ →
-    B.agreeOnLinked ρ.env γ →
-    B.wf st.decls →
-    B.typedSubst Θ Γ γ →
-    S.wfIn Signature.empty →
-    sc.wfIn st.decls →
-    (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → TinyML.ValHasType Θ v branch.2.ty → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
-    ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
-      TinyML.ValHasType Θ payload ty_i →
-      st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ := by
+theorem compileBranch_correct (branch : Binder × Expr) : correctBranch branch := by
+  intro Θ R S B Γ sc n i ty_i st ρ γ Ψ Φ
   intro heval hagree hbwf hts hSwf hsc_wf hpost payload hsc_eval htype_payload
   obtain ⟨binder, body⟩ := branch
   simp only [compileBranch] at heval
@@ -1281,7 +1326,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       simp only [Runtime.Subst.update', Runtime.Subst.updateAll'_cons, Runtime.Subst.updateAll'_nil_left]
       exact (sep_mono_l hinterp_eq).trans <| SpecMap.satisfiedBy_dup.trans <| (hst₂_owns_eq ▸
         by simpa [Runtime.Subst.update] using
-          compile_correct Θ (S.satisfiedBy Θ γ ∗ R) body S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
+          compile_correct body Θ (S.satisfiedBy Θ γ ∗ R) S B (Γ.extendBinder binder ty_i) _ ρ₁ γ Ψ Φ
             heval_body'' hagree₁ hbwf₁ hts₁ hSwf
             (fun v ρ' st' se hΨ hs hw ht =>
               by simpa [hty] using hpost v ρ' st' se hΨ hs hw ht))
@@ -1320,7 +1365,7 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
       exact (sep_mono_l hinterp_eq).trans <| SpecMap.satisfiedBy_dup.trans <|
         (SpecMap.satisfiedBy_weaken SpecMap.satisfiedBy_erase).trans <| by
           simpa [hst₂_owns_eq, Runtime.Subst.update] using
-          compile_correct Θ (S.satisfiedBy Θ γ ∗ R) body (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
+          compile_correct body Θ (S.satisfiedBy Θ γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) _ ρ₁
             (Runtime.Subst.update γ x payload) Ψ Φ heval_body'' hagree₁ hbwf₂ hts₁
             (SpecMap.wfIn_erase hSwf)
             (fun v ρ' st' se hΨ hs hw ht =>
@@ -1328,24 +1373,8 @@ theorem compileBranch_correct (Θ : TinyML.TypeEnv) (R : iProp) (branch : Binder
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
     exact False.elim (hty (VerifM.eval_expectEq hexpect).1)
 
-theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : List (Binder × Expr)) (S : SpecMap) (B : Bindings)
-    (Γ : TinyML.TyCtx) (sc : Term .value) (n : Nat) (ts : List TinyML.Typ)
-    (idx : Nat)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-    (Ψ : Term .value → TransState → VerifM.Env → Prop)
-    (Φ : Runtime.Val → iProp) :
-    B.agreeOnLinked ρ.env γ →
-    B.wf st.decls →
-    B.typedSubst Θ Γ γ →
-    S.wfIn Signature.empty →
-    sc.wfIn st.decls →
-    (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → TinyML.ValHasType Θ v (branches[j]).2.ty → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
-    ∀ (j : Nat) (hj : j < branches.length),
-      VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
-      ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
-        TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) →
-        st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ := by
+theorem compileBranches_correct (branches : List (Binder × Expr)) : correctBranches branches := by
+  intro Θ R S B Γ sc n ts idx st ρ γ Ψ Φ
   intro hagree hbwf hts hSwf hsc_wf hpost
   match branches with
   | [] =>
@@ -1357,29 +1386,21 @@ theorem compileBranches_correct (Θ : TinyML.TypeEnv) (R : iProp) (branches : Li
     | zero =>
       simp only [Nat.add_zero, List.getElem_cons_zero]
       intro heval
-      exact compileBranch_correct Θ R b S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
+      exact compileBranch_correct b Θ R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
         heval hagree hbwf hts hSwf hsc_wf (by simpa using hpost 0 hj)
     | succ k =>
       have hk : k < bs.length := by simp at hj; omega
       have hidx : idx + (k + 1) = (idx + 1) + k := by omega
       simp only [hidx, List.getElem_cons_succ]
-      exact compileBranches_correct Θ R bs S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
+      exact compileBranches_correct bs Θ R S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
         hagree hbwf hts hSwf hsc_wf
         (by
           intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
           simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
         k hk
 
-theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-    (Ψ : List (Term .value) → TransState → VerifM.Env → Prop) (Φ : List Runtime.Val → iProp) :
-    VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
-    B.agreeOnLinked ρ.env γ → B.wf st.decls → B.typedSubst Θ Γ γ →
-    S.wfIn Signature.empty →
-    (∀ vs ρ' st' terms, Ψ terms st' ρ' →
-      (∀ t ∈ terms, t.wfIn st'.decls) →
-      Terms.Eval ρ'.env terms vs →
-      TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) → st'.sl ρ' ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
-    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ := by
+theorem compileExprs_correct (es : List Expr) : correctExprs es := by
+  intro Θ R S B Γ st ρ γ Ψ Φ
   intro heval hagree hbwf hts hSwf hpost
   match es with
   | [] =>
@@ -1392,7 +1413,7 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
     simp only [List.map, wps_cons]
     have heval_rest : (compileExprs Θ S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpecMap.satisfiedBy_dup.trans <|
-      compileExprs_correct Θ (S.satisfiedBy Θ γ ∗ R) rest S B Γ st ρ γ _ _
+      compileExprs_correct rest Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st ρ γ _ _
         (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hts hSwf ?_
     intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest htyping_vs
     obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
@@ -1400,7 +1421,7 @@ theorem compileExprs_correct (Θ : TinyML.TypeEnv) (R : iProp) (es : List Expr) 
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
     have hbwf_vs : B.wf st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
     have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
-    refine compile_correct Θ (S.satisfiedBy Θ γ ∗ R) e S B Γ st_vs ρ_vs γ _ _
+    refine compile_correct e Θ (S.satisfiedBy Θ γ ∗ R) S B Γ st_vs ρ_vs γ _ _
       (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hts hSwf ?_
     intro v ρ' st' se hΨ_e hse_wf heval_se htyping_e
     obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -1484,46 +1484,46 @@ theorem compileExprsCons_correct (e : Expr) (rest : List Expr)
 /-! #### Correctness Theorem -/
 
 mutual
-theorem compile_correct_core (e : Expr) : correctExpr e := by
+theorem compile_correct (e : Expr) : correctExpr e := by
   cases e with
   | const c =>
     simpa using compileConst_correct c
   | var x vty =>
     simpa using compileVar_correct x vty
   | inj tag arity payload =>
-    simpa using compileInj_correct tag arity payload (compile_correct_core payload)
+    simpa using compileInj_correct tag arity payload (compile_correct payload)
   | cast e ty =>
-    simpa using compileCast_correct e ty (compile_correct_core e)
+    simpa using compileCast_correct e ty (compile_correct e)
   | assert e =>
-    simpa using compileAssert_correct e (compile_correct_core e)
+    simpa using compileAssert_correct e (compile_correct e)
   | fix self args retTy body =>
     simpa using compileFix_correct self args retTy body
   | ref e =>
-    simpa using compileRef_correct e (compile_correct_core e)
+    simpa using compileRef_correct e (compile_correct e)
   | deref e ty =>
-    simpa using compileDeref_correct e ty (compile_correct_core e)
+    simpa using compileDeref_correct e ty (compile_correct e)
   | store loc val =>
-    simpa using compileStore_correct loc val (compile_correct_core val) (compile_correct_core loc)
+    simpa using compileStore_correct loc val (compile_correct val) (compile_correct loc)
   | unop op e uty =>
-    simpa using compileUnop_correct op e uty (compile_correct_core e)
+    simpa using compileUnop_correct op e uty (compile_correct e)
   | binop op l r bty =>
-    simpa using compileBinop_correct op l r bty (compile_correct_core r) (compile_correct_core l)
+    simpa using compileBinop_correct op l r bty (compile_correct r) (compile_correct l)
   | letIn b e body =>
-    simpa using compileLetIn_correct b e body (compile_correct_core e) (compile_correct_core body)
+    simpa using compileLetIn_correct b e body (compile_correct e) (compile_correct body)
   | ifThenElse cond thn els ty =>
     simpa using compileIfThenElse_correct cond thn els ty
-      (compile_correct_core cond) (compile_correct_core thn) (compile_correct_core els)
+      (compile_correct cond) (compile_correct thn) (compile_correct els)
   | app fn args aty =>
     simpa using compileApp_correct fn args aty (compileExprs_correct args)
   | tuple es =>
     simpa using compileTuple_correct es (compileExprs_correct es)
   | match_ scrut branches ty =>
     simpa using compileMatch_correct scrut branches ty
-      (compile_correct_core scrut) (compileBranches_correct branches)
+      (compile_correct scrut) (compileBranches_correct branches)
 
 theorem compileBranch_correct (branch : Binder × Expr) : correctBranch branch := by
   obtain ⟨binder, body⟩ := branch
-  simpa using compileSingleBranch_correct binder body (compile_correct_core body)
+  simpa using compileSingleBranch_correct binder body (compile_correct body)
 
 theorem compileBranches_correct (branches : List (Binder × Expr)) : correctBranches branches := by
   match branches with
@@ -1544,5 +1544,5 @@ theorem compileExprs_correct (es : List Expr) : correctExprs es := by
     exact hpost [] ρ st [] heval (by simp) .nil .nil
   | e :: rest =>
     simpa using compileExprsCons_correct e rest
-      (compile_correct_core e) (compileExprs_correct rest)
+      (compile_correct e) (compileExprs_correct rest)
 end

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -129,7 +129,7 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
   have hbody_wp :
       st'.sl ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Q) ⊢
         wp (body.runtime.subst γ_body) P := by
-    refine compile_correct Θ Q body S' B Γ st' ρ' γ_body _ _
+    refine compile_correct body Θ Q S' B Γ st' ρ' γ_body _ _
       (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hts hS'wf ?_
     intro v ρ'' st'' se hΨ hse_wf heval_se htyped
     obtain ⟨_, _, hΨ⟩ := hΨ

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -124,7 +124,7 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
   have hcomp :=
-    compile_correct Θ iprop(S.satisfiedBy Θ γ) d.body S [] TinyML.TyCtx.empty TransState.empty ρ γ
+    compile_correct d.body Θ iprop(S.satisfiedBy Θ γ) S [] TinyML.TyCtx.empty TransState.empty ρ γ
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => Φ)
     hcompile


### PR DESCRIPTION
This PR is a simple refactoring to break up the large `compile_correct` proof into per-case lemmas. One key benefit if this refactoring is that it is now much easier to see termination for Lean and future changes should not meaningfully affect termination checking. 