### PR TITLE
Uninterpreted predicates

### DIFF
--- a/Mica/Engine/State.lean
+++ b/Mica/Engine/State.lean
@@ -76,7 +76,9 @@ def allDecls (s : State) : Signature :=
   ⟨s.frames.flatMap (·.decls.vars),
    s.frames.flatMap (·.decls.consts),
    s.frames.flatMap (·.decls.unary),
-   s.frames.flatMap (·.decls.binary)⟩
+   s.frames.flatMap (·.decls.binary),
+   s.frames.flatMap (·.decls.unaryRel),
+   s.frames.flatMap (·.decls.binaryRel)⟩
 
 /-- All assertions active in the current state. -/
 def allAsserts (s : State) : List Formula :=

--- a/Mica/FOL/Formulas.lean
+++ b/Mica/FOL/Formulas.lean
@@ -46,20 +46,37 @@ def Formula.freeVars : Formula → List Var
 
 def UnPred.wfIn : UnPred τ → Signature → Prop
   | .uninterpreted name τ, Δ => ⟨name, τ⟩ ∈ Δ.unaryRel
+                                   ∧ (∀ τ₁ τ₂, ⟨name, τ₁, τ₂⟩ ∉ Δ.unary)
+                                   ∧ (∀ τ', ⟨name, τ'⟩ ∈ Δ.unaryRel → τ' = τ)
   | _, _                      => True
 
 def BinPred.wfIn : BinPred τ₁ τ₂ → Signature → Prop
   | .uninterpreted name τ₁ τ₂, Δ => ⟨name, τ₁, τ₂⟩ ∈ Δ.binaryRel
+                                      ∧ (∀ τ₁' τ₂' τ₃', ⟨name, τ₁', τ₂', τ₃'⟩ ∉ Δ.binary)
+                                      ∧ (∀ τ₁' τ₂', ⟨name, τ₁', τ₂'⟩ ∈ Δ.binaryRel →
+                                          τ₁' = τ₁ ∧ τ₂' = τ₂)
   | _, _                          => True
 
 def UnPred.checkWf : UnPred τ → Signature → Except String Unit
   | .uninterpreted name τ, Δ =>
-    if ⟨name, τ⟩ ∈ Δ.unaryRel then .ok () else .error s!"unary predicate {name} not in signature"
+    if ⟨name, τ⟩ ∈ Δ.unaryRel then
+      if Δ.unary.any (·.name == name) then
+        .error s!"unary predicate {name} conflicts with a unary operator"
+      else if Δ.unaryRel.any (fun u => u.name == name && u.arg != τ) then
+        .error s!"unary predicate {name} has multiple signatures in signature"
+      else .ok ()
+    else .error s!"unary predicate {name} not in signature"
   | _, _ => .ok ()
 
 def BinPred.checkWf : BinPred τ₁ τ₂ → Signature → Except String Unit
   | .uninterpreted name τ₁ τ₂, Δ =>
-    if ⟨name, τ₁, τ₂⟩ ∈ Δ.binaryRel then .ok () else .error s!"binary predicate {name} not in signature"
+    if ⟨name, τ₁, τ₂⟩ ∈ Δ.binaryRel then
+      if Δ.binary.any (·.name == name) then
+        .error s!"binary predicate {name} conflicts with a binary operator"
+      else if Δ.binaryRel.any (fun b => b.name == name && (b.arg1 != τ₁ || b.arg2 != τ₂)) then
+        .error s!"binary predicate {name} has multiple signatures in signature"
+      else .ok ()
+    else .error s!"binary predicate {name} not in signature"
   | _, _ => .ok ()
 
 def Formula.wfIn : Formula → Signature → Prop
@@ -94,7 +111,28 @@ private theorem UnPred.checkWf_ok {p : UnPred τ} {Δ : Signature}
   | uninterpreted name τ =>
     simp only [UnPred.checkWf] at h
     split at h
-    · assumption
+    · rename_i hmem
+      split at h
+      · simp at h
+      · rename_i hunary
+        split at h
+        · simp at h
+        · rename_i hdup
+          refine ⟨hmem, ?_, ?_⟩
+          · intro τ₁ τ₂ hu
+            have hany : (Δ.unary.any fun x => x.name == name) = true := by
+              apply List.any_eq_true.mpr
+              refine ⟨⟨name, τ₁, τ₂⟩, hu, ?_⟩
+              simp
+            exact hunary hany
+          · intro τ' hu'
+            by_cases hs : τ' = τ
+            · exact hs
+            · exfalso
+              apply hdup
+              apply List.any_eq_true.mpr
+              refine ⟨⟨name, τ'⟩, hu', ?_⟩
+              simp [hs]
     · simp at h
   | _ => trivial
 
@@ -104,7 +142,34 @@ private theorem BinPred.checkWf_ok {p : BinPred τ₁ τ₂} {Δ : Signature}
   | uninterpreted name τ₁ τ₂ =>
     simp only [BinPred.checkWf] at h
     split at h
-    · assumption
+    · rename_i hmem
+      split at h
+      · simp at h
+      · rename_i hbinary
+        split at h
+        · simp at h
+        · rename_i hdup
+          refine ⟨hmem, ?_, ?_⟩
+          · intro τ₁' τ₂' τ₃' hb
+            have hany : (Δ.binary.any fun x => x.name == name) = true := by
+              apply List.any_eq_true.mpr
+              refine ⟨⟨name, τ₁', τ₂', τ₃'⟩, hb, ?_⟩
+              simp
+            exact hbinary hany
+          · intro τ₁' τ₂' hb'
+            by_cases harg1 : τ₁' = τ₁
+            · by_cases harg2 : τ₂' = τ₂
+              · exact ⟨harg1, harg2⟩
+              · exfalso
+                apply hdup
+                apply List.any_eq_true.mpr
+                refine ⟨⟨name, τ₁', τ₂'⟩, hb', ?_⟩
+                simp [harg1, harg2]
+            · exfalso
+              apply hdup
+              apply List.any_eq_true.mpr
+              refine ⟨⟨name, τ₁', τ₂'⟩, hb', ?_⟩
+              simp [harg1]
     · simp at h
   | _ => trivial
 
@@ -134,24 +199,34 @@ theorem Formula.checkWf_ok {φ : Formula} {Δ : Signature} (h : φ.checkWf Δ = 
     exact ih h
 
 private theorem UnPred.wfIn_mono {p : UnPred τ} {Δ Δ' : Signature}
-    (h : p.wfIn Δ) (hsub : Δ.Subset Δ') : p.wfIn Δ' := by
+    (h : p.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : p.wfIn Δ' := by
   cases p with
-  | uninterpreted name τ => exact hsub.unaryRel _ h
+  | uninterpreted name τ =>
+    refine ⟨hsub.unaryRel _ h.1, ?_, ?_⟩
+    · intro τ₁ τ₂ hu
+      exact Signature.wf_no_unaryRel_of_unary hwf hu (hsub.unaryRel _ h.1)
+    · intro τ' hu'
+      exact Signature.wf_unique_unaryRel hwf (hsub.unaryRel _ h.1) hu'
   | _ => trivial
 
 private theorem BinPred.wfIn_mono {p : BinPred τ₁ τ₂} {Δ Δ' : Signature}
-    (h : p.wfIn Δ) (hsub : Δ.Subset Δ') : p.wfIn Δ' := by
+    (h : p.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : p.wfIn Δ' := by
   cases p with
-  | uninterpreted name τ₁ τ₂ => exact hsub.binaryRel _ h
+  | uninterpreted name τ₁ τ₂ =>
+    refine ⟨hsub.binaryRel _ h.1, ?_, ?_⟩
+    · intro τ₁' τ₂' τ₃' hb
+      exact Signature.wf_no_binaryRel_of_binary hwf hb (hsub.binaryRel _ h.1)
+    · intro τ₁' τ₂' hb'
+      exact Signature.wf_unique_binaryRel hwf (hsub.binaryRel _ h.1) hb'
   | _ => trivial
 
 theorem Formula.wfIn_mono (φ : Formula) (h : φ.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : φ.wfIn Δ' := by
   induction φ generalizing Δ Δ' with
   | true_ | false_ => trivial
   | eq _ t₁ t₂ => exact ⟨Term.wfIn_mono t₁ h.1 hsub hwf, Term.wfIn_mono t₂ h.2 hsub hwf⟩
-  | unpred p t => exact ⟨UnPred.wfIn_mono h.1 hsub, Term.wfIn_mono t h.2 hsub hwf⟩
+  | unpred p t => exact ⟨UnPred.wfIn_mono h.1 hsub hwf, Term.wfIn_mono t h.2 hsub hwf⟩
   | binpred p t₁ t₂ =>
-    exact ⟨BinPred.wfIn_mono h.1 hsub, Term.wfIn_mono t₁ h.2.1 hsub hwf, Term.wfIn_mono t₂ h.2.2 hsub hwf⟩
+    exact ⟨BinPred.wfIn_mono h.1 hsub hwf, Term.wfIn_mono t₁ h.2.1 hsub hwf, Term.wfIn_mono t₂ h.2.2 hsub hwf⟩
   | not φ ih => exact ih h hsub hwf
   | and φ ψ ihφ ihψ | or φ ψ ihφ ihψ | implies φ ψ ihφ ihψ =>
     exact ⟨ihφ h.1 hsub hwf, ihψ h.2 hsub hwf⟩
@@ -210,7 +285,7 @@ theorem Formula.eval_env_agree {φ : Formula} {ρ ρ' : Env} {Δ : Signature} :
     cases p with
     | uninterpreted name τ =>
       simp only [UnPred.eval]
-      have hrel := hagree.2.2.2.2.1 ⟨name, _⟩ hwf.1
+      have hrel := hagree.2.2.2.2.1 ⟨name, _⟩ hwf.1.1
       simp [hrel]
     | _ => rfl
   | binpred p a b =>
@@ -219,7 +294,7 @@ theorem Formula.eval_env_agree {φ : Formula} {ρ ρ' : Env} {Δ : Signature} :
     cases p with
     | uninterpreted name τ₁ τ₂ =>
       simp only [BinPred.eval]
-      have hrel := hagree.2.2.2.2.2 ⟨name, _, _⟩ hwf.1
+      have hrel := hagree.2.2.2.2.2 ⟨name, _, _⟩ hwf.1.1
       simp [hrel]
     | _ => rfl
   | not φ ih =>

--- a/Mica/FOL/Formulas.lean
+++ b/Mica/FOL/Formulas.lean
@@ -8,11 +8,13 @@ inductive UnPred : Srt → Type where
   | isLoc   : UnPred .value
   | isTuple : UnPred .value
   | isInj (tag : Nat) (arity : Nat) : UnPred .value
+  | uninterpreted : String → (τ : Srt) → UnPred τ
   deriving DecidableEq, Repr
 
 inductive BinPred : Srt → Srt → Type where
   | lt : BinPred .int .int
   | le : BinPred .int .int
+  | uninterpreted : String → (τ₁ τ₂ : Srt) → BinPred τ₁ τ₂
   deriving DecidableEq, Repr
 
 inductive Formula where
@@ -42,12 +44,30 @@ def Formula.freeVars : Formula → List Var
   | .forall_ y τ φ => φ.freeVars.filter (· != ⟨y, τ⟩)
   | .exists_ y τ φ => φ.freeVars.filter (· != ⟨y, τ⟩)
 
+def UnPred.wfIn : UnPred τ → Signature → Prop
+  | .uninterpreted name τ, Δ => ⟨name, τ⟩ ∈ Δ.unaryRel
+  | _, _                      => True
+
+def BinPred.wfIn : BinPred τ₁ τ₂ → Signature → Prop
+  | .uninterpreted name τ₁ τ₂, Δ => ⟨name, τ₁, τ₂⟩ ∈ Δ.binaryRel
+  | _, _                          => True
+
+def UnPred.checkWf : UnPred τ → Signature → Except String Unit
+  | .uninterpreted name τ, Δ =>
+    if ⟨name, τ⟩ ∈ Δ.unaryRel then .ok () else .error s!"unary predicate {name} not in signature"
+  | _, _ => .ok ()
+
+def BinPred.checkWf : BinPred τ₁ τ₂ → Signature → Except String Unit
+  | .uninterpreted name τ₁ τ₂, Δ =>
+    if ⟨name, τ₁, τ₂⟩ ∈ Δ.binaryRel then .ok () else .error s!"binary predicate {name} not in signature"
+  | _, _ => .ok ()
+
 def Formula.wfIn : Formula → Signature → Prop
   | .true_, _            => True
   | .false_, _           => True
   | .eq _ t₁ t₂, Δ      => t₁.wfIn Δ ∧ t₂.wfIn Δ
-  | .unpred _ t, Δ       => t.wfIn Δ
-  | .binpred _ t₁ t₂, Δ => t₁.wfIn Δ ∧ t₂.wfIn Δ
+  | .unpred p t, Δ       => p.wfIn Δ ∧ t.wfIn Δ
+  | .binpred p t₁ t₂, Δ => p.wfIn Δ ∧ t₁.wfIn Δ ∧ t₂.wfIn Δ
   | .not φ, Δ            => φ.wfIn Δ
   | .and φ ψ, Δ          => φ.wfIn Δ ∧ ψ.wfIn Δ
   | .or φ ψ, Δ           => φ.wfIn Δ ∧ ψ.wfIn Δ
@@ -59,14 +79,34 @@ def Formula.checkWf : Formula → Signature → Except String Unit
   | .true_, _            => .ok ()
   | .false_, _           => .ok ()
   | .eq _ t₁ t₂, Δ      => do t₁.checkWf Δ; t₂.checkWf Δ
-  | .unpred _ t, Δ       => t.checkWf Δ
-  | .binpred _ t₁ t₂, Δ => do t₁.checkWf Δ; t₂.checkWf Δ
+  | .unpred p t, Δ       => do p.checkWf Δ; t.checkWf Δ
+  | .binpred p t₁ t₂, Δ => do p.checkWf Δ; t₁.checkWf Δ; t₂.checkWf Δ
   | .not φ, Δ            => φ.checkWf Δ
   | .and φ ψ, Δ          => do φ.checkWf Δ; ψ.checkWf Δ
   | .or φ ψ, Δ           => do φ.checkWf Δ; ψ.checkWf Δ
   | .implies φ ψ, Δ      => do φ.checkWf Δ; ψ.checkWf Δ
   | .forall_ x τ φ, Δ    => φ.checkWf (Δ.declVar ⟨x, τ⟩)
   | .exists_ x τ φ, Δ    => φ.checkWf (Δ.declVar ⟨x, τ⟩)
+
+private theorem UnPred.checkWf_ok {p : UnPred τ} {Δ : Signature}
+    (h : p.checkWf Δ = .ok ()) : p.wfIn Δ := by
+  cases p with
+  | uninterpreted name τ =>
+    simp only [UnPred.checkWf] at h
+    split at h
+    · assumption
+    · simp at h
+  | _ => trivial
+
+private theorem BinPred.checkWf_ok {p : BinPred τ₁ τ₂} {Δ : Signature}
+    (h : p.checkWf Δ = .ok ()) : p.wfIn Δ := by
+  cases p with
+  | uninterpreted name τ₁ τ₂ =>
+    simp only [BinPred.checkWf] at h
+    split at h
+    · assumption
+    · simp at h
+  | _ => trivial
 
 theorem Formula.checkWf_ok {φ : Formula} {Δ : Signature} (h : φ.checkWf Δ = .ok ()) : φ.wfIn Δ := by
   induction φ generalizing Δ with
@@ -75,11 +115,15 @@ theorem Formula.checkWf_ok {φ : Formula} {Δ : Signature} (h : φ.checkWf Δ = 
     simp only [Formula.checkWf] at h
     have ⟨_, h1, h2⟩ := Except.bind_ok h
     exact ⟨Term.checkWf_ok h1, Term.checkWf_ok h2⟩
-  | unpred _ t => exact Term.checkWf_ok h
-  | binpred _ t₁ t₂ =>
+  | unpred p t =>
     simp only [Formula.checkWf] at h
-    have ⟨_, h1, h2⟩ := Except.bind_ok h
-    exact ⟨Term.checkWf_ok h1, Term.checkWf_ok h2⟩
+    have ⟨_, hp, ht⟩ := Except.bind_ok h
+    exact ⟨UnPred.checkWf_ok hp, Term.checkWf_ok ht⟩
+  | binpred p t₁ t₂ =>
+    simp only [Formula.checkWf] at h
+    have ⟨_, hp, h12⟩ := Except.bind_ok h
+    have ⟨_, h1, h2⟩ := Except.bind_ok h12
+    exact ⟨BinPred.checkWf_ok hp, Term.checkWf_ok h1, Term.checkWf_ok h2⟩
   | not φ ih => exact ih h
   | and φ ψ ihφ ihψ | or φ ψ ihφ ihψ | implies φ ψ ihφ ihψ =>
     simp only [Formula.checkWf] at h
@@ -89,12 +133,25 @@ theorem Formula.checkWf_ok {φ : Formula} {Δ : Signature} (h : φ.checkWf Δ = 
     simp only [Formula.checkWf] at h
     exact ih h
 
+private theorem UnPred.wfIn_mono {p : UnPred τ} {Δ Δ' : Signature}
+    (h : p.wfIn Δ) (hsub : Δ.Subset Δ') : p.wfIn Δ' := by
+  cases p with
+  | uninterpreted name τ => exact hsub.unaryRel _ h
+  | _ => trivial
+
+private theorem BinPred.wfIn_mono {p : BinPred τ₁ τ₂} {Δ Δ' : Signature}
+    (h : p.wfIn Δ) (hsub : Δ.Subset Δ') : p.wfIn Δ' := by
+  cases p with
+  | uninterpreted name τ₁ τ₂ => exact hsub.binaryRel _ h
+  | _ => trivial
+
 theorem Formula.wfIn_mono (φ : Formula) (h : φ.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : φ.wfIn Δ' := by
   induction φ generalizing Δ Δ' with
   | true_ | false_ => trivial
   | eq _ t₁ t₂ => exact ⟨Term.wfIn_mono t₁ h.1 hsub hwf, Term.wfIn_mono t₂ h.2 hsub hwf⟩
-  | unpred _ t => exact Term.wfIn_mono t h hsub hwf
-  | binpred _ t₁ t₂ => exact ⟨Term.wfIn_mono t₁ h.1 hsub hwf, Term.wfIn_mono t₂ h.2 hsub hwf⟩
+  | unpred p t => exact ⟨UnPred.wfIn_mono h.1 hsub, Term.wfIn_mono t h.2 hsub hwf⟩
+  | binpred p t₁ t₂ =>
+    exact ⟨BinPred.wfIn_mono h.1 hsub, Term.wfIn_mono t₁ h.2.1 hsub hwf, Term.wfIn_mono t₂ h.2.2 hsub hwf⟩
   | not φ ih => exact ih h hsub hwf
   | and φ ψ ihφ ihψ | or φ ψ ihφ ihψ | implies φ ψ ihφ ihψ =>
     exact ⟨ihφ h.1 hsub hwf, ihψ h.2 hsub hwf⟩
@@ -110,23 +167,25 @@ def Context.wfIn (Γ : Context) (Δ : Signature) : Prop :=
 theorem Context.wfIn_mono (Γ : Context) (h : Γ.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : Γ.wfIn Δ' :=
   fun φ hφ => Formula.wfIn_mono φ (h φ hφ) hsub hwf
 
-@[simp] def UnPred.eval : UnPred τ → τ.denote → Prop
-  | .isInt,   v => match v with | .int _ => True | _ => False
-  | .isBool,  v => match v with | .bool _ => True | _ => False
-  | .isLoc,   v => match v with | .loc _ => True | _ => False
-  | .isTuple, v => match v with | .tuple _ => True | _ => False
-  | .isInj tag arity, v => match v with | .inj t a _ => t = tag ∧ a = arity | _ => False
+@[simp] def UnPred.eval : Env → UnPred τ → τ.denote → Prop
+  | _, .isInt,   v => match v with | .int _ => True | _ => False
+  | _, .isBool,  v => match v with | .bool _ => True | _ => False
+  | _, .isLoc,   v => match v with | .loc _ => True | _ => False
+  | _, .isTuple, v => match v with | .tuple _ => True | _ => False
+  | _, .isInj tag arity, v => match v with | .inj t a _ => t = tag ∧ a = arity | _ => False
+  | ρ, .uninterpreted name _, v => ρ.unaryRel τ name v
 
-@[simp] def BinPred.eval : BinPred τ₁ τ₂ → τ₁.denote → τ₂.denote → Prop
-  | .lt, a, b => a < b
-  | .le, a, b => a ≤ b
+@[simp] def BinPred.eval : Env → BinPred τ₁ τ₂ → τ₁.denote → τ₂.denote → Prop
+  | _, .lt, a, b => a < b
+  | _, .le, a, b => a ≤ b
+  | ρ, .uninterpreted name _ _, a, b => ρ.binaryRel τ₁ τ₂ name a b
 
 def Formula.eval (ρ : Env) : Formula → Prop
   | .true_         => True
   | .false_        => False
   | .eq _τ a b     => a.eval ρ = b.eval ρ
-  | .unpred p v    => p.eval (v.eval ρ)
-  | .binpred p a b => p.eval (a.eval ρ) (b.eval ρ)
+  | .unpred p v    => p.eval ρ (v.eval ρ)
+  | .binpred p a b => p.eval ρ (a.eval ρ) (b.eval ρ)
   | .not φ         => ¬ φ.eval ρ
   | .and φ ψ       => φ.eval ρ ∧ ψ.eval ρ
   | .or φ ψ        => φ.eval ρ ∨ ψ.eval ρ
@@ -147,10 +206,22 @@ theorem Formula.eval_env_agree {φ : Formula} {ρ ρ' : Env} {Δ : Signature} :
     rw [Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
   | unpred p v =>
     simp only [Formula.eval]
-    rw [Term.eval_env_agree hwf hagree]
+    rw [Term.eval_env_agree hwf.2 hagree]
+    cases p with
+    | uninterpreted name τ =>
+      simp only [UnPred.eval]
+      have hrel := hagree.2.2.2.2.1 ⟨name, _⟩ hwf.1
+      simp [hrel]
+    | _ => rfl
   | binpred p a b =>
     simp only [Formula.eval]
-    rw [Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
+    rw [Term.eval_env_agree hwf.2.1 hagree, Term.eval_env_agree hwf.2.2 hagree]
+    cases p with
+    | uninterpreted name τ₁ τ₂ =>
+      simp only [BinPred.eval]
+      have hrel := hagree.2.2.2.2.2 ⟨name, _, _⟩ hwf.1
+      simp [hrel]
+    | _ => rfl
   | not φ ih =>
     simp only [Formula.eval]; rw [ih hwf hagree]
   | and φ ψ ihφ ihψ | or φ ψ ihφ ihψ | implies φ ψ ihφ ihψ =>

--- a/Mica/FOL/Printing.lean
+++ b/Mica/FOL/Printing.lean
@@ -56,10 +56,12 @@ def UnPred.toSMTLIB : UnPred τ → String
   | .isLoc   => "is-of_loc"
   | .isTuple => "is-of_tuple"
   | .isInj _ _ => ""  -- handled specially in Formula.toSMTLIB
+  | .uninterpreted name _ => name
 
 def BinPred.toSMTLIB : BinPred τ₁ τ₂ → String
   | .lt => "<"
   | .le => "<="
+  | .uninterpreted name _ _ => name
 
 def Term.toSMTLIB : Term τ → String
   | .var _ name   => name
@@ -159,9 +161,11 @@ private def formulaStr (p : Prec) : Formula → String
     | .isLoc   => s!"isLoc({termStr .bottom v})"
     | .isTuple => s!"isTuple({termStr .bottom v})"
     | .isInj tag arity => s!"isInj({tag}/{arity}, {termStr .bottom v})"
+    | .uninterpreted name _ => s!"{name}({termStr .bottom v})"
   | .binpred pred a b => match pred with
     | .lt => parens (Prec.lt .cmp p) s!"{termStr .add a} < {termStr .add b}"
     | .le => parens (Prec.lt .cmp p) s!"{termStr .add a} <= {termStr .add b}"
+    | .uninterpreted name _ _ => s!"{name}({termStr .bottom a}, {termStr .bottom b})"
   | .eq _ a b        => parens (Prec.lt .cmp     p) s!"{termStr .add a} = {termStr .add b}"
   | .not φ           => parens (Prec.lt .not_    p) s!"not {formulaStr .cmp φ}"
   | .and φ ψ         => parens (Prec.lt .and_    p) s!"{formulaStr .and_ φ} && {formulaStr .not_ ψ}"

--- a/Mica/FOL/Subst.lean
+++ b/Mica/FOL/Subst.lean
@@ -356,8 +356,14 @@ theorem Subst.eval_bind_agreeOn {σ : Subst} {ρ : Env} {τ : Srt} {y y' : Strin
     · constructor
       · intro u hu
         rfl
-      · intro b hb
-        rfl
+      · constructor
+        · intro b hb
+          rfl
+        · constructor
+          · intro u hu
+            rfl
+          · intro b hb
+            rfl
 
 theorem Formula.eval_subst {σ : Subst} {ρ : Env} {φ : Formula} {Δ Δ' : Signature}
     (hφ : φ.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hsymbols : Δ.SymbolSubset Δ')
@@ -368,9 +374,12 @@ theorem Formula.eval_subst {σ : Subst} {ρ : Env} {φ : Formula} {Δ Δ' : Sign
   | eq τ a b =>
     simp [Formula.subst, Formula.eval, Term.eval_subst hφ.1 hσ hwfΔ', Term.eval_subst hφ.2 hσ hwfΔ']
   | unpred p t =>
-    simp [Formula.subst, Formula.eval, Term.eval_subst hφ hσ hwfΔ']
+    simp [Formula.subst, Formula.eval, Term.eval_subst hφ.2 hσ hwfΔ']
+    cases p <;> simp [Subst.eval]
   | binpred p a b =>
-    simp [Formula.subst, Formula.eval, Term.eval_subst hφ.1 hσ hwfΔ', Term.eval_subst hφ.2 hσ hwfΔ']
+    simp [Formula.subst, Formula.eval, Term.eval_subst hφ.2.1 hσ hwfΔ',
+      Term.eval_subst hφ.2.2 hσ hwfΔ']
+    cases p <;> simp [Subst.eval]
   | not φ ih =>
     simp [Formula.subst, Formula.eval, ih hφ hσ hsymbols hwfΔ hwfΔ']
   | and φ ψ ihφ ihψ | or φ ψ ihφ ihψ | implies φ ψ ihφ ihψ =>
@@ -410,6 +419,14 @@ theorem Formula.eval_subst {σ : Subst} {ρ : Env} {φ : Formula} {Δ Δ' : Sign
       · intro b hb
         simpa [hremove, Signature.addVar] using
           (Signature.SymbolSubset.declVar hsymbols ⟨y, τ⟩).binary b
+            (by simpa [Signature.declVar, Signature.addVar] using hb)
+      · intro u hu
+        simpa [hremove, Signature.addVar] using
+          (Signature.SymbolSubset.declVar hsymbols ⟨y, τ⟩).unaryRel u
+            (by simpa [Signature.declVar, Signature.addVar] using hu)
+      · intro b hb
+        simpa [hremove, Signature.addVar] using
+          (Signature.SymbolSubset.declVar hsymbols ⟨y, τ⟩).binaryRel b
             (by simpa [Signature.declVar, Signature.addVar] using hb)
     have hagree (v : τ.denote) : Env.agreeOn ((Δ.remove y).addVar ⟨y, τ⟩)
         ((σ.bind y τ y').eval (ρ.updateConst τ y' v))
@@ -461,6 +478,14 @@ theorem Formula.eval_subst {σ : Subst} {ρ : Env} {φ : Formula} {Δ Δ' : Sign
       · intro b hb
         simpa [hremove, Signature.addVar] using
           (Signature.SymbolSubset.declVar hsymbols ⟨y, τ⟩).binary b
+            (by simpa [Signature.declVar, Signature.addVar] using hb)
+      · intro u hu
+        simpa [hremove, Signature.addVar] using
+          (Signature.SymbolSubset.declVar hsymbols ⟨y, τ⟩).unaryRel u
+            (by simpa [Signature.declVar, Signature.addVar] using hu)
+      · intro b hb
+        simpa [hremove, Signature.addVar] using
+          (Signature.SymbolSubset.declVar hsymbols ⟨y, τ⟩).binaryRel b
             (by simpa [Signature.declVar, Signature.addVar] using hb)
     have hagree (v : τ.denote) : Env.agreeOn ((Δ.remove y).addVar ⟨y, τ⟩)
         ((σ.bind y τ y').eval (ρ.updateConst τ y' v))
@@ -533,11 +558,17 @@ theorem Formula.subst_wfIn {φ : Formula} {σ : Subst} {Δ Δ' : Signature}
       Term.subst_wfIn hwf.2 hσ (by intro x hx; exact hx) hsymbols hwfΔ'⟩
   | unpred p t =>
     simp [Formula.subst, Formula.wfIn]
-    exact Term.subst_wfIn hwf hσ (by intro x hx; exact hx) hsymbols hwfΔ'
+    refine ⟨?_, Term.subst_wfIn hwf.2 hσ (by intro x hx; exact hx) hsymbols hwfΔ'⟩
+    cases p with
+    | uninterpreted name τ => exact hsymbols.unaryRel _ hwf.1
+    | _ => trivial
   | binpred p a b =>
     simp [Formula.subst, Formula.wfIn]
-    exact ⟨Term.subst_wfIn hwf.1 hσ (by intro x hx; exact hx) hsymbols hwfΔ',
-      Term.subst_wfIn hwf.2 hσ (by intro x hx; exact hx) hsymbols hwfΔ'⟩
+    refine ⟨?_, Term.subst_wfIn hwf.2.1 hσ (by intro x hx; exact hx) hsymbols hwfΔ',
+      Term.subst_wfIn hwf.2.2 hσ (by intro x hx; exact hx) hsymbols hwfΔ'⟩
+    cases p with
+    | uninterpreted name τ₁ τ₂ => exact hsymbols.binaryRel _ hwf.1
+    | _ => trivial
   | not φ ih =>
     simpa [Formula.subst, Formula.wfIn] using ih hwf hσ hsymbols hwfΔ'
   | and φ ψ ihφ ihψ | or φ ψ ihφ ihψ | implies φ ψ ihφ ihψ =>
@@ -582,8 +613,20 @@ theorem Formula.subst_wfIn {φ : Formula} {σ : Subst} {Δ Δ' : Signature}
       refine Signature.mem_remove_binary.mpr ⟨hsymbols.binary _ hb, ?_⟩
       intro hbeq
       exact hy'_fresh (hbeq ▸ Signature.mem_allNames_of_binary (hsymbols.binary _ hb))
+    have hunaryRel' : ((Δ.remove y).addVar ⟨y, τ⟩).unaryRel ⊆ ((Δ'.remove y').addVar ⟨y', τ⟩).unaryRel := by
+      intro u hu
+      rcases Signature.mem_remove_unaryRel.mp hu with ⟨hu, huy⟩
+      refine Signature.mem_remove_unaryRel.mpr ⟨hsymbols.unaryRel _ hu, ?_⟩
+      intro hueq
+      exact hy'_fresh (hueq ▸ Signature.mem_allNames_of_unaryRel (hsymbols.unaryRel _ hu))
+    have hbinaryRel' : ((Δ.remove y).addVar ⟨y, τ⟩).binaryRel ⊆ ((Δ'.remove y').addVar ⟨y', τ⟩).binaryRel := by
+      intro b hb
+      rcases Signature.mem_remove_binaryRel.mp hb with ⟨hb, hby⟩
+      refine Signature.mem_remove_binaryRel.mpr ⟨hsymbols.binaryRel _ hb, ?_⟩
+      intro hbeq
+      exact hy'_fresh (hbeq ▸ Signature.mem_allNames_of_binaryRel (hsymbols.binaryRel _ hb))
     have hsymbols' : ((Δ.remove y).addVar ⟨y, τ⟩).SymbolSubset ((Δ'.remove y').addVar ⟨y', τ⟩) :=
-      ⟨hconsts', hunary', hbinary'⟩
+      ⟨hconsts', hunary', hbinary', hunaryRel', hbinaryRel'⟩
     exact (by
       simpa [y', Signature.allNames_remove_addVar_of_not_in hy'_fresh] using
         ih hwf hσ' hsymbols' hwf_target)

--- a/Mica/FOL/Subst.lean
+++ b/Mica/FOL/Subst.lean
@@ -570,14 +570,24 @@ theorem Formula.subst_wfIn {φ : Formula} {σ : Subst} {Δ Δ' : Signature}
     simp [Formula.subst, Formula.wfIn]
     refine ⟨?_, Term.subst_wfIn hwf.2 hσ (by intro x hx; exact hx) hsymbols hwfΔ'⟩
     cases p with
-    | uninterpreted name τ => exact hsymbols.unaryRel _ hwf.1
+    | uninterpreted name τ =>
+      refine ⟨hsymbols.unaryRel _ hwf.1.1, ?_, ?_⟩
+      · intro τ₁ τ₂ hu
+        exact Signature.wf_no_unaryRel_of_unary hwfΔ' hu (hsymbols.unaryRel _ hwf.1.1)
+      · intro τ' hu'
+        exact Signature.wf_unique_unaryRel hwfΔ' (hsymbols.unaryRel _ hwf.1.1) hu'
     | _ => trivial
   | binpred p a b =>
     simp [Formula.subst, Formula.wfIn]
     refine ⟨?_, Term.subst_wfIn hwf.2.1 hσ (by intro x hx; exact hx) hsymbols hwfΔ',
       Term.subst_wfIn hwf.2.2 hσ (by intro x hx; exact hx) hsymbols hwfΔ'⟩
     cases p with
-    | uninterpreted name τ₁ τ₂ => exact hsymbols.binaryRel _ hwf.1
+    | uninterpreted name τ₁ τ₂ =>
+      refine ⟨hsymbols.binaryRel _ hwf.1.1, ?_, ?_⟩
+      · intro τ₁' τ₂' τ₃' hb
+        exact Signature.wf_no_binaryRel_of_binary hwfΔ' hb (hsymbols.binaryRel _ hwf.1.1)
+      · intro τ₁' τ₂' hb'
+        exact Signature.wf_unique_binaryRel hwfΔ' (hsymbols.binaryRel _ hwf.1.1) hb'
     | _ => trivial
   | not φ ih =>
     simpa [Formula.subst, Formula.wfIn] using ih hwf hσ hsymbols hwfΔ'

--- a/Mica/FOL/Subst.lean
+++ b/Mica/FOL/Subst.lean
@@ -153,14 +153,24 @@ theorem Term.subst_wfIn {t : Term τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Sign
     simp only [Term.subst, Term.wfIn]
     refine ⟨?_, iha ht.2 hσ hdom hsymbols hwf⟩
     cases op with
-    | uninterpreted name _ _ => exact hsymbols.unary _ ht.1
+    | uninterpreted name _ _ =>
+      refine ⟨hsymbols.unary _ ht.1.1, ?_, ?_⟩
+      · intro τ' hrel
+        exact Signature.wf_no_unaryRel_of_unary hwf (hsymbols.unary _ ht.1.1) hrel
+      · intro τ₁' τ₂' hu'
+        exact Signature.wf_unique_unary hwf (hsymbols.unary _ ht.1.1) hu'
     | _ => trivial
   | binop op a b iha ihb =>
     simp only [Term.subst, Term.wfIn]
     refine ⟨?_, iha ht.2.1 hσ hdom hsymbols hwf,
       ihb ht.2.2 hσ hdom hsymbols hwf⟩
     cases op with
-    | uninterpreted name _ _ _ => exact hsymbols.binary _ ht.1
+    | uninterpreted name _ _ _ =>
+      refine ⟨hsymbols.binary _ ht.1.1, ?_, ?_⟩
+      · intro τ₁' τ₂' hrel
+        exact Signature.wf_no_binaryRel_of_binary hwf (hsymbols.binary _ ht.1.1) hrel
+      · intro τ₁' τ₂' τ₃' hb'
+        exact Signature.wf_unique_binary hwf (hsymbols.binary _ ht.1.1) hb'
     | _ => trivial
   | ite c t e ihc iht ihe =>
     simp only [Term.subst, Term.wfIn]

--- a/Mica/FOL/Terms.lean
+++ b/Mica/FOL/Terms.lean
@@ -296,7 +296,7 @@ theorem Term.eval_env_agree {t : Term τ} {ρ ρ' : Env} {Δ : Signature} :
     cases op with
     | uninterpreted name _ _ _ =>
       simp only [BinOp.eval]
-      exact congrFun (congrFun (hagree.2.2.2 ⟨name, _, _, _⟩ hwf.1) _) _
+      exact congrFun (congrFun (hagree.2.2.2.1 ⟨name, _, _, _⟩ hwf.1) _) _
     | _ => rfl
   | ite c t e ihc iht ihe =>
     simp [Term.eval]
@@ -306,17 +306,27 @@ theorem Term.eval_update_fresh {t : Term τ'} {x : String} {τ : Srt} {v : τ.de
     {Δ : Signature} (hwf : t.wfIn Δ) (hfresh : x ∉ Δ.allNames) :
     Term.eval (ρ.updateConst τ x v) t = Term.eval ρ t :=
   Term.eval_env_agree hwf
-    ⟨fun w hw => by
-      have hne : w.name ≠ x := by
-        intro heq
-        exact hfresh (heq ▸ Signature.mem_allNames_of_var hw)
-      exact Env.lookupConst_updateConst_ne' (Or.inl hne),
-     fun c hc => by
-      have hne : c.name ≠ x := by
-        intro heq
-        exact hfresh (heq ▸ Signature.mem_allNames_of_const hc)
-      exact Env.lookupConst_updateConst_ne' (Or.inl hne),
-     fun _ _ => rfl, fun _ _ => rfl⟩
+    ⟨
+      (fun w hw => by
+        have hne : w.name ≠ x := by
+          intro heq
+          exact hfresh (heq ▸ Signature.mem_allNames_of_var hw)
+        exact Env.lookupConst_updateConst_ne' (Or.inl hne)),
+      ⟨
+        (fun c hc => by
+          have hne : c.name ≠ x := by
+            intro heq
+            exact hfresh (heq ▸ Signature.mem_allNames_of_const hc)
+          exact Env.lookupConst_updateConst_ne' (Or.inl hne)),
+        ⟨
+          (fun _ _ => rfl),
+          ⟨
+            (fun _ _ => rfl),
+            ⟨(fun _ _ => rfl), (fun _ _ => rfl)⟩
+          ⟩
+        ⟩
+      ⟩
+    ⟩
 
 /-! simple helper lemmas -/
 

--- a/Mica/FOL/Terms.lean
+++ b/Mica/FOL/Terms.lean
@@ -74,10 +74,16 @@ def Const.wfIn : Const τ → Signature → Prop
 
 def UnOp.wfIn : UnOp τ₁ τ₂ → Signature → Prop
   | .uninterpreted name τ₁ τ₂, Δ => ⟨name, τ₁, τ₂⟩ ∈ Δ.unary
+                                   ∧ (∀ τ', ⟨name, τ'⟩ ∉ Δ.unaryRel)
+                                   ∧ (∀ τ₁' τ₂', ⟨name, τ₁', τ₂'⟩ ∈ Δ.unary →
+                                       τ₁' = τ₁ ∧ τ₂' = τ₂)
   | _, _                          => True
 
 def BinOp.wfIn : BinOp τ₁ τ₂ τ₃ → Signature → Prop
   | .uninterpreted name τ₁ τ₂ τ₃, Δ => ⟨name, τ₁, τ₂, τ₃⟩ ∈ Δ.binary
+                                      ∧ (∀ τ₁' τ₂', ⟨name, τ₁', τ₂'⟩ ∉ Δ.binaryRel)
+                                      ∧ (∀ τ₁' τ₂' τ₃', ⟨name, τ₁', τ₂', τ₃'⟩ ∈ Δ.binary →
+                                          τ₁' = τ₁ ∧ τ₂' = τ₂ ∧ τ₃' = τ₃)
   | _, _                              => True
 
 def Const.checkWf : Const τ → Signature → Except String Unit
@@ -92,12 +98,25 @@ def Const.checkWf : Const τ → Signature → Except String Unit
 
 def UnOp.checkWf : UnOp τ₁ τ₂ → Signature → Except String Unit
   | .uninterpreted name τ₁ τ₂, Δ =>
-    if ⟨name, τ₁, τ₂⟩ ∈ Δ.unary then .ok () else .error s!"unary op {name} not in signature"
+    if ⟨name, τ₁, τ₂⟩ ∈ Δ.unary then
+      if name ∈ Δ.unaryRel.map FOL.UnaryRel.name then
+        .error s!"unary op {name} conflicts with a unary predicate"
+      else if Δ.unary.any (fun u => u.name == name && (u.arg != τ₁ || u.ret != τ₂)) then
+        .error s!"unary op {name} has multiple signatures in signature"
+      else .ok ()
+    else .error s!"unary op {name} not in signature"
   | _, _ => .ok ()
 
 def BinOp.checkWf : BinOp τ₁ τ₂ τ₃ → Signature → Except String Unit
   | .uninterpreted name τ₁ τ₂ τ₃, Δ =>
-    if ⟨name, τ₁, τ₂, τ₃⟩ ∈ Δ.binary then .ok () else .error s!"binary op {name} not in signature"
+    if ⟨name, τ₁, τ₂, τ₃⟩ ∈ Δ.binary then
+      if name ∈ Δ.binaryRel.map FOL.BinaryRel.name then
+        .error s!"binary op {name} conflicts with a binary predicate"
+      else if Δ.binary.any
+          (fun b => b.name == name && (b.arg1 != τ₁ || b.arg2 != τ₂ || b.ret != τ₃)) then
+        .error s!"binary op {name} has multiple signatures in signature"
+      else .ok ()
+    else .error s!"binary op {name} not in signature"
   | _, _ => .ok ()
 
 def Term.wfIn : Term τ → Signature → Prop
@@ -150,14 +169,72 @@ private theorem UnOp.checkWf_ok {op : UnOp τ₁ τ₂} {Δ : Signature} (h : op
     op.wfIn Δ := by
   cases op with
   | uninterpreted name τ₁ τ₂ =>
-    simp only [UnOp.checkWf] at h; split at h; assumption; simp at h
+    simp only [UnOp.checkWf] at h
+    split at h
+    · rename_i hmem
+      split at h
+      · simp at h
+      · rename_i hpred
+        split at h
+        · simp at h
+        · rename_i hdup
+          refine ⟨hmem, ?_, ?_⟩
+          · intro τ' hrel
+            exact hpred (List.mem_map_of_mem hrel)
+          · intro τ₁' τ₂' hu'
+            by_cases harg : τ₁' = τ₁
+            · by_cases hret : τ₂' = τ₂
+              · exact ⟨harg, hret⟩
+              · exfalso
+                apply hdup
+                apply List.any_eq_true.mpr
+                refine ⟨⟨name, τ₁', τ₂'⟩, hu', ?_⟩
+                simp [harg, hret]
+            · exfalso
+              apply hdup
+              apply List.any_eq_true.mpr
+              refine ⟨⟨name, τ₁', τ₂'⟩, hu', ?_⟩
+              simp [harg]
+    · simp at h
   | _ => trivial
 
 private theorem BinOp.checkWf_ok {op : BinOp τ₁ τ₂ τ₃} {Δ : Signature}
     (h : op.checkWf Δ = .ok ()) : op.wfIn Δ := by
   cases op with
   | uninterpreted name τ₁ τ₂ τ₃ =>
-    simp only [BinOp.checkWf] at h; split at h; assumption; simp at h
+    simp only [BinOp.checkWf] at h
+    split at h
+    · rename_i hmem
+      split at h
+      · simp at h
+      · rename_i hpred
+        split at h
+        · simp at h
+        · rename_i hdup
+          refine ⟨hmem, ?_, ?_⟩
+          · intro τ₁' τ₂' hrel
+            exact hpred (List.mem_map_of_mem hrel)
+          · intro τ₁' τ₂' τ₃' hb'
+            by_cases harg1 : τ₁' = τ₁
+            · by_cases harg2 : τ₂' = τ₂
+              · by_cases hret : τ₃' = τ₃
+                · exact ⟨harg1, harg2, hret⟩
+                · exfalso
+                  apply hdup
+                  apply List.any_eq_true.mpr
+                  refine ⟨⟨name, τ₁', τ₂', τ₃'⟩, hb', ?_⟩
+                  simp [harg1, harg2, hret]
+              · exfalso
+                apply hdup
+                apply List.any_eq_true.mpr
+                refine ⟨⟨name, τ₁', τ₂', τ₃'⟩, hb', ?_⟩
+                simp [harg1, harg2]
+            · exfalso
+              apply hdup
+              apply List.any_eq_true.mpr
+              refine ⟨⟨name, τ₁', τ₂', τ₃'⟩, hb', ?_⟩
+              simp [harg1]
+    · simp at h
   | _ => trivial
 
 theorem Term.checkWf_ok {t : Term τ} {Δ : Signature} (h : t.checkWf Δ = .ok ()) : t.wfIn Δ := by
@@ -210,15 +287,25 @@ private theorem Const.wfIn_mono {c : Const τ} {Δ Δ' : Signature} (h : c.wfIn 
   | _ => trivial
 
 private theorem UnOp.wfIn_mono {op : UnOp τ₁ τ₂} {Δ Δ' : Signature} (h : op.wfIn Δ)
-    (hsub : Δ.Subset Δ') : op.wfIn Δ' := by
+    (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : op.wfIn Δ' := by
   cases op with
-  | uninterpreted name τ₁ τ₂ => exact hsub.unary _ h
+  | uninterpreted name τ₁ τ₂ =>
+    refine ⟨hsub.unary _ h.1, ?_, ?_⟩
+    · intro τ' hrel
+      exact Signature.wf_no_unaryRel_of_unary hwf (hsub.unary _ h.1) hrel
+    · intro τ₁' τ₂' hu'
+      exact Signature.wf_unique_unary hwf (hsub.unary _ h.1) hu'
   | _ => trivial
 
 private theorem BinOp.wfIn_mono {op : BinOp τ₁ τ₂ τ₃} {Δ Δ' : Signature} (h : op.wfIn Δ)
-    (hsub : Δ.Subset Δ') : op.wfIn Δ' := by
+    (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : op.wfIn Δ' := by
   cases op with
-  | uninterpreted name τ₁ τ₂ τ₃ => exact hsub.binary _ h
+  | uninterpreted name τ₁ τ₂ τ₃ =>
+    refine ⟨hsub.binary _ h.1, ?_, ?_⟩
+    · intro τ₁' τ₂' hrel
+      exact Signature.wf_no_binaryRel_of_binary hwf (hsub.binary _ h.1) hrel
+    · intro τ₁' τ₂' τ₃' hb'
+      exact Signature.wf_unique_binary hwf (hsub.binary _ h.1) hb'
   | _ => trivial
 
 theorem Term.wfIn_mono (t : Term τ) (h : t.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : t.wfIn Δ' := by
@@ -230,8 +317,9 @@ theorem Term.wfIn_mono (t : Term τ) (h : t.wfIn Δ) (hsub : Δ.Subset Δ') (hwf
     · intro τ' hv'
       exact Signature.wf_unique_var hwf (hsub.vars _ h.1) hv'
   | const c => exact Const.wfIn_mono h hsub hwf
-  | unop op a iha => exact ⟨UnOp.wfIn_mono h.1 hsub, iha h.2 hsub hwf⟩
-  | binop op a b iha ihb => exact ⟨BinOp.wfIn_mono h.1 hsub, iha h.2.1 hsub hwf, ihb h.2.2 hsub hwf⟩
+  | unop op a iha => exact ⟨UnOp.wfIn_mono h.1 hsub hwf, iha h.2 hsub hwf⟩
+  | binop op a b iha ihb =>
+    exact ⟨BinOp.wfIn_mono h.1 hsub hwf, iha h.2.1 hsub hwf, ihb h.2.2 hsub hwf⟩
   | ite c t e ihc iht ihe => exact ⟨ihc h.1 hsub hwf, iht h.2.1 hsub hwf, ihe h.2.2 hsub hwf⟩
 
 @[simp] def UnOp.eval : Env → UnOp τ₁ τ₂ → τ₁.denote → τ₂.denote
@@ -288,7 +376,7 @@ theorem Term.eval_env_agree {t : Term τ} {ρ ρ' : Env} {Δ : Signature} :
     cases op with
     | uninterpreted name _ _ =>
       simp only [UnOp.eval]
-      exact congrFun (hagree.2.2.1 ⟨name, _, _⟩ hwf.1) _
+      exact congrFun (hagree.2.2.1 ⟨name, _, _⟩ hwf.1.1) _
     | _ => rfl
   | binop op a b iha ihb =>
     simp only [Term.eval]
@@ -296,7 +384,7 @@ theorem Term.eval_env_agree {t : Term τ} {ρ ρ' : Env} {Δ : Signature} :
     cases op with
     | uninterpreted name _ _ _ =>
       simp only [BinOp.eval]
-      exact congrFun (congrFun (hagree.2.2.2.1 ⟨name, _, _, _⟩ hwf.1) _) _
+      exact congrFun (congrFun (hagree.2.2.2.1 ⟨name, _, _, _⟩ hwf.1.1) _) _
     | _ => rfl
   | ite c t e ihc iht ihe =>
     simp [Term.eval]

--- a/Mica/FOL/Variables.lean
+++ b/Mica/FOL/Variables.lean
@@ -600,6 +600,37 @@ private theorem unique_sig_of_nodup_map_binary_name {l : List FOL.Binary} {x : S
       · exact absurd (List.mem_map_of_mem hmem) hnd.1
       · exact ih hnd.2 hmem hmem'
 
+private theorem unique_sort_of_nodup_map_unaryRel_name {l : List FOL.UnaryRel} {x : String}
+    {τ τ' : Srt} (hnd : (l.map FOL.UnaryRel.name).Nodup)
+    (hu : ⟨x, τ⟩ ∈ l) (hu' : ⟨x, τ'⟩ ∈ l) : τ' = τ := by
+  induction l with
+  | nil => simp at hu
+  | cons u us ih =>
+    rw [List.map, List.nodup_cons] at hnd
+    rcases List.mem_cons.mp hu with rfl | hmem
+    · rcases List.mem_cons.mp hu' with heq | hmem'
+      · exact (FOL.UnaryRel.mk.inj heq).2
+      · exact absurd (List.mem_map_of_mem hmem') hnd.1
+    · rcases List.mem_cons.mp hu' with rfl | hmem'
+      · exact absurd (List.mem_map_of_mem hmem) hnd.1
+      · exact ih hnd.2 hmem hmem'
+
+private theorem unique_sig_of_nodup_map_binaryRel_name {l : List FOL.BinaryRel} {x : String}
+    {τ₁ τ₂ τ₁' τ₂' : Srt} (hnd : (l.map FOL.BinaryRel.name).Nodup)
+    (hb : ⟨x, τ₁, τ₂⟩ ∈ l) (hb' : ⟨x, τ₁', τ₂'⟩ ∈ l) : τ₁' = τ₁ ∧ τ₂' = τ₂ := by
+  induction l with
+  | nil => simp at hb
+  | cons b bs ih =>
+    rw [List.map, List.nodup_cons] at hnd
+    rcases List.mem_cons.mp hb with rfl | hmem
+    · rcases List.mem_cons.mp hb' with heq | hmem'
+      · rcases FOL.BinaryRel.mk.inj heq with ⟨_, harg1, harg2⟩
+        exact ⟨harg1, harg2⟩
+      · exact absurd (List.mem_map_of_mem hmem') hnd.1
+    · rcases List.mem_cons.mp hb' with rfl | hmem'
+      · exact absurd (List.mem_map_of_mem hmem) hnd.1
+      · exact ih hnd.2 hmem hmem'
+
 theorem wf_unique_var {Δ : Signature} {x : String} {τ τ' : Srt}
     (hΔ : Δ.wf) (hv : ⟨x, τ⟩ ∈ Δ.vars) (hv' : ⟨x, τ'⟩ ∈ Δ.vars) : τ' = τ :=
   by
@@ -634,6 +665,18 @@ theorem wf_unique_binary {Δ : Signature} {x : String} {τ₁ τ₂ τ₃ τ₁'
   have hABCD := (List.nodup_append.mp hABCDE).1
   exact unique_sig_of_nodup_map_binary_name (l := Δ.binary) (x := x)
     (List.nodup_append.mp hABCD).2.1 hb hb'
+
+theorem wf_unique_unaryRel {Δ : Signature} {x : String} {τ τ' : Srt}
+    (hΔ : Δ.wf) (hu : ⟨x, τ⟩ ∈ Δ.unaryRel) (hu' : ⟨x, τ'⟩ ∈ Δ.unaryRel) : τ' = τ := by
+  have hABCDE := (List.nodup_append.mp hΔ).1
+  exact unique_sort_of_nodup_map_unaryRel_name (l := Δ.unaryRel) (x := x)
+    (List.nodup_append.mp hABCDE).2.1 hu hu'
+
+theorem wf_unique_binaryRel {Δ : Signature} {x : String} {τ₁ τ₂ τ₁' τ₂' : Srt}
+    (hΔ : Δ.wf) (hb : ⟨x, τ₁, τ₂⟩ ∈ Δ.binaryRel) (hb' : ⟨x, τ₁', τ₂'⟩ ∈ Δ.binaryRel) :
+    τ₁' = τ₁ ∧ τ₂' = τ₂ := by
+  exact unique_sig_of_nodup_map_binaryRel_name (l := Δ.binaryRel) (x := x)
+    (List.nodup_append.mp hΔ).2.1 hb hb'
 
 theorem wf_no_const_of_var {Δ : Signature} {x : String} {τ τ' : Srt}
     (hΔ : Δ.wf) (hv : ⟨x, τ⟩ ∈ Δ.vars) : ⟨x, τ'⟩ ∉ Δ.consts := by

--- a/Mica/FOL/Variables.lean
+++ b/Mica/FOL/Variables.lean
@@ -62,6 +62,17 @@ structure Binary where
   ret  : Srt
   deriving DecidableEq, Repr
 
+structure UnaryRel where
+  name : String
+  arg  : Srt
+  deriving DecidableEq, Repr
+
+structure BinaryRel where
+  name : String
+  arg1 : Srt
+  arg2 : Srt
+  deriving DecidableEq, Repr
+
 end FOL
 
 structure Signature where
@@ -69,15 +80,19 @@ structure Signature where
   consts : List FOL.Const
   unary  : List FOL.Unary
   binary : List FOL.Binary
+  unaryRel  : List FOL.UnaryRel
+  binaryRel : List FOL.BinaryRel
 
 namespace Signature
 
-def empty : Signature := ⟨[], [], [], []⟩
+def empty : Signature := ⟨[], [], [], [], [], []⟩
 
 @[simp] theorem empty_vars    : (empty : Signature).vars   = [] := rfl
 @[simp] theorem empty_consts  : (empty : Signature).consts = [] := rfl
 @[simp] theorem empty_unary   : (empty : Signature).unary  = [] := rfl
 @[simp] theorem empty_binary  : (empty : Signature).binary = [] := rfl
+@[simp] theorem empty_unaryRel : (empty : Signature).unaryRel = [] := rfl
+@[simp] theorem empty_binaryRel : (empty : Signature).binaryRel = [] := rfl
 
 def addVar (Δ : Signature) (v : Var) : Signature := { Δ with vars := v :: Δ.vars }
 def addVars (Δ : Signature) (vs : List Var) : Signature := { Δ with vars := vs ++ Δ.vars }
@@ -85,11 +100,15 @@ def addVars (Δ : Signature) (vs : List Var) : Signature := { Δ with vars := vs
 def addConst (Δ : Signature) (c : FOL.Const) : Signature := { Δ with consts := c :: Δ.consts }
 def addUnary (Δ : Signature) (u : FOL.Unary) : Signature := { Δ with unary := u :: Δ.unary }
 def addBinary (Δ : Signature) (b : FOL.Binary) : Signature := { Δ with binary := b :: Δ.binary }
+def addUnaryRel (Δ : Signature) (u : FOL.UnaryRel) : Signature := { Δ with unaryRel := u :: Δ.unaryRel }
+def addBinaryRel (Δ : Signature) (b : FOL.BinaryRel) : Signature := { Δ with binaryRel := b :: Δ.binaryRel }
 def remove (Δ : Signature) (x : String) : Signature :=
   { vars := Δ.vars.filter (·.name != x)
     consts := Δ.consts.filter (·.name != x)
     unary := Δ.unary.filter (·.name != x)
-    binary := Δ.binary.filter (·.name != x) }
+    binary := Δ.binary.filter (·.name != x)
+    unaryRel := Δ.unaryRel.filter (·.name != x)
+    binaryRel := Δ.binaryRel.filter (·.name != x) }
 
 /-- Declare a variable with binder-shadowing semantics. -/
 def declVar (Δ : Signature) (v : Var) : Signature := (Δ.remove v.name).addVar v
@@ -99,25 +118,40 @@ def declVars (Δ : Signature) (vs : List Var) : Signature := vs.foldl declVar Δ
 
 def allNames (Δ : Signature) : List String :=
   Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
-  Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name
+  Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+  Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name
 
 def wf (Δ : Signature) : Prop := Δ.allNames.Nodup
 
 theorem mem_allNames_of_var {Δ : Signature} {v : Var} (h : v ∈ Δ.vars) :
-    v.name ∈ Δ.allNames :=
-  List.mem_append_left _ (List.mem_append_left _ (List.mem_append_left _ (List.mem_map.mpr ⟨v, h, rfl⟩)))
+    v.name ∈ Δ.allNames := by
+  simp [allNames]
+  exact Or.inl ⟨v, h, rfl⟩
 
 theorem mem_allNames_of_const {Δ : Signature} {c : FOL.Const} (h : c ∈ Δ.consts) :
-    c.name ∈ Δ.allNames :=
-  List.mem_append_left _ (List.mem_append_left _ (List.mem_append_right _ (List.mem_map.mpr ⟨c, h, rfl⟩)))
+    c.name ∈ Δ.allNames := by
+  simp [allNames]
+  exact Or.inr (Or.inl ⟨c, h, rfl⟩)
 
 theorem mem_allNames_of_unary {Δ : Signature} {u : FOL.Unary} (h : u ∈ Δ.unary) :
-    u.name ∈ Δ.allNames :=
-  List.mem_append_left _ (List.mem_append_right _ (List.mem_map.mpr ⟨u, h, rfl⟩))
+    u.name ∈ Δ.allNames := by
+  simp [allNames]
+  exact Or.inr (Or.inr (Or.inl ⟨u, h, rfl⟩))
 
 theorem mem_allNames_of_binary {Δ : Signature} {b : FOL.Binary} (h : b ∈ Δ.binary) :
-    b.name ∈ Δ.allNames :=
-  List.mem_append_right _ (List.mem_map.mpr ⟨b, h, rfl⟩)
+    b.name ∈ Δ.allNames := by
+  simp [allNames]
+  exact Or.inr (Or.inr (Or.inr (Or.inl ⟨b, h, rfl⟩)))
+
+theorem mem_allNames_of_unaryRel {Δ : Signature} {u : FOL.UnaryRel} (h : u ∈ Δ.unaryRel) :
+    u.name ∈ Δ.allNames := by
+  simp [allNames]
+  exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl ⟨u, h, rfl⟩))))
+
+theorem mem_allNames_of_binaryRel {Δ : Signature} {b : FOL.BinaryRel} (h : b ∈ Δ.binaryRel) :
+    b.name ∈ Δ.allNames := by
+  simp [allNames]
+  exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr ⟨b, h, rfl⟩))))
 
 theorem nodup_allNames_addConst {Δ : Signature} {c : FOL.Const}
     (hnd : Δ.allNames.Nodup) (hfresh : c.name ∉ Δ.allNames) :
@@ -125,19 +159,22 @@ theorem nodup_allNames_addConst {Δ : Signature} {c : FOL.Const}
   suffices h : (Δ.addConst c).allNames.Perm (c.name :: Δ.allNames) from
     h.nodup_iff.mpr (List.nodup_cons.mpr ⟨hfresh, hnd⟩)
   -- addConst c inserts c.name between vars and consts in allNames
-  -- allNames (addConst c Δ) = vs ++ (c :: cs) ++ us ++ bs
-  -- c :: allNames Δ           = c :: (vs ++ cs ++ us ++ bs)
+  -- allNames (addConst c Δ) = vs ++ (c :: cs) ++ us ++ bs ++ urs ++ brs
+  -- c :: allNames Δ           = c :: (vs ++ cs ++ us ++ bs ++ urs ++ brs)
   -- These are permutations via comm of the first two segments.
   show (Δ.vars.map Var.name ++ (c.name :: Δ.consts.map FOL.Const.name) ++
-    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name).Perm
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name).Perm
     (c.name :: (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
-    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name))
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
   simp only [List.append_assoc]
   exact List.perm_middle
 
 theorem allNames_addConst (Δ : Signature) (c : FOL.Const) :
     (Δ.addConst c).allNames = Δ.vars.map Var.name ++ (c.name :: Δ.consts.map FOL.Const.name) ++
-    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name := by
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name := by
   simp [allNames, addConst]
 
 @[simp] theorem mem_remove_vars {Δ : Signature} {v : Var} {x : String} :
@@ -156,14 +193,34 @@ theorem allNames_addConst (Δ : Signature) (c : FOL.Const) :
     b ∈ (Δ.remove x).binary ↔ b ∈ Δ.binary ∧ b.name ≠ x := by
   simp [remove]
 
+@[simp] theorem mem_remove_unaryRel {Δ : Signature} {u : FOL.UnaryRel} {x : String} :
+    u ∈ (Δ.remove x).unaryRel ↔ u ∈ Δ.unaryRel ∧ u.name ≠ x := by
+  simp [remove]
+
+@[simp] theorem mem_remove_binaryRel {Δ : Signature} {b : FOL.BinaryRel} {x : String} :
+    b ∈ (Δ.remove x).binaryRel ↔ b ∈ Δ.binaryRel ∧ b.name ≠ x := by
+  simp [remove]
+
 theorem remove_allNames {Δ : Signature} {n x : String} (h : n ∈ (Δ.remove x).allNames) :
     n ≠ x := by
-  simp only [allNames, List.mem_append, List.mem_map] at h
-  rcases h with ⟨⟨⟨v, hv, rfl⟩ | ⟨c, hc, rfl⟩⟩ | ⟨u, hu, rfl⟩⟩ | ⟨b, hb, rfl⟩
-  · exact (mem_remove_vars.mp hv).2
-  · exact (mem_remove_consts.mp hc).2
-  · exact (mem_remove_unary.mp hu).2
-  · exact (mem_remove_binary.mp hb).2
+  intro hnx
+  subst hnx
+  cases Δ with
+  | mk vars consts unary binary unaryRel binaryRel =>
+    simp [allNames, remove] at h
+    rcases h with h | h | h | h | h | h
+    · rcases h with ⟨v, hv, hname⟩
+      exact (hv.2 hname).elim
+    · rcases h with ⟨c, hc, hname⟩
+      exact (hc.2 hname).elim
+    · rcases h with ⟨u, hu, hname⟩
+      exact (hu.2 hname).elim
+    · rcases h with ⟨b, hb, hname⟩
+      exact (hb.2 hname).elim
+    · rcases h with ⟨u, hu, hname⟩
+      exact (hu.2 hname).elim
+    · rcases h with ⟨b, hb, hname⟩
+      exact (hb.2 hname).elim
 
 theorem wf_empty : Signature.empty.wf := by simp [wf, allNames]
 
@@ -177,12 +234,14 @@ theorem wf_addVar {Δ : Signature} {v : Var}
   suffices h : (Δ.addVar v).allNames.Perm (v.name :: Δ.allNames) from
     h.nodup_iff.mpr (List.nodup_cons.mpr ⟨hfresh, hΔ⟩)
   show ((v :: Δ.vars).map Var.name ++ Δ.consts.map FOL.Const.name ++
-    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name).Perm
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name).Perm
     (v.name :: (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
-    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name))
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
   simp
 
-def ofVars (vars : VarCtx) : Signature := ⟨vars, [], [], []⟩
+def ofVars (vars : VarCtx) : Signature := ⟨vars, [], [], [], [], []⟩
 
 @[simp] theorem ofVars_vars (vars : VarCtx) : (ofVars vars).vars = vars := rfl
 
@@ -210,7 +269,23 @@ def ofVars (vars : VarCtx) : Signature := ⟨vars, [], [], []⟩
     simpa [Signature.declVars, Signature.declVar, Signature.ofVars, Signature.addVar, Signature.remove]
       using ih (vars := v :: vars.filter (fun w => w.name != v.name))
 
-def ofConsts (consts : List FOL.Const) : Signature := ⟨[], consts, [], []⟩
+@[simp] theorem ofVars_declVars_unaryRel (vars vs : List Var) :
+    ((Signature.ofVars vars).declVars vs).unaryRel = [] := by
+  induction vs generalizing vars with
+  | nil => rfl
+  | cons v vs ih =>
+    simpa [Signature.declVars, Signature.declVar, Signature.ofVars, Signature.addVar, Signature.remove]
+      using ih (vars := v :: vars.filter (fun w => w.name != v.name))
+
+@[simp] theorem ofVars_declVars_binaryRel (vars vs : List Var) :
+    ((Signature.ofVars vars).declVars vs).binaryRel = [] := by
+  induction vs generalizing vars with
+  | nil => rfl
+  | cons v vs ih =>
+    simpa [Signature.declVars, Signature.declVar, Signature.ofVars, Signature.addVar, Signature.remove]
+      using ih (vars := v :: vars.filter (fun w => w.name != v.name))
+
+def ofConsts (consts : List FOL.Const) : Signature := ⟨[], consts, [], [], [], []⟩
 
 @[simp] theorem ofConsts_consts (consts : List FOL.Const) : (ofConsts consts).consts = consts := rfl
 
@@ -219,17 +294,21 @@ structure Subset (Δ₁ Δ₂ : Signature) : Prop where
   consts : ∀ c ∈ Δ₁.consts, c ∈ Δ₂.consts
   unary  : ∀ u ∈ Δ₁.unary, u ∈ Δ₂.unary
   binary : ∀ b ∈ Δ₁.binary, b ∈ Δ₂.binary
+  unaryRel : ∀ u ∈ Δ₁.unaryRel, u ∈ Δ₂.unaryRel
+  binaryRel : ∀ b ∈ Δ₁.binaryRel, b ∈ Δ₂.binaryRel
 
 structure SymbolSubset (Δ₁ Δ₂ : Signature) : Prop where
   consts : ∀ c ∈ Δ₁.consts, c ∈ Δ₂.consts
   unary  : ∀ u ∈ Δ₁.unary, u ∈ Δ₂.unary
   binary : ∀ b ∈ Δ₁.binary, b ∈ Δ₂.binary
+  unaryRel : ∀ u ∈ Δ₁.unaryRel, u ∈ Δ₂.unaryRel
+  binaryRel : ∀ b ∈ Δ₁.binaryRel, b ∈ Δ₂.binaryRel
 
 theorem Subset.refl (Δ : Signature) : Δ.Subset Δ :=
-  ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
+  ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
 theorem SymbolSubset.refl (Δ : Signature) : Δ.SymbolSubset Δ :=
-  ⟨fun _ h => h, fun _ h => h, fun _ h => h⟩
+  ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
 theorem SymbolSubset.ofVars (vars : VarCtx) (Δ : Signature) : (Signature.ofVars vars).SymbolSubset Δ :=
   by
@@ -239,11 +318,13 @@ theorem SymbolSubset.trans {Δ₁ Δ₂ Δ₃ : Signature}
     (h₁₂ : Δ₁.SymbolSubset Δ₂) (h₂₃ : Δ₂.SymbolSubset Δ₃) : Δ₁.SymbolSubset Δ₃ :=
   ⟨fun c hc => h₂₃.consts c (h₁₂.consts c hc),
    fun u hu => h₂₃.unary u (h₁₂.unary u hu),
-   fun b hb => h₂₃.binary b (h₁₂.binary b hb)⟩
+   fun b hb => h₂₃.binary b (h₁₂.binary b hb),
+   fun u hu => h₂₃.unaryRel u (h₁₂.unaryRel u hu),
+   fun b hb => h₂₃.binaryRel b (h₁₂.binaryRel b hb)⟩
 
 theorem SymbolSubset.subset_addConst (Δ : Signature) (c : FOL.Const) :
     Δ.SymbolSubset (Δ.addConst c) :=
-  ⟨fun _ hc' => List.mem_cons_of_mem _ hc', fun _ hu => hu, fun _ hb => hb⟩
+  ⟨fun _ hc' => List.mem_cons_of_mem _ hc', fun _ hu => hu, fun _ hb => hb, fun _ hu => hu, fun _ hb => hb⟩
 
 theorem SymbolSubset.declVar {Δ Δ' : Signature} (h : Δ.SymbolSubset Δ') (v : Var) :
     (Δ.declVar v).SymbolSubset Δ' := by
@@ -257,21 +338,29 @@ theorem SymbolSubset.declVar {Δ Δ' : Signature} (h : Δ.SymbolSubset Δ') (v :
   · intro b hb
     rcases Signature.mem_remove_binary.mp (by simpa [Signature.declVar, Signature.addVar] using hb) with ⟨hb, _⟩
     exact h.binary b hb
+  · intro u hu
+    rcases Signature.mem_remove_unaryRel.mp (by simpa [Signature.declVar, Signature.addVar] using hu) with ⟨hu, _⟩
+    exact h.unaryRel u hu
+  · intro b hb
+    rcases Signature.mem_remove_binaryRel.mp (by simpa [Signature.declVar, Signature.addVar] using hb) with ⟨hb, _⟩
+    exact h.binaryRel b hb
 
 theorem allNames_subset {Δ Δ' : Signature} (h : Δ.Subset Δ') :
     ∀ n ∈ Δ.allNames, n ∈ Δ'.allNames := by
   intro n hn
   simp only [allNames, List.mem_append, List.mem_map] at hn ⊢
-  rcases hn with ⟨⟨⟨v, hv, rfl⟩ | ⟨c, hc, rfl⟩⟩ | ⟨u, hu, rfl⟩⟩ | ⟨b, hb, rfl⟩
-  · left; left; left; exact ⟨v, h.vars v hv, rfl⟩
-  · left; left; right; exact ⟨c, h.consts c hc, rfl⟩
-  · left; right; exact ⟨u, h.unary u hu, rfl⟩
-  · right; exact ⟨b, h.binary b hb, rfl⟩
+  rcases hn with ⟨⟨⟨⟨⟨v, hv, rfl⟩ | ⟨c, hc, rfl⟩⟩ | ⟨u, hu, rfl⟩⟩ | ⟨b, hb, rfl⟩⟩ | ⟨u, hu, rfl⟩⟩ | ⟨b, hb, rfl⟩
+  · left; left; left; left; left; exact ⟨v, h.vars v hv, rfl⟩
+  · left; left; left; left; right; exact ⟨c, h.consts c hc, rfl⟩
+  · left; left; left; right; exact ⟨u, h.unary u hu, rfl⟩
+  · left; left; right; exact ⟨b, h.binary b hb, rfl⟩
+  · left; right; exact ⟨u, h.unaryRel u hu, rfl⟩
+  · right; exact ⟨b, h.binaryRel b hb, rfl⟩
 
 theorem Subset.addVar {Δ Δ' : Signature} (h : Δ.Subset Δ') (v : Var) :
     (Δ.addVar v).Subset (Δ'.addVar v) :=
   ⟨fun x hx => by cases hx with | head => left | tail _ hmem => right; exact h.vars x hmem,
-   h.consts, h.unary, h.binary⟩
+   h.consts, h.unary, h.binary, h.unaryRel, h.binaryRel⟩
 
 theorem Subset.addVars {Δ Δ' : Signature} (h : Δ.Subset Δ') (vs : List Var) :
     (Δ.addVars vs).Subset (Δ'.addVars vs) :=
@@ -279,27 +368,35 @@ theorem Subset.addVars {Δ Δ' : Signature} (h : Δ.Subset Δ') (vs : List Var) 
     cases List.mem_append.mp hx with
     | inl hmem => exact List.mem_append_left _ hmem
     | inr hmem => exact List.mem_append_right _ (h.vars x hmem),
-   h.consts, h.unary, h.binary⟩
+   h.consts, h.unary, h.binary, h.unaryRel, h.binaryRel⟩
 
 theorem Subset.subset_addVar (Δ : Signature) (v : Var) :
     Δ.Subset (Δ.addVar v) :=
-  ⟨fun _ hx => List.mem_cons_of_mem _ hx, fun _ h => h, fun _ h => h, fun _ h => h⟩
+  ⟨fun _ hx => List.mem_cons_of_mem _ hx, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
 theorem Subset.subset_addConst (Δ : Signature) (c : FOL.Const) :
     Δ.Subset (Δ.addConst c) :=
-  ⟨fun _ h => h, fun _ hc => List.mem_cons_of_mem _ hc, fun _ h => h, fun _ h => h⟩
+  ⟨fun _ h => h, fun _ hc => List.mem_cons_of_mem _ hc, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
 theorem Subset.subset_addUnary (Δ : Signature) (u : FOL.Unary) :
     Δ.Subset (Δ.addUnary u) :=
-  ⟨fun _ h => h, fun _ h => h, fun _ hu => List.mem_cons_of_mem _ hu, fun _ h => h⟩
+  ⟨fun _ h => h, fun _ h => h, fun _ hu => List.mem_cons_of_mem _ hu, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
 theorem Subset.subset_addBinary (Δ : Signature) (b : FOL.Binary) :
     Δ.Subset (Δ.addBinary b) :=
-  ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ hb => List.mem_cons_of_mem _ hb⟩
+  ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ hb => List.mem_cons_of_mem _ hb, fun _ h => h, fun _ h => h⟩
+
+theorem Subset.subset_addUnaryRel (Δ : Signature) (u : FOL.UnaryRel) :
+    Δ.Subset (Δ.addUnaryRel u) :=
+  ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ hu => List.mem_cons_of_mem _ hu, fun _ h => h⟩
+
+theorem Subset.subset_addBinaryRel (Δ : Signature) (b : FOL.BinaryRel) :
+    Δ.Subset (Δ.addBinaryRel b) :=
+  ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ hb => List.mem_cons_of_mem _ hb⟩
 
 theorem Subset.subset_addVars (Δ : Signature) (vs : List Var) :
     Δ.Subset (Δ.addVars vs) :=
-  ⟨fun _ hx => List.mem_append_right _ hx, fun _ h => h, fun _ h => h, fun _ h => h⟩
+  ⟨fun _ hx => List.mem_append_right _ hx, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
 theorem Subset.addVars_cons (Δ : Signature) (v : Var) (vs : List Var) :
     (Δ.addVars (v :: vs)).Subset ((Δ.addVar v).addVars vs) := by
@@ -313,6 +410,8 @@ theorem Subset.addVars_cons (Δ : Signature) (v : Var) (vs : List Var) :
     · left; exact hx
     · right; right; exact hx
   · intro c hc; exact hc
+  · intro u hu; exact hu
+  · intro b hb; exact hb
   · intro u hu; exact hu
   · intro b hb; exact hb
 
@@ -330,17 +429,21 @@ theorem Subset.addVar_addVars (Δ : Signature) (v : Var) (vs : List Var) :
   · intro c hc; exact hc
   · intro u hu; exact hu
   · intro b hb; exact hb
+  · intro u hu; exact hu
+  · intro b hb; exact hb
 
 theorem Subset.of_vars_subset_ofVars {vars vars' : VarCtx} (h : vars ⊆ vars') :
     (Signature.ofVars vars).Subset (Signature.ofVars vars') :=
-  ⟨h, fun _ h => h, fun _ h => h, fun _ h => h⟩
+  ⟨h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
 theorem Subset.trans {Δ₁ Δ₂ Δ₃ : Signature} (h₁₂ : Δ₁.Subset Δ₂) (h₂₃ : Δ₂.Subset Δ₃) :
     Δ₁.Subset Δ₃ :=
   ⟨fun x hx => h₂₃.vars x (h₁₂.vars x hx),
    fun c hc => h₂₃.consts c (h₁₂.consts c hc),
    fun u hu => h₂₃.unary u (h₁₂.unary u hu),
-   fun b hb => h₂₃.binary b (h₁₂.binary b hb)⟩
+   fun b hb => h₂₃.binary b (h₁₂.binary b hb),
+   fun u hu => h₂₃.unaryRel u (h₁₂.unaryRel u hu),
+   fun b hb => h₂₃.binaryRel b (h₁₂.binaryRel b hb)⟩
 
 theorem Subset.mono_vars {Δ Δ' : Signature} (h : Δ.Subset Δ') : Δ.vars ⊆ Δ'.vars :=
   h.vars
@@ -349,7 +452,9 @@ theorem remove_subset (Δ : Signature) (x : String) : (Δ.remove x).Subset Δ :=
   ⟨fun _ h => (mem_remove_vars.mp h).1,
    fun _ h => (mem_remove_consts.mp h).1,
    fun _ h => (mem_remove_unary.mp h).1,
-   fun _ h => (mem_remove_binary.mp h).1⟩
+   fun _ h => (mem_remove_binary.mp h).1,
+   fun _ h => (mem_remove_unaryRel.mp h).1,
+   fun _ h => (mem_remove_binaryRel.mp h).1⟩
 
 theorem remove_allNames_subset {Δ : Signature} {x n : String} (h : n ∈ (Δ.remove x).allNames) :
     n ∈ Δ.allNames :=
@@ -362,42 +467,40 @@ theorem remove_idempotent (Δ : Signature) (x : String) : (Δ.remove x).remove x
 theorem remove_eq_of_not_in {Δ : Signature} {x : String} (h : x ∉ Δ.allNames) :
     Δ.remove x = Δ := by
   cases Δ with
-  | mk vars consts unary binary =>
-  simp only [allNames, List.mem_append, List.mem_map] at h
-  have hvars : List.filter (fun v : Var => v.name != x) vars = vars := by
-    apply List.filter_eq_self.2
-    intro v hv
-    have hx : v.name ≠ x := by
-      intro hname
-      exact h (Or.inl (Or.inl (Or.inl ⟨v, hv, hname⟩)))
-    simp [hx]
-  have hconsts : List.filter (fun c : FOL.Const => c.name != x) consts = consts := by
-    apply List.filter_eq_self.2
-    intro c hc
-    have hx : c.name ≠ x := by
-      intro hname
-      exact h (Or.inl (Or.inl (Or.inr ⟨c, hc, hname⟩)))
-    simp [hx]
-  have hunary : List.filter (fun u : FOL.Unary => u.name != x) unary = unary := by
-    apply List.filter_eq_self.2
-    intro u hu
-    have hx : u.name ≠ x := by
-      intro hname
-      exact h (Or.inl (Or.inr ⟨u, hu, hname⟩))
-    simp [hx]
-  have hbinary : List.filter (fun b : FOL.Binary => b.name != x) binary = binary := by
-    apply List.filter_eq_self.2
-    intro b hb
-    have hx : b.name ≠ x := by
-      intro hname
-      exact h (Or.inr ⟨b, hb, hname⟩)
-    simp [hx]
-  simp [remove, hvars, hconsts, hunary, hbinary]
+  | mk vars consts unary binary unaryRel binaryRel =>
+    simp [allNames] at h
+    rcases h with ⟨hvars, hconsts, hunary, hbinary, hunaryRel, hbinaryRel⟩
+    have hvars' : List.filter (fun v : Var => v.name != x) vars = vars := by
+      apply List.filter_eq_self.2
+      intro v hv
+      simp [hvars v hv]
+    have hconsts' : List.filter (fun c : FOL.Const => c.name != x) consts = consts := by
+      apply List.filter_eq_self.2
+      intro c hc
+      simp [hconsts c hc]
+    have hunary' : List.filter (fun u : FOL.Unary => u.name != x) unary = unary := by
+      apply List.filter_eq_self.2
+      intro u hu
+      simp [hunary u hu]
+    have hbinary' : List.filter (fun b : FOL.Binary => b.name != x) binary = binary := by
+      apply List.filter_eq_self.2
+      intro b hb
+      simp [hbinary b hb]
+    have hunaryRel' : List.filter (fun u : FOL.UnaryRel => u.name != x) unaryRel = unaryRel := by
+      apply List.filter_eq_self.2
+      intro u hu
+      simp [hunaryRel u hu]
+    have hbinaryRel' : List.filter (fun b : FOL.BinaryRel => b.name != x) binaryRel = binaryRel := by
+      apply List.filter_eq_self.2
+      intro b hb
+      simp [hbinaryRel b hb]
+    simp [remove,
+      hvars', hconsts', hunary', hbinary', hunaryRel', hbinaryRel']
 
 private theorem allNames_remove_sublist (Δ : Signature) (x : String) :
     List.Sublist (Δ.remove x).allNames Δ.allNames := by
   cases Δ with
-  | mk vars consts unary binary =>
+  | mk vars consts unary binary unaryRel binaryRel =>
     simp [remove, allNames]
     apply List.Sublist.append
     · exact (List.filter_sublist (l := vars) (p := fun v : Var => v.name != x)).map Var.name
@@ -405,7 +508,11 @@ private theorem allNames_remove_sublist (Δ : Signature) (x : String) :
       · exact (List.filter_sublist (l := consts) (p := fun c : FOL.Const => c.name != x)).map FOL.Const.name
       · apply List.Sublist.append
         · exact (List.filter_sublist (l := unary) (p := fun u : FOL.Unary => u.name != x)).map FOL.Unary.name
-        · exact (List.filter_sublist (l := binary) (p := fun b : FOL.Binary => b.name != x)).map FOL.Binary.name
+        · apply List.Sublist.append
+          · exact (List.filter_sublist (l := binary) (p := fun b : FOL.Binary => b.name != x)).map FOL.Binary.name
+          · apply List.Sublist.append
+            · exact (List.filter_sublist (l := unaryRel) (p := fun u : FOL.UnaryRel => u.name != x)).map FOL.UnaryRel.name
+            · exact (List.filter_sublist (l := binaryRel) (p := fun b : FOL.BinaryRel => b.name != x)).map FOL.BinaryRel.name
 
 theorem wf_remove {Δ : Signature} (hΔ : Δ.wf) (x : String) : (Δ.remove x).wf := by
   rw [wf] at hΔ ⊢
@@ -462,24 +569,32 @@ private theorem unique_sort_of_nodup_map_const_name {l : List FOL.Const} {x : St
 
 theorem wf_unique_var {Δ : Signature} {x : String} {τ τ' : Srt}
     (hΔ : Δ.wf) (hv : ⟨x, τ⟩ ∈ Δ.vars) (hv' : ⟨x, τ'⟩ ∈ Δ.vars) : τ' = τ :=
-  unique_sort_of_nodup_map_name
-    (List.nodup_append.mp (List.nodup_append.mp (List.nodup_append.mp hΔ).1).1).1
-    hv hv'
+  by
+    have hABCDE := (List.nodup_append.mp hΔ).1
+    have hABCD := (List.nodup_append.mp hABCDE).1
+    have hABC := (List.nodup_append.mp hABCD).1
+    have hAB := (List.nodup_append.mp hABC).1
+    exact unique_sort_of_nodup_map_name (l := Δ.vars) (x := x) (List.nodup_append.mp hAB).1 hv hv'
 
 theorem wf_unique_const {Δ : Signature} {x : String} {τ τ' : Srt}
     (hΔ : Δ.wf) (hc : ⟨x, τ⟩ ∈ Δ.consts) (hc' : ⟨x, τ'⟩ ∈ Δ.consts) : τ' = τ :=
-  unique_sort_of_nodup_map_const_name
-    (List.nodup_append.mp (List.nodup_append.mp (List.nodup_append.mp hΔ).1).1).2.1
-    hc hc'
+  by
+    have hABCDE := (List.nodup_append.mp hΔ).1
+    have hABCD := (List.nodup_append.mp hABCDE).1
+    have hABC := (List.nodup_append.mp hABCD).1
+    have hAB := (List.nodup_append.mp hABC).1
+    exact unique_sort_of_nodup_map_const_name (l := Δ.consts) (x := x) (List.nodup_append.mp hAB).2.1 hc hc'
 
 theorem wf_no_const_of_var {Δ : Signature} {x : String} {τ τ' : Srt}
     (hΔ : Δ.wf) (hv : ⟨x, τ⟩ ∈ Δ.vars) : ⟨x, τ'⟩ ∉ Δ.consts := by
   intro hc
-  have hnodup : Δ.allNames.Nodup := hΔ
-  have hsplit₁ := List.nodup_append.mp hnodup
-  have hsplit₂ := List.nodup_append.mp hsplit₁.1
-  have hsplit₃ := List.nodup_append.mp hsplit₂.1
-  have hdisj := hsplit₃.2.2
+  have hABCDE := (List.nodup_append.mp hΔ).1
+  have hABCD := (List.nodup_append.mp hABCDE).1
+  have hABC := (List.nodup_append.mp hABCD).1
+  have hAB := (List.nodup_append.mp hABC).1
+  have hdisj :
+      ∀ a ∈ Δ.vars.map Var.name, ∀ b ∈ Δ.consts.map FOL.Const.name, a ≠ b :=
+    (List.nodup_append.mp hAB).2.2
   have hxv : x ∈ Δ.vars.map Var.name := List.mem_map.mpr ⟨⟨x, τ⟩, hv, rfl⟩
   have hxc : x ∈ Δ.consts.map FOL.Const.name := List.mem_map.mpr ⟨⟨x, τ'⟩, hc, rfl⟩
   exact hdisj x hxv x hxc rfl
@@ -504,6 +619,12 @@ theorem Subset.remove {Δ Δ' : Signature} (h : Δ.Subset Δ') (x : String) :
   · intro b hb
     rcases mem_remove_binary.mp hb with ⟨hb, hx⟩
     exact mem_remove_binary.mpr ⟨h.binary b hb, hx⟩
+  · intro u hu
+    rcases mem_remove_unaryRel.mp hu with ⟨hu, hx⟩
+    exact mem_remove_unaryRel.mpr ⟨h.unaryRel u hu, hx⟩
+  · intro b hb
+    rcases mem_remove_binaryRel.mp hb with ⟨hb, hx⟩
+    exact mem_remove_binaryRel.mpr ⟨h.binaryRel b hb, hx⟩
 
 theorem Subset.declVar {Δ Δ' : Signature} (h : Δ.Subset Δ') (v : Var) :
     (Δ.declVar v).Subset (Δ'.declVar v) := by
@@ -521,7 +642,12 @@ theorem Subset.declVars {Δ Δ' : Signature} (h : Δ.Subset Δ') (vs : List Var)
 theorem Subset.ofVars {vars vs : List Var} {Δ : Signature}
     (hvars : ((Signature.ofVars vars).declVars vs).vars ⊆ Δ.vars) :
     ((Signature.ofVars vars).declVars vs).Subset Δ :=
-  ⟨hvars, fun _ hc => by simp at hc, fun _ hu => by simp at hu, fun _ hb => by simp at hb⟩
+  ⟨hvars,
+   fun _ hc => by simp at hc,
+   fun _ hu => by simp at hu,
+   fun _ hb => by simp at hb,
+   fun _ hu => by simp at hu,
+   fun _ hb => by simp at hb⟩
 
 
 end Signature
@@ -540,10 +666,13 @@ structure Env where
   consts : (τ : Srt) → String → τ.denote
   unary  : (τ₁ τ₂ : Srt) → String → τ₁.denote → τ₂.denote
   binary : (τ₁ τ₂ τ₃ : Srt) → String → τ₁.denote → τ₂.denote → τ₃.denote
+  unaryRel : (τ : Srt) → String → τ.denote → Prop
+  binaryRel : (τ₁ τ₂ : Srt) → String → τ₁.denote → τ₂.denote → Prop
 
 theorem Env.ext {e1 e2 : Env}
     (h1 : e1.consts = e2.consts)
-    (h2 : e1.unary = e2.unary) (h3 : e1.binary = e2.binary) : e1 = e2 := by
+    (h2 : e1.unary = e2.unary) (h3 : e1.binary = e2.binary)
+    (h4 : e1.unaryRel = e2.unaryRel) (h5 : e1.binaryRel = e2.binaryRel) : e1 = e2 := by
   cases e1; cases e2; congr
 
 def Env.lookupConst (ρ : Env) (τ : Srt) (x : String) : τ.denote := ρ.consts τ x
@@ -561,8 +690,18 @@ def Env.updateBinary (ρ : Env) (τ₁ τ₂ τ₃ : Srt) (x : String)
     if h : τ₁' = τ₁ ∧ τ₂' = τ₂ ∧ τ₃' = τ₃ ∧ y = x then h.1 ▸ h.2.1 ▸ h.2.2.1 ▸ f
     else ρ.binary τ₁' τ₂' τ₃' y }
 
+def Env.updateUnaryRel (ρ : Env) (τ : Srt) (x : String) (f : τ.denote → Prop) : Env :=
+  { ρ with unaryRel := fun τ' y =>
+    if h : τ' = τ ∧ y = x then h.1 ▸ f else ρ.unaryRel τ' y }
+
+def Env.updateBinaryRel (ρ : Env) (τ₁ τ₂ : Srt) (x : String)
+    (f : τ₁.denote → τ₂.denote → Prop) : Env :=
+  { ρ with binaryRel := fun τ₁' τ₂' y =>
+    if h : τ₁' = τ₁ ∧ τ₂' = τ₂ ∧ y = x then h.1 ▸ h.2.1 ▸ f else ρ.binaryRel τ₁' τ₂' y }
+
 def Env.empty : Env :=
-  ⟨fun _ _ => default, fun _ _ _ _ => default, fun _ _ _ _ _ => default⟩
+  ⟨fun _ _ => default, fun _ _ _ _ => default, fun _ _ _ _ _ => default,
+   fun _ _ _ => False, fun _ _ _ _ _ => False⟩
 
 instance : Inhabited Env := { default := Env.empty }
 
@@ -589,21 +728,31 @@ theorem Env.updateConst_unary {ρ : Env} {τ : Srt} {x : String} {v : τ.denote}
 theorem Env.updateConst_binary {ρ : Env} {τ : Srt} {x : String} {v : τ.denote} :
     (ρ.updateConst τ x v).binary = ρ.binary := rfl
 
+theorem Env.updateConst_unaryRel {ρ : Env} {τ : Srt} {x : String} {v : τ.denote} :
+    (ρ.updateConst τ x v).unaryRel = ρ.unaryRel := rfl
+
+theorem Env.updateConst_binaryRel {ρ : Env} {τ : Srt} {x : String} {v : τ.denote} :
+    (ρ.updateConst τ x v).binaryRel = ρ.binaryRel := rfl
+
 def Env.agreeOn (Δ : Signature) (ρ ρ' : Env) : Prop :=
   (∀ v ∈ Δ.vars, ρ.consts v.sort v.name = ρ'.consts v.sort v.name) ∧
   (∀ c ∈ Δ.consts, ρ.consts c.sort c.name = ρ'.consts c.sort c.name) ∧
   (∀ u ∈ Δ.unary, ρ.unary u.arg u.ret u.name = ρ'.unary u.arg u.ret u.name) ∧
-  (∀ b ∈ Δ.binary, ρ.binary b.arg1 b.arg2 b.ret b.name = ρ'.binary b.arg1 b.arg2 b.ret b.name)
+  (∀ b ∈ Δ.binary, ρ.binary b.arg1 b.arg2 b.ret b.name = ρ'.binary b.arg1 b.arg2 b.ret b.name) ∧
+  (∀ u ∈ Δ.unaryRel, ρ.unaryRel u.arg u.name = ρ'.unaryRel u.arg u.name) ∧
+  (∀ b ∈ Δ.binaryRel, ρ.binaryRel b.arg1 b.arg2 b.name = ρ'.binaryRel b.arg1 b.arg2 b.name)
 
 theorem Env.agreeOn_refl : Env.agreeOn Δ ρ ρ :=
-  ⟨fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl⟩
+  ⟨fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl⟩
 
 theorem Env.agreeOn_mono {Δ₁ Δ₂ : Signature} (hsub : Δ₁.Subset Δ₂)
     (h : Env.agreeOn Δ₂ ρ ρ') : Env.agreeOn Δ₁ ρ ρ' :=
   ⟨fun x hx => h.1 x (hsub.vars x hx),
    fun c hc => h.2.1 c (hsub.consts c hc),
    fun u hu => h.2.2.1 u (hsub.unary u hu),
-   fun b hb => h.2.2.2 b (hsub.binary b hb)⟩
+   fun b hb => h.2.2.2.1 b (hsub.binary b hb),
+   fun u hu => h.2.2.2.2.1 u (hsub.unaryRel u hu),
+   fun b hb => h.2.2.2.2.2 b (hsub.binaryRel b hb)⟩
 
 theorem Env.agreeOn_remove {Δ : Signature} {ρ ρ' : Env} {x : String}
     (h : Env.agreeOn Δ ρ ρ') : Env.agreeOn (Δ.remove x) ρ ρ' :=
@@ -613,14 +762,18 @@ theorem Env.agreeOn_symm {Δ : Signature} {ρ ρ' : Env} (h : Env.agreeOn Δ ρ 
   ⟨fun v hv => (h.1 v hv).symm,
    fun c hc => (h.2.1 c hc).symm,
    fun u hu => (h.2.2.1 u hu).symm,
-   fun b hb => (h.2.2.2 b hb).symm⟩
+   fun b hb => (h.2.2.2.1 b hb).symm,
+   fun u hu => (h.2.2.2.2.1 u hu).symm,
+   fun b hb => (h.2.2.2.2.2 b hb).symm⟩
 
 theorem Env.agreeOn_trans {Δ : Signature}
     (h₁₂ : Env.agreeOn Δ ρ₁ ρ₂) (h₂₃ : Env.agreeOn Δ ρ₂ ρ₃) : Env.agreeOn Δ ρ₁ ρ₃ :=
   ⟨fun x hx => (h₁₂.1 x hx).trans (h₂₃.1 x hx),
    fun c hc => (h₁₂.2.1 c hc).trans (h₂₃.2.1 c hc),
    fun u hu => (h₁₂.2.2.1 u hu).trans (h₂₃.2.2.1 u hu),
-   fun b hb => (h₁₂.2.2.2 b hb).trans (h₂₃.2.2.2 b hb)⟩
+   fun b hb => (h₁₂.2.2.2.1 b hb).trans (h₂₃.2.2.2.1 b hb),
+   fun u hu => (h₁₂.2.2.2.2.1 u hu).trans (h₂₃.2.2.2.2.1 u hu),
+   fun b hb => (h₁₂.2.2.2.2.2 b hb).trans (h₂₃.2.2.2.2.2 b hb)⟩
 
 theorem Env.agreeOn_addVars_cons (Δ : Signature) (v : Var) (vs : List Var) (ρ ρ' : Env) :
     Env.agreeOn (Δ.addVars (v :: vs)) ρ ρ' ↔ Env.agreeOn ((Δ.addVar v).addVars vs) ρ ρ' :=
@@ -648,7 +801,9 @@ theorem Env.agreeOn_update {ρ ρ' : Env} {Δ : Signature} {τ : Srt} {x : Strin
      · simp [Env.updateConst, hn, hagree.2.1 c hc]
      · simp [Env.updateConst, hn, hagree.2.1 c hc],
    fun u hu => by rw [Env.updateConst_unary]; exact hagree.2.2.1 u hu,
-   fun b hb => by rw [Env.updateConst_binary]; exact hagree.2.2.2 b hb⟩
+   fun b hb => by rw [Env.updateConst_binary]; exact hagree.2.2.2.1 b hb,
+   fun u hu => by rw [Env.updateConst_unaryRel]; exact hagree.2.2.2.2.1 u hu,
+   fun b hb => by rw [Env.updateConst_binaryRel]; exact hagree.2.2.2.2.2 b hb⟩
 
 theorem Env.agreeOn_declVar {ρ ρ' : Env} {Δ : Signature} {τ : Srt} {x : String} {v : τ.denote} :
     Env.agreeOn Δ ρ ρ' →
@@ -678,8 +833,14 @@ theorem Env.agreeOn_update_fresh_const {ρ : Env} {c : FOL.Const} {u : c.sort.de
     · constructor
       · intro u' hu'
         rw [Env.updateConst_unary]
-      · intro b' hb'
-        rw [Env.updateConst_binary]
+      · constructor
+        · intro b' hb'
+          rw [Env.updateConst_binary]
+        · constructor
+          · intro u' hu'
+            rw [Env.updateConst_unaryRel]
+          · intro b' hb'
+            rw [Env.updateConst_binaryRel]
 
 /-- Double update with the same variable - second update wins. -/
 @[simp] theorem Env.updateConst_updateConst_same {ρ : Env} {τ : Srt} {x : String} {v w : τ.denote} :

--- a/Mica/FOL/Variables.lean
+++ b/Mica/FOL/Variables.lean
@@ -567,6 +567,39 @@ private theorem unique_sort_of_nodup_map_const_name {l : List FOL.Const} {x : St
       · exact absurd (List.mem_map_of_mem hmem) hnd.1
       · exact ih hnd.2 hmem hmem'
 
+private theorem unique_sig_of_nodup_map_unary_name {l : List FOL.Unary} {x : String}
+    {τ₁ τ₂ τ₁' τ₂' : Srt} (hnd : (l.map FOL.Unary.name).Nodup)
+    (hu : ⟨x, τ₁, τ₂⟩ ∈ l) (hu' : ⟨x, τ₁', τ₂'⟩ ∈ l) : τ₁' = τ₁ ∧ τ₂' = τ₂ := by
+  induction l with
+  | nil => simp at hu
+  | cons u us ih =>
+    rw [List.map, List.nodup_cons] at hnd
+    rcases List.mem_cons.mp hu with rfl | hmem
+    · rcases List.mem_cons.mp hu' with heq | hmem'
+      · rcases FOL.Unary.mk.inj heq with ⟨_, harg, hret⟩
+        exact ⟨harg, hret⟩
+      · exact absurd (List.mem_map_of_mem hmem') hnd.1
+    · rcases List.mem_cons.mp hu' with rfl | hmem'
+      · exact absurd (List.mem_map_of_mem hmem) hnd.1
+      · exact ih hnd.2 hmem hmem'
+
+private theorem unique_sig_of_nodup_map_binary_name {l : List FOL.Binary} {x : String}
+    {τ₁ τ₂ τ₃ τ₁' τ₂' τ₃' : Srt} (hnd : (l.map FOL.Binary.name).Nodup)
+    (hb : ⟨x, τ₁, τ₂, τ₃⟩ ∈ l) (hb' : ⟨x, τ₁', τ₂', τ₃'⟩ ∈ l) :
+    τ₁' = τ₁ ∧ τ₂' = τ₂ ∧ τ₃' = τ₃ := by
+  induction l with
+  | nil => simp at hb
+  | cons b bs ih =>
+    rw [List.map, List.nodup_cons] at hnd
+    rcases List.mem_cons.mp hb with rfl | hmem
+    · rcases List.mem_cons.mp hb' with heq | hmem'
+      · rcases FOL.Binary.mk.inj heq with ⟨_, harg1, harg2, hret⟩
+        exact ⟨harg1, harg2, hret⟩
+      · exact absurd (List.mem_map_of_mem hmem') hnd.1
+    · rcases List.mem_cons.mp hb' with rfl | hmem'
+      · exact absurd (List.mem_map_of_mem hmem) hnd.1
+      · exact ih hnd.2 hmem hmem'
+
 theorem wf_unique_var {Δ : Signature} {x : String} {τ τ' : Srt}
     (hΔ : Δ.wf) (hv : ⟨x, τ⟩ ∈ Δ.vars) (hv' : ⟨x, τ'⟩ ∈ Δ.vars) : τ' = τ :=
   by
@@ -584,6 +617,23 @@ theorem wf_unique_const {Δ : Signature} {x : String} {τ τ' : Srt}
     have hABC := (List.nodup_append.mp hABCD).1
     have hAB := (List.nodup_append.mp hABC).1
     exact unique_sort_of_nodup_map_const_name (l := Δ.consts) (x := x) (List.nodup_append.mp hAB).2.1 hc hc'
+
+theorem wf_unique_unary {Δ : Signature} {x : String} {τ₁ τ₂ τ₁' τ₂' : Srt}
+    (hΔ : Δ.wf) (hu : ⟨x, τ₁, τ₂⟩ ∈ Δ.unary) (hu' : ⟨x, τ₁', τ₂'⟩ ∈ Δ.unary) :
+    τ₁' = τ₁ ∧ τ₂' = τ₂ := by
+  have hABCDE := (List.nodup_append.mp hΔ).1
+  have hABCD := (List.nodup_append.mp hABCDE).1
+  have hABC := (List.nodup_append.mp hABCD).1
+  exact unique_sig_of_nodup_map_unary_name (l := Δ.unary) (x := x)
+    (List.nodup_append.mp hABC).2.1 hu hu'
+
+theorem wf_unique_binary {Δ : Signature} {x : String} {τ₁ τ₂ τ₃ τ₁' τ₂' τ₃' : Srt}
+    (hΔ : Δ.wf) (hb : ⟨x, τ₁, τ₂, τ₃⟩ ∈ Δ.binary) (hb' : ⟨x, τ₁', τ₂', τ₃'⟩ ∈ Δ.binary) :
+    τ₁' = τ₁ ∧ τ₂' = τ₂ ∧ τ₃' = τ₃ := by
+  have hABCDE := (List.nodup_append.mp hΔ).1
+  have hABCD := (List.nodup_append.mp hABCDE).1
+  exact unique_sig_of_nodup_map_binary_name (l := Δ.binary) (x := x)
+    (List.nodup_append.mp hABCD).2.1 hb hb'
 
 theorem wf_no_const_of_var {Δ : Signature} {x : String} {τ τ' : Srt}
     (hΔ : Δ.wf) (hv : ⟨x, τ⟩ ∈ Δ.vars) : ⟨x, τ'⟩ ∉ Δ.consts := by
@@ -603,6 +653,45 @@ theorem wf_no_var_of_const {Δ : Signature} {x : String} {τ τ' : Srt}
     (hΔ : Δ.wf) (hc : ⟨x, τ⟩ ∈ Δ.consts) : ⟨x, τ'⟩ ∉ Δ.vars := by
   intro hv
   exact wf_no_const_of_var hΔ hv hc
+
+theorem wf_no_unaryRel_of_unary {Δ : Signature} {x : String} {τ₁ τ₂ τ' : Srt}
+    (hΔ : Δ.wf) (hu : ⟨x, τ₁, τ₂⟩ ∈ Δ.unary) : ⟨x, τ'⟩ ∉ Δ.unaryRel := by
+  intro hrel
+  have hABCDE := (List.nodup_append.mp hΔ).1
+  have hdisj :
+      ∀ a ∈ (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+        Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name),
+      ∀ b ∈ Δ.unaryRel.map FOL.UnaryRel.name, a ≠ b :=
+    (List.nodup_append.mp hABCDE).2.2
+  have hxu :
+      x ∈ (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+        Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name) := by
+    have hxunary : x ∈ Δ.unary.map FOL.Unary.name :=
+      List.mem_map.mpr ⟨(⟨x, τ₁, τ₂⟩ : FOL.Unary), hu, rfl⟩
+    simp [List.mem_append, hxunary]
+  have hxr : x ∈ Δ.unaryRel.map FOL.UnaryRel.name :=
+    List.mem_map.mpr ⟨(⟨x, τ'⟩ : FOL.UnaryRel), hrel, rfl⟩
+  exact hdisj x hxu x hxr rfl
+
+theorem wf_no_binaryRel_of_binary {Δ : Signature} {x : String} {τ₁ τ₂ τ₃ τ₁' τ₂' : Srt}
+    (hΔ : Δ.wf) (hb : ⟨x, τ₁, τ₂, τ₃⟩ ∈ Δ.binary) : ⟨x, τ₁', τ₂'⟩ ∉ Δ.binaryRel := by
+  intro hrel
+  have hdisj :
+      ∀ a ∈ (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+        Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+        Δ.unaryRel.map FOL.UnaryRel.name),
+      ∀ b ∈ Δ.binaryRel.map FOL.BinaryRel.name, a ≠ b :=
+    (List.nodup_append.mp hΔ).2.2
+  have hxb :
+      x ∈ (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+        Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+        Δ.unaryRel.map FOL.UnaryRel.name) := by
+    have hxbinary : x ∈ Δ.binary.map FOL.Binary.name :=
+      List.mem_map.mpr ⟨(⟨x, τ₁, τ₂, τ₃⟩ : FOL.Binary), hb, rfl⟩
+    simp [List.mem_append, hxbinary]
+  have hxr : x ∈ Δ.binaryRel.map FOL.BinaryRel.name :=
+    List.mem_map.mpr ⟨(⟨x, τ₁', τ₂'⟩ : FOL.BinaryRel), hrel, rfl⟩
+  exact hdisj x hxb x hxr rfl
 
 theorem Subset.remove {Δ Δ' : Signature} (h : Δ.Subset Δ') (x : String) :
     (Δ.remove x).Subset (Δ'.remove x) := by

--- a/Mica/SeparationLogic/LogicalRelation.lean
+++ b/Mica/SeparationLogic/LogicalRelation.lean
@@ -1011,16 +1011,16 @@ mutual
     cases ty with
     | int =>
       simp [typeConstraints]
-      simp only [Formula.wfIn]; exact ht
+      simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
     | bool =>
       simp [typeConstraints]
-      simp only [Formula.wfIn]; exact ht
+      simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
     | tuple ts =>
       simp only [typeConstraints]
       intro φ hφ
       cases hφ with
       | head =>
-        simp only [Formula.wfIn]; exact ht
+        simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
       | tail _ hφ =>
         exact typeConstraintsList_wfIn (by simp only [Term.wfIn]; exact ⟨trivial, ht⟩) φ hφ
     | _ => simp [typeConstraints]

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -305,9 +305,18 @@ theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ :
 theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Signature}
     (hmem : (φ, t) ∈ a.candidates) (h : a.wfIn Δ) : φ.wfIn Δ ∧ t.wfIn Δ := by
   cases a with
-  | isint v  => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
-  | isbool v => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
-  | isinj tag arity v => simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem; exact ⟨h, trivial, h⟩
+  | isint v =>
+    simp [candidates] at hmem
+    obtain ⟨rfl, rfl⟩ := hmem
+    exact ⟨⟨trivial, h⟩, ⟨trivial, h⟩⟩
+  | isbool v =>
+    simp [candidates] at hmem
+    obtain ⟨rfl, rfl⟩ := hmem
+    exact ⟨⟨trivial, h⟩, ⟨trivial, h⟩⟩
+  | isinj tag arity v =>
+    simp [candidates] at hmem
+    obtain ⟨rfl, rfl⟩ := hmem
+    exact ⟨⟨trivial, h⟩, ⟨trivial, h⟩⟩
   | own l => simp [candidates] at hmem
 
 

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -1216,7 +1216,13 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
           obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hy'
           exact ((hagreeOn_e.2.1 p.2 (hbwf p hp)).trans
             (hagreeOn_body_e.2.1 p.2 (hbwf_e p hp))).symm
-        · constructor <;> intro z hz <;> cases hz
+        · constructor
+          · intro z hz; cases hz
+          · constructor
+            · intro z hz; cases hz
+            · constructor
+              · intro z hz; cases hz
+              · intro z hz; cases hz
     have hρ_body_lookup : ρ_body.env.consts .value v.name = v_e := by
       simp [ρ_body, VerifM.Env.updateConst, Env.updateConst]
     have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body.env γ_body := by
@@ -1510,7 +1516,7 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
           Spec.argsEnv_agreeOn (Δ := Signature.empty)
             (ρ₁ := VerifM.Env.withEnv ρ_args (FiniteSubst.id.subst.eval ρ_args.env))
             (ρ₂ := VerifM.Env.empty)
-            (by exact ⟨nofun, nofun, nofun, nofun⟩) spec.args vs
+            (by exact ⟨nofun, nofun, nofun, nofun, nofun, nofun⟩) spec.args vs
             (by simp [List.length_map] at hlen_vs; omega)
       ispecialize Hspec $$ %Φ
       ispecialize Hspec $$ %vs
@@ -1758,7 +1764,13 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
           · intro c hc
             obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hc
             exact (hagreeOn_st.2.1 p.2 (hbwf p hp)).symm
-          · constructor <;> intro z hz <;> cases hz
+          · constructor
+            · intro z hz; cases hz
+            · constructor
+              · intro z hz; cases hz
+              · constructor
+                · intro z hz; cases hz
+                · intro z hz; cases hz
       have hbwf₂ : Bindings.wfIn ((x, xv) :: B) st₂.decls := hst₂_decls ▸ Bindings.wfIn_cons hbwf
       have hρ₁_lookup : ρ₁.env.consts .value xv.name = payload := by
         simp [ρ₁, VerifM.Env.updateConst, Env.updateConst]

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -508,7 +508,7 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
     Spec.argsEnv_agreeOn (Δ := Signature.empty)
       (ρ₁ := VerifM.Env.empty)
       (ρ₂ := VerifM.Env.withEnv ρ (FiniteSubst.id.subst.eval ρ.env))
-      (by exact ⟨nofun, nofun, nofun, nofun⟩) s.args vs
+      (by exact ⟨nofun, nofun, nofun, nofun, nofun, nofun⟩) s.args vs
       (by
         simp [List.length_map] at hlen_vals
         omega)

--- a/Mica/Verifier/Utils.lean
+++ b/Mica/Verifier/Utils.lean
@@ -127,6 +127,10 @@ theorem FiniteSubst.rename_wf {σ : FiniteSubst} {v : Var} {name' : String} {Δ 
         exact hrange.unary u hu
       · intro b hb
         exact hrange.binary b hb
+      · intro u hu
+        exact hrange.unaryRel u hu
+      · intro b hb
+        exact hrange.binaryRel b hb
     · exact Signature.wf_addConst hwfRange hfresh
 
 /-- Generic bundle for renaming `σ` on `v` to a fresh name `name'`. -/
@@ -251,6 +255,8 @@ theorem FiniteSubst.id_wf (Δ : Signature) : FiniteSubst.id.wf Δ := by
     · exact Signature.wf_empty
   · constructor
     · constructor
+      · intro _ h; cases h
+      · intro _ h; cases h
       · intro _ h; cases h
       · intro _ h; cases h
       · intro _ h; cases h


### PR DESCRIPTION
This PR adds support for uninterpreted predicates to the first-order logic. To make sure there are no name conflicts with unary operations, wellformedness ensures that names are unique w.r.t other symbols of the same arity.