### PR TITLE
Allow threading through persistent state

### DIFF
--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -37,6 +37,7 @@ def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM
       | .error msg => VerifM.fatal msg
     | _ => VerifM.fatal "checkSpec: expected function"
   let S' := SpecMap.eraseAll argNames (S.insertBinder fb s)
+  VerifM.persist
   Spec.implement s (checkBody Θ S' s argNames body)
 
 /-- Soundness of `checkBody`: given argument variables supplied by
@@ -176,9 +177,9 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (ρ : VerifM.Env) :
-    VerifM.eval (checkSpec Θ S e s) TransState.empty ρ (fun _ _ _ => True) →
-    S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
+    (st : TransState) (ρ : VerifM.Env) :
+    VerifM.eval (checkSpec Θ S e s) st ρ (fun _ _ _ => True) →
+    st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
   intro heval
   -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
   have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
@@ -194,7 +195,9 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       exact (elim_bind_fatal heval).elim
     | ok argNames =>
       simp [hext] at heval
-      have himpl := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
+      have hcont := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
+      have hpersist := VerifM.eval_persist (VerifM.eval_bind _ _ _ _ hcont)
+      have himpl := hpersist
       dsimp only at himpl
       set bs := argBinders.map (·.runtime)
       set γ' := (γ.remove' fb.runtime).removeAll' bs with hγ'_def
@@ -212,7 +215,8 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       apply SpatialContext.wp_func
       apply Spec.isPrecondFor_fix
       istart
-      iintro □Hspec
+      iintro H
+      icases H with ⟨Hsl, #Hspec⟩
       imodintro
       iintro Hrec %vs %P #Htyped Hpred
       -- `isPrecondFor_fix` hands us the body's subst as `id.updateBinder ... |>.updateAllBinder ...`;
@@ -231,7 +235,7 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
         iintro H
         icases H with ⟨Htyped', Hpred'⟩
         iintuitionistic Htyped'
-        ihave Hwand := Spec.implement_correct Θ s _ TransState.empty ρ vs P
+        ihave Hwand := Spec.implement_correct Θ s _ (TransState.persist st) ρ vs P
           (TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
             (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
               wp (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
@@ -246,18 +250,18 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
               · iexact Htyped''
               · iexact HQ) $$ [Htyped' Hpred']
         · isplitl []
-          · simp [TransState.sl]
+          · simp
             iemp_intro
           · isplitl [Htyped']
             · iexact Htyped'
             · iexact Hpred'
         iapply Hwand
         iexact Htyped'
-      iapply hbody' $$ [Htyped Hpred] [Hrec]
+      iapply hbody' $$ [Htyped Hpred] [Hspec Hrec]
       · isplitl [Htyped]
         · iexact Htyped
         · iexact Hpred
-      · isplitl []
+      · isplitl [Hspec]
         · iexact Hspec
         · iexact Hrec
   all_goals

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -53,6 +53,10 @@ instance : Monad VerifM where
 def VerifM.ctxPure (f : List Formula → α) : VerifM α :=
   VerifM.ctx (fun st => (f st.asserts, st.owns))
 
+/-- Drop the current spatial context, keeping only the persistent verifier state. -/
+def VerifM.persist : VerifM Unit :=
+  VerifM.ctx (fun st => ((), (TransState.persist st).owns))
+
 /-- Assert-and-check: check φ is provable, fail if not. -/
 def VerifM.assert (φ : Formula) : VerifM Unit := do
   if ← VerifM.check φ then pure ()
@@ -602,6 +606,14 @@ theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : Ve
     ∧ st.asserts.wfIn st.decls :=
   let ⟨hq, howns, hg, hwf⟩ := VerifM.eval_ctx h
   ⟨hq howns, hg, hwf⟩
+
+theorem VerifM.eval_persist {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval VerifM.persist st ρ Q) :
+    Q () (TransState.persist st) ρ := by
+  let ⟨hq, howns, _, _⟩ := VerifM.eval_ctx h
+  apply hq
+  simp [TransState.persist]
 
 theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : VerifM.Env}
     {Q : β → TransState → VerifM.Env → Prop}

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -115,17 +115,17 @@ theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
     exact VerifM.eval_ret heval
 
 theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env)
+    (hSwf : S.wfIn Signature.empty) (st : TransState) (ρ : VerifM.Env)
     {Q : Unit → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.checkExpr Θ S d) TransState.empty ρ Q) :
-    (S.satisfiedBy Θ γ ⊢ Φ) →
-    S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
+    (heval : VerifM.eval (ValDecl.checkExpr Θ S d) st ρ Q) :
+    (□ st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ Φ) →
+    □ st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
   intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
   have hcomp :=
-    compile_correct d.body Θ iprop(S.satisfiedBy Θ γ) S [] TinyML.TyCtx.empty TransState.empty ρ γ
+    compile_correct d.body Θ iprop(□ st.sl ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => Φ)
     hcompile
@@ -134,29 +134,32 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed
     hSwf
     (fun _ _ _ _ _ _ _ => by
       istart
-      iintro ⟨_, Hsat⟩
-      icases Hsat with ⟨_, Hsat⟩
-      iapply Hent
-      iexact Hsat)
+      iintro ⟨_, _, Hctx⟩
+      icases Hctx with ⟨_, HΦ⟩
+      iexact HΦ)
   refine (BIBase.Entails.trans ?_ hcomp)
   istart
-  iintro □Hspec
-  isplitl []
-  . simp [TransState.empty]
-    iemp_intro
-  . isplitl []
-    . iexact Hspec
-    . isplitl []
+  iintro ⟨□Hsl, □Hspec⟩
+  isplitl [Hsl]
+  · iexact Hsl
+  · isplitl []
+    · iexact Hspec
+    · isplitl []
       · iapply Bindings.typedSubst_nil
-      · iexact Hspec
+      · isplitl [Hsl]
+        · iexact Hsl
+        · iapply Hent
+          isplitl [Hsl]
+          · iexact Hsl
+          · iexact Hspec
 
 theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env)
+    (hSwf : S.wfIn Signature.empty) (st : TransState) (ρ : VerifM.Env)
     {Q : Spec → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.check Θ S d) TransState.empty ρ Q) :
+    (heval : VerifM.eval (ValDecl.check Θ S d) st ρ Q) :
     ∃ spec, spec.wfIn Signature.empty ∧
-            (S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
-            Q spec TransState.empty ρ := by
+            (□ st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
+            Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.spec with
   | none =>
@@ -188,18 +191,29 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
           have h4 := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ h3)
           have hswf : spec.wfIn Signature.empty := Spec.checkWf_ok (by cases u; exact hwf)
           have ⟨hcheckSpec, hpure⟩ := VerifM.eval_seq h4
-          exact ⟨spec, hswf, checkSpec_correct Θ S d.body spec γ hswf hSwf ρ hcheckSpec,
+          exact ⟨spec, hswf,
+            by
+              have hcheck :=
+                checkSpec_correct Θ S d.body spec γ hswf hSwf st ρ hcheckSpec
+              refine BIBase.Entails.trans ?_ hcheck
+              istart
+              iintro ⟨□Hsl, □Hspec⟩
+              isplitl [Hsl]
+              · iexact Hsl
+              · iexact Hspec,
                  VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (ρ : VerifM.Env) :
-    VerifM.eval (Program.check Θ S prog) TransState.empty ρ (fun _ _ _ => True) →
-    S.satisfiedBy Θ γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
-  induction prog generalizing S γ ρ with
+    (hSwf : S.wfIn Signature.empty) (st : TransState) (ρ : VerifM.Env) :
+    VerifM.eval (Program.check Θ S prog) st ρ (fun _ _ _ => True) →
+    □ st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
+  induction prog generalizing S γ st ρ with
   | nil =>
     intro _
     simp only [Typed.Program.runtime, List.map_nil, Runtime.Program.subst, pwp]
-    exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
+    istart
+    iintro _
+    iemp_intro
   | cons d ds ih =>
     intro heval
     have hpwp_unfold : pwp ((Typed.Program.runtime (d :: ds)).subst γ) ⊣⊢
@@ -220,16 +234,16 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
         simp only [hname, hspec] at heval
         have hbind := VerifM.eval_bind _ _ _ _ heval
         have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-        have hih := ih S γ hSwf ρ (VerifM.eval_ret hcont)
-        have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf ρ hbind hih
+        have hih := ih S γ hSwf st ρ (VerifM.eval_ret hcont)
+        have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf st ρ hbind hih
         refine hwp.trans (wp.mono ?_)
         intro v; rw [hupd v]; exact .rfl
       | some _ =>
         -- unnamed, with spec
         simp only [hname, hspec] at heval
         obtain ⟨spec, _, hwp, hcont⟩ :=
-          ValDecl.check_correct Θ S d γ hSwf ρ (VerifM.eval_bind _ _ _ _ heval)
-        have hih := ih S γ hSwf ρ hcont
+          ValDecl.check_correct Θ S d γ hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
+        have hih := ih S γ hSwf st ρ hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
@@ -260,37 +274,60 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
               (args.map (·.runtime))))
           apply SpatialContext.wp_func
           rw [hupd fval]
-          have heval' : VerifM.eval (Program.check Θ (S.erase n) ds) TransState.empty ρ (fun _ _ _ => True) := by
+          have heval' : VerifM.eval (Program.check Θ (S.erase n) ds) st ρ (fun _ _ _ => True) := by
             convert heval
           have hih := ih (S.erase n) (γ.update n fval)
-            (SpecMap.wfIn_erase hSwf) ρ heval'
-          exact (SpecMap.satisfiedBy_erase (x := n) (v := fval)).trans hih
+            (SpecMap.wfIn_erase hSwf) st ρ heval'
+          refine BIBase.Entails.trans ?_ hih
+          istart
+          iintro ⟨□Hsl, □Hspec⟩
+          isplitl [Hsl]
+          · iexact Hsl
+          · iapply SpecMap.satisfiedBy_erase
+            iexact Hspec
         · -- named, no spec, not a function
           have hbind := VerifM.eval_bind _ _ _ _ heval
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          have hcont' : VerifM.eval (Program.check Θ (S.erase n) ds) TransState.empty ρ (fun _ _ _ => True) :=
+          have hcont' : VerifM.eval (Program.check Θ (S.erase n) ds) st ρ (fun _ _ _ => True) :=
             VerifM.eval_ret hcont
-          have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf ρ hbind
+          have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf st ρ hbind
             (Φ := iprop(emp)) (by istart; iintro _; iemp_intro)
           refine SpatialContext.wp_strengthen_persistent hwp ?_
           intro v
           rw [hupd v]
-          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) ρ hcont'
-          exact wand_intro (sep_elim_l.trans <|
-            (SpecMap.satisfiedBy_erase (x := n) (v := v)).trans hih)
+          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) st ρ hcont'
+          exact wand_intro (sep_elim_l.trans <| by
+            refine BIBase.Entails.trans ?_ hih
+            istart
+            iintro ⟨□Hsl, □Hspec⟩
+            isplitl [Hsl]
+            · iexact Hsl
+            · iapply SpecMap.satisfiedBy_erase
+              iexact Hspec)
       | some _ =>
         simp only [hname, hspec] at heval
         obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          ValDecl.check_correct Θ S d γ hSwf ρ (VerifM.eval_bind _ _ _ _ heval)
-        have hcont' : VerifM.eval (Program.check Θ (S.insert n spec) ds) TransState.empty ρ (fun _ _ _ => True) := by
+          ValDecl.check_correct Θ S d γ hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
+        have hcont' : VerifM.eval (Program.check Θ (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
           convert hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
         have hih := ih (S.insert n spec) (γ.update n v)
-          (SpecMap.wfIn_insert hSwf hswf) ρ hcont'
-        exact wand_intro
-          ((SpecMap.satisfiedBy_insert_update (x := n) (v := v) (spec := spec)).trans hih)
+          (SpecMap.wfIn_insert hSwf hswf) st ρ hcont'
+        have hstep : (□ st.sl ρ ∗ S.satisfiedBy Θ γ) ∗ spec.isPrecondFor Θ v ⊢
+            pwp ((Typed.Program.runtime ds).subst (γ.update n v)) := by
+          refine BIBase.Entails.trans ?_ hih
+          istart
+          iintro ⟨Hctx, Hpre⟩
+          icases Hctx with ⟨□Hsl, □Hspec⟩
+          isplitl [Hsl]
+          · iexact Hsl
+          · iapply SpecMap.satisfiedBy_insert_update
+            isplitl [Hspec]
+            · iexact Hspec
+            · iexact Hpre
+        exact wand_intro hstep
 
 theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
   Smt.Strategy.checks (Program.verify p) (⊢ pwp (Untyped.Program.runtime p)) := by
@@ -316,8 +353,13 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
     obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty VerifM.Env.empty hbind
     have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
-                       (SpecMap.empty_wfIn _) VerifM.Env.empty hcheck
+                       (SpecMap.empty_wfIn _) TransState.empty VerifM.Env.empty hcheck
     rw [Runtime.Program.subst_id] at hcorrect
-    have hsat : (⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) Runtime.Subst.id) :=
-      SpecMap.empty_satisfiedBy _
-    simpa [hrt] using hsat.trans hcorrect
+    have hctx : (⊢ □ TransState.empty.sl VerifM.Env.empty ∗ SpecMap.satisfiedBy Θ (∅ : SpecMap) Runtime.Subst.id) := by
+      istart
+      isplitl []
+      · simp [TransState.sl, TransState.empty]
+        imodintro
+        iemp_intro
+      · iapply SpecMap.empty_satisfiedBy
+    simpa [hrt] using hctx.trans hcorrect

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -95,6 +95,23 @@ def TransState.sl (st : TransState) (ρ : VerifM.Env) : iProp :=
 @[simp] theorem TransState.sl_eq (st : TransState) (ρ : VerifM.Env) :
     st.sl ρ = SpatialContext.interp ρ.env st.owns := rfl
 
+/-- Drop the non-persistent spatial part of the verifier state. -/
+def TransState.persist (st : TransState) : TransState :=
+  { st with owns := [] }
+
+@[simp] theorem TransState.persist_decls (st : TransState) :
+    st.persist.decls = st.decls := rfl
+
+@[simp] theorem TransState.persist_asserts (st : TransState) :
+    st.persist.asserts = st.asserts := rfl
+
+theorem TransState.sl_entails_persist (st : TransState) (ρ : VerifM.Env) :
+    st.sl ρ ⊢ □ st.persist.sl ρ := by
+  istart
+  iintro _
+  imodintro
+  simp [TransState.persist]
+
 /-- Translation to `ScopedM`'s flat context. -/
 def TransState.toFlatCtx (st : TransState) : FlatCtx :=
   ⟨st.decls, st.asserts⟩
@@ -178,3 +195,12 @@ theorem TransState.addSpatial.wf (st : TransState) :
   · exact hwf.assertsWf
   · exact hwf.namesDisjoint
   · simpa [SpatialContext.wfIn_cons] using And.intro ha hwf.ownsWf
+
+theorem TransState.persist_wf (st : TransState) :
+    TransState.wf st →
+    TransState.wf st.persist := by
+  intro hwf
+  constructor
+  · exact hwf.assertsWf
+  · exact hwf.namesDisjoint
+  · simp [TransState.persist]


### PR DESCRIPTION
This PR generalises the foundation of the verifier by allowing one to thread through persistent state. This is a preparation for allowing user-defined constants. 