### PR TITLE
Generalize declaration threading

### DIFF
--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -369,494 +369,525 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
 -- Correctness theorems
 -- ---------------------------------------------------------------------------
 
-theorem Assertion.assume_correct (m : Assertion α) (σ : FiniteSubst)
+theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
-    σ.wf st.decls →
-    (Signature.ofVars σ.dom).wf →
-    m.wfIn retWf (Signature.ofVars σ.dom) →
+    σ.wfIn Δ_base st.decls →
+    m.wfIn retWf (Δ_base.declVars σ.dom) →
     VerifM.eval (Assertion.assume σ m) st ρ Ψ →
-    (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wf st'.decls → (Signature.ofVars σ'.dom).wf →
-      retWf a (Signature.ofVars σ'.dom) →
+    (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
+      retWf a (Δ_base.declVars σ'.dom) →
       st'.sl ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
     st.sl ρ ∗ R ⊢ Assertion.post Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
-  intro hσwf hdomwf hwf heval hpost
-  have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
-  induction m generalizing σ st ρ Ψ with
+  intro hσwf hwf heval hpost
+  induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
-    exact hpost _ _ _ _ (VerifM.eval_ret heval) hσwf hdomwf hwf
+      exact hpost _ _ _ _ (VerifM.eval_ret heval) hσwf hwf
   | assert φ k ih =>
-    obtain ⟨hφwf, hkwf⟩ := hwf
-    simp only [Assertion.assume] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    simp only [Assertion.post]
-    iintro Howns %hφ
-    have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
-      FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
-    have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-    have hassume := VerifM.eval_assumePure hb hsubst_wf hsubst_eval
-    iapply (ih σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkwf hassume hpost hwfst)
-    simp [TransState.sl]
+      obtain ⟨hφwf, hkwf⟩ := hwf
+      simp only [Assertion.assume] at heval
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls := ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+      have hb := VerifM.eval_bind _ _ _ _ heval
+      simp only [Assertion.post]
+      iintro Howns %hφ
+      have hsubst_wf_range : (φ.subst σ.subst σ.range.allNames).wfIn σ.range :=
+        FiniteSubst.subst_wfIn_formula_range hσwf hφwf
+      have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
+        Formula.wfIn_mono _ hsubst_wf_range huse hwfst
+      have hsubst_eval := (FiniteSubst.eval_subst_formula hσwf hφwf).mpr hφ
+      have hassume := VerifM.eval_assumePure hb hsubst_wf hsubst_eval
+      iapply (ih Δ_base σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hkwf hassume hpost)
+      simp [TransState.sl]
   | let_ v t k ih =>
-    obtain ⟨htwf, hkwf⟩ := hwf
-    simp only [Assertion.assume] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    have hdecl := VerifM.eval_decl hb
-    simp only [Assertion.post]
-    set v' := st.freshConst (some v.name) v.sort
-    have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
-      Fresh.freshNumbers_not_mem v.name st.decls.allNames
-    have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
-      fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-    set u := t.eval (σ.subst.eval ρ.env)
-    specialize hdecl u
-    have hb2 := VerifM.eval_bind _ _ _ _ hdecl
-    -- Show the equality formula is well-formed and holds
-    have ht_subst_wf_range : (t.subst σ.subst).wfIn σ.range :=
-      Term.subst_wfIn htwf hσwf.1 (by simp [Signature.ofVars])
-        (Signature.SymbolSubset.ofVars _ _)
-        hσwf.2.2
-    have ht_subst_wf : (t.subst σ.subst).wfIn st.decls :=
-      Term.wfIn_mono _ ht_subst_wf_range hσwf.2.1 hwfst
-    have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).wfIn
-        (st.decls.addConst v') := by
-      refine ⟨?_, ?_⟩
-      · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+      obtain ⟨htwf, hkwf⟩ := hwf
+      simp only [Assertion.assume] at heval
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls := ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+      have hb := VerifM.eval_bind _ _ _ _ heval
+      have hdecl := VerifM.eval_decl hb
+      simp only [Assertion.post]
+      set v' := st.freshConst (some v.name) v.sort
+      have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
+        Fresh.freshNumbers_not_mem v.name st.decls.allNames
+      have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
+        fun h => hv'_fresh_decls (Signature.allNames_subset huse _ h)
+      set u := t.eval (σ.subst.eval ρ.env)
+      specialize hdecl u
+      have hb2 := VerifM.eval_bind _ _ _ _ hdecl
+      have ht_subst_wf : (t.subst σ.subst).wfIn st.decls :=
+        FiniteSubst.subst_wfIn_term hσwf htwf
+      have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).wfIn
+          (st.decls.addConst v') := by
+        refine ⟨?_, ?_⟩
+        · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+          have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
+          refine ⟨List.Mem.head _, ?_, ?_⟩
+          · intro τ' hvar
+            exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
+          · intro τ' hc'
+            exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
+        · exact Term.wfIn_mono _ ht_subst_wf (Signature.Subset.subset_addConst _ _)
+            (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
+      have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).eval
+          (ρ.updateConst v.sort v'.name u).env := by
+        rw [Formula.eval, Term.eval, Const.denote]
+        rw [FiniteSubst.eval_subst_term hσwf htwf]
+        simpa [u, Env.lookupConst, Env.updateConst] using
+          (Term.eval_env_agree htwf
+            (FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
+              (τ := v.sort) (name' := v'.name) (u := u) hσwf hv'_fresh_range))
+      have hassume := VerifM.eval_assumePure hb2 heq_wf heq_holds
+      set σ' := σ.rename v v'.name
+      have hσ'wf : σ'.wfIn Δ_base (st.decls.addConst v') := by
+        simpa [σ'] using
+          (FiniteSubst.rename_wfIn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+            (v := v) (name' := v'.name) hσwf hv'_fresh_range hv'_fresh_decls)
+      have hkwf' : k.wfIn retWf (Δ_base.declVars σ'.dom) := by
+        simpa [σ', FiniteSubst.rename_source_eq] using hkwf
+      have hih := ih Δ_base σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
+        (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
+      have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
+        SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+          (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+      exact (sep_mono hinterp_bi.1 (by
+        iintro HR
+        iexact HR)).trans <| hih.trans <| Assertion.post_env_agree hkwf'
+        (by
+          simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+            (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+              (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
+        hΦ
+  | pred v p k ih =>
+      obtain ⟨hpwf, hkwf⟩ := hwf
+      simp only [Assertion.post]
+      apply forall_intro; intro u
+      iintro Howns
+      iintro Hpu
+      simp only [Assertion.assume] at heval
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls := ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+      have hb := VerifM.eval_bind _ _ _ _ heval
+      have hdecl := VerifM.eval_decl hb
+      set v' := st.freshConst (some v.name) v.sort
+      have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
+        Fresh.freshNumbers_not_mem v.name st.decls.allNames
+      have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
+        fun h => hv'_fresh_decls (Signature.allNames_subset huse _ h)
+      specialize hdecl u
+      have hb2 := VerifM.eval_bind _ _ _ _ hdecl
+      have hsymbols : (Δ_base.declVars σ.dom).SymbolSubset σ.range :=
+        Signature.SymbolSubset.trans declVars_symbolSubset hbase
+      have hp_subst_wf_range : (p.subst σ.subst).wfIn σ.range :=
+        Atom.subst_wfIn hpwf hsubst (by intro x hx; exact hx) hsymbols hrangewf
+      have hp_subst_wf : (p.subst σ.subst).wfIn st.decls :=
+        Atom.wfIn_mono hp_subst_wf_range huse hwfst
+      have hvar_wf : (Term.const (.uninterpreted v'.name v.sort)).wfIn (st.decls.addConst v') := by
+        simp only [Term.wfIn, Const.wfIn, Signature.addConst]
         have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
         refine ⟨List.Mem.head _, ?_, ?_⟩
         · intro τ' hvar
           exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
         · intro τ' hc'
           exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-      · exact Term.wfIn_mono _ ht_subst_wf (Signature.Subset.subset_addConst _ _) (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).eval
-        (ρ.updateConst v.sort v'.name u).env := by
-      rw [Formula.eval, Term.eval, Const.denote]
-      rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
-      simpa [u, Env.lookupConst, Env.updateConst] using
-        (Term.eval_env_agree htwf (FiniteSubst.eval_update_fresh hσwf.1 hv'_fresh_range))
-    have hassume := VerifM.eval_assumePure hb2 heq_wf heq_holds
-    -- Apply IH with σ' = σ.rename v v'.name
-    set σ' := σ.rename v v'.name
-    have hσ'wf : σ'.wf (st.decls.addConst v') :=
-      by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
-    have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
-      simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
-    have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
-      simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-    have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
-      (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-        (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
-      SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
-        (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-    exact (sep_mono hinterp_bi.1 (by
-      iintro HR
-      iexact HR)).trans <| hih.trans <| Assertion.post_env_agree hkwf
-      (by
-        simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-          (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-      hΦ
-  | ite φ kt ke iht ihe =>
-    obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
-    simp only [Assertion.assume] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    have hall := VerifM.eval_all hb
-    simp only [Assertion.post]
-    apply and_intro
-    · iintro Howns %hφ
-      have htrue := hall true (List.mem_cons_self ..)
-      simp at htrue
-      have hb2 := VerifM.eval_bind _ _ _ _ htrue
-      have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
-        FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
-      have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
-      iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
-      simp [TransState.sl]
-    · iintro Howns %hnφ
-      have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
-      simp at hfalse
-      have hb2 := VerifM.eval_bind _ _ _ _ hfalse
-      have hnot_wf : (Formula.not φ).wfIn (Signature.ofVars σ.dom) := by
-        simp only [Formula.wfIn]; exact hφwf
-      have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
-        FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
-      have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
-      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
-      iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
-      simp [TransState.sl]
-  | pred v p k ih =>
-    obtain ⟨hpwf, hkwf⟩ := hwf
-    simp only [Assertion.post]
-    apply forall_intro; intro u
-    iintro Howns
-    iintro Hpu
-    simp only [Assertion.assume] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    have hdecl := VerifM.eval_decl hb
-    set v' := st.freshConst (some v.name) v.sort
-    have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
-      Fresh.freshNumbers_not_mem v.name st.decls.allNames
-    have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
-      fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-    specialize hdecl u
-    have hb2 := VerifM.eval_bind _ _ _ _ hdecl
-    -- Show the atom formula is well-formed and holds
-    have hp_subst_wf_range : (p.subst σ.subst).wfIn σ.range :=
-      Atom.subst_wfIn hpwf hσwf.1 (by simp [Signature.ofVars])
-        (Signature.SymbolSubset.ofVars _ _)
-        hσwf.2.2
-    have hp_subst_wf : (p.subst σ.subst).wfIn st.decls :=
-      Atom.wfIn_mono hp_subst_wf_range hσwf.2.1 hwfst
-    have hvar_wf : (Term.const (.uninterpreted v'.name v.sort)).wfIn (st.decls.addConst v') := by
-      simp only [Term.wfIn, Const.wfIn, Signature.addConst]
-      have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
-      refine ⟨List.Mem.head _, ?_, ?_⟩
-      · intro τ' hvar
-        exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
-      · intro τ' hc'
-        exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-    have hitem_wf : ((p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))).wfIn
-        (st.decls.addConst v') :=
-      Atom.toItem_wfIn
-        (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
-          (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint) hvar_wf
-    have hpu' : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢ (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
-        ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval (ρ.updateConst v.sort v'.name u).env) := by
-      have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
-          (ρ.updateConst v.sort v'.name u).env) = u := by
-        simp [Term.eval, Const.denote, Env.updateConst]
-      rw [hconst]
-      rw [Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
-      have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
-        (τ := v.sort) (name' := v'.name) (u := u) hσwf.1 hv'_fresh_range
-      have heval_agree :
-          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) =
-            p.eval ((ρ.updateConst v.sort v'.name u).withEnv
-              (σ.subst.eval (ρ.updateConst v.sort v'.name u).env)) :=
-        Atom.eval_env_agree (p := p)
-          (ρ := ρ.withEnv (σ.subst.eval ρ.env))
-          (ρ' := (ρ.updateConst v.sort v'.name u).withEnv
-            (σ.subst.eval (ρ.updateConst v.sort v'.name u).env))
-          (Δ := Signature.ofVars σ.dom) hpwf (by
-            simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv_env] using hagree)
-      rw [heval_agree]
-      exact .rfl
-    set item := (p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))
-    set σ' := σ.rename v v'.name
-    have hσ'wf : σ'.wf (st.decls.addConst v') :=
-      by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
-    have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
-      simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
-    have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
-      simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-    cases hitem : item with
-    | pure φ =>
-      have hφ_entail : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-          ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ := by
-        simpa [item, hitem] using
-          (hpu'.trans (Atom.eval_purePart (p := p.subst σ.subst)
-            (t := .const (.uninterpreted v'.name v.sort))
-            (ρ := (ρ.updateConst v.sort v'.name u))))
-      ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ $$ [Hpu]
-      · iapply hφ_entail
-        simp [VerifM.Env.withEnv]
-      icases Hφ with %hφ
-      have hb2' : (VerifM.assume (.pure φ)).eval
-          { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
-          (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
-        simpa [item, hitem] using hb2
-      have hitem_wf' : (.pure φ : CtxItem).wfIn (st.decls.addConst v') := by
-        simpa [item, hitem] using hitem_wf
-      have hassume := VerifM.eval_assume hb2' hitem_wf' hφ
-      have hih := ih σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ))
-        (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-          (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-      have hframe :
-          st.sl ρ ∗ R ⊢
-            (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).sl
-              (ρ.updateConst v.sort v'.name u) ∗ R := by
-        simp [TransState.addItem]
-        exact sep_mono
+      have hitem_wf : ((p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))).wfIn
+          (st.decls.addConst v') :=
+        Atom.toItem_wfIn
+          (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
+            (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint) hvar_wf
+      have hpu' : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+          (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
+            ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
+              (ρ.updateConst v.sort v'.name u).env) := by
+        have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
+            (ρ.updateConst v.sort v'.name u).env) = u := by
+          simp [Term.eval, Const.denote, Env.updateConst]
+        rw [hconst]
+        rw [Atom.eval_subst hpwf hsubst hrangewf]
+        have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
+          (τ := v.sort) (name' := v'.name) (u := u) hσwf hv'_fresh_range
+        have heval_agree :
+            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) =
+              p.eval ((ρ.updateConst v.sort v'.name u).withEnv
+                (σ.subst.eval (ρ.updateConst v.sort v'.name u).env)) :=
+          Atom.eval_env_agree (p := p)
+            (ρ := ρ.withEnv (σ.subst.eval ρ.env))
+            (ρ' := (ρ.updateConst v.sort v'.name u).withEnv
+              (σ.subst.eval (ρ.updateConst v.sort v'.name u).env))
+            (Δ := Δ_base.declVars σ.dom) hpwf (by
+              simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv_env] using hagree)
+        rw [heval_agree]
+        exact .rfl
+      set item := (p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))
+      set σ' := σ.rename v v'.name
+      have hσ'wf : σ'.wfIn Δ_base (st.decls.addConst v') := by
+        simpa [σ'] using
+          (FiniteSubst.rename_wfIn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+            (v := v) (name' := v'.name) hσwf hv'_fresh_range hv'_fresh_decls)
+      have hkwf' : k.wfIn retWf (Δ_base.declVars σ'.dom) := by
+        simpa [σ', FiniteSubst.rename_source_eq] using hkwf
+      cases hitem : item with
+      | pure φ =>
+        have hφ_entail : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+            ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ := by
+          simpa [item, hitem] using
+            (hpu'.trans (Atom.eval_purePart (p := p.subst σ.subst)
+              (t := .const (.uninterpreted v'.name v.sort))
+              (ρ := (ρ.updateConst v.sort v'.name u))))
+        ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ $$ [Hpu]
+        · iapply hφ_entail
+          simp [VerifM.Env.withEnv]
+        icases Hφ with %hφ
+        have hb2' : (VerifM.assume (.pure φ)).eval
+            { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
+            (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
+          simpa [item, hitem] using hb2
+        have hitem_wf' : (.pure φ : CtxItem).wfIn (st.decls.addConst v') := by
+          simpa [item, hitem] using hitem_wf
+        have hassume := VerifM.eval_assume hb2' hitem_wf' hφ
+        have hih := ih Δ_base σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ))
+          (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
+        have hframe :
+            st.sl ρ ∗ R ⊢
+              (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).sl
+                (ρ.updateConst v.sort v'.name u) ∗ R := by
+          simp [TransState.addItem]
+          exact sep_mono
+            (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+              (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
+            (by
+              iintro HR
+              iexact HR)
+        iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree hkwf'
+          (by
+            simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+              (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+                (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
+          hΦ)
+        iexact Howns
+      | spatial a =>
+        have hb2' : (VerifM.assume (.spatial a)).eval
+            { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
+            (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
+          simpa [item, hitem] using hb2
+        have hitem_wf' : (.spatial a : CtxItem).wfIn (st.decls.addConst v') := by
+          simpa [item, hitem] using hitem_wf
+        have hassume := VerifM.eval_assume hb2' hitem_wf' trivial
+        have hih := ih Δ_base σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.spatial a))
+          (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
+        have hitem_interp :
+            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+              CtxItem.interp (ρ.updateConst v.sort v'.name u) item := by
+          simpa [item] using
+            (hpu'.trans (Atom.toItem_eval (p := p.subst σ.subst)
+              (t := .const (.uninterpreted v'.name v.sort))
+              (ρ := (ρ.updateConst v.sort v'.name u))).2)
+        have hspatial_interp :
+            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+              SpatialAtom.interp (ρ.updateConst v.sort v'.name u).env a := by
+          simpa [item, hitem, CtxItem.interp] using hitem_interp
+        have howns_agree :
+            st.sl ρ ⊢
+              st.sl (ρ.updateConst v.sort v'.name u) :=
           (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
             (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
+        iapply (hih.trans <| Assertion.post_env_agree hkwf'
           (by
-            iintro HR
-            iexact HR)
-      iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree hkwf'
-        (by
-          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-            (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-        hΦ)
-      iexact Howns
-    | spatial a =>
-      have hb2' : (VerifM.assume (.spatial a)).eval
-          { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
-          (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
-        simpa [item, hitem] using hb2
-      have hitem_wf' : (.spatial a : CtxItem).wfIn (st.decls.addConst v') := by
-        simpa [item, hitem] using hitem_wf
-      have hassume := VerifM.eval_assume hb2' hitem_wf' trivial
-      have hih := ih σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.spatial a))
-        (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-          (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-      have hitem_interp :
-          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-            CtxItem.interp (ρ.updateConst v.sort v'.name u) item := by
-        simpa [item] using
-          (hpu'.trans (Atom.toItem_eval (p := p.subst σ.subst)
-            (t := .const (.uninterpreted v'.name v.sort))
-            (ρ := (ρ.updateConst v.sort v'.name u))).2)
-      have hspatial_interp :
-          p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-            SpatialAtom.interp (ρ.updateConst v.sort v'.name u).env a := by
-        simpa [item, hitem, CtxItem.interp] using hitem_interp
-      have howns_agree :
-          st.sl ρ ⊢
-            st.sl (ρ.updateConst v.sort v'.name u) :=
-        (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
-          (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
-      iapply (hih.trans <| Assertion.post_env_agree hkwf'
-        (by
-          simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-            (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-        hΦ)
-      simp [TransState.addItem]
-      icases Howns with ⟨HS, HR⟩
-      isplitr [HR]
-      · isplitr [HS]
-        · have hspatial_interp' :
-            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-              SpatialAtom.interp (Env.updateConst ρ.env v.sort v'.name u) a := by
-            simpa [VerifM.Env.updateConst] using hspatial_interp
-          iapply hspatial_interp'
-          simp [VerifM.Env.withEnv]
-        · have howns_agree' :
-            st.sl ρ ⊢ SpatialContext.interp (Env.updateConst ρ.env v.sort v'.name u) st.owns := by
-            simpa [TransState.sl, VerifM.Env.updateConst] using howns_agree
-          iapply howns_agree'
-          simp [TransState.sl]
-      · iexact HR
+            simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+              (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+                (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
+          hΦ)
+        simp [TransState.addItem]
+        icases Howns with ⟨HS, HR⟩
+        isplitr [HR]
+        · isplitr [HS]
+          · have hspatial_interp' :
+              p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+                SpatialAtom.interp (Env.updateConst ρ.env v.sort v'.name u) a := by
+              simpa [VerifM.Env.updateConst] using hspatial_interp
+            iapply hspatial_interp'
+            simp [VerifM.Env.withEnv]
+          · have howns_agree' :
+              st.sl ρ ⊢ SpatialContext.interp (Env.updateConst ρ.env v.sort v'.name u) st.owns := by
+              simpa [TransState.sl, VerifM.Env.updateConst] using howns_agree
+            iapply howns_agree'
+            simp [TransState.sl]
+        · iexact HR
+  | ite φ kt ke iht ihe =>
+      obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
+      simp only [Assertion.assume] at heval
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls := ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+      have hb := VerifM.eval_bind _ _ _ _ heval
+      have hall := VerifM.eval_all hb
+      simp only [Assertion.post]
+      apply and_intro
+      · iintro Howns %hφ
+        have htrue := hall true (List.mem_cons_self ..)
+        simp at htrue
+        have hb2 := VerifM.eval_bind _ _ _ _ htrue
+        have hsubst_wf_range : (φ.subst σ.subst σ.range.allNames).wfIn σ.range :=
+          FiniteSubst.subst_wfIn_formula_range hσwf hφwf
+        have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
+          Formula.wfIn_mono _ hsubst_wf_range huse hwfst
+        have hsubst_eval := (FiniteSubst.eval_subst_formula hσwf hφwf).mpr hφ
+        have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
+        iapply (iht Δ_base σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hktwf hassume hpost)
+        simp [TransState.sl]
+      · iintro Howns %hnφ
+        have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
+        simp at hfalse
+        have hb2 := VerifM.eval_bind _ _ _ _ hfalse
+        have hnot_wf : (Formula.not φ).wfIn (Δ_base.declVars σ.dom) := by
+          simp only [Formula.wfIn]; exact hφwf
+        have hsubst_wf_range : (φ.not.subst σ.subst σ.range.allNames).wfIn σ.range :=
+          FiniteSubst.subst_wfIn_formula_range hσwf hnot_wf
+        have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
+          Formula.wfIn_mono _ hsubst_wf_range huse hwfst
+        have hsubst_eval := (FiniteSubst.eval_subst_formula hσwf hnot_wf).mpr hnφ
+        have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
+        iapply (ihe Δ_base σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hkewf hassume hpost)
+        simp [TransState.sl]
 
-theorem Assertion.prove_correct (m : Assertion α) (σ : FiniteSubst)
+theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
-    σ.wf st.decls →
-    (Signature.ofVars σ.dom).wf →
-    m.wfIn retWf (Signature.ofVars σ.dom) →
+    σ.wfIn Δ_base st.decls →
+    m.wfIn retWf (Δ_base.declVars σ.dom) →
     VerifM.eval (Assertion.prove σ m) st ρ Ψ →
-    (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wf st'.decls → (Signature.ofVars σ'.dom).wf →
-      retWf a (Signature.ofVars σ'.dom) →
+    (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
+      retWf a (Δ_base.declVars σ'.dom) →
       st'.sl ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
     st.sl ρ ∗ R ⊢ Assertion.pre Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
-  intro hσwf hdomwf hwf heval hpost
-  have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
-  induction m generalizing σ st ρ Ψ with
+  intro hσwf hwf heval hpost
+  induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
-    exact hpost _ _ _ _ (VerifM.eval_ret heval) hσwf hdomwf hwf
+      exact hpost _ _ _ _ (VerifM.eval_ret heval) hσwf hwf
   | assert φ k ih =>
-    obtain ⟨hφwf, hkwf⟩ := hwf
-    simp only [Assertion.prove] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
-      FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
-    have hassert := VerifM.eval_assert hb hsubst_wf
-    have hφ_holds := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mp hassert.1
-    show st.sl ρ ∗ R ⊢
-      (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
-    istart
-    iintro ⟨Howns, HR⟩
-    isplitr [Howns HR]
-    · ipure_intro
-      exact hφ_holds
-    · iapply (ih σ st ρ Ψ hσwf hdomwf hkwf hassert.2 hpost hwfst)
-      isplitl [Howns]
-      · iexact Howns
-      · iexact HR
+      obtain ⟨hφwf, hkwf⟩ := hwf
+      simp only [Assertion.prove] at heval
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls := ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+      have hb := VerifM.eval_bind _ _ _ _ heval
+      have hsubst_wf_range : (φ.subst σ.subst σ.range.allNames).wfIn σ.range :=
+        FiniteSubst.subst_wfIn_formula_range hσwf hφwf
+      have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
+        Formula.wfIn_mono _ hsubst_wf_range huse hwfst
+      have hassert := VerifM.eval_assert hb hsubst_wf
+      have hφ_holds := (FiniteSubst.eval_subst_formula hσwf hφwf).mp hassert.1
+      show st.sl ρ ∗ R ⊢
+        (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
+      istart
+      iintro ⟨Howns, HR⟩
+      isplitr [Howns HR]
+      · ipure_intro
+        exact hφ_holds
+      · iapply (ih Δ_base σ st ρ Ψ hσwf hkwf hassert.2 hpost)
+        isplitl [Howns]
+        · iexact Howns
+        · iexact HR
   | let_ v t k ih =>
-    obtain ⟨htwf, hkwf⟩ := hwf
-    simp only [Assertion.prove] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    have hdecl := VerifM.eval_decl hb
-    simp only [Assertion.pre]
-    set v' := st.freshConst (some v.name) v.sort
-    have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
-      Fresh.freshNumbers_not_mem v.name st.decls.allNames
-    have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
-      fun h => hv'_fresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-    set u := t.eval (σ.subst.eval ρ.env)
-    specialize hdecl u
-    have hb2 := VerifM.eval_bind _ _ _ _ hdecl
-    have ht_subst_wf_range : (t.subst σ.subst).wfIn σ.range :=
-      Term.subst_wfIn htwf hσwf.1 (by simp [Signature.ofVars])
-        (Signature.SymbolSubset.ofVars _ _)
-        hσwf.2.2
-    have ht_subst_wf : (t.subst σ.subst).wfIn st.decls :=
-      Term.wfIn_mono _ ht_subst_wf_range hσwf.2.1 hwfst
-    have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).wfIn
-        (st.decls.addConst v') := by
-      refine ⟨?_, ?_⟩
-      · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
-        have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
-        refine ⟨List.Mem.head _, ?_, ?_⟩
-        · intro τ' hvar
-          exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
-        · intro τ' hc'
-          exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-      · exact Term.wfIn_mono _ ht_subst_wf (Signature.Subset.subset_addConst _ _) (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).eval
-        (ρ.updateConst v.sort v'.name u).env := by
-      rw [Formula.eval, Term.eval, Const.denote]
-      rw [Term.eval_subst htwf hσwf.1 hσwf.2.2]
-      simpa [u, Env.lookupConst, Env.updateConst] using
-        (Term.eval_env_agree htwf (FiniteSubst.eval_update_fresh hσwf.1 hv'_fresh_range))
-    have hassume := VerifM.eval_assumePure hb2 heq_wf heq_holds
-    set σ' := σ.rename v v'.name
-    have hσ'wf : σ'.wf (st.decls.addConst v') :=
-      by simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
-    have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
-      simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
-    have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
-      simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-    have hih := ih σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
-      (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-        (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
-    have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
-      SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
-        (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-    exact (sep_mono hinterp_bi.1 (by
-      iintro HR
-      iexact HR)).trans <| hih.trans <| Assertion.pre_env_agree hkwf'
-      (by
-        simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-          (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-      hΦ
+      obtain ⟨htwf, hkwf⟩ := hwf
+      simp only [Assertion.prove] at heval
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls := ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+      have hb := VerifM.eval_bind _ _ _ _ heval
+      have hdecl := VerifM.eval_decl hb
+      simp only [Assertion.pre]
+      set v' := st.freshConst (some v.name) v.sort
+      have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
+        Fresh.freshNumbers_not_mem v.name st.decls.allNames
+      have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
+        fun h => hv'_fresh_decls (Signature.allNames_subset huse _ h)
+      set u := t.eval (σ.subst.eval ρ.env)
+      specialize hdecl u
+      have hb2 := VerifM.eval_bind _ _ _ _ hdecl
+      have ht_subst_wf : (t.subst σ.subst).wfIn st.decls :=
+        FiniteSubst.subst_wfIn_term hσwf htwf
+      have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).wfIn
+          (st.decls.addConst v') := by
+        refine ⟨?_, ?_⟩
+        · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+          have hwf_add : (st.decls.addConst v').wf := Signature.wf_addConst hwfst hv'_fresh_decls
+          refine ⟨List.Mem.head _, ?_, ?_⟩
+          · intro τ' hvar
+            exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
+          · intro τ' hc'
+            exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
+        · exact Term.wfIn_mono _ ht_subst_wf (Signature.Subset.subset_addConst _ _)
+            (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint
+      have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) (t.subst σ.subst)).eval
+          (ρ.updateConst v.sort v'.name u).env := by
+        rw [Formula.eval, Term.eval, Const.denote]
+        rw [FiniteSubst.eval_subst_term hσwf htwf]
+        simpa [u, Env.lookupConst, Env.updateConst] using
+          (Term.eval_env_agree htwf
+            (FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
+              (τ := v.sort) (name' := v'.name) (u := u) hσwf hv'_fresh_range))
+      have hassume := VerifM.eval_assumePure hb2 heq_wf heq_holds
+      set σ' := σ.rename v v'.name
+      have hσ'wf : σ'.wfIn Δ_base (st.decls.addConst v') := by
+        simpa [σ'] using
+          (FiniteSubst.rename_wfIn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+            (v := v) (name' := v'.name) hσwf hv'_fresh_range hv'_fresh_decls)
+      have hkwf' : k.wfIn retWf (Δ_base.declVars σ'.dom) := by
+        simpa [σ', FiniteSubst.rename_source_eq] using hkwf
+      have hih := ih Δ_base σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
+        (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
+      have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
+        SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+          (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+      exact (sep_mono hinterp_bi.1 (by
+        iintro HR
+        iexact HR)).trans <| hih.trans <| Assertion.pre_env_agree hkwf'
+        (by
+          simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+            (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+              (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
+        hΦ
   | pred v p k ih =>
-    obtain ⟨hpwf, hkwf⟩ := hwf
-    simp only [Assertion.prove] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    have hpwf_range : (p.subst σ.subst).wfIn σ.range :=
-      Atom.subst_wfIn hpwf hσwf.1 (by simp [Signature.ofVars])
-        (Signature.SymbolSubset.ofVars _ _)
-        hσwf.2.2
-    have hpwf_decls : (p.subst σ.subst).wfIn st.decls :=
-      Atom.wfIn_mono hpwf_range hσwf.2.1 hwfst
-    exact VerifM.eval_resolve hb hpwf_decls
-      (fun st' hq hdecls => by
-        simp at hq
-        exact (VerifM.eval_fatal hq).elim)
-      (fun t st' hq hdecls htwf => by
-        simp [Assertion.pre]
-        have hwfst' : st'.decls.wf := by simpa [hdecls] using hwfst
-        have htwf' : t.wfIn st'.decls := by simpa [hdecls] using htwf
-        istart
-        iintro H
-        icases H with ⟨Hpred, Howns, HR⟩
-        iexists (t.eval ρ.env)
-        isplitr [Howns HR]
-        · have hpred_subst :
-              (p.subst σ.subst).eval ρ (t.eval ρ.env) ⊢
-                p.eval (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ.env) := by
+      obtain ⟨hpwf, hkwf⟩ := hwf
+      simp only [Assertion.prove] at heval
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls := ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+      have hb := VerifM.eval_bind _ _ _ _ heval
+      have hsymbols : (Δ_base.declVars σ.dom).SymbolSubset σ.range :=
+        Signature.SymbolSubset.trans declVars_symbolSubset hbase
+      have hpwf_range : (p.subst σ.subst).wfIn σ.range :=
+        Atom.subst_wfIn hpwf hsubst (by intro x hx; exact hx) hsymbols hrangewf
+      have hpwf_decls : (p.subst σ.subst).wfIn st.decls :=
+        Atom.wfIn_mono hpwf_range huse hwfst
+      exact VerifM.eval_resolve hb hpwf_decls
+        (fun st' hq hdecls => by
+          simp at hq
+          exact (VerifM.eval_fatal hq).elim)
+        (fun t st' hq hdecls htwf => by
+          simp [Assertion.pre]
+          have hwfst' : st'.decls.wf := by simpa [hdecls] using hwfst
+          have htwf' : t.wfIn st'.decls := by simpa [hdecls] using htwf
+          istart
+          iintro H
+          icases H with ⟨Hpred, Howns, HR⟩
+          iexists (t.eval ρ.env)
+          isplitr [Howns HR]
+          · have hpred_subst :
+                (p.subst σ.subst).eval ρ (t.eval ρ.env) ⊢
+                  p.eval (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ.env) := by
               simpa [VerifM.Env.withEnv] using
                 (show (p.subst σ.subst).eval ρ (t.eval ρ.env) ⊢
                     p.eval (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ.env) by
-                  rw [Atom.eval_subst hpwf hσwf.1 hσwf.2.2]
+                  rw [Atom.eval_subst hpwf hsubst hrangewf]
                   exact BIBase.Entails.rfl)
-          iapply hpred_subst
-          iexact Hpred
-        · have hb2 := VerifM.eval_bind _ _ _ _ hq
-          have hdecl := VerifM.eval_decl hb2
-          set v' := st'.freshConst (some v.name) v.sort
-          have hv'_fresh_decls : v'.name ∉ st'.decls.allNames :=
-            Fresh.freshNumbers_not_mem v.name st'.decls.allNames
-          have hv'_fresh_range : v'.name ∉ σ.range.allNames := by
-            intro h
-            apply hv'_fresh_decls
-            rw [hdecls]
-            exact Signature.allNames_subset hσwf.2.1 _ h
-          specialize hdecl (t.eval ρ.env)
-          have hb3 := VerifM.eval_bind _ _ _ _ hdecl
-          have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
-              (st'.decls.addConst v') := by
-            refine ⟨?_, ?_⟩
-            · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
-              have hwf_add : (st'.decls.addConst v').wf := Signature.wf_addConst hwfst' hv'_fresh_decls
-              refine ⟨List.Mem.head _, ?_, ?_⟩
-              · intro τ' hvar
-                exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
-              · intro τ' hc'
-                exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
-            · exact Term.wfIn_mono _ htwf' (Signature.Subset.subset_addConst _ _)
-                (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
-          have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
-              (ρ.updateConst v.sort v'.name (t.eval ρ.env)).env := by
-            simp only [Formula.eval, Term.eval, Const.denote]
-            simpa [Env.lookupConst, Env.updateConst] using
-              (Term.eval_env_agree htwf' (Env.agreeOn_update_fresh_const hv'_fresh_decls))
-          have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
-          set σ' := σ.rename v v'.name
-          have hσ'wf : σ'.wf (st'.decls.addConst v') := by
-            rw [hdecls]
-            simpa [σ'] using (FiniteSubst.rename_wf (σ := σ) (v := v) (name' := v'.name) hσwf hv'_fresh_range)
-          have hσ'domwf : (Signature.ofVars σ'.dom).wf := by
-            simpa [σ'] using (FiniteSubst.rename_dom_wf (σ := σ) (v := v) (name' := v'.name) hdomwf)
-          have hkwf' : k.wfIn retWf (Signature.ofVars σ'.dom) := by
-            simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using hkwf
-          have hih := ih σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
-            (ρ.updateConst v.sort v'.name (t.eval ρ.env)) Ψ hσ'wf hσ'domwf hkwf' hassume hpost
-            (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
-          have hinterp_bi : st'.sl ρ ⊣⊢ st'.sl (ρ.updateConst v.sort v'.name (t.eval ρ.env)) :=
-            SpatialContext.interp_env_agree (VerifM.eval.wf hq).ownsWf
-              (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-          have hframe : st'.sl ρ ∗ R ⊢
-              st'.sl (ρ.updateConst v.sort v'.name (t.eval ρ.env)) ∗ R := by
-            exact sep_mono hinterp_bi.1 (by
-              iintro HR
-              iexact HR)
-          iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
-            (by
-              simpa [σ', FiniteSubst.rename, Signature.ofVars, Signature.remove, Signature.addVar] using
-                (FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := v') hσwf.1 hv'_fresh_range rfl))
-            hΦ)
-          isplitl [Howns]
-          · simp [TransState.sl]
-          · iexact HR)
+            iapply hpred_subst
+            iexact Hpred
+          · have hb2 := VerifM.eval_bind _ _ _ _ hq
+            have hdecl := VerifM.eval_decl hb2
+            set v' := st'.freshConst (some v.name) v.sort
+            have hv'_fresh_decls : v'.name ∉ st'.decls.allNames :=
+              Fresh.freshNumbers_not_mem v.name st'.decls.allNames
+            have hv'_fresh_range : v'.name ∉ σ.range.allNames := by
+              intro h
+              apply hv'_fresh_decls
+              rw [hdecls]
+              exact Signature.allNames_subset huse _ h
+            specialize hdecl (t.eval ρ.env)
+            have hb3 := VerifM.eval_bind _ _ _ _ hdecl
+            have heq_wf : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).wfIn
+                (st'.decls.addConst v') := by
+              refine ⟨?_, ?_⟩
+              · simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+                have hwf_add : (st'.decls.addConst v').wf := Signature.wf_addConst hwfst' hv'_fresh_decls
+                refine ⟨List.Mem.head _, ?_, ?_⟩
+                · intro τ' hvar
+                  exact hv'_fresh_decls (Signature.mem_allNames_of_var hvar)
+                · intro τ' hc'
+                  exact Signature.wf_unique_const hwf_add (List.Mem.head _) hc'
+              · exact Term.wfIn_mono _ htwf' (Signature.Subset.subset_addConst _ _)
+                  (TransState.freshConst.wf _ (VerifM.eval.wf hq)).namesDisjoint
+            have heq_holds : (Formula.eq v.sort (.const (.uninterpreted v'.name v.sort)) t).eval
+                (ρ.updateConst v.sort v'.name (t.eval ρ.env)).env := by
+              simp only [Formula.eval, Term.eval, Const.denote]
+              simpa [Env.lookupConst, Env.updateConst] using
+                (Term.eval_env_agree htwf'
+                  (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls))
+            have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
+            set σ' := σ.rename v v'.name
+            have hσ'wf : σ'.wfIn Δ_base (st'.decls.addConst v') := by
+              rw [hdecls]
+              simpa [σ'] using
+                (FiniteSubst.rename_wfIn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+                  (v := v) (name' := v'.name) hσwf hv'_fresh_range (by
+                    simpa [hdecls] using hv'_fresh_decls))
+            have hkwf' : k.wfIn retWf (Δ_base.declVars σ'.dom) := by
+              simpa [σ', FiniteSubst.rename_source_eq] using hkwf
+            have hih := ih Δ_base σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
+              (ρ.updateConst v.sort v'.name (t.eval ρ.env)) Ψ hσ'wf hkwf' hassume hpost
+            have hinterp_bi : st'.sl ρ ⊣⊢ st'.sl (ρ.updateConst v.sort v'.name (t.eval ρ.env)) :=
+              SpatialContext.interp_env_agree (VerifM.eval.wf hq).ownsWf
+                (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
+            have hframe : st'.sl ρ ∗ R ⊢
+                st'.sl (ρ.updateConst v.sort v'.name (t.eval ρ.env)) ∗ R := by
+              exact sep_mono hinterp_bi.1 (by
+                iintro HR
+                iexact HR)
+            iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
+              (by
+                simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+                  (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+                    (v := v) (name' := v'.name) (ρ := ρ.env) (u := t.eval ρ.env) hσwf hv'_fresh_range))
+              hΦ)
+            isplitl [Howns]
+            · simp [TransState.sl]
+            · iexact HR)
   | ite φ kt ke iht ihe =>
-    obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
-    simp only [Assertion.prove] at heval
-    have hb := VerifM.eval_bind _ _ _ _ heval
-    have hall := VerifM.eval_all hb
-    simp only [Assertion.pre]
-    iintro Howns
-    apply BI.and_intro
-    · apply wand_intro
-      iintro H
-      icases H with ⟨Howns, %hφ⟩
-      have htrue := hall true (List.mem_cons_self ..)
-      simp at htrue
-      have hb2 := VerifM.eval_bind _ _ _ _ htrue
-      have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
-        FiniteSubst.subst_wfIn_formula hσwf hφwf hwfst
-      have hsubst_eval := (FiniteSubst.eval_subst_formula hφwf hσwf.1 hdomwf hσwf.2.2).mpr hφ
-      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
-      iapply (iht σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hktwf hassume hpost hwfst)
-      simp [TransState.sl]
-    · apply wand_intro
-      iintro H
-      icases H with ⟨Howns, %hnφ⟩
-      have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
-      simp at hfalse
-      have hb2 := VerifM.eval_bind _ _ _ _ hfalse
-      have hnot_wf : (Formula.not φ).wfIn (Signature.ofVars σ.dom) := by
-        simp only [Formula.wfIn]; exact hφwf
-      have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
-        FiniteSubst.subst_wfIn_formula hσwf hnot_wf hwfst
-      have hsubst_eval := (FiniteSubst.eval_subst_formula hnot_wf hσwf.1 hdomwf hσwf.2.2).mpr hnφ
-      have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
-      iapply (ihe σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hdomwf hkewf hassume hpost hwfst)
-      simp [TransState.sl]
+      obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
+      simp only [Assertion.prove] at heval
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls := ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hwfst : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
+      have hb := VerifM.eval_bind _ _ _ _ heval
+      have hall := VerifM.eval_all hb
+      simp only [Assertion.pre]
+      iintro Howns
+      apply BI.and_intro
+      · apply wand_intro
+        iintro H
+        icases H with ⟨Howns, %hφ⟩
+        have htrue := hall true (List.mem_cons_self ..)
+        simp at htrue
+        have hb2 := VerifM.eval_bind _ _ _ _ htrue
+        have hsubst_wf_range : (φ.subst σ.subst σ.range.allNames).wfIn σ.range :=
+          FiniteSubst.subst_wfIn_formula_range hσwf hφwf
+        have hsubst_wf : (φ.subst σ.subst σ.range.allNames).wfIn st.decls :=
+          Formula.wfIn_mono _ hsubst_wf_range huse hwfst
+        have hsubst_eval := (FiniteSubst.eval_subst_formula hσwf hφwf).mpr hφ
+        have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
+        iapply (iht Δ_base σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hktwf hassume hpost)
+        simp [TransState.sl]
+      · apply wand_intro
+        iintro H
+        icases H with ⟨Howns, %hnφ⟩
+        have hfalse := hall false (List.mem_cons.mpr (Or.inr (List.mem_cons_self ..)))
+        simp at hfalse
+        have hb2 := VerifM.eval_bind _ _ _ _ hfalse
+        have hnot_wf : (Formula.not φ).wfIn (Δ_base.declVars σ.dom) := by
+          simp only [Formula.wfIn]; exact hφwf
+        have hsubst_wf_range : (φ.not.subst σ.subst σ.range.allNames).wfIn σ.range :=
+          FiniteSubst.subst_wfIn_formula_range hσwf hnot_wf
+        have hsubst_wf : (φ.not.subst σ.subst σ.range.allNames).wfIn st.decls :=
+          Formula.wfIn_mono _ hsubst_wf_range huse hwfst
+        have hsubst_eval := (FiniteSubst.eval_subst_formula hσwf hnot_wf).mpr hnφ
+        have hassume := VerifM.eval_assumePure hb2 hsubst_wf hsubst_eval
+        iapply (ihe Δ_base σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hkewf hassume hpost)
+        simp [TransState.sl]

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -105,7 +105,7 @@ theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : VerifM.En
 /-! ### Compiler and Top-Level Verifier -/
 
 mutual
-  def compile (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
+  def compile (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
     | .const (.int n)  => pure (.unop .ofInt  (.const (.i n)))
     | .const (.bool b) => pure (.unop .ofBool (.const (.b b)))
     | .const .unit     => pure (Term.const .unit)
@@ -114,7 +114,7 @@ mutual
         VerifM.expectEq s!"type annotation mismatch for variable: {x}" (Γ x |>.getD .value) vty
         pure (.const (.uninterpreted x'.name .value))
     | .unop op e uty => do
-        let se ← compile Θ S B Γ e
+        let se ← compile Θ Δ_spec S B Γ e
         let ty ← VerifM.expectSome
           s!"type error: operator {repr op} cannot be applied to {repr e.ty}"
           (TinyML.UnOp.typeOf op e.ty)
@@ -124,12 +124,12 @@ mutual
           (compileUnop op se)
         pure t
     | .assert e => do
-        let sl ← compile Θ S B Γ e
+        let sl ← compile Θ Δ_spec S B Γ e
         VerifM.assert (Formula.eq .bool (Term.unop .toBool sl) (Term.const (.b true)))
         pure (Term.const .unit)
     | .binop op l r bty => do
-        let sr ← compile Θ S B Γ r
-        let sl ← compile Θ S B Γ l
+        let sr ← compile Θ Δ_spec S B Γ r
+        let sl ← compile Θ Δ_spec S B Γ l
         let ty ← VerifM.expectSome
           s!"type error: operator {repr op} cannot be applied to {repr l.ty} and {repr r.ty}"
           (TinyML.BinOp.typeOf op l.ty r.ty)
@@ -145,50 +145,50 @@ mutual
             (compileOp op sl sr)
           pure t
     | .letIn b e body => do
-        let se ← compile Θ S B Γ e
+        let se ← compile Θ Δ_spec S B Γ e
         VerifM.expectEq "let type annotation mismatch" b.ty e.ty
         match b.name with
-        | none => compile Θ S B Γ body
+        | none => compile Θ Δ_spec S B Γ body
         | some x =>
           let x' ← VerifM.decl (some x) .value
           VerifM.assume (.pure (Formula.eq .value (.const (.uninterpreted x'.name .value)) se))
-          compile Θ (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
+          compile Θ Δ_spec (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
     | .ifThenElse cond thn els ty => do
-        let sc ← compile Θ S B Γ cond
+        let sc ← compile Θ Δ_spec S B Γ cond
         VerifM.expectEq "if condition type mismatch" cond.ty .bool
         VerifM.expectEq "if branch type annotation mismatch" thn.ty ty
         VerifM.expectEq "if branch type annotation mismatch" els.ty ty
         let branch ← VerifM.all [true, false]
         if branch then do
           VerifM.assume (.pure (.not (.eq .value sc (.unop .ofBool (.const (.b false))))))
-          compile Θ S B Γ thn
+          compile Θ Δ_spec S B Γ thn
         else do
           VerifM.assume (.pure (.eq .value sc (.unop .ofBool (.const (.b false)))))
-          compile Θ S B Γ els
+          compile Θ Δ_spec S B Γ els
     | .app (.var f fty) args aty => do
         let spec ← VerifM.expectSome s!"no spec for function {f}" (S.lookup f)
-        let sterms ← compileExprs Θ S B Γ args
+        let sterms ← compileExprs Θ Δ_spec S B Γ args
         let sargs := (args.map Expr.ty).zip sterms
         VerifM.expectEq "app type annotation mismatch" spec.retTy aty
         VerifM.expectEq "app type annotation mismatch"
           fty (Typed.arrowOfArgs (spec.args.map fun arg => Binder.named arg.1 arg.2) spec.retTy)
-        let (_, result) ← Spec.call Θ FiniteSubst.id spec sargs
+        let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) spec sargs
         pure result
     | .tuple es => do
-        let terms ← compileExprs Θ S B Γ es
+        let terms ← compileExprs Θ Δ_spec S B Γ es
         pure (.unop .ofValList (Terms.toValList terms))
     | .inj tag arity payload => do
         if tag ≥ arity then VerifM.fatal "inj tag out of range"
         else
-          let s ← compile Θ S B Γ payload
+          let s ← compile Θ Δ_spec S B Γ payload
           pure (.unop (.mkInj tag arity) s)
     | .match_ scrut branches ty => do
-        let sc ← compile Θ S B Γ scrut
+        let sc ← compile Θ Δ_spec S B Γ scrut
         match scrut.ty with
         | .sum ts =>
           if ts.length ≠ branches.length then VerifM.fatal "match arity mismatch"
           else if ∀ br ∈ branches, br.2.ty = ty then do
-            let actions := compileBranches Θ S B Γ sc ts branches 0
+            let actions := compileBranches Θ Δ_spec S B Γ sc ts branches 0
             let i ← VerifM.all (List.range actions.length)
             match actions[i]? with
             | some m => m
@@ -197,29 +197,29 @@ mutual
             VerifM.fatal "match branch type annotation mismatch"
         | _ => VerifM.fatal "match on non-sum type"
     | .cast e ty => do
-        let se ← compile Θ S B Γ e
+        let se ← compile Θ Δ_spec S B Γ e
         if TinyML.Typ.sub Θ e.ty ty then pure se
         else VerifM.fatal s!"cast type mismatch"
     | .ref e => do
-        let _ ← compile Θ S B Γ e
+        let _ ← compile Θ Δ_spec S B Γ e
         let l ← VerifM.decl none .value
         pure (.const (.uninterpreted l.name .value))
     | .deref e ty => do
         VerifM.expectEq "deref type annotation mismatch" e.ty (.ref ty)
-        let _ ← compile Θ S B Γ e
+        let _ ← compile Θ Δ_spec S B Γ e
         let v ← VerifM.decl none .value
         let sv := Term.const (.uninterpreted v.name .value)
         VerifM.assumeAll (TinyML.typeConstraints ty sv)
         pure sv
     | .store loc val => do
         VerifM.expectEq "store location type mismatch" loc.ty (.ref val.ty)
-        let _ ← compile Θ S B Γ val
-        let _ ← compile Θ S B Γ loc
+        let _ ← compile Θ Δ_spec S B Γ val
+        let _ ← compile Θ Δ_spec S B Γ loc
         pure (Term.const .unit)
     | .app _ _ _ | .fix _ _ _ _ => VerifM.fatal "unsupported expression"
 
   /-- Compile a single match branch: assume the scrutinee is `mkInj i n payload`, then compile the body. -/
-  def compileBranch (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  def compileBranch (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
       (sc : Term .value) (n : Nat) (i : Nat) (ty_i : TinyML.Typ)
       : Binder × Expr → VerifM (Term .value)
     | (binder, body) => do
@@ -229,35 +229,35 @@ mutual
         VerifM.assumeAll (TinyML.typeConstraints ty_i (.const (.uninterpreted xv.name .value)))
         match binder.name with
         | some x =>
-          compile Θ (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body
+          compile Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body
         | none =>
-          compile Θ S B (Γ.extendBinder binder ty_i) body
+          compile Θ Δ_spec S B (Γ.extendBinder binder ty_i) body
 
-  def compileBranches (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  def compileBranches (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
       (sc : Term .value) (ts : List TinyML.Typ) :
       List (Binder × Expr) → Nat → List (VerifM (Term .value))
     | [], _ => []
     | branch :: rest, i =>
-      compileBranch Θ S B Γ sc ts.length i (ts[i]?.getD .value) branch
-        :: compileBranches Θ S B Γ sc ts rest (i + 1)
+      compileBranch Θ Δ_spec S B Γ sc ts.length i (ts[i]?.getD .value) branch
+        :: compileBranches Θ Δ_spec S B Γ sc ts rest (i + 1)
 
-  def compileExprs (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : List Expr → VerifM (List (Term .value))
+  def compileExprs (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : List Expr → VerifM (List (Term .value))
     | [] => pure []
     | e :: es => do
-      let rest ← compileExprs Θ S B Γ es
-      let se ← compile Θ S B Γ e
+      let rest ← compileExprs Θ Δ_spec S B Γ es
+      let se ← compile Θ Δ_spec S B Γ e
       pure (se :: rest)
 end
 
 /-! ### Helper lemmas -/
 
-theorem compileBranches_length_get (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+theorem compileBranches_length_get (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (ts : List TinyML.Typ)
     (branches : List (Binder × Expr)) (idx : Nat) :
-    (compileBranches Θ S B Γ sc ts branches idx).length = branches.length ∧
+    (compileBranches Θ Δ_spec S B Γ sc ts branches idx).length = branches.length ∧
     ∀ j, j < branches.length →
-      (compileBranches Θ S B Γ sc ts branches idx)[j]? =
-        branches[j]?.map (fun branch => compileBranch Θ S B Γ sc ts.length (idx + j) (ts[idx + j]?.getD .value) branch) := by
+      (compileBranches Θ Δ_spec S B Γ sc ts branches idx)[j]? =
+        branches[j]?.map (fun branch => compileBranch Θ Δ_spec S B Γ sc ts.length (idx + j) (ts[idx + j]?.getD .value) branch) := by
   induction branches generalizing idx with
   | nil => exact ⟨rfl, fun j hj => absurd hj (Nat.not_lt_zero _)⟩
   | cons b bs ih =>
@@ -275,12 +275,13 @@ theorem compileBranches_length_get (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bind
 
 namespace Helpers
 
-theorem ctx_dup (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+theorem ctx_dup (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl ρ ∗
-        (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗
-          (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R)) := by
+        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R)) := by
   iintro ⟨Howns, □HS, □HT, HR⟩
   isplitl [Howns]
   · iexact Howns
@@ -294,12 +295,13 @@ theorem ctx_dup (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.
           · iexact HT
           · iexact HR
 
-theorem ctx_dup_flip (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+theorem ctx_dup_flip (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl ρ ∗
-        (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗
-          (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ γ ∗ R))) := by
+        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+          (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))) := by
   iintro ⟨Howns, □HS, □HT, HR⟩
   isplitl [Howns]
   · iexact Howns
@@ -313,12 +315,13 @@ theorem ctx_dup_flip (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : Ti
           · iexact HS
           · iexact HR
 
-theorem ctx_push (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+theorem ctx_push (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl ρ ∗
-        (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗
+        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (TinyML.ValHasType Θ v ty ∗ R)) := by
   iintro ⟨Howns, Hv, □HS, □HT, HR⟩
   isplitl [Howns]
@@ -331,12 +334,13 @@ theorem ctx_push (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML
         · iexact Hv
         · iexact HR
 
-theorem ctx_push_flip (Θ : TinyML.TypeEnv) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+theorem ctx_push_flip (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
+    st.sl ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
       st.sl ρ ∗
-        (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗
+        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (TinyML.ValHasType Θ v ty ∗ R)) := by
   iintro ⟨Howns, Hv, □HT, □HS, HR⟩
   isplitl [Howns]
@@ -356,70 +360,100 @@ end Helpers
 
 /-! #### Correctness Statements -/
 
+private theorem specInvariants_mono
+    {Δ_spec : Signature} {ρ_spec st st' : VerifM.Env} {decls decls' : Signature}
+    (hΔspec : Δ_spec.Subset decls)
+    (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec st)
+    (hdecls : decls.Subset decls')
+    (hagree : VerifM.Env.agreeOn decls st st') :
+    Δ_spec.Subset decls' ∧ VerifM.Env.agreeOn Δ_spec ρ_spec st' := by
+  refine ⟨hΔspec.trans hdecls, VerifM.Env.agreeOn_trans hρspec ?_⟩
+  exact VerifM.Env.agreeOn_mono hΔspec hagree
+
 def correctExpr (e : Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+  (Δ_spec : Signature) (ρ_spec : VerifM.Env)
   (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
-    VerifM.eval (compile Θ S B Γ e) st ρ Ψ →
+    VerifM.eval (compile Θ Δ_spec S B Γ e) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
-    S.wfIn Signature.empty →
+    S.wfIn Δ_spec →
+    Δ_spec.wf →
+    Δ_spec.vars = [] →
+    Δ_spec.Subset st.decls →
+    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
       st'.sl ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢ Φ v) →
-    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ
+    st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ
 
 def correctBranch (branch : Binder × Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp),
-    VerifM.eval (compileBranch Θ S B Γ sc n i ty_i branch) st ρ Ψ →
+    VerifM.eval (compileBranch Θ Δ_spec S B Γ sc n i ty_i branch) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
-    S.wfIn Signature.empty →
+    S.wfIn Δ_spec →
+    Δ_spec.wf →
+    Δ_spec.vars = [] →
+    Δ_spec.Subset st.decls →
+    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
-      st.sl ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
+      st.sl ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
 
 def correctBranches (branches : List (Binder × Expr)) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n : Nat) (ts : List TinyML.Typ) (idx : Nat)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp),
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
-    S.wfIn Signature.empty →
+    S.wfIn Δ_spec →
+    Δ_spec.wf →
+    Δ_spec.vars = [] →
+    Δ_spec.Subset st.decls →
+    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
-      VerifM.eval (compileBranch Θ S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
+      VerifM.eval (compileBranch Θ Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
-        st.sl ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
+        st.sl ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
 
 def correctExprs (es : List Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (Ψ : List (Term .value) → TransState → VerifM.Env → Prop)
     (Φ : List Runtime.Val → iProp),
-    VerifM.eval (compileExprs Θ S B Γ es) st ρ Ψ →
+    VerifM.eval (compileExprs Θ Δ_spec S B Γ es) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
-    S.wfIn Signature.empty →
+    S.wfIn Δ_spec →
+    Δ_spec.wf →
+    Δ_spec.vars = [] →
+    Δ_spec.Subset st.decls →
+    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ'.env terms vs →
-       st'.sl ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ γ ∗ R) ⊢ Φ vs) →
-    st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ
+       st'.sl ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
+    st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ
 
 /-! #### Correctness Compatibility Lemmas -/
 
 theorem compileConst_correct (c : TinyML.Const) :
     correctExpr (.const c) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval _hagree _hbwf _hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hpost
   cases c with
   | int n =>
     simp only [compile] at heval
@@ -478,7 +512,7 @@ theorem compileConst_correct (c : TinyML.Const) :
 
 theorem compileVar_correct (x : String) (vty : TinyML.Typ) :
     correctExpr (.var x vty) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf _hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hpost
   simp only [compile] at heval
   obtain ⟨x', hbind, heval⟩ := VerifM.eval_bind_expectSome heval
   obtain ⟨hcheck, hcont⟩ := VerifM.eval_bind_expectEq heval
@@ -548,7 +582,7 @@ theorem compileVar_correct (x : String) (vty : TinyML.Typ) :
 theorem compileInj_correct (tag arity : Nat) (payload : Expr)
     (ihPayload : correctExpr payload) :
     correctExpr (.inj tag arity payload) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
@@ -557,9 +591,9 @@ theorem compileInj_correct (tag arity : Nat) (payload : Expr)
     exact (VerifM.eval_fatal heval).elim
   · push_neg at htag
     simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
-    have heval_p : (compile Θ S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpatialContext.wp_bind_inj <| ihPayload Θ R S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hSwf ?_
+    have heval_p : (compile Θ Δ_spec S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_inj <| ihPayload Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
     intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p
     obtain ⟨_hdecls_p, _hagreeOn_p, hΨ_p⟩ := hΨ_p
     obtain hΨ_p := VerifM.eval_ret hΨ_p
@@ -586,12 +620,12 @@ theorem compileInj_correct (tag arity : Nat) (payload : Expr)
 theorem compileCast_correct (e : Expr) (ty : TinyML.Typ)
     (ih : correctExpr e) :
     correctExpr (.cast e ty) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   simp only [Expr.ty] at hpost
   simp only [compile] at heval
-  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   simp [Expr.runtime]
-  refine ih Θ R S B Γ st ρ γ _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf ?_
+  refine ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   intro v ρ' st' se hΨ hse_wf heval_se
   obtain ⟨_, _, hΨ⟩ := hΨ
   cases hsub : TinyML.Typ.sub Θ e.ty ty with
@@ -611,13 +645,13 @@ theorem compileCast_correct (e : Expr) (ty : TinyML.Typ)
 theorem compileAssert_correct (e : Expr)
     (ih : correctExpr e) :
     correctExpr (.assert e) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-  refine SpatialContext.wp_bind_assert <| ih Θ R S B Γ st ρ γ _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf ?_
+  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_assert <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_, _, hΨ_e⟩ := hΨ_e
   let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
@@ -642,21 +676,21 @@ theorem compileAssert_correct (e : Expr)
 
 theorem compileFix_correct (self : Binder) (args : List Binder) (retTy : TinyML.Typ) (body : Expr) :
     correctExpr (.fix self args retTy body) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval _hagree _hbwf _hSwf _hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
   simp only [compile] at heval
   exact (VerifM.eval_fatal heval).elim
 
 theorem compileRef_correct (e : Expr)
     (ih : correctExpr e) :
     correctExpr (.ref e) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
-  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-  refine SpatialContext.wp_bind_ref <| ih Θ R S B Γ st ρ γ _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf ?_
+  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_ref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hwf_st₁ := VerifM.eval.wf hΨ_e
@@ -717,15 +751,15 @@ theorem compileRef_correct (e : Expr)
 theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
     (ih : correctExpr e) :
     correctExpr (.deref e ty) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨hannot, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-  refine SpatialContext.wp_bind_deref <| ih Θ R S B Γ st ρ γ _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf ?_
+  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_deref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   intro v_e ρ_e st₁ se hΨ_e _hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
@@ -781,36 +815,37 @@ theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
 theorem compileStore_correct (loc val : Expr)
     (ihVal : correctExpr val) (ihLoc : correctExpr loc) :
     correctExpr (.store loc val) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨hannot, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_v : (compile Θ S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_v : (compile Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl ρ ∗
-          (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ γ ∗ R))) :=
-    Helpers.ctx_dup_flip Θ S B Γ st ρ γ R
+          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))) :=
+    Helpers.ctx_dup_flip Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ γ ∗ R)) S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf ?_)
+    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
   have hagree_v : B.agreeOnLinked ρ_v.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
-  have heval_l : (compile Θ S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
+  have heval_l : (compile Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
   have hlocStart :
       st₁.sl ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
-        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ γ ∗ R)) ⊢
-          st₁.sl ρ_v ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+          st₁.sl ρ_v ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (TinyML.ValHasType Θ v_v val.ty ∗ R)) :=
-    Helpers.ctx_push_flip Θ S B Γ st₁ ρ_v γ R v_v val.ty
-  refine hlocStart.trans <| ihLoc Θ (TinyML.ValHasType Θ v_v val.ty ∗ R) S B Γ st₁ ρ_v γ _ _
-    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf ?_
+    Helpers.ctx_push_flip Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
+  have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
+  refine hlocStart.trans <| ihLoc Θ (TinyML.ValHasType Θ v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 ?_
   intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
   obtain hret := VerifM.eval_ret hΨ_l
@@ -845,13 +880,13 @@ theorem compileStore_correct (loc val : Expr)
 theorem compileUnop_correct (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
     (ih : correctExpr e) :
     correctExpr (.unop op e uty) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_e : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-  refine SpatialContext.wp_bind_unop <| ih Θ R S B Γ st ρ γ _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf ?_
+  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_unop <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_, _, hΨ_e⟩ := hΨ_e
   obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
@@ -886,36 +921,37 @@ theorem compileUnop_correct (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
 theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
     (ihR : correctExpr r) (ihL : correctExpr l) :
     correctExpr (.binop op l r bty) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_r : (compile Θ S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_r : (compile Θ Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl ρ ∗
-          (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup Θ S B Γ st ρ γ R
+          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+    Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_binop <| hstart.trans <|
-    ihR Θ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf ?_
+    ihR Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr
   obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
   have hagree_r : B.agreeOnLinked ρ_r.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
   have hbwf_r : B.wfIn st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
-  have heval_l : (compile Θ S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
+  have heval_l : (compile Θ Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
   have hleftStart :
       st₁.sl ρ_r ∗ TinyML.ValHasType Θ vr r.ty ∗
-        (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
           st₁.sl ρ_r ∗
-            (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
               (TinyML.ValHasType Θ vr r.ty ∗ R)) :=
-    Helpers.ctx_push Θ S B Γ st₁ ρ_r γ R vr r.ty
+    Helpers.ctx_push Θ Δ_spec ρ_spec S B Γ st₁ ρ_r γ R vr r.ty
+  have hspecInv_r := specInvariants_mono hΔspec hρspec hdecls_r hagreeOn_r
   refine hleftStart.trans <|
-    ihL Θ (TinyML.ValHasType Θ vr r.ty ∗ R) S B Γ st₁ ρ_r γ _ _
-      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hSwf ?_
+    ihL Θ (TinyML.ValHasType Θ vr r.ty ∗ R) S B Γ st₁ ρ_r γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hSwf hΔwf hΔvars hspecInv_r.1 hspecInv_r.2 ?_
   intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
   obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
@@ -1107,20 +1143,20 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
 theorem compileLetIn_correct (b : Binder) (e body : Expr)
     (ihE : correctExpr e) (ihBody : correctExpr body) :
     correctExpr (.letIn b e body) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.letIn_subst]
-  have heval_e_outer : (compile Θ S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e_outer : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl ρ ∗
-          (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup Θ S B Γ st ρ γ R
-  refine (hstart.trans <| ihE Θ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ _ _
-    (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hSwf ?_).trans wp.letIn
+          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+    Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
+  refine (hstart.trans <| ihE Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_).trans wp.letIn
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e
   obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
@@ -1130,8 +1166,8 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
   | none =>
     simp [hname] at hΨ_e
     have hdrop :
-        st₁.sl ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-          st₁.sl ρ_e ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          st₁.sl ρ_e ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       iintro ⟨Howns, _Hv, □HS, □HT, HR⟩
       isplitl [Howns]
       · iexact Howns
@@ -1140,14 +1176,15 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
         · isplitl []
           · iexact HT
           · iexact HR
-    have hbody := hdrop.trans <| ihBody Θ R S B Γ st₁ ρ_e γ _ _
-      (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hSwf
+    have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
+    have hbody := hdrop.trans <| ihBody Θ R S B Γ st₁ ρ_e γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hSwf hΔwf hΔvars hspecInv_e.1 hspecInv_e.2
       (fun v ρ' st' se hΨ hs hw =>
         let ⟨_, _, hΨ'⟩ := hΨ
         hpost v ρ' st' se hΨ' hs hw)
     have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ Runtime.Binder.none v_e
     have hbody' : st₁.sl ρ_e ∗
-          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
             wp
               (Runtime.Expr.subst
                 (Runtime.Subst.updateBinder Runtime.Binder.none v_e Runtime.Subst.id)
@@ -1171,11 +1208,11 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
     set ρ_body := ρ_e.updateConst .value v.name v_e
     set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
     suffices st₂.sl ρ_body ∗
-        (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+        (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
           wp (body.runtime.subst γ_body) Φ by
       have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ (.named x) v_e
       have hbody' : st₂.sl ρ_body ∗
-            (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+            (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
               wp
                 (Runtime.Expr.subst
                   (Runtime.Subst.updateBinder (.named x) v_e Runtime.Subst.id)
@@ -1191,7 +1228,7 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
           using hbody'
     have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
       Env.agreeOn_update_fresh_const hfresh
-    have hΨ_body : (compile Θ (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
+    have hΨ_body : (compile Θ Δ_spec (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
       have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
       have hdecl := VerifM.eval_decl hdecl_eval
       have h := hdecl v_e
@@ -1230,9 +1267,9 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
       rwa [hρ_body_lookup] at h
     have hres :
         st₂.sl ρ_body ∗
-          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
             st₂.sl ρ_body ∗
-              (SpecMap.satisfiedBy Θ (Finmap.erase x S) γ_body ∗
+              (SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
                 Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body ∗ R) := by
       iintro ⟨Howns, Hve, □HS, □HT, HR⟩
       isplitl [Howns]
@@ -1246,8 +1283,11 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
             · iexact HT
             · iexact Hve
           · iexact HR
-    refine hres.trans <| ihBody Θ R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _
-      (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ (SpecMap.wfIn_erase hSwf) ?_
+    have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
+    have hspecInv_body := specInvariants_mono hspecInv_e.1 hspecInv_e.2
+      (Signature.Subset.subset_addConst st₁.decls v) hagreeOn_body_e
+    refine hres.trans <| ihBody Θ R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ (SpecMap.wfIn_erase hSwf) hΔwf hΔvars hspecInv_body.1 hspecInv_body.2 ?_
     intro v' ρ' st' se' hΨ hs hw
     obtain ⟨_, _, hΨ'⟩ := hΨ
     exact hpost v' ρ' st' se' hΨ' hs hw
@@ -1255,25 +1295,26 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
 theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
     (ihCond : correctExpr cond) (ihThn : correctExpr thn) (ihEls : correctExpr els) :
     correctExpr (.ifThenElse cond thn els ty) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_cond : (compile Θ S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_cond : (compile Θ Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl ρ ∗
-          (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup Θ S B Γ st ρ γ R
+          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+    Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_if <| hstart.trans <|
-    ihCond Θ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hSwf ?_
+    ihCond Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c
   obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
   have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
   have hbwf_c : B.wfIn st₁.decls := fun p hp => hdecls_c.consts _ (hbwf p hp)
+  have hspecInv_c := specInvariants_mono hΔspec hρspec hdecls_c hagreeOn_c
   obtain ⟨hcond_bool, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
   obtain ⟨hthn_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
   obtain ⟨hels_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
@@ -1293,9 +1334,9 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
   let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
   let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
   have hbool_cases_bool :
-      st₁.sl ρ_c ∗ (TinyML.ValHasType Θ v_c .bool ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+      st₁.sl ρ_c ∗ (TinyML.ValHasType Θ v_c .bool ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
         st₁.sl ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     iintro ⟨Howns, Hv, □HS, □HT, HR⟩
     ihave Hv_bool := (TinyML.ValHasType.bool Θ v_c).1 $$ Hv
     icases Hv_bool with ⟨%b, %hv⟩
@@ -1309,9 +1350,9 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
           · iexact HT
           · iexact HR
   have hbool_cases :
-      st₁.sl ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+      st₁.sl ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
         st₁.sl ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     simpa [hcond_bool] using hbool_cases_bool
   refine hbool_cases.trans ?_
   istart
@@ -1319,21 +1360,21 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
   icases Hbool with %hbool
   rcases hbool with hfalse_val | htrue_val
   · subst hfalse_val
-    have heval_els : (compile Θ S B Γ els).eval st_els ρ_c Ψ :=
+    have heval_els : (compile Θ Δ_spec S B Γ els).eval st_els ρ_c Ψ :=
       hfalse_cont hwf_eq (by
         simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_c)
     have hwp :
-        st_els.sl ρ_c ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st_els.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
           wp (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_false
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
-        ihEls Θ R S B Γ st_els ρ_c γ Ψ Φ heval_els hagree_c hbwf_c hSwf
+        ihEls Θ R S B Γ st_els ρ_c γ Δ_spec ρ_spec Ψ Φ heval_els hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hels_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl ρ_c ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_els.sl ρ_c ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          st_els.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       simp [st_els, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -1347,21 +1388,21 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
     have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by
       rw [heval_c]
       simp
-    have heval_thn : (compile Θ S B Γ thn).eval st_thn ρ_c Ψ :=
+    have heval_thn : (compile Θ Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
       htrue_cont hwf_ne (by
         simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_ne)
     have hwp :
-        st_thn.sl ρ_c ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st_thn.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
           wp (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_true
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
-        ihThn Θ R S B Γ st_thn ρ_c γ Ψ Φ heval_thn hagree_c hbwf_c hSwf
+        ihThn Θ R S B Γ st_thn ρ_c γ Δ_spec ρ_spec Ψ Φ heval_thn hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hthn_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl ρ_c ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_thn.sl ρ_c ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          st_thn.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       simp [st_thn, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -1375,14 +1416,14 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
 theorem compileTuple_correct (es : List Expr)
     (ihEs : correctExprs es) :
     correctExpr (.tuple es) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
-  have heval_es : (compileExprs Θ S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-  refine SpatialContext.wp_bind_tuple <| ihEs Θ R S B Γ st ρ γ _ _
-    (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hSwf ?_
+  have heval_es : (compileExprs Θ Δ_spec S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  refine SpatialContext.wp_bind_tuple <| ihEs Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   intro vs ρ' st' terms hΨ hwf_terms heval_terms
   obtain ⟨_, _, hΨ⟩ := hΨ
   obtain hΨ := VerifM.eval_ret hΨ
@@ -1393,7 +1434,7 @@ theorem compileTuple_correct (es : List Expr)
     exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
   refine SpatialContext.wp_tuple ?_
   have hstep :
-      st'.sl ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ γ ∗ R) ⊢
+      st'.sl ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢
         st'.sl ρ' ∗ TinyML.ValHasType Θ (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
     iintro ⟨Howns, Hvals, □HS, HR⟩
     isplitl [Howns]
@@ -1412,7 +1453,7 @@ theorem compileTuple_correct (es : List Expr)
 theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
     (ihArgs : correctExprs args) :
     correctExpr (.app fn args aty) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst, List.map_map]
@@ -1420,9 +1461,9 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
   | var f fty =>
     simp only [compile] at heval
     obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
-    have heval_args : (compileExprs Θ S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    have heval_args : (compileExprs Θ Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpecMap.project
-      (P := st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ S γ ?_ hlookup ?_
+      (P := st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ Δ_spec ρ_spec S γ ?_ hlookup ?_
     · istart
       iintro ⟨_, □HS, _⟩
       iexact HS
@@ -1430,11 +1471,11 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
       simp [Expr.runtime, Runtime.Expr.subst, hγf]
       refine SpatialContext.wp_bind_app ?_
       have hctx :
-          spec.isPrecondFor Θ fval ∗
-              (st.sl ρ ∗ (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          spec.isPrecondFor Θ Δ_spec ρ_spec fval ∗
+              (st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
             st.sl ρ ∗
-              (S.satisfiedBy Θ γ ∗
-                Bindings.typedSubst Θ B Γ γ ∗ (spec.isPrecondFor Θ fval ∗ R)) := by
+              (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗
+                Bindings.typedSubst Θ B Γ γ ∗ (spec.isPrecondFor Θ Δ_spec ρ_spec fval ∗ R)) := by
         istart
         iintro ⟨□Hspec, Howns, □HS, □HT, HR⟩
         isplitl [Howns]
@@ -1447,29 +1488,31 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
               · iexact Hspec
               · iexact HR
       refine hctx.trans <|
-        ihArgs Θ (spec.isPrecondFor Θ fval ∗ R) S B Γ st ρ γ _ _
-          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf ?_
+        ihArgs Θ (spec.isPrecondFor Θ Δ_spec ρ_spec fval ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
       intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
-      obtain ⟨_, _, hΨ_args⟩ := hΨ_args
+      obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
       let typedArgs := (args.map Expr.ty).zip sargs
       have hlen_sargs : sargs.length = vs.length := by
         simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
       obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
       obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-      have hwf_pred : spec.pred.wfIn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars spec.args)) := by
-        simpa [Spec.wfIn, FiniteSubst.id, Signature.empty, Signature.ofVars] using hSwf f spec hlookup
-      have hid_wf : FiniteSubst.id.wf st_args.decls := FiniteSubst.id_wf st_args.decls
+      have hΔspec_args : Δ_spec.Subset st_args.decls := hΔspec.trans hdecls_args
+      have hst_args_wf : st_args.decls.wf := (VerifM.eval.wf hΨ_args).namesDisjoint
+      have hwf_pred : spec.pred.wfIn ((Δ_spec.declVars (FiniteSubst.base Δ_spec).dom).declVars (Spec.argVars spec.args)) := by
+        simpa [FiniteSubst.base, Signature.declVars] using hSwf f spec hlookup
+      have hbase_wf : (FiniteSubst.base Δ_spec).wf Δ_spec st_args.decls :=
+        FiniteSubst.base_wfIn hΔspec_args hΔwf hst_args_wf hΔvars
       have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
         intro p hp
         have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
         exact hsargs_wf _ hp''
-      have hcall_eval : VerifM.eval (Spec.call Θ FiniteSubst.id spec typedArgs) st_args ρ_args
+      have hcall_eval : VerifM.eval (Spec.call Θ (FiniteSubst.base Δ_spec) spec typedArgs) st_args ρ_args
           (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
-      have hcall := Spec.call_correct Θ spec FiniteSubst.id typedArgs st_args ρ_args
+      have hcall := Spec.call_correct Θ spec Δ_spec (FiniteSubst.base Δ_spec) typedArgs st_args ρ_args
         (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
         hwf_pred
-        (by simpa [FiniteSubst.id, Signature.ofVars] using Signature.wf_empty)
-        hid_wf htypedArgs_wf hcall_eval
+        hbase_wf htypedArgs_wf hcall_eval
         (fun v st' ρ' t hΨ hwf heval => by
           have h := hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval
           rw [← hret_eq] at h
@@ -1510,17 +1553,17 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
       have happly' :
           st_args.sl ρ_args ∗ R ⊢
             PredTrans.apply (fun r => TinyML.ValHasType Θ r spec.retTy -∗ Φ r) spec.pred
-              (Spec.argsEnv VerifM.Env.empty spec.args vs) := by
+              (Spec.argsEnv ρ_args spec.args vs) := by
         rw [heval_sargs_map] at happly
-        refine happly.trans <| PredTrans.apply_env_agree hwf_pred <|
-          Spec.argsEnv_agreeOn (Δ := Signature.empty)
-            (ρ₁ := VerifM.Env.withEnv ρ_args (FiniteSubst.id.subst.eval ρ_args.env))
-            (ρ₂ := VerifM.Env.empty)
-            (by exact ⟨nofun, nofun, nofun, nofun, nofun, nofun⟩) spec.args vs
-            (by simp [List.length_map] at hlen_vs; omega)
+        exact happly
+      have hagree_ρ_args : VerifM.Env.agreeOn Δ_spec ρ_spec ρ_args :=
+        VerifM.Env.agreeOn_trans hρspec (VerifM.Env.agreeOn_mono hΔspec hagreeOn_args)
+      ispecialize Hspec $$ %ρ_args
       ispecialize Hspec $$ %Φ
       ispecialize Hspec $$ %vs
       iapply Hspec
+      · ipure_intro
+        exact hagree_ρ_args
       · iapply (TinyML.ValsHaveTypes.sub hsub_ty')
         iexact Hvals
       · iapply happly'
@@ -1534,16 +1577,16 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
 theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (ty : TinyML.Typ)
     (ihScrut : correctExpr scrut) (ihBranches : correctBranches branches) :
     correctExpr (.match_ scrut branches ty) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
-  have heval_scrut : (compile Θ S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_scrut : (compile Θ Δ_spec S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_match <| BIBase.Entails.trans ?_ <|
-    ihScrut Θ (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hSwf ?_
-  · exact Helpers.ctx_dup Θ S B Γ st ρ γ R
+    ihScrut Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+  · exact Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
   intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se
   obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
   cases hscrut_ty : scrut.ty with
@@ -1559,12 +1602,12 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
       by_cases htys : ∀ br ∈ branches, br.2.ty = ty
       · have hΨ_scrut' :
             (do
-              let i ← VerifM.all (List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length)
-              match (compileBranches Θ S B Γ se_scrut ts branches 0)[i]? with
+              let i ← VerifM.all (List.range (compileBranches Θ Δ_spec S B Γ se_scrut ts branches 0).length)
+              match (compileBranches Θ Δ_spec S B Γ se_scrut ts branches 0)[i]? with
               | some m => m
               | none => VerifM.fatal "match branch index out of range").eval st_scrut ρ_scrut Ψ := by
           simpa [if_pos hlen, if_pos htys] using hΨ_scrut
-        have hcb := compileBranches_length_get Θ S B Γ se_scrut ts branches 0
+        have hcb := compileBranches_length_get Θ Δ_spec S B Γ se_scrut ts branches 0
         have hactions_len := hcb.1
         have heval_all := VerifM.eval_bind _ _ _ _ hΨ_scrut'
         have hall := VerifM.eval_all heval_all
@@ -1576,7 +1619,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           icases Hscrut_sum with ⟨%tag, %v_payload, %hval_eq, Hsum⟩
           ihave %htag_bound := TinyML.ValSumRel.bound $$ Hsum
           have htag_branches : tag < branches.length := hlen ▸ htag_bound
-          have htag_range : tag ∈ List.range (compileBranches Θ S B Γ se_scrut ts branches 0).length := by
+          have htag_range : tag ∈ List.range (compileBranches Θ Δ_spec S B Γ se_scrut ts branches 0).length := by
             rw [hactions_len]
             exact List.mem_range.mpr htag_branches
           have heval_tag := hall tag htag_range
@@ -1586,9 +1629,10 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           have hget : ts[tag]? = some (ts[tag]?.getD .value) := by
             rw [List.getElem?_eq_getElem htag_bound]
             simp
+          have hspecInv_scrut := specInvariants_mono hΔspec hρspec hdecls_scrut hagreeOn_scrut
           have hbranch_wp := ihBranches Θ R S B Γ se_scrut ts.length ts 0
-            st_scrut ρ_scrut γ Ψ Φ
-            hagree_scrut hbwf_scrut hSwf hse_wf
+            st_scrut ρ_scrut γ Δ_spec ρ_spec Ψ Φ
+            hagree_scrut hbwf_scrut hSwf hΔwf hΔvars hspecInv_scrut.1 hspecInv_scrut.2 hse_wf
             (fun j hj v ρ' st' se hΨ hse_wf hse_eval => by
               iintro ⟨Hsl, Hv, □HS, HR⟩
               iapply (hpost v ρ' st' se hΨ hse_wf hse_eval)
@@ -1604,7 +1648,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           have hbranch_entail :
               st_scrut.sl ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+                    (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
                 wp
                   ((Runtime.Expr.subst γ
                         (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime)).app
@@ -1626,7 +1670,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           have hmatch_entail :
               st_scrut.sl ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+                    (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
                 wp
                   ((Runtime.Expr.val (Runtime.Val.inj tag ts.length v_payload)).match_
                     (List.map (Runtime.Expr.subst γ ∘ fun p =>
@@ -1635,7 +1679,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
             SpatialContext.wp_match
               (R := st_scrut.sl ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy Θ γ ∗ B.typedSubst Θ Γ γ ∗ R))
+                    (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R))
               (branch :=
                 Runtime.Expr.subst γ
                   (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime))
@@ -1659,7 +1703,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
 theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
     (ihBody : correctExpr body) :
     correctBranch (binder, body) := by
-  intro Θ R S B Γ sc n i ty_i st ρ γ Ψ Φ heval hagree hbwf hSwf hsc_wf hpost payload hsc_eval
+  intro Θ R S B Γ sc n i ty_i st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf hpost payload hsc_eval
   simp only [compileBranch] at heval
   by_cases hty : binder.ty = ty_i
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
@@ -1719,15 +1763,17 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
       have hagree₁ : B.agreeOnLinked ρ₁.env γ :=
         Bindings.agreeOnLinked_env_agree hagree hagreeOn_st hbwf
       have hbwf₁ : B.wfIn st₂.decls := hst₂_decls ▸ fun p hp => List.Mem.tail _ (hbwf p hp)
-      have heval_body'' : (compile Θ S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+      have heval_body'' : (compile Θ Δ_spec S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, hname] using heval_body'
+      have hspecInv₁ := specInvariants_mono hΔspec hρspec
+        (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
           st₂.sl ρ₁ ∗
-              (S.satisfiedBy Θ γ ∗ Bindings.typedSubst Θ B (Γ.extendBinder binder ty_i) γ ∗
-                (S.satisfiedBy Θ γ ∗ R)) ⊢
+              (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B (Γ.extendBinder binder ty_i) γ ∗
+                (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
             wp (body.runtime.subst γ) Φ :=
-        ihBody Θ (S.satisfiedBy Θ γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Ψ Φ
-          heval_body'' hagree₁ hbwf₁ hSwf
+        ihBody Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Δ_spec ρ_spec Ψ Φ
+          heval_body'' hagree₁ hbwf₁ hSwf hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
       rw [Binder.runtime_of_name_none hname]
       simp only [Runtime.Expr.subst_fix]
@@ -1778,16 +1824,19 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
         have h := Bindings.agreeOnLinked_cons (x := x) (v := xv) (γ := γ) hagree hagreeOn_B (hvty := rfl)
         rwa [hρ₁_lookup] at h
       have heval_body'' :
-          (compile Θ (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+          (compile Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, TinyML.TyCtx.extendBinder, hname] using heval_body'
+      have hspecInv₁ := specInvariants_mono hΔspec hρspec
+        (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
           st₂.sl ρ₁ ∗
-              (SpecMap.satisfiedBy Θ (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
+              (SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
                 Bindings.typedSubst Θ ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) ∗
-                (S.satisfiedBy Θ γ ∗ R)) ⊢
+                (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
             wp (body.runtime.subst (Runtime.Subst.update γ x payload)) Φ :=
-        ihBody Θ (S.satisfiedBy Θ γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
-          (Runtime.Subst.update γ x payload) Ψ Φ heval_body'' hagree₁ hbwf₂ (SpecMap.wfIn_erase hSwf)
+        ihBody Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
+          (Runtime.Subst.update γ x payload) Δ_spec ρ_spec Ψ Φ heval_body'' hagree₁ hbwf₂ (SpecMap.wfIn_erase hSwf)
+          hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
       rw [Binder.runtime_of_name_some hname]
       simp only [Runtime.Expr.subst_fix]
@@ -1823,19 +1872,19 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
 theorem compileBranchesCons_correct (b : Binder × Expr) (bs : List (Binder × Expr))
     (ihHead : correctBranch b) (ihTail : correctBranches bs) :
     correctBranches (b :: bs) := by
-  intro Θ R S B Γ sc n ts idx st ρ γ Ψ Φ hagree hbwf hSwf hsc_wf hpost j hj
+  intro Θ R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf hpost j hj
   cases j with
   | zero =>
     simp only [Nat.add_zero, List.getElem_cons_zero]
     intro heval
-    exact ihHead Θ R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ
-      heval hagree hbwf hSwf hsc_wf (by simpa using hpost 0 hj)
+    exact ihHead Θ R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Δ_spec ρ_spec Ψ Φ
+      heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf (by simpa using hpost 0 hj)
   | succ k =>
     have hk : k < bs.length := by simp at hj; omega
     have hidx : idx + (k + 1) = (idx + 1) + k := by omega
     simp only [hidx, List.getElem_cons_succ]
-    exact ihTail Θ R S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ
-      hagree hbwf hSwf hsc_wf
+    exact ihTail Θ R S B Γ sc n ts (idx + 1) st ρ γ Δ_spec ρ_spec Ψ Φ
+      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf
       (by
         intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
         simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
@@ -1844,13 +1893,13 @@ theorem compileBranchesCons_correct (b : Binder × Expr) (bs : List (Binder × E
 theorem compileExprsCons_correct (e : Expr) (rest : List Expr)
     (ihE : correctExpr e) (ihRest : correctExprs rest) :
     correctExprs (e :: rest) := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   simp only [compileExprs] at heval
   simp only [List.map, wps_cons]
-  have heval_rest : (compileExprs Θ S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_rest : (compileExprs Θ Δ_spec S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine BIBase.Entails.trans ?_ <|
-    ihRest Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ γ ∗ R)) S B Γ st ρ γ _ _
-      (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hSwf ?_
+    ihRest Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
   · iintro ⟨Hsl, □HS, □HT, HR⟩
     isplitl [Hsl]
     · iexact Hsl
@@ -1868,11 +1917,12 @@ theorem compileExprsCons_correct (e : Expr) (rest : List Expr)
   have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
   have hbwf_vs : B.wfIn st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
-  have heval_e : (compile Θ S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
+  have heval_e : (compile Θ Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
+  have hspecInv_vs := specInvariants_mono hΔspec hρspec hdecls_vs hagreeOn_vs
   refine BIBase.Entails.trans ?_ <|
-    ihE Θ (TinyML.ValsHaveTypes Θ vs (rest.map Expr.ty) ∗ (S.satisfiedBy Θ γ ∗ R))
-    S B Γ st_vs ρ_vs γ _ _
-    (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hSwf ?_
+    ihE Θ (TinyML.ValsHaveTypes Θ vs (rest.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))
+    S B Γ st_vs ρ_vs γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hSwf hΔwf hΔvars hspecInv_vs.1 hspecInv_vs.2 ?_
   · iintro ⟨Hsl, Hvs, □HS, □HT, □HSpare, HR⟩
     isplitl [Hsl]
     · iexact Hsl
@@ -1921,12 +1971,12 @@ theorem compileExprsCons_correct (e : Expr) (rest : List Expr)
 
 theorem compileBranchesNil_correct :
     correctBranches [] := by
-  intro Θ R S B Γ sc n ts idx st ρ γ Ψ Φ hagree hbwf hSwf hsc_wf hpost j hj
+  intro Θ R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf hpost j hj
   exact absurd hj (Nat.not_lt_zero _)
 
 theorem compileExprsNil_correct :
     correctExprs [] := by
-  intro Θ R S B Γ st ρ γ Ψ Φ heval hagree hbwf hSwf hpost
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   simp only [compileExprs] at heval
   simp only [List.map, wps]
   obtain heval := VerifM.eval_ret heval

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -18,18 +18,18 @@ open Typed
 
 /-- Compile the body of a specification under its argument context and
     check that the inferred return type is a subtype of the declared one. -/
-def checkBody (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
+def checkBody (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (s : Spec)
     (argNames : List String) (body : Expr)
     (argVars : List FOL.Const) : VerifM (Term .value) := do
   let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
   let Γ := (argNames.zip (s.args.map Prod.snd)).foldl
     (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
-  let se ← compile Θ S B Γ body
+  let se ← compile Θ Δ_spec S B Γ body
   if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
   else VerifM.fatal s!"checkSpec: return type mismatch"
   pure se
 
-def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
+def checkSpec (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
   let (fb, argNames, body) ← match e with
     | .fix fb argBinders _ body => do
       match extractArgNames argBinders s.args with
@@ -38,14 +38,16 @@ def checkSpec (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec) : VerifM
     | _ => VerifM.fatal "checkSpec: expected function"
   let S' := SpecMap.eraseAll argNames (S.insertBinder fb s)
   VerifM.persist
-  Spec.implement s (checkBody Θ S' s argNames body)
+  Spec.implement Δ_spec s (checkBody Θ Δ_spec S' s argNames body)
 
 /-- Soundness of `checkBody`: given argument variables supplied by
     `Spec.implement_correct` and a successful `checkBody` evaluation, the
     compiled body's `wp` holds. -/
 theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     (γ : Runtime.Subst)
-    (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
+    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (hswf : s.wfIn Δ_spec) (hSwf : S.wfIn Δ_spec)
+    (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
     (fb : Binder) (argBinders : List Binder) (body : Expr)
     (argNames : List String)
     (hext : extractArgNames argBinders s.args = Except.ok argNames)
@@ -54,24 +56,26 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     (vs : List Runtime.Val)
     (P : Runtime.Val → iProp)
     {argVars : List FOL.Const} {st' : TransState} {ρ' : VerifM.Env} {Q : iProp}
+    (hΔspec : Δ_spec.Subset st'.decls)
+    (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ')
     (hargVars_mem : ∀ v ∈ argVars, v ∈ st'.decls.consts)
     (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
     (hargVars_lookup : List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs)
     (hbody_eval : VerifM.eval
-        (checkBody Θ (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
+        (checkBody Θ Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
           st''.sl ρ'' ∗ Q ∗
             ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
     st'.sl ρ' ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗ Q ⊢
-      (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
+      (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval) -∗
         wp (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
   simp only [checkBody] at hbody_eval
   obtain ⟨hargNames_len, _, hbs_eq⟩ := extractArgNames_spec hext
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_def ▸ hbs_eq
   set γ_body := γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs
   set S' : SpecMap := SpecMap.eraseAll argNames (S.insertBinder fb s)
-  have hS'wf : S'.wfIn Signature.empty :=
+  have hS'wf : S'.wfIn Δ_spec :=
     SpecMap.wfIn_eraseAll (SpecMap.wfIn_insertBinder hSwf hswf)
   set Γ := (argNames.zip (s.args.map Prod.snd)).foldl
     (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
@@ -124,21 +128,23 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     rw [hsnd]
     iassumption
   have hS'_sat :
-      S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval ⊢ S'.satisfiedBy Θ γ_body := by
+      S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
+        S'.satisfiedBy Θ Δ_spec ρ_spec γ_body := by
     have hinsert :
-        S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval ⊢
-          (S.insertBinder fb s).satisfiedBy Θ (γ.updateBinder fb.runtime fval) :=
+        S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
+          (S.insertBinder fb s).satisfiedBy Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) :=
       SpecMap.satisfiedBy_insertBinder_updateBinder
     have herase :
-        (S.insertBinder fb s).satisfiedBy Θ (γ.updateBinder fb.runtime fval) ⊢
-          S'.satisfiedBy Θ ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
+        (S.insertBinder fb s).satisfiedBy Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) ⊢
+          S'.satisfiedBy Θ Δ_spec ρ_spec ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
       SpecMap.satisfiedBy_eraseAll_updateAllBinder hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
-      st'.sl ρ' ∗ (S'.satisfiedBy Θ γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
+      st'.sl ρ' ∗ (S'.satisfiedBy Θ Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
         wp (body.runtime.subst γ_body) P := by
-    refine compile_correct body Θ Q S' B Γ st' ρ' γ_body _ _
-      (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hS'wf ?_
+    refine compile_correct body Θ Q S' B Γ st' ρ' γ_body Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hS'wf hΔwf hΔvars
+      hΔspec hρspec ?_
     intro v ρ'' st'' se hΨ hse_wf heval_se
     obtain ⟨_, _, hΨ⟩ := hΨ
     by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
@@ -176,10 +182,14 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
 
 theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
-    (hswf : s.wfIn Signature.empty) (hSwf : S.wfIn Signature.empty)
-    (st : TransState) (ρ : VerifM.Env) :
-    VerifM.eval (checkSpec Θ S e s) st ρ (fun _ _ _ => True) →
-    st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ v) := by
+    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (hswf : s.wfIn Δ_spec) (hSwf : S.wfIn Δ_spec)
+    (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (st : TransState) (ρ : VerifM.Env)
+    (hΔspec : Δ_spec.Subset st.decls)
+    (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ) :
+    VerifM.eval (checkSpec Θ Δ_spec S e s) st ρ (fun _ _ _ => True) →
+    st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ Δ_spec ρ_spec v) := by
   intro heval
   -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
   have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
@@ -218,7 +228,7 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       iintro H
       icases H with ⟨Hsl, #Hspec⟩
       imodintro
-      iintro Hrec %vs %P #Htyped Hpred
+      iintro Hrec %ρ_call %vs %P %hagree_call #Htyped Hpred
       -- `isPrecondFor_fix` hands us the body's subst as `id.updateBinder ... |>.updateAllBinder ...`;
       -- fuse it with γ via `subst_fix_comp` so it matches `body_correct`.
       ihave %hlen_typed := TinyML.ValsHaveTypes.length_eq $$ Htyped
@@ -229,21 +239,26 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       simp only [] at hsub; rw [hsub]
       have hbody' : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
           PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
-          (Spec.argsEnv VerifM.Env.empty s.args vs) ⊢
-          SpecMap.satisfiedBy Θ S γ ∗ s.isPrecondFor Θ fval -∗
+          (Spec.argsEnv ρ_call s.args vs) ⊢
+          SpecMap.satisfiedBy Θ Δ_spec ρ_spec S γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval -∗
             wp (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
         iintro H
         icases H with ⟨Htyped', Hpred'⟩
         iintuitionistic Htyped'
-        ihave Hwand := Spec.implement_correct Θ s _ (TransState.persist st) ρ vs P
+        have hΔspec_persist : Δ_spec.Subset (TransState.persist st).decls := by
+          simpa using hΔspec
+        ihave Hwand := Spec.implement_correct Θ s _ Δ_spec ρ_spec (TransState.persist st) ρ vs P
           (TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
-            (S.satisfiedBy Θ γ ∗ s.isPrecondFor Θ fval) -∗
+            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval) -∗
               wp (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
-          hswf himpl
-          (fun argVars st' ρ' Q hargVars_mem hargVars_sort hargVars_lookup hbody_eval => by
+          hswf hΔspec_persist hρspec hΔwf hΔvars himpl
+          (fun argVars st' ρ' Q hst_sub hρ_agree hargVars_mem hargVars_sort hargVars_lookup hbody_eval => by
+            have hΔspec' : Δ_spec.Subset st'.decls := hΔspec_persist.trans hst_sub
+            have hρspec' : VerifM.Env.agreeOn Δ_spec ρ_spec ρ' := by
+              exact VerifM.Env.agreeOn_trans hρspec (VerifM.Env.agreeOn_mono hΔspec_persist hρ_agree)
             iintro ⟨Hsl, HQ⟩ Htyped''
-            iapply (checkBody_correct Θ S s γ hswf hSwf fb argBinders body argNames
-              hext bs rfl fval vs P hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
+            iapply (checkBody_correct Θ S s γ Δ_spec ρ_spec hswf hSwf hΔwf hΔvars fb argBinders body argNames
+              hext bs rfl fval vs P hΔspec' hρspec' hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
             isplitl [Hsl]
             · iexact Hsl
             · isplitl [Htyped'']
@@ -254,7 +269,15 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
             iemp_intro
           · isplitl [Htyped']
             · iexact Htyped'
-            · iexact Hpred'
+            · have hlen_vals_call : s.args.length ≤ vs.length := by
+                have hlen := hlen_typed
+                simp [List.length_map] at hlen
+                omega
+              iapply (PredTrans.apply_env_agree (ρ := Spec.argsEnv ρ_call s.args vs)
+                (ρ' := Spec.argsEnv ρ_spec s.args vs) hswf
+                (Spec.argsEnv_agreeOn (Δ := Δ_spec) (ρ₁ := ρ_call) (ρ₂ := ρ_spec)
+                  (VerifM.Env.agreeOn_symm hagree_call) s.args vs hlen_vals_call))
+              iexact Hpred'
         iapply Hwand
         iexact Htyped'
       iapply hbody' $$ [Htyped Hpred] [Hspec Hrec]

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -117,17 +117,16 @@ theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
 -- Correctness
 -- ---------------------------------------------------------------------------
 
-theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
+theorem PredTrans.call_correct (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) R :
-    pt.wfIn (Signature.ofVars σ.dom) →
-    (Signature.ofVars σ.dom).wf →
-    σ.wf st.decls →
+    pt.wfIn (Δ_base.declVars σ.dom) →
+    σ.wfIn Δ_base st.decls →
     VerifM.eval (PredTrans.call σ pt) st ρ Ψ →
     (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
       (st'.sl ρ' ∗ R ⊢ Φ v)) →
     st.sl ρ ∗ R ⊢ PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
-  intro hwf hdomwf hσwf heval hΨ
+  intro hwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   let retWf : (String × Assertion Unit) → Signature → Prop :=
@@ -144,37 +143,39 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
           let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
           Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
   have hpre : st.sl ρ ∗ R ⊢ Assertion.pre Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
-    exact Assertion.prove_correct pt σ retWf st ρ Ψcall Φpost R
+    exact Assertion.prove_correct pt Δ_base σ retWf st ρ Ψcall Φpost R
       (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree =>
         forall_intro fun v =>
           (forall_elim v).trans <|
             Assertion.post_env_agree hwf_post
               (VerifM.Env.agreeOn_declVar hagree)
               (fun _ _ _ _ _ _ => .rfl))
-      hσwf hdomwf hwf hb
-      (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ hcont hσ₁wf hσ₁domwf hwf₁ => by
+      hσwf hwf hb
+      (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ hcont hσ₁wf hwf₁ => by
         apply forall_intro
         intro v
+        rcases hσ₁wf with ⟨hσ₁subst, hσ₁base, hσ₁use, hσ₁srcwf, hσ₁rangewf, hσ₁usewf, hσ₁basevars⟩
+        have hσ₁wf : σ₁.wfIn Δ_base st₁.decls :=
+          ⟨hσ₁subst, hσ₁base, hσ₁use, hσ₁srcwf, hσ₁rangewf, hσ₁usewf, hσ₁basevars⟩
         have hb2 := VerifM.eval_bind _ _ _ _ hcont
         have hdecl := VerifM.eval_decl hb2
         set resVar := st₁.freshConst (some postName) .value
         have hfresh_decls : resVar.name ∉ st₁.decls.allNames :=
           Fresh.freshNumbers_not_mem postName st₁.decls.allNames
         have hfresh_range : resVar.name ∉ σ₁.range.allNames :=
-          fun h => hfresh_decls (Signature.allNames_subset hσ₁wf.2.1 _ h)
+          fun h => hfresh_decls (Signature.allNames_subset hσ₁use _ h)
         specialize hdecl v
         have hb3 := VerifM.eval_bind _ _ _ _ hdecl
         set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
-        have hσ₂wf : σ₂.wf (st₁.decls.addConst resVar) := by
+        have hσ₂wf : σ₂.wfIn Δ_base (st₁.decls.addConst resVar) := by
           simpa [σ₂] using
-            (FiniteSubst.rename_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁wf hfresh_range)
-        have hσ₂domwf : (Signature.ofVars σ₂.dom).wf := by
-          simpa [σ₂] using
-            (FiniteSubst.rename_dom_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁domwf)
-        have hwf₁' : Assertion.wfIn (fun _ _ => True) (Signature.ofVars σ₂.dom) postBody := by
-          simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using hwf₁
+            (FiniteSubst.rename_wfIn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₁.decls)
+              (v := ⟨postName, .value⟩) (name' := resVar.name)
+              hσ₁wf hfresh_range hfresh_decls)
+        have hwf₁' : Assertion.wfIn (fun _ _ => True) (Δ_base.declVars σ₂.dom) postBody := by
+          simpa [σ₂, FiniteSubst.rename_source_eq] using hwf₁
         have hgrow := VerifM.eval.decls_grow (ρ₁.updateConst .value resVar.name v) hb3
-        have hassume := Assertion.assume_correct postBody σ₂ (fun _ _ => True)
+        have hassume := Assertion.assume_correct postBody Δ_base σ₂ (fun _ _ => True)
           { st₁ with decls := st₁.decls.addConst resVar }
           (ρ₁.updateConst .value resVar.name v)
           (fun a st' ρ' =>
@@ -184,8 +185,8 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
               (Pure.pure (Term.const (.uninterpreted resVar.name .value)) : VerifM (Term .value)).eval st' ρ' Ψ)
           (fun () _ => Φ v) R
           (fun _ _ _ _ _ _ => .rfl)
-          hσ₂wf hσ₂domwf hwf₁' hgrow
-          (fun _ () st₂ ρ₂ ⟨hsub, hagree, hcont'⟩ _ _ _ => by
+          hσ₂wf hwf₁' hgrow
+          (fun _ () st₂ ρ₂ ⟨hsub, hagree, hcont'⟩ _ _ => by
             have hret := VerifM.eval_ret hcont'
             have hwfst₂ : st₂.decls.wf := (VerifM.eval.wf hcont').namesDisjoint
             apply hΨ _ st₂ ρ₂ (.const (.uninterpreted resVar.name .value)) hret
@@ -206,19 +207,19 @@ theorem PredTrans.call_correct (pt : PredTrans) (σ : FiniteSubst)
           iintro HR
           iexact HR)).trans <| hassume.trans <| Assertion.post_env_agree hwf₁'
           (by
-            simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using
-              (FiniteSubst.rename_agreeOn (σ := σ₁) (v := ⟨postName, .value⟩) (c := resVar)
-                hσ₁wf.1 hfresh_range rfl))
+            simpa [σ₂, VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+              (FiniteSubst.rename_agreeOn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₁.decls)
+                (v := ⟨postName, .value⟩) (name' := resVar.name)
+                (ρ := ρ₁.env) (u := v) hσ₁wf hfresh_range))
           (fun _ _ _ _ _ _ => .rfl))
   simpa [PredTrans.apply, Φpost] using hpre
 
 
-theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
+theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
     (body : VerifM (Term .value))
     (st : TransState) (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (R : iProp) :
-    pt.wfIn (Signature.ofVars σ.dom) →
-    (Signature.ofVars σ.dom).wf →
-    σ.wf st.decls →
+    pt.wfIn (Δ_base.declVars σ.dom) →
+    σ.wfIn Δ_base st.decls →
     VerifM.eval (PredTrans.implement σ pt body) st ρ (fun _ _ _ => True) →
     (∀ st' ρ' (Q : iProp),
       st.decls.Subset st'.decls →
@@ -230,7 +231,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         (st''.sl ρ'' ∗ Q ∗ (Φ (result.eval ρ''.env) -∗ S) ⊢ S)) →
       st'.sl ρ' ∗ Q ⊢ R) →
     st.sl ρ ∗ PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ⊢ R := by
-  intro hwf hdomwf hσwf heval hbody
+  intro hwf hσwf heval hbody
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   have hb_grow := VerifM.eval.decls_grow ρ hb
@@ -242,7 +243,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         Assertion.post (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
   let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
-  have hpost := Assertion.assume_correct pt σ retWf
+  have hpost := Assertion.assume_correct pt Δ_base σ retWf
     st ρ _ Φpost emp
     (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree => by
       refine wand_intro ?_
@@ -255,10 +256,13 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
         Assertion.post_env_agree hwf_post
           (Env.agreeOn_symm (Env.agreeOn_declVar hagree))
           (fun _ _ _ _ _ _ => .rfl))
-    hσwf hdomwf hwf hb_grow
-    (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ ⟨hdsub_st, hagree_st, hcont⟩ hσ₁wf hσ₁domwf hwf_postBody => by
+    hσwf hwf hb_grow
+    (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ ⟨hdsub_st, hagree_st, hcont⟩ hσ₁wf hwf_postBody => by
       apply BIBase.Entails.trans sep_comm.1
       apply BIBase.Entails.trans emp_sep.1
+      rcases hσ₁wf with ⟨hσ₁subst, hσ₁base, hσ₁use, hσ₁srcwf, hσ₁rangewf, hσ₁usewf, hσ₁basevars⟩
+      have hσ₁wf : σ₁.wfIn Δ_base st₁.decls :=
+        ⟨hσ₁subst, hσ₁base, hσ₁use, hσ₁srcwf, hσ₁rangewf, hσ₁usewf, hσ₁basevars⟩
       have hcont_body := VerifM.eval_bind _ _ _ _ hcont
       change st₁.sl ρ₁ ⊢ OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) -∗ R
       refine wand_intro ?_
@@ -271,7 +275,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
       have hfresh_decls : resVar.name ∉ st₂.decls.allNames :=
         Fresh.freshNumbers_not_mem postName st₂.decls.allNames
       have hfresh_range : resVar.name ∉ σ₁.range.allNames :=
-        fun hmem => hfresh_decls (Signature.allNames_subset (Signature.Subset.trans hσ₁wf.2.1 hdsub_body) _ hmem)
+        fun hmem => hfresh_decls (Signature.allNames_subset (Signature.Subset.trans hσ₁use hdsub_body) _ hmem)
       specialize hdecl (result.eval ρ₂.env)
       have hb3 := VerifM.eval_bind _ _ _ _ hdecl
       have heq_wf : (Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result).wfIn
@@ -292,47 +296,44 @@ theorem PredTrans.implement_correct (pt : PredTrans) (σ : FiniteSubst)
           (Term.eval_env_agree hwf_result (Env.agreeOn_update_fresh_const hfresh_decls))
       have hassume := VerifM.eval_assumePure hb3 heq_wf heq_holds
       set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
-      have hσ₂wf : σ₂.wf (st₂.decls.addConst resVar) := by
+      have hσ₁wf₂ : σ₁.wfIn Δ_base st₂.decls := by
+        exact ⟨hσ₁subst, hσ₁base, Signature.Subset.trans hσ₁use hdsub_body,
+          hσ₁srcwf, hσ₁rangewf, (VerifM.eval.wf hrest).namesDisjoint, hσ₁basevars⟩
+      have hσ₂wf : σ₂.wfIn Δ_base (st₂.decls.addConst resVar) := by
         simpa [σ₂] using
-          (FiniteSubst.rename_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name)
-            ⟨hσ₁wf.1, Signature.Subset.trans hσ₁wf.2.1 hdsub_body, hσ₁wf.2.2⟩ hfresh_range)
-      have hσ₂domwf : (Signature.ofVars σ₂.dom).wf := by
-        simpa [σ₂] using
-          (FiniteSubst.rename_dom_wf (σ := σ₁) (v := ⟨postName, .value⟩) (name' := resVar.name) hσ₁domwf)
+          (FiniteSubst.rename_wfIn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₂.decls)
+            (v := ⟨postName, .value⟩) (name' := resVar.name)
+            hσ₁wf₂ hfresh_range hfresh_decls)
       have hb4 := VerifM.eval_bind _ _ _ _ hassume
-      have hwf_postBody' : Assertion.wfIn (fun _ _ => True) (Signature.ofVars σ₂.dom) postBody := by
-        simpa [σ₂, FiniteSubst.rename, Signature.ofVars, Signature.declVar] using hwf_postBody
+      have hwf_postBody' : Assertion.wfIn (fun _ _ => True) (Δ_base.declVars σ₂.dom) postBody := by
+        simpa [σ₂, FiniteSubst.rename_source_eq] using hwf_postBody
       let st₃ : TransState :=
         { st₂ with
           decls := st₂.decls.addConst resVar
           asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st₂.asserts }
-      have hpre := @Assertion.prove_correct Unit postBody σ₂ (fun _ _ => True)
+      have hpre := @Assertion.prove_correct Unit postBody Δ_base σ₂ (fun _ _ => True)
         st₃
         (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
         _ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) (Φ (result.eval ρ₂.env) -∗ S)
         (fun _ _ _ _ _ _ => .rfl)
-        hσ₂wf hσ₂domwf hwf_postBody' hb4
-        (fun _ () st' ρ' hret _ _ _ => by
-          iintro H
-          icases H with ⟨_, HR⟩
-          iexact HR)
-      have hag_rename := @FiniteSubst.rename_agreeOn σ₁ ⟨postName, .value⟩ resVar
-        ρ₂.env (result.eval ρ₂.env) hσ₁wf.1 hfresh_range rfl
-      have hag_eval := FiniteSubst.eval_agreeOn hσ₁wf.1
-        (Env.agreeOn_mono hσ₁wf.2.1 (Env.agreeOn_symm hagree_body))
-      have hag_eval' : Env.agreeOn (Signature.ofVars σ₂.dom)
+        hσ₂wf hwf_postBody' hb4
+        (fun _ () st' ρ' hret _ _ => by
+          show st'.sl ρ' ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+            (Φ (result.eval ρ₂.env) -∗ S)
+          exact sep_elim_r)
+      have hag_rename :=
+        FiniteSubst.rename_agreeOn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₂.decls)
+          (v := ⟨postName, .value⟩) (name' := resVar.name)
+          (ρ := ρ₂.env) (u := result.eval ρ₂.env) hσ₁wf₂ hfresh_range
+      have hagree_st₁ : Env.agreeOn st₁.decls ρ₂.env ρ₁.env := by
+        simpa [VerifM.Env.agreeOn] using VerifM.Env.agreeOn_symm hagree_body
+      have hag_eval := FiniteSubst.eval_agreeOn hσ₁wf hagree_st₁
+      have hag_eval' : Env.agreeOn (Δ_base.declVars σ₂.dom)
           ((σ₁.subst.eval ρ₂.env).updateConst .value postName (result.eval ρ₂.env))
           ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env)) := by
         apply Env.agreeOn_mono
-          (Δ₁ := Signature.ofVars σ₂.dom)
-          (Δ₂ := Signature.ofVars (⟨postName, .value⟩ :: σ₁.dom))
-          (Signature.Subset.of_vars_subset_ofVars (vars := σ₂.dom) (vars' := ⟨postName, .value⟩ :: σ₁.dom)
-            (fun x hx => by
-              simp [σ₂, FiniteSubst.rename] at hx ⊢
-              rcases hx with rfl | ⟨hx, _⟩
-              · exact Or.inl rfl
-              · exact Or.inr hx))
-        exact Env.agreeOn_update hag_eval
+          (FiniteSubst.rename_source_subset_rev σ₁ Δ_base ⟨postName, .value⟩ resVar.name)
+        exact Env.agreeOn_update (Env.agreeOn_remove hag_eval)
       have hpost_transport : Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
           (VerifM.Env.withEnv ρ₁ ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env))) ⊢
           Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -48,7 +48,7 @@ def Program.prepare (prog : Untyped.Program Untyped.Expr) :
 
 /-- Check an individual declaration. Each declaration's `checkSpec` runs inside a `seq` bracket so its
     declarations and assertions don't pollute subsequent verifications. -/
-def ValDecl.check (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) : VerifM Spec := do
+def ValDecl.check (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) : VerifM Spec := do
   let specExpr ← match d.spec with
     | some e => .ret e
     | none => .fatal "declaration has no spec"
@@ -58,43 +58,49 @@ def ValDecl.check (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped
   let spec ← match Spec.complete sp d.body with
     | .ok s => .ret s
     | .error e => .fatal e
-  let () ← match Spec.checkWf spec Signature.empty with
+  let () ← match Spec.checkWf spec Δ_spec with
     | .ok () => .ret ()
     | .error msg => .fatal msg
-  VerifM.seq (checkSpec Θ S d.body spec) (pure spec)
+  VerifM.seq (checkSpec Θ Δ_spec S d.body spec) (pure spec)
 
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
-def ValDecl.checkExpr (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) : VerifM Unit :=
-  VerifM.seq (do let _ ← compile Θ S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
+def ValDecl.checkExpr (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) : VerifM Unit :=
+  VerifM.seq (do let _ ← compile Θ Δ_spec S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
 
 /-- Verify all declarations in a program, accumulating specs as we go. -/
-def Program.check (Θ : TinyML.TypeEnv) : SpecMap → Typed.Program Untyped.Expr → VerifM Unit
+def Program.check (Θ : TinyML.TypeEnv) (Δ_spec : Signature) : SpecMap → Typed.Program Untyped.Expr → VerifM Unit
   | _, [] => pure ()
   | S, d :: ds => do
     match d.name.name, d.spec with
     | none, none =>
-      ValDecl.checkExpr Θ S d
-      Program.check Θ S ds
+      ValDecl.checkExpr Θ Δ_spec S d
+      Program.check Θ Δ_spec S ds
     | some n, none =>
     -- Named declaration without a spec: skip if it's a function definition
     -- (no code executes), otherwise check it. Erase any old spec for this
     -- name since the new binding shadows it.
       if d.body.isFunc then
-        Program.check Θ (S.erase n) ds
+        Program.check Θ Δ_spec (S.erase n) ds
       else
-        ValDecl.checkExpr Θ S d
-        Program.check Θ (S.erase n) ds
+        ValDecl.checkExpr Θ Δ_spec S d
+        Program.check Θ Δ_spec (S.erase n) ds
     | _, _ =>
-      let spec ← ValDecl.check Θ S d
+      let spec ← ValDecl.check Θ Δ_spec S d
       let S' := match d.name.name with
         | some name => S.insert name spec
         | none => S
-      Program.check Θ S' ds
+      Program.check Θ Δ_spec S' ds
+
+/-- Initial signature threaded through program verification. -/
+def Δ_spec : Signature := Signature.empty
+
+/-- Initial verifier environment threaded through program verification. -/
+def ρ_spec : VerifM.Env := VerifM.Env.empty
 
 def Program.verify (prog : Untyped.Program Untyped.Expr) : Smt.Strategy Smt.Strategy.Outcome :=
   VerifM.strategy do
     let (Θ, typed) ← Program.prepare prog
-    Program.check Θ ∅ typed
+    Program.check Θ Δ_spec ∅ typed
 
 /-! ## Correctness -/
 
@@ -114,24 +120,29 @@ theorem Program.prepare_correct (prog : Untyped.Program Untyped.Expr)
     simp [helab] at heval
     exact VerifM.eval_ret heval
 
-theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (st : TransState) (ρ : VerifM.Env)
+theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
+    (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (st : TransState) (ρ : VerifM.Env)
+    (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
     {Q : Unit → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.checkExpr Θ S d) st ρ Q) :
-    (□ st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ Φ) →
-    □ st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
+    (heval : VerifM.eval (ValDecl.checkExpr Θ Δ_spec S d) st ρ Q) :
+    (□ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ Φ) →
+    □ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
   intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
   have hcomp :=
-    compile_correct d.body Θ iprop(□ st.sl ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ
+    compile_correct d.body Θ iprop(□ st.sl ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ Δ_spec ρ_spec
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => Φ)
     hcompile
     (fun _ _ h => by simp at h)
     (fun _ h => by simp at h)
-    hSwf
+    hSwf hΔwf hΔvars
+    hΔspec
+    hρspec
     (fun _ _ _ _ _ _ _ => by
       istart
       iintro ⟨_, _, Hctx⟩
@@ -153,12 +164,15 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed
           · iexact Hsl
           · iexact Hspec
 
-theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (st : TransState) (ρ : VerifM.Env)
+theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (S : SpecMap) (d : Typed.ValDecl Untyped.Expr) (γ : Runtime.Subst)
+    (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (st : TransState) (ρ : VerifM.Env)
+    (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
     {Q : Spec → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.check Θ S d) st ρ Q) :
-    ∃ spec, spec.wfIn Signature.empty ∧
-            (□ st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ v)) ∧
+    (heval : VerifM.eval (ValDecl.check Θ Δ_spec S d) st ρ Q) :
+    ∃ spec, spec.wfIn Δ_spec ∧
+            (□ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ Δ_spec ρ_spec v)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.spec with
@@ -182,19 +196,20 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
       | ok spec =>
         simp only [hcomplete] at h2
         have h3 := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ h2)
-        cases hwf : Spec.checkWf spec Signature.empty with
+        cases hwf : Spec.checkWf spec Δ_spec with
         | error msg =>
           simp only [hwf] at h3
           exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ h3)).elim
         | ok u =>
           simp only [hwf] at h3
           have h4 := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ h3)
-          have hswf : spec.wfIn Signature.empty := Spec.checkWf_ok (by cases u; exact hwf)
+          have hswf : spec.wfIn Δ_spec := Spec.checkWf_ok (by cases u; exact hwf)
           have ⟨hcheckSpec, hpure⟩ := VerifM.eval_seq h4
           exact ⟨spec, hswf,
             by
               have hcheck :=
-                checkSpec_correct Θ S d.body spec γ hswf hSwf st ρ hcheckSpec
+                checkSpec_correct Θ S d.body spec γ Δ_spec ρ_spec
+                  hswf hSwf hΔwf hΔvars st ρ hΔspec hρspec hcheckSpec
               refine BIBase.Entails.trans ?_ hcheck
               istart
               iintro ⟨□Hsl, □Hspec⟩
@@ -203,10 +218,13 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (d : Typed.Val
               · iexact Hspec,
                  VerifM.eval_ret hpure⟩
 
-theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Signature.empty) (st : TransState) (ρ : VerifM.Env) :
-    VerifM.eval (Program.check Θ S prog) st ρ (fun _ _ _ => True) →
-    □ st.sl ρ ∗ S.satisfiedBy Θ γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
+theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (S : SpecMap) (prog : Typed.Program Untyped.Expr) (γ : Runtime.Subst)
+    (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (st : TransState) (ρ : VerifM.Env)
+    (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ) :
+    VerifM.eval (Program.check Θ Δ_spec S prog) st ρ (fun _ _ _ => True) →
+    □ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ st ρ with
   | nil =>
     intro _
@@ -234,16 +252,16 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
         simp only [hname, hspec] at heval
         have hbind := VerifM.eval_bind _ _ _ _ heval
         have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-        have hih := ih S γ hSwf st ρ (VerifM.eval_ret hcont)
-        have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf st ρ hbind hih
+        have hih := ih S γ hSwf st ρ hΔspec hρspec (VerifM.eval_ret hcont)
+        have hwp := ValDecl.checkExpr_correct Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hbind hih
         refine hwp.trans (wp.mono ?_)
         intro v; rw [hupd v]; exact .rfl
       | some _ =>
         -- unnamed, with spec
         simp only [hname, hspec] at heval
         obtain ⟨spec, _, hwp, hcont⟩ :=
-          ValDecl.check_correct Θ S d γ hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
-        have hih := ih S γ hSwf st ρ hcont
+          ValDecl.check_correct Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec (VerifM.eval_bind _ _ _ _ heval)
+        have hih := ih S γ hSwf st ρ hΔspec hρspec hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
@@ -274,10 +292,10 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
               (args.map (·.runtime))))
           apply SpatialContext.wp_func
           rw [hupd fval]
-          have heval' : VerifM.eval (Program.check Θ (S.erase n) ds) st ρ (fun _ _ _ => True) := by
+          have heval' : VerifM.eval (Program.check Θ Δ_spec (S.erase n) ds) st ρ (fun _ _ _ => True) := by
             convert heval
           have hih := ih (S.erase n) (γ.update n fval)
-            (SpecMap.wfIn_erase hSwf) st ρ heval'
+            (SpecMap.wfIn_erase hSwf) st ρ hΔspec hρspec heval'
           refine BIBase.Entails.trans ?_ hih
           istart
           iintro ⟨□Hsl, □Hspec⟩
@@ -288,14 +306,14 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
         · -- named, no spec, not a function
           have hbind := VerifM.eval_bind _ _ _ _ heval
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          have hcont' : VerifM.eval (Program.check Θ (S.erase n) ds) st ρ (fun _ _ _ => True) :=
+          have hcont' : VerifM.eval (Program.check Θ Δ_spec (S.erase n) ds) st ρ (fun _ _ _ => True) :=
             VerifM.eval_ret hcont
-          have hwp := ValDecl.checkExpr_correct Θ S d γ hSwf st ρ hbind
+          have hwp := ValDecl.checkExpr_correct Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hbind
             (Φ := iprop(emp)) (by istart; iintro _; iemp_intro)
           refine SpatialContext.wp_strengthen_persistent hwp ?_
           intro v
           rw [hupd v]
-          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) st ρ hcont'
+          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) st ρ hΔspec hρspec hcont'
           exact wand_intro (sep_elim_l.trans <| by
             refine BIBase.Entails.trans ?_ hih
             istart
@@ -307,15 +325,15 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (prog : Typed.
       | some _ =>
         simp only [hname, hspec] at heval
         obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          ValDecl.check_correct Θ S d γ hSwf st ρ (VerifM.eval_bind _ _ _ _ heval)
-        have hcont' : VerifM.eval (Program.check Θ (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
+          ValDecl.check_correct Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec (VerifM.eval_bind _ _ _ _ heval)
+        have hcont' : VerifM.eval (Program.check Θ Δ_spec (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
           convert hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
         have hih := ih (S.insert n spec) (γ.update n v)
-          (SpecMap.wfIn_insert hSwf hswf) st ρ hcont'
-        have hstep : (□ st.sl ρ ∗ S.satisfiedBy Θ γ) ∗ spec.isPrecondFor Θ v ⊢
+          (SpecMap.wfIn_insert hSwf hswf) st ρ hΔspec hρspec hcont'
+        have hstep : (□ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ) ∗ spec.isPrecondFor Θ Δ_spec ρ_spec v ⊢
             pwp ((Typed.Program.runtime ds).subst (γ.update n v)) := by
           refine BIBase.Entails.trans ?_ hih
           istart
@@ -348,14 +366,24 @@ theorem Program.verify_correct (p : Untyped.Program Untyped.Expr) :
     have hverifM := VerifM.eval_of_translate
                       (do
                         let (Θ, typed) ← Program.prepare p
-                        Program.check Θ ∅ typed)
+                        Program.check Θ Δ_spec ∅ typed)
                       TransState.empty VerifM.Env.empty ctx_mid hverif hholdsFor hwf
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
     obtain ⟨Θ, typed, hrt, hcheck⟩ := Program.prepare_correct p TransState.empty VerifM.Env.empty hbind
-    have hcorrect := Program.check_correct Θ ∅ typed Runtime.Subst.id
-                       (SpecMap.empty_wfIn _) TransState.empty VerifM.Env.empty hcheck
+    have hcorrect := Program.check_correct Θ Δ_spec ρ_spec ∅ typed Runtime.Subst.id
+                       (SpecMap.empty_wfIn _)
+                       (by simp [Δ_spec, Signature.wf_empty])
+                       (by simp [Δ_spec, Signature.empty])
+                       TransState.empty VerifM.Env.empty
+                       (by
+                         constructor <;> intro x hx <;> simp [Δ_spec] at hx)
+                       (by
+                         change VerifM.Env.agreeOn Signature.empty VerifM.Env.empty VerifM.Env.empty
+                         exact ⟨nofun, nofun, nofun, nofun, nofun, nofun⟩)
+                       hcheck
     rw [Runtime.Program.subst_id] at hcorrect
-    have hctx : (⊢ □ TransState.empty.sl VerifM.Env.empty ∗ SpecMap.satisfiedBy Θ (∅ : SpecMap) Runtime.Subst.id) := by
+    have hctx : (⊢ □ TransState.empty.sl VerifM.Env.empty ∗
+        SpecMap.satisfiedBy Θ Δ_spec ρ_spec (∅ : SpecMap) Runtime.Subst.id) := by
       istart
       isplitl []
       · simp [TransState.sl, TransState.empty]

--- a/Mica/Verifier/SpecMaps.lean
+++ b/Mica/Verifier/SpecMaps.lean
@@ -17,20 +17,23 @@ open Iris Iris.BI
 
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
-def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) : iProp :=
-  iprop(□ (∀ x s, ⌜S.lookup x = some s⌝ -∗ ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor Θ f))
+def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (S : SpecMap) (γ : Runtime.Subst) : iProp :=
+  iprop(□ (∀ x s, ⌜S.lookup x = some s⌝ -∗
+    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor Θ Δ_spec ρ_spec f))
 
-instance : Iris.BI.Persistent (SpecMap.satisfiedBy Θ S γ) := by
+instance : Iris.BI.Persistent (SpecMap.satisfiedBy Θ Δ_spec ρ_spec S γ) := by
   unfold SpecMap.satisfiedBy; infer_instance
 
-theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp) (Θ : TinyML.TypeEnv) (S : SpecMap) (γ : Runtime.Subst) :
-  (P ⊢ S.satisfiedBy Θ γ) →
+theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp)
+    (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (S : SpecMap) (γ : Runtime.Subst) :
+  (P ⊢ S.satisfiedBy Θ Δ_spec ρ_spec γ) →
   S.lookup x = some s →
-  (∀ fval, γ x = some fval → s.isPrecondFor Θ fval ∗ P ⊢ Q) →
+  (∀ fval, γ x = some fval → s.isPrecondFor Θ Δ_spec ρ_spec fval ∗ P ⊢ Q) →
   (P ⊢ Q) := by
   intro hsat hlook hcont
   simp only [SpecMap.satisfiedBy] at hsat
-  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor Θ fval) ∗ P := by
+  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval) ∗ P := by
     refine (persistent_entails_r hsat).trans ?_
     istart
     iintro ⟨□Hall, HP⟩
@@ -122,10 +125,11 @@ def SpecMap.eraseBinder (S : SpecMap) (b : Typed.Binder) : SpecMap :=
 
 /-- Generic preservation: if every `y` in the domain of `S'` has the same spec in `S` and
     its value is preserved from `γ` to `γ'`, then satisfiedness transfers. -/
-theorem SpecMap.satisfiedBy_preserved {Θ : TinyML.TypeEnv} {S S' : SpecMap} {γ γ' : Runtime.Subst}
+theorem SpecMap.satisfiedBy_preserved {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+    {S S' : SpecMap} {γ γ' : Runtime.Subst}
     (h : ∀ y s, S'.lookup y = some s →
       S.lookup y = some s ∧ (∀ f, γ y = some f → γ' y = some f)) :
-    S.satisfiedBy Θ γ ⊢ S'.satisfiedBy Θ γ' := by
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ S'.satisfiedBy Θ Δ_spec ρ_spec γ' := by
   simp only [SpecMap.satisfiedBy]
   iintro □HS
   imodintro
@@ -139,12 +143,12 @@ theorem SpecMap.satisfiedBy_preserved {Θ : TinyML.TypeEnv} {S S' : SpecMap} {γ
   · iexact Hpre
 
 /-- Generic insert: fresh precondition for `x ↦ fval` plus preservation elsewhere. -/
-theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {S : SpecMap}
+theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap}
     {γ γ' : Runtime.Subst} {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
     (hγ' : γ' x = some fval)
     (hγ : ∀ y f, y ≠ x → γ y = some f → γ' y = some f) :
-    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ fval ⊢
-      SpecMap.satisfiedBy Θ (Finmap.insert x spec S) γ' := by
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ' := by
   simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
   iintro ⟨□HS, □Hf⟩
   imodintro
@@ -165,16 +169,16 @@ theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {S : SpecM
     · ipure_intro; exact hγ y f hyx hγf
     · iexact Hpre
 
-theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
-    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ fval ⊢
-      SpecMap.satisfiedBy Θ (Finmap.insert x spec S) γ :=
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ :=
   SpecMap.satisfiedBy_insert_of_preserved hγ (fun _ _ _ hf => hf)
 
-theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ v ⊢
-      SpecMap.satisfiedBy Θ (Finmap.insert x spec S) (γ.update x v) :=
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec v ⊢
+      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.insert x spec S) (γ.update x v) :=
   SpecMap.satisfiedBy_insert_of_preserved
     (by simp [Runtime.Subst.update])
     (fun y f hyx hf => by simp [Runtime.Subst.update, beq_false_of_ne hyx, hf])
@@ -186,18 +190,20 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup; exact hs
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup; exact hS y s' hlookup
 
-theorem SpecMap.satisfiedBy_insertBinder {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insertBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
     (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval) :
-    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ fval ⊢ SpecMap.satisfiedBy Θ (S.insertBinder b spec) γ := by
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (S.insertBinder b spec) γ := by
   rcases hb : b.name with _ | x
   · rw [SpecMap.insertBinder_none hb]; iintro ⟨HS, _⟩; iexact HS
   · obtain ⟨_, ty⟩ := b; cases hb
     rw [SpecMap.insertBinder_some rfl]; exact SpecMap.satisfiedBy_insert (hγ x ty rfl)
 
-theorem SpecMap.satisfiedBy_insertBinder_updateBinder {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insertBinder_updateBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy Θ γ ∗ spec.isPrecondFor Θ v ⊢ SpecMap.satisfiedBy Θ (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec v ⊢
+      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.insertBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]; iintro ⟨HS, _⟩; iexact HS
@@ -216,9 +222,11 @@ theorem SpecMap.wfIn_eraseBinder {S : SpecMap} {b : Typed.Binder} {Δ : Signatur
   · rwa [SpecMap.eraseBinder_none hb]
   · rw [SpecMap.eraseBinder_some hb]; exact SpecMap.wfIn_erase hS
 
-theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+    {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
     {vs : List Runtime.Val} (hlen : keys.length = vs.length) :
-    S.satisfiedBy Θ γ ⊢ (SpecMap.eraseAll keys S).satisfiedBy Θ (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢
+      (SpecMap.eraseAll keys S).satisfiedBy Θ Δ_spec ρ_spec (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hy_notin : y ∉ keys := by
@@ -232,8 +240,8 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {keys
       findVal_none_of_not_mem keys vs y (by omega) hy_notin]
   exact hf
 
-theorem SpecMap.empty_satisfiedBy (γ : Runtime.Subst) :
-    ⊢ SpecMap.satisfiedBy Θ (∅ : SpecMap) γ := by
+theorem SpecMap.empty_satisfiedBy (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (γ : Runtime.Subst) :
+    ⊢ SpecMap.satisfiedBy Θ Δ_spec ρ_spec (∅ : SpecMap) γ := by
   simp only [SpecMap.satisfiedBy]
   imodintro
   iintro %x %s %h
@@ -243,8 +251,10 @@ theorem SpecMap.empty_wfIn (Δ : Signature) :
     SpecMap.wfIn (∅ : SpecMap) Δ := by
   intro f spec h; simp [Finmap.lookup_empty] at h
 
-theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
-    S.satisfiedBy Θ γ ⊢ SpecMap.satisfiedBy Θ (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
+theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+    {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢
+      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by
@@ -252,18 +262,19 @@ theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runt
   exact ⟨by rwa [Finmap.lookup_erase_ne hyx] at hlookup,
     fun f hf => by simp [Runtime.Subst.update, hyx, hf]⟩
 
-theorem SpecMap.satisfiedBy_eraseBinder {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_eraseBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} :
-    S.satisfiedBy Θ γ ⊢ SpecMap.satisfiedBy Θ (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢
+      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.eraseBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]
   · rw [SpecMap.eraseBinder_some hb, Typed.Binder.runtime_of_name_some hb]
     exact SpecMap.satisfiedBy_erase
 
-theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} (hx : S.lookup x = none) :
-    S.satisfiedBy Θ γ ⊢ S.satisfiedBy Θ (γ.update x v) := by
+    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ S.satisfiedBy Θ Δ_spec ρ_spec (γ.update x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -43,11 +43,13 @@ def argsEnv (ρ : VerifM.Env) : List (String × TinyML.Typ) → List Runtime.Val
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
 
-def isPrecondFor (Θ : TinyML.TypeEnv) (f : Runtime.Val) (s : Spec) : iProp :=
-  iprop(□ ∀ (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
+def isPrecondFor (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (f : Runtime.Val) (s : Spec) : iProp :=
+  iprop(□ ∀ (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
+      ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
       TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
         PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
-          (argsEnv VerifM.Env.empty s.args vs) -∗
+          (argsEnv ρ s.args vs) -∗
         wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
@@ -96,66 +98,94 @@ def declareImplArgs (σ : FiniteSubst) :
 
 /-- Full implementation protocol for a spec: declare argument variables,
     assume type constraints, then invoke `PredTrans.implement`. Dual to `call`. -/
-def implement (s : Spec) (body : List FOL.Const → VerifM (Term .value)) : VerifM Unit := do
-  let (σ, argVars) ← declareImplArgs FiniteSubst.id s.args
+def implement (Δ_base : Signature) (s : Spec) (body : List FOL.Const → VerifM (Term .value)) : VerifM Unit := do
+  let (σ, argVars) ← declareImplArgs (FiniteSubst.base Δ_base) s.args
   PredTrans.implement σ s.pred (body argVars)
 
 /-! ## Precondition Proofs -/
 section Precondition
 
-instance : Iris.BI.Persistent (isPrecondFor Θ f s) := by
+instance : Iris.BI.Persistent (isPrecondFor Θ Δ_spec ρ_spec f s) := by
   unfold isPrecondFor
   infer_instance
 
 /-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
-theorem isPrecondFor_intro (Θ : TinyML.TypeEnv) (s : Spec)
+theorem isPrecondFor_intro (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (s : Spec)
     (f : Runtime.Val) :
-    iprop(□ ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-      (TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
+    iprop(□ ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      (⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
+        TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
         PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
-          (argsEnv VerifM.Env.empty s.args vs)) -∗
-        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ f := by
+          (argsEnv ρ s.args vs)) -∗
+        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ Δ_spec ρ_spec f := by
   unfold isPrecondFor
   iintro □H
   imodintro
-  iintro %Φ %vs Htyped Hpred
-  ispecialize H $$ %vs %Φ
+  iintro %ρ %Φ %vs Hagree Htyped Hpred
+  ispecialize H $$ %ρ %vs %Φ
   iapply H
-  isplitl [Htyped]
-  · iexact Htyped
-  · iexact Hpred
+  isplitl [Hagree]
+  · iexact Hagree
+  · isplitl [Htyped]
+    · iexact Htyped
+    · iexact Hpred
 
 /-- Löb-style rule for spec preconditions on `fix`: to prove
     `s.isPrecondFor Θ (.fix f args e)`, assume it as the recursive hypothesis and
     prove the `wp` of the body (after the usual fix-substitution). -/
-theorem isPrecondFor_fix {Θ : TinyML.TypeEnv} {s : Spec}
+theorem isPrecondFor_fix {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {s : Spec}
     {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {R : iProp}
-    (h : R ⊢ □ (s.isPrecondFor Θ (.fix f args e) -∗
-        ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+    (h : R ⊢ □ (s.isPrecondFor Θ Δ_spec ρ_spec (.fix f args e) -∗
+        ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+          ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
           TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
           PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
-              (argsEnv VerifM.Env.empty s.args vs) -∗
+              (argsEnv ρ s.args vs) -∗
           wp (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
-    R ⊢ s.isPrecondFor Θ (.fix f args e) := by
-  refine (SpatialContext.wp_fix' (Φ := fun P vs =>
-      iprop(TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-        PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
-            (argsEnv VerifM.Env.empty s.args vs))) (h.trans ?_)).trans
-    (isPrecondFor_intro Θ s _)
-  istart
-  iintro □HR
-  imodintro
-  iintro IH %vs %P ⟨htyped, hpred⟩
-  ispecialize HR $$ [IH]
-  · iapply (isPrecondFor_intro Θ s (.fix f args e))
-    iexact IH
-  ihave Hres := HR $$ %vs %P [htyped] [hpred]
-  · iexact htyped
-  · iexact hpred
-  iexact Hres
-
+    R ⊢ s.isPrecondFor Θ Δ_spec ρ_spec (.fix f args e) := by
+  refine (SpatialContext.wp_fix' (f := f) (args := args) (e := e) (Φ := fun P vs =>
+      iprop(∃ ρ : VerifM.Env,
+        ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
+          TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
+          PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+            (argsEnv ρ s.args vs))) (h.trans ?_)).trans ?_
+  · istart
+    iintro □HR
+    imodintro
+    iintro □IH %vs %P Hpre
+    ispecialize HR $$ [IH]
+    · unfold isPrecondFor
+      imodintro
+      iintro %ρ %Φ %vs Hagree Htyped Hpred
+      ispecialize IH $$ %vs %Φ
+      iapply IH
+      iexists ρ
+      isplitl [Hagree]
+      · iexact Hagree
+      · isplitl [Htyped]
+        · iexact Htyped
+        · iexact Hpred
+    icases Hpre with ⟨%ρ, %hagr0, □Htyped0, Hpred0⟩
+    ispecialize HR $$ %ρ %vs %P
+    iapply HR
+    · ipure_intro
+      exact hagr0
+    · iexact Htyped0
+    · iexact Hpred0
+  · unfold isPrecondFor
+    iintro □Hfix
+    imodintro
+    iintro %ρ %Φ %vs Hagree Htyped Hpred
+    ispecialize Hfix $$ %vs %Φ
+    iapply Hfix
+    iexists ρ
+    isplitl [Hagree]
+    · iexact Hagree
+    · isplitl [Htyped]
+      · iexact Htyped
+      · iexact Hpred
 end Precondition
 
 /-! ## Well-Formedness Proofs -/
@@ -206,36 +236,35 @@ section CallCorrectness
     substitution is well-formed, types match, and the env agrees with `argsEnv`. -/
 theorem declareArgs_correct (Θ : TinyML.TypeEnv) :
     ∀ (args : List (String × TinyML.Typ)) (sargs : List (TinyML.Typ × Term .value))
-      (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
+      (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
       (Ψ : FiniteSubst → TransState → VerifM.Env → Prop),
-    σ.wf st.decls →
-    (Signature.ofVars σ.dom).wf →
+    σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.declareArgs Θ σ args sargs) st ρ Ψ →
     ∃ σ' st' ρ', Ψ σ' st' ρ' ∧
-      σ'.wf st'.decls ∧
-      (Signature.ofVars σ'.dom).wf ∧
+      σ'.wfIn Δ_base st'.decls ∧
       st'.owns = st.owns ∧
       @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
-      (((Signature.ofVars σ.dom).declVars (Spec.argVars args)).vars ⊆ σ'.dom) ∧
-      VerifM.Env.agreeOn ((Signature.ofVars σ.dom).declVars (Spec.argVars args))
+      ((Δ_base.declVars σ.dom).declVars (Spec.argVars args)).Subset
+        (Δ_base.declVars σ'.dom) ∧
+      VerifM.Env.agreeOn ((Δ_base.declVars σ.dom).declVars (Spec.argVars args))
         (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env))
         (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) args
           (sargs.map fun p => p.2.eval ρ.env)) := by
   intro args
   induction args with
   | nil =>
-    intro sargs σ st ρ Ψ hσwf hσdomwf _ heval
+    intro sargs Δ_base σ st ρ Ψ hσwf _ heval
     cases sargs with
     | nil =>
       simp [Spec.declareArgs] at heval
-      exact ⟨σ, st, ρ, VerifM.eval_ret heval, hσwf, hσdomwf, rfl, .nil, fun _ hx => hx,
+      exact ⟨σ, st, ρ, VerifM.eval_ret heval, hσwf, rfl, .nil, Signature.Subset.refl _,
         by simp [Spec.argVars, Spec.argsEnv]; exact VerifM.Env.agreeOn_refl⟩
     | cons _ _ =>
       simp [Spec.declareArgs] at heval
       exact (VerifM.eval_fatal heval).elim
   | cons arg rest ih =>
-    intro sargs σ st ρ Ψ hσwf hσdomwf hsargs heval
+    intro sargs Δ_base σ st ρ Ψ hσwf hsargs heval
     obtain ⟨name, ty⟩ := arg
     cases sargs with
     | nil =>
@@ -252,8 +281,18 @@ theorem declareArgs_correct (Θ : TinyML.TypeEnv) :
         set σ' := σ.rename ⟨name, .value⟩ argVar.name
         set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ.env)
         have hstwf : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
-        obtain ⟨hfresh_decls, _hfresh_range, hσ'wf, hσ'domwf⟩ :=
-          FiniteSubst.rename_bundle_of_freshConst (hint := some name) (v := ⟨name, .value⟩) hσwf hσdomwf
+        rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+        have hσwf : σ.wfIn Δ_base st.decls :=
+          ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+        have hfresh_decls : argVar.name ∉ st.decls.allNames :=
+          Fresh.freshNumbers_not_mem name st.decls.allNames
+        have hfresh_range : argVar.name ∉ σ.range.allNames :=
+          fun h => hfresh_decls (Signature.allNames_subset huse _ h)
+        have hσ'wf : σ'.wfIn Δ_base (st.decls.addConst argVar) := by
+          simpa [σ', argVar] using
+            (FiniteSubst.rename_wfIn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+              (v := ⟨name, .value⟩) (name' := argVar.name)
+              hσwf hfresh_range hfresh_decls)
         have hsarg_wf : sarg.wfIn st.decls := hsargs _ (List.mem_cons_self ..)
         have hassume := VerifM.eval_assumePure
           (VerifM.eval_bind _ _ _ _ (hdecl (sarg.eval ρ.env)))
@@ -275,37 +314,45 @@ theorem declareArgs_correct (Θ : TinyML.TypeEnv) :
           List.map_congr_left fun p hp => Term.eval_env_agree
             (hsargs p (List.mem_cons_of_mem _ hp))
             (Env.agreeOn_symm (Env.agreeOn_update_fresh_const hfresh_decls))
-        obtain ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf, howns, hsublist, hdom_sub, hagree⟩ :=
-          ih sargs_rest σ' _ ρ₁ Ψ hσ'wf hσ'domwf hsargs_rest hassume
-        refine ⟨σ'', st'', ρ'', hΨ, hσ''wf, hσ''domwf, howns,
+        obtain ⟨σ'', st'', ρ'', hΨ, hσ''wf, howns, hsublist, hdom_sub, hagree⟩ :=
+          ih sargs_rest Δ_base σ' _ ρ₁ Ψ hσ'wf hsargs_rest hassume
+        refine ⟨σ'', st'', ρ'', hΨ, hσ''wf, howns,
           .cons (TinyML.Typ.sub_sound hsub_ty) hsublist, ?_, ?_⟩
-        · simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars,
-                 Signature.declVars, Signature.declVar] using hdom_sub
+        · change (((Δ_base.declVars σ.dom).declVar ⟨name, .value⟩).declVars
+              (Spec.argVars rest)).Subset (Δ_base.declVars σ''.dom)
+          simpa [σ', FiniteSubst.rename_source_eq] using hdom_sub
         · have hlen : rest.length ≤ sargs_rest.length := by
             have := TinyML.Typ.SubList.length_eq hsublist
             simp [List.length_map] at this; omega
-          have hag_rename := FiniteSubst.rename_agreeOn_declVar
-            (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar)
-            (ρ := ρ.env) (u := sarg.eval ρ.env) hσwf hfresh_decls rfl
+          have hag_rename := FiniteSubst.rename_agreeOn
+            (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+            (v := ⟨name, .value⟩) (name' := argVar.name)
+            (ρ := ρ.env) (u := sarg.eval ρ.env) hσwf hfresh_range
           have hag_env := Spec.argsEnv_agreeOn
             (ρ₁ := VerifM.Env.withEnv ρ (σ'.subst.eval ρ₁.env))
             (ρ₂ := VerifM.Env.withEnv ρ ((σ.subst.eval ρ.env).updateConst .value name (sarg.eval ρ.env)))
-            (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', FiniteSubst.rename] using hag_rename)
+            (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', VerifM.Env.withEnv_env] using hag_rename)
             rest (sargs_rest.map fun p => p.2.eval ρ.env) (by simp [List.length_map]; omega)
           rw [hsargs_eval] at hagree
-          simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars,
-            Signature.declVar, VerifM.Env.withEnv, VerifM.Env.agreeOn] using
+          change VerifM.Env.agreeOn
+            (((Δ_base.declVars σ.dom).declVar ⟨name, .value⟩).declVars (Spec.argVars rest))
+            (VerifM.Env.withEnv ρ'' (σ''.subst.eval ρ''.env))
+            (Spec.argsEnv ((VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)).updateConst
+              .value name (sarg.eval ρ.env)) rest
+              (sargs_rest.map fun p => p.2.eval ρ.env))
+          simpa [σ', FiniteSubst.rename_source_eq, Spec.argsEnv, VerifM.Env.withEnv,
+            VerifM.Env.agreeOn] using
             (VerifM.Env.agreeOn_trans hagree hag_env)
       · simp [hsub_ty] at heval
         exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim
 
-theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
+theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (Δ_base : Signature)
+    (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : (TinyML.Typ × Term .value) → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp) (R : iProp) :
-    s.pred.wfIn ((Signature.ofVars σ.dom).declVars (Spec.argVars s.args)) →
-    (Signature.ofVars σ.dom).wf →
-    σ.wf st.decls →
+    s.pred.wfIn ((Δ_base.declVars σ.dom).declVars (Spec.argVars s.args)) →
+    σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.call Θ σ s sargs) st ρ Ψ →
     (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
@@ -314,17 +361,20 @@ theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (σ : FiniteSubst) (sargs 
     (st.sl ρ ∗ R ⊢ PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
       (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) s.args
         (sargs.map fun p => p.2.eval ρ.env))) := by
-  intro hwf hσdomwf hσwf hsargs heval hΨ
+  intro hwf hσwf hsargs heval hΨ
   simp only [Spec.call] at heval
   have hb_grow := VerifM.eval.decls_grow ρ (VerifM.eval_bind _ _ _ _ heval)
-  obtain ⟨σ', st', ρ', ⟨hdsub, hragree, hΨ'⟩, hσ'wf, hσ'domwf, howns, hsublist, hdom_sub, hagree⟩ :=
-    declareArgs_correct Θ s.args sargs σ st ρ _ hσwf hσdomwf hsargs hb_grow
+  obtain ⟨σ', st', ρ', ⟨hdsub, hragree, hΨ'⟩, hσ'wf, howns, hsublist, hdom_sub, hagree⟩ :=
+    declareArgs_correct Θ s.args sargs Δ_base σ st ρ _ hσwf hsargs hb_grow
   refine ⟨hsublist, ?_⟩
-  have hwf'' : s.pred.wfIn (Signature.ofVars σ'.dom) :=
-    PredTrans.wfIn_mono hwf (Signature.Subset.ofVars hdom_sub) hσ'domwf
-  have hcall := PredTrans.call_correct s.pred σ' st' ρ'
+  rcases hσ'wf with ⟨hσ'subst, hσ'base, hσ'use, hσ'srcwf, hσ'rangewf, hσ'usewf, hσ'basevars⟩
+  have hσ'wf : σ'.wfIn Δ_base st'.decls :=
+    ⟨hσ'subst, hσ'base, hσ'use, hσ'srcwf, hσ'rangewf, hσ'usewf, hσ'basevars⟩
+  have hwf'' : s.pred.wfIn (Δ_base.declVars σ'.dom) :=
+    PredTrans.wfIn_mono hwf hdom_sub hσ'srcwf
+  have hcall := PredTrans.call_correct s.pred Δ_base σ' st' ρ'
     _ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) R
-    hwf'' hσ'domwf hσ'wf (VerifM.eval_bind _ _ _ _ hΨ')
+    hwf'' hσ'wf (VerifM.eval_bind _ _ _ _ hΨ')
     (fun v st'' ρ'' t hΨ'' htwf hteval => by
       apply wand_intro
       iintro H
@@ -354,16 +404,16 @@ section ImplementCorrectness
 
 /-- Correctness payload for `declareImplArgs`. -/
 def DeclareImplArgs.Result (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
-    (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
+    (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
     (Ψ : (FiniteSubst × List FOL.Const) → TransState → VerifM.Env → Prop) : Prop :=
   ∃ σ' implVars st' ρ', Ψ (σ', implVars) st' ρ' ∧
-    σ'.wf st'.decls ∧
-    (Signature.ofVars σ'.dom).wf ∧
+    σ'.wfIn Δ_base st'.decls ∧
     st.decls.Subset st'.decls ∧
     VerifM.Env.agreeOn st.decls ρ ρ' ∧
     st'.owns = st.owns ∧
-    (((Signature.ofVars σ.dom).declVars (argVars args)).vars ⊆ σ'.dom) ∧
-    VerifM.Env.agreeOn ((Signature.ofVars σ.dom).declVars (argVars args))
+    ((Δ_base.declVars σ.dom).declVars (argVars args)).Subset
+      (Δ_base.declVars σ'.dom) ∧
+    VerifM.Env.agreeOn ((Δ_base.declVars σ.dom).declVars (argVars args))
       (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env))
       (argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) args vs) ∧
     (∀ v ∈ implVars, v ∈ st'.decls.consts) ∧
@@ -372,17 +422,16 @@ def DeclareImplArgs.Result (args : List (String × TinyML.Typ)) (vs : List Runti
 
 theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
     ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
-      (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
+      (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
       (Ψ : (FiniteSubst × List FOL.Const) → TransState → VerifM.Env → Prop),
-    σ.wf st.decls →
-    (Signature.ofVars σ.dom).wf →
+    σ.wfIn Δ_base st.decls →
     VerifM.eval (Spec.declareImplArgs σ args) st ρ Ψ →
     TinyML.ValsHaveTypes Θ vs (args.map Prod.snd) ⊢
-      ⌜Spec.DeclareImplArgs.Result args vs σ st ρ Ψ⌝ := by
+      ⌜Spec.DeclareImplArgs.Result args vs Δ_base σ st ρ Ψ⌝ := by
   intro args
   induction args with
   | nil =>
-    intro vs σ st ρ Ψ hσwf hσdomwf heval
+    intro vs Δ_base σ st ρ Ψ hσwf heval
     iintro Hvs
     ihave %hlen := TinyML.ValsHaveTypes.length_eq $$ Hvs
     cases vs with
@@ -390,8 +439,8 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       simp [Spec.declareImplArgs] at heval
       have := VerifM.eval_ret heval
       ipure_intro
-      exact ⟨σ, [], st, ρ, this, hσwf, hσdomwf,
-        Signature.Subset.refl _, VerifM.Env.agreeOn_refl, rfl, fun x hx => hx,
+      exact ⟨σ, [], st, ρ, this, hσwf,
+        Signature.Subset.refl _, VerifM.Env.agreeOn_refl, rfl, Signature.Subset.refl _,
         by simp [Spec.argVars, Spec.argsEnv]; exact VerifM.Env.agreeOn_refl,
         nofun,
         nofun,
@@ -399,7 +448,7 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
     | cons _ _ =>
       simp at hlen
   | cons arg rest ih =>
-    intro vs σ st ρ Ψ hσwf hσdomwf heval
+    intro vs Δ_base σ st ρ Ψ hσwf heval
     obtain ⟨name, ty⟩ := arg
     cases vs with
     | nil =>
@@ -415,8 +464,18 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       set ρ₁ := ρ.updateConst .value argVar.name v
       specialize hdecl v
       have hstwf : st.decls.wf := (VerifM.eval.wf heval).namesDisjoint
-      obtain ⟨hfresh_decls, _hfresh_range, hσ'wf, hσ'domwf⟩ :=
-        FiniteSubst.rename_bundle_of_freshConst (hint := some name) (v := ⟨name, .value⟩) hσwf hσdomwf
+      rcases hσwf with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hσwf : σ.wfIn Δ_base st.decls :=
+        ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+      have hfresh_decls : argVar.name ∉ st.decls.allNames :=
+        Fresh.freshNumbers_not_mem name st.decls.allNames
+      have hfresh_range : argVar.name ∉ σ.range.allNames :=
+        fun h => hfresh_decls (Signature.allNames_subset huse _ h)
+      have hσ'wf : σ'.wfIn Δ_base (st.decls.addConst argVar) := by
+        simpa [σ', argVar] using
+          (FiniteSubst.rename_wfIn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+            (v := ⟨name, .value⟩) (name' := argVar.name)
+            hσwf hfresh_range hfresh_decls)
       have hvar_wf : (Term.const (.uninterpreted argVar.name .value)).wfIn (st.decls.addConst argVar) := by
         simpa using
           (Term.const_wfIn_addConst_of_fresh (Δ := st.decls) (c := argVar) hstwf hfresh_decls)
@@ -431,33 +490,40 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
           (fun φ hφ => htyped_formulas φ hφ)
       have hst_st₂ : st.decls.Subset st₂.decls :=
         hst₂_decls ▸ Signature.Subset.subset_addConst _ _
-      ihave %hih := ih vs' σ' st₂ ρ₁
+      ihave %hih := ih vs' Δ_base σ' st₂ ρ₁
         (fun p st' ρ' => Ψ (p.1, argVar :: p.2) st' ρ')
-        (hst₂_decls ▸ hσ'wf) hσ'domwf
+        (hst₂_decls ▸ hσ'wf)
         ((VerifM.eval_bind _ _ _ _ hdecl₂).mono (fun _ _ _ hp => VerifM.eval_ret hp))
         $$ Hvs_rest
-      obtain ⟨σ'', argVars', st', ρ', hΨ, hσ''wf, hσ''domwf, hdsub', hragree',
+      obtain ⟨σ'', argVars', st', ρ', hΨ, hσ''wf, hdsub', hragree',
         howns, hdom_sub, hagree, hmem_decls, hsorts, hlookups⟩ := hih
       ihave %hlen_rest := TinyML.ValsHaveTypes.length_eq $$ Hvs_rest
-      have hag_rename := FiniteSubst.rename_agreeOn_declVar
-        (σ := σ) (decls := st.decls) (v := ⟨name, .value⟩) (c := argVar)
-        (ρ := ρ.env) (u := v) hσwf hfresh_decls rfl
+      have hag_rename := FiniteSubst.rename_agreeOn
+        (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
+        (v := ⟨name, .value⟩) (name' := argVar.name)
+        (ρ := ρ.env) (u := v) hσwf hfresh_range
       have hag_env := Spec.argsEnv_agreeOn
         (ρ₁ := VerifM.Env.withEnv ρ₁ (σ'.subst.eval ρ₁.env))
         (ρ₂ := VerifM.Env.withEnv ρ ((σ.subst.eval ρ.env).updateConst .value name v))
-        (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', FiniteSubst.rename] using hag_rename)
+        (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', VerifM.Env.withEnv_env] using hag_rename)
         rest vs' (by simp [List.length_map] at hlen_rest; omega)
       ipure_intro
-      refine ⟨σ'', argVar :: argVars', st', ρ', hΨ, hσ''wf, hσ''domwf,
+      refine ⟨σ'', argVar :: argVars', st', ρ', hΨ, hσ''wf,
         Signature.Subset.trans hst_st₂ hdsub',
         VerifM.Env.agreeOn_trans
           (VerifM.Env.agreeOn_update_fresh (ρ := ρ) (c := argVar) (u := v) hfresh_decls)
           (VerifM.Env.agreeOn_mono hst_st₂ hragree'),
         howns.trans hst₂_owns, ?_, ?_, ?_, ?_, ?_⟩
-      · simpa [σ', FiniteSubst.rename, Signature.ofVars, Spec.argVars,
-               Signature.declVars, Signature.declVar] using hdom_sub
-      · simpa [σ', FiniteSubst.rename, Spec.argsEnv, Spec.argVars, Signature.declVars,
-               Signature.declVar, VerifM.Env.withEnv, VerifM.Env.agreeOn] using
+      · change (((Δ_base.declVars σ.dom).declVar ⟨name, .value⟩).declVars
+            (Spec.argVars rest)).Subset (Δ_base.declVars σ''.dom)
+        simpa [σ', FiniteSubst.rename_source_eq] using hdom_sub
+      · change VerifM.Env.agreeOn
+          (((Δ_base.declVars σ.dom).declVar ⟨name, .value⟩).declVars (Spec.argVars rest))
+          (VerifM.Env.withEnv ρ' (σ''.subst.eval ρ'.env))
+          (Spec.argsEnv ((VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)).updateConst .value name v)
+            rest vs')
+        simpa [σ', FiniteSubst.rename_source_eq, Spec.argsEnv, VerifM.Env.withEnv,
+          VerifM.Env.agreeOn] using
           (VerifM.Env.agreeOn_trans hagree hag_env)
       · intro w hw
         cases List.mem_cons.mp hw with
@@ -475,10 +541,17 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         exact h1'.trans hvar_eval
 
 theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
+    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (st : TransState) (ρ : VerifM.Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
-    s.wfIn Signature.empty →
-    VerifM.eval (Spec.implement s body) st ρ (fun _ _ _ => True) →
+    s.wfIn Δ_spec →
+    Δ_spec.Subset st.decls →
+    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
+    Δ_spec.wf →
+    Δ_spec.vars = [] →
+    VerifM.eval (Spec.implement Δ_spec s body) st ρ (fun _ _ _ => True) →
     (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : VerifM.Env) (Q : iProp),
+      st.decls.Subset st'.decls →
+      VerifM.Env.agreeOn st.decls ρ ρ' →
       (∀ v ∈ argVars, v ∈ st'.decls.consts) →
       (∀ v ∈ argVars, v.sort = .value) →
       List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs →
@@ -487,28 +560,34 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
           ∀ (S : iProp), result.wfIn st''.decls →
             st''.sl ρ'' ∗ Q ∗ ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ Φ (result.eval ρ''.env)) -∗ S) ⊢ S) →
       st'.sl ρ' ∗ Q ⊢ R) →
-    st.sl ρ ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗ PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
-      (Spec.argsEnv VerifM.Env.empty s.args vs) ⊢ R := by
-  intro hswf heval hbody
+    st.sl ρ ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
+      PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+        (Spec.argsEnv ρ_spec s.args vs) ⊢ R := by
+  intro hswf hΔspec hρspec hΔwf hΔvars heval hbody
   simp only [Spec.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
   iintro H
   icases H with ⟨Howns, Hvals, Happ⟩
   iintuitionistic Hvals
   ihave %hlen_vals := TinyML.ValsHaveTypes.length_eq $$ Hvals
-  ihave Hdecl := declareImplArgs_correct Θ s.args vs FiniteSubst.id st ρ _
-      (FiniteSubst.id_wf st.decls)
-      (by simpa [Signature.ofVars] using Signature.wf_empty) hb $$ Hvals
+  ihave Hdecl := declareImplArgs_correct Θ s.args vs Δ_spec (FiniteSubst.base Δ_spec) st ρ _
+      (FiniteSubst.base_wfIn hΔspec hΔwf (VerifM.eval.wf heval).namesDisjoint hΔvars)
+      hb $$ Hvals
   ipure Hdecl
-  obtain ⟨σ', argVars, st', ρ', hΨ, hσ'wf, hσ'domwf, hdsub, hragree, howns, hdom_sub, hagree,
+  obtain ⟨σ', argVars, st', ρ', hΨ, hσ'wf, hdsub, hragree, howns, hdom_sub, hagree,
     hmem_decls, hsorts, hlookups⟩ := Hdecl
-  have hag_empty : VerifM.Env.agreeOn ((Signature.ofVars FiniteSubst.id.dom).declVars (Spec.argVars s.args))
-      (Spec.argsEnv VerifM.Env.empty s.args vs)
-      (Spec.argsEnv (VerifM.Env.withEnv ρ (FiniteSubst.id.subst.eval ρ.env)) s.args vs) :=
-    Spec.argsEnv_agreeOn (Δ := Signature.empty)
-      (ρ₁ := VerifM.Env.empty)
-      (ρ₂ := VerifM.Env.withEnv ρ (FiniteSubst.id.subst.eval ρ.env))
-      (by exact ⟨nofun, nofun, nofun, nofun, nofun, nofun⟩) s.args vs
+  rcases hσ'wf with ⟨hσ'subst, hσ'base, hσ'use, hσ'srcwf, hσ'rangewf, hσ'usewf, hσ'basevars⟩
+  have hσ'wf : σ'.wfIn Δ_spec st'.decls :=
+    ⟨hσ'subst, hσ'base, hσ'use, hσ'srcwf, hσ'rangewf, hσ'usewf, hσ'basevars⟩
+  have hag_base :
+      VerifM.Env.agreeOn (Δ_spec.declVars (Spec.argVars s.args))
+        (Spec.argsEnv ρ_spec s.args vs)
+            (Spec.argsEnv (VerifM.Env.withEnv ρ ((FiniteSubst.base Δ_spec).subst.eval ρ.env)) s.args vs) :=
+    Spec.argsEnv_agreeOn (Δ := Δ_spec)
+      (ρ₁ := ρ_spec)
+      (ρ₂ := VerifM.Env.withEnv ρ ((FiniteSubst.base Δ_spec).subst.eval ρ.env))
+      (by simpa [FiniteSubst.base, VerifM.Env.withEnv] using hρspec)
+      s.args vs
       (by
         simp [List.length_map] at hlen_vals
         omega)
@@ -516,12 +595,14 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
   iapply (show st'.sl ρ' ∗
         PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
           (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) ⊢ R from
-    PredTrans.implement_correct s.pred σ' (body argVars) st' ρ'
+    PredTrans.implement_correct s.pred Δ_spec σ' (body argVars) st' ρ'
       (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) R
-      (PredTrans.wfIn_mono hswf (Signature.Subset.ofVars hdom_sub) hσ'domwf)
-      hσ'domwf hσ'wf hΨ
+      (PredTrans.wfIn_mono hswf hdom_sub hσ'srcwf)
+      hσ'wf hΨ
       (fun st'' ρ'' Q hdsub' hragree' hbody_eval => by
         apply hbody argVars st'' ρ'' Q
+          (hdsub.trans hdsub')
+          (VerifM.Env.agreeOn_trans hragree (VerifM.Env.agreeOn_mono hdsub hragree'))
           (fun v hv => hdsub'.consts v (hmem_decls v hv)) hsorts
         · refine Terms.Eval.lookup_const (Terms.Eval.env_agree (ρ := ρ'.env) ?_ hragree' hlookups)
           intro t ht
@@ -537,7 +618,8 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
       simpa [TransState.sl] using
         (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1)
     iexact Howns
-  · iapply (PredTrans.apply_env_agree hswf (VerifM.Env.agreeOn_trans hag_empty (VerifM.Env.agreeOn_symm hagree)))
+  · iapply (PredTrans.apply_env_agree hswf (VerifM.Env.agreeOn_trans hag_base (by
+        simpa [FiniteSubst.base, Signature.declVars] using VerifM.Env.agreeOn_symm hagree)))
     iexact Happ
 
 end ImplementCorrectness

--- a/Mica/Verifier/Utils.lean
+++ b/Mica/Verifier/Utils.lean
@@ -11,17 +11,6 @@ import Mica.Verifier.Bindings
 import Mica.Verifier.State
 import Mathlib.Data.Finmap
 
-theorem argVars_cons_perm {name : String}
-    {rest : List (String × TinyML.Typ)} {dom : List Var} {x : Var}
-    (hx : x ∈ (⟨name, .value⟩ :: rest.map (fun (name, _) => ⟨name, .value⟩) ++ dom)) :
-    x ∈ (rest.map (fun (name, _) => ⟨name, .value⟩) ++ ⟨name, .value⟩ :: dom) := by
-  simp only [List.cons_append, List.mem_cons,
-    List.mem_append, List.mem_map] at hx ⊢
-  rcases hx with rfl | ⟨a, ha, rfl⟩ | hmem
-  · exact Or.inr (Or.inl rfl)
-  · exact Or.inl ⟨a, ha, rfl⟩
-  · exact Or.inr (Or.inr hmem)
-
 /-- Extract argument names from binders, pairing with spec arg info.
     Requires exact length match. -/
 def extractArgNames : List Typed.Binder → List (String × TinyML.Typ) →
@@ -78,195 +67,413 @@ def FiniteSubst.id : FiniteSubst where
   dom   := []
   range := Signature.empty
 
-def FiniteSubst.wf (σ : FiniteSubst) (Δ : Signature) : Prop :=
-  σ.subst.wfIn σ.dom σ.range ∧ σ.range.Subset Δ ∧ σ.range.wf
+def FiniteSubst.base (Δ_base : Signature) : FiniteSubst where
+  subst := Subst.id
+  dom   := []
+  range := Δ_base
+
+/-- `σ.wfIn Δ_base Δ_use` separates the source and target sides of a finite substitution.
+
+- `Δ_base` is the signature in which source formulas are written before substitution.
+  It contributes ambient constants/unary/binary symbols, but no free variables of its own.
+- `σ.dom` is the list of source variables that may be substituted, so source formulas are
+  checked in `Δ_base.declVars σ.dom`.
+- `σ.range` is the signature available inside the substituted terms themselves; it contains
+  every symbol that may appear after substitution.
+- `Δ_use` is the larger signature available at the eventual use site; substituted formulas
+  are first shown well-formed in `σ.range`, then transported to `Δ_use` by monotonicity.
+
+The well-formedness conditions enforce exactly that split:
+- `σ.subst` is well-formed for the source variable context `Δ_base.declVars σ.dom`
+  and produces terms in `σ.range`;
+- every non-variable symbol from `Δ_base` is also available in `σ.range`;
+- `σ.range` is available at the use site `Δ_use`;
+- the source, range, and use signatures are themselves well-formed;
+- `Δ_base` has no free variables of its own. -/
+def FiniteSubst.wfIn (σ : FiniteSubst) (Δ_base Δ_use : Signature) : Prop :=
+  σ.subst.wfIn (Δ_base.declVars σ.dom).vars σ.range ∧
+  Δ_base.SymbolSubset σ.range ∧
+  σ.range.Subset Δ_use ∧
+  (Δ_base.declVars σ.dom).wf ∧
+  σ.range.wf ∧
+  Δ_use.wf ∧
+  Δ_base.vars = []
+
+abbrev FiniteSubst.wf := FiniteSubst.wfIn
 
 def FiniteSubst.rename (σ : FiniteSubst) (v : Var) (name' : String) : FiniteSubst where
   subst := (σ.subst.remove v.name).update v.sort v.name (.const (.uninterpreted name' v.sort))
-  dom   := v :: σ.dom.filter (·.name != v.name)
+  dom   := σ.dom ++ [v]
   range := σ.range.addConst ⟨name', v.sort⟩
 
-theorem FiniteSubst.rename_dom_wf {σ : FiniteSubst} {v : Var} {name' : String}
-    (hdomwf : (Signature.ofVars σ.dom).wf) :
-    (Signature.ofVars (σ.rename v name').dom).wf := by
-  simpa [FiniteSubst.rename, Signature.ofVars, Signature.declVar, Signature.remove] using
-    (Signature.wf_declVar (Δ := Signature.ofVars σ.dom) (v := v) hdomwf)
+private theorem declVars_append_single (Δ : Signature) (vs : List Var) (v : Var) :
+    Δ.declVars (vs ++ [v]) = (Δ.declVars vs).declVar v := by
+  induction vs generalizing Δ with
+  | nil => simp [Signature.declVars]
+  | cons w vs ih =>
+      simp [Signature.declVars]
 
-theorem FiniteSubst.rename_wf {σ : FiniteSubst} {v : Var} {name' : String} {Δ : Signature}
-    (hσ : σ.wf Δ) (hfresh : name' ∉ σ.range.allNames) :
-    (σ.rename v name').wf (Δ.addConst ⟨name', v.sort⟩) := by
-  rcases hσ with ⟨hsubst, hrange, hwfRange⟩
-  constructor
-  · have hrangeWf : (σ.range.addConst ⟨name', v.sort⟩).wf :=
-      Signature.wf_addConst hwfRange hfresh
-    have hsubst' : σ.subst.wfIn σ.dom (σ.range.addConst ⟨name', v.sort⟩) :=
-      Subst.wfIn_mono hsubst (Signature.Subset.subset_addConst _ _) hrangeWf
-    have herase :
-        (σ.subst.remove v.name).wfIn (σ.dom.filter (fun w => w.name != v.name))
-          (σ.range.addConst ⟨name', v.sort⟩) :=
-      Subst.wfIn_remove hsubst'
-    have hconstwf : (Term.const (.uninterpreted name' v.sort)).wfIn (σ.range.addConst ⟨name', v.sort⟩) := by
-      refine ⟨List.Mem.head _, ?_, ?_⟩
-      · intro τ' hvar
-        exact Signature.wf_no_var_of_const hrangeWf (List.Mem.head _) hvar
-      · intro τ' hc'
-        exact Signature.wf_unique_const hrangeWf (List.Mem.head _) hc'
-    simpa [FiniteSubst.rename] using
-      (Subst.wfIn_update (σ := σ.subst.remove v.name)
-        (dom := σ.dom.filter (fun w => w.name != v.name))
-        (τ := v.sort) (x := v.name) herase hconstwf)
-  · constructor
-    · constructor
-      · intro x hx
-        exact hrange.vars x hx
-      · intro c hc
-        cases hc with
-        | head => exact List.Mem.head _
-        | tail _ hc => exact List.Mem.tail _ (hrange.consts c hc)
-      · intro u hu
-        exact hrange.unary u hu
-      · intro b hb
-        exact hrange.binary b hb
-      · intro u hu
-        exact hrange.unaryRel u hu
-      · intro b hb
-        exact hrange.binaryRel b hb
-    · exact Signature.wf_addConst hwfRange hfresh
+/-- The source signature induced by a renamed substitution is exactly the old source
+    signature with the renamed variable redeclared. -/
+theorem FiniteSubst.rename_source_eq (σ : FiniteSubst) (Δ : Signature)
+    (v : Var) (name' : String) :
+    Δ.declVars (σ.rename v name').dom = (Δ.declVars σ.dom).declVar v := by
+  simpa [FiniteSubst.rename] using declVars_append_single Δ σ.dom v
 
-/-- Generic bundle for renaming `σ` on `v` to a fresh name `name'`. -/
-theorem FiniteSubst.rename_bundle_of_fresh {σ : FiniteSubst} {decls : Signature}
+/-- Redeclaring `v` after all old source variables is contained in the source signature
+    induced by `σ.rename v name'`. This is the direction used to transport assertion
+    well-formedness after a verifier-side fresh declaration. -/
+theorem FiniteSubst.rename_source_subset (σ : FiniteSubst) (Δ : Signature)
+    (v : Var) (name' : String) :
+    ((Δ.declVars σ.dom).declVar v).Subset
+      (Δ.declVars (σ.rename v name').dom) := by
+  rw [FiniteSubst.rename_source_eq]
+  exact Signature.Subset.refl _
+
+/-- Converse of `FiniteSubst.rename_source_subset`; useful for obligations that need
+    to interpret renamed source variables back in the pre-rename source signature. -/
+theorem FiniteSubst.rename_source_subset_rev (σ : FiniteSubst) (Δ : Signature)
+    (v : Var) (name' : String) :
+    (Δ.declVars (σ.rename v name').dom).Subset
+      ((Δ.declVars σ.dom).declVar v) := by
+  rw [FiniteSubst.rename_source_eq]
+  exact Signature.Subset.refl _
+
+/-- Renaming preserves well-formedness of the source signature. The proof uses that the
+    renamed source has the same names, up to permutation, as the old source with `v`
+    redeclared. -/
+theorem FiniteSubst.rename_source_wf {σ : FiniteSubst} {Δ : Signature}
     {v : Var} {name' : String}
-    (hσwf : σ.wf decls) (hσdomwf : (Signature.ofVars σ.dom).wf)
-    (_hfresh_decls : name' ∉ decls.allNames)
-    (hfresh_range : name' ∉ σ.range.allNames) :
-    let c : FOL.Const := ⟨name', v.sort⟩
-    let σ' := σ.rename v name'
-    σ'.wf (decls.addConst c) ∧
-    (Signature.ofVars σ'.dom).wf := by
-  exact ⟨FiniteSubst.rename_wf hσwf hfresh_range,
-    FiniteSubst.rename_dom_wf hσdomwf⟩
+    (h : (Δ.declVars σ.dom).wf) :
+    (Δ.declVars (σ.rename v name').dom).wf := by
+  rw [FiniteSubst.rename_source_eq]
+  exact Signature.wf_declVar h
 
-/-- Standard bundle after declaring a fresh constant of `v.sort` and renaming `σ` on `v`:
-    freshness facts and well-formedness of the renamed substitution in the extended
-    signature. -/
-theorem FiniteSubst.rename_bundle_of_freshConst {σ : FiniteSubst} {st : TransState}
-    {hint : Option String} {v : Var}
-    (hσwf : σ.wf st.decls) (hσdomwf : (Signature.ofVars σ.dom).wf) :
-    let c := st.freshConst hint v.sort
-    let σ' := σ.rename v c.name
-    c.name ∉ st.decls.allNames ∧
-    c.name ∉ σ.range.allNames ∧
-    σ'.wf (st.decls.addConst c) ∧
-    (Signature.ofVars σ'.dom).wf := by
-  have hfresh_decls := TransState.freshConst_fresh st hint v.sort
-  have hfresh_range : (st.freshConst hint v.sort).name ∉ σ.range.allNames :=
-    fun h => hfresh_decls (Signature.allNames_subset hσwf.2.1 _ h)
-  have hrename :=
-    rename_bundle_of_fresh (v := v) (name' := (st.freshConst hint v.sort).name)
-      hσwf hσdomwf hfresh_decls hfresh_range
-  exact ⟨hfresh_decls, hfresh_range, hrename.1, hrename.2⟩
+private theorem subst_wfIn_dom_congr {σ : Subst} {dom dom' : VarCtx} {Δ : Signature}
+    (hσ : σ.wfIn dom Δ) (h₁ : dom' ⊆ dom) (h₂ : dom ⊆ dom') :
+    σ.wfIn dom' Δ :=
+  ⟨fun v hv => hσ.1 v (h₁ hv),
+   fun v hv => hσ.2 v (fun h => hv (h₂ h))⟩
 
-theorem FiniteSubst.rename_agreeOn {σ : FiniteSubst} {v : Var} {c : FOL.Const}
-    {ρ : Env} {u : v.sort.denote}
-    (hσwf : σ.subst.wfIn σ.dom σ.range) (hfresh : c.name ∉ σ.range.allNames)
-    (hsort : c.sort = v.sort) :
-    Env.agreeOn (Signature.ofVars (σ.rename v c.name).dom)
-      ((σ.rename v c.name).subst.eval (ρ.updateConst v.sort c.name u))
-      ((σ.subst.eval ρ).updateConst v.sort v.name u) := by
-  constructor
-  · intro w hw
-    simp [FiniteSubst.rename, Signature.ofVars] at hw
-    rcases hw with rfl | ⟨hwdom, hneq⟩
-    · change
-        Term.eval (ρ.updateConst w.sort c.name u)
-          (((σ.subst.remove w.name).update w.sort w.name
-            (Term.const (Const.uninterpreted c.name w.sort))).apply w.sort w.name) =
-          (((σ.subst.eval ρ).updateConst w.sort w.name u).lookupConst w.sort w.name)
-      simp [Subst.eval, Env.updateConst, Env.lookupConst, Subst.apply, Subst.update,
-        Term.eval, Const.denote]
-    · have hne : w.name ≠ v.name := hneq
-      change
-        Term.eval (ρ.updateConst v.sort c.name u)
-            (((σ.subst.remove v.name).update v.sort v.name
-              (Term.const (Const.uninterpreted c.name v.sort))).apply w.sort w.name) =
-          ((σ.subst.eval ρ).updateConst v.sort v.name u).lookupConst w.sort w.name
-      rw [Subst.apply_update_ne (Or.inl hne), Subst.apply_remove_ne hne,
-        Env.lookupConst_updateConst_ne' (Or.inl hne), Subst.eval_lookup]
-      exact (Term.eval_env_agree (hσwf.1 w hwdom)
-        (Env.agreeOn_update_fresh_const (c := ⟨c.name, v.sort⟩) hfresh)).symm
-  · simp [Signature.ofVars]
+private theorem subset_addConst_same {Δ Δ' : Signature} (h : Δ.Subset Δ') (c : FOL.Const) :
+    (Δ.addConst c).Subset (Δ'.addConst c) :=
+  ⟨h.vars,
+   fun c' hc' => by
+    cases hc' with
+    | head => left
+    | tail _ hc => exact List.mem_cons_of_mem _ (h.consts c' hc),
+   h.unary,
+   h.binary,
+   h.unaryRel,
+   h.binaryRel⟩
 
-theorem FiniteSubst.rename_dom_declVar {σ : FiniteSubst} {Δ : Signature} {v : Var} {name' : String}
-    (hdom : Δ.vars ⊆ σ.dom) :
-    (Δ.declVar v).vars ⊆ (σ.rename v name').dom := by
-  intro w hw
-  simp [Signature.declVar, Signature.addVar, FiniteSubst.rename] at hw ⊢
-  rcases hw with rfl | ⟨hw, hneq⟩
-  · exact Or.inl rfl
-  · exact Or.inr ⟨hdom hw, hneq⟩
+private theorem const_wfIn_addConst {Δ : Signature} {name : String} {τ : Srt}
+    (hΔ : Δ.wf) (hfresh : name ∉ Δ.allNames) :
+    (Term.const (.uninterpreted name τ)).wfIn (Δ.addConst ⟨name, τ⟩) := by
+  simp only [Term.wfIn, Const.wfIn, Signature.addConst]
+  have hΔ' : (Δ.addConst ⟨name, τ⟩).wf := Signature.wf_addConst hΔ hfresh
+  refine ⟨List.Mem.head _, ?_, ?_⟩
+  · intro τ' hvar
+    exact hfresh (Signature.mem_allNames_of_var hvar)
+  · intro τ' hc'
+    exact Signature.wf_unique_const hΔ' (List.Mem.head _) hc'
 
-theorem FiniteSubst.rename_agreeOn_declVar {σ : FiniteSubst} {decls : Signature}
-    {v : Var} {c : FOL.Const} {ρ : Env} {u : v.sort.denote}
-    (hσwf : σ.wf decls)
-    (hfresh : c.name ∉ decls.allNames) (hsort : c.sort = v.sort) :
-    Env.agreeOn ((Signature.ofVars σ.dom).declVar v)
-      ((σ.rename v c.name).subst.eval (ρ.updateConst v.sort c.name u))
-      ((σ.subst.eval ρ).updateConst v.sort v.name u) := by
-  have hfresh_range : c.name ∉ σ.range.allNames := by
-    intro h
-    exact hfresh (Signature.allNames_subset hσwf.2.1 _ h)
-  have hrename := FiniteSubst.rename_agreeOn (σ := σ) (v := v) (c := c) (ρ := ρ) (u := u)
-    hσwf.1 hfresh_range hsort
-  constructor
-  · intro w hw
-    exact hrename.1 w (FiniteSubst.rename_dom_declVar (σ := σ) (Δ := Signature.ofVars σ.dom) (v := v) (name' := c.name) (by intro x hx; exact hx) hw)
-  · simp [Signature.declVar, Signature.ofVars, Signature.addVar, Signature.remove]
+/-- Renaming a source variable to a fresh use-site constant preserves finite-substitution
+    well-formedness, extending both the substitution range and the use-site signature by
+    that fresh constant. -/
+theorem FiniteSubst.rename_wfIn {σ : FiniteSubst} {Δ_base Δ_use : Signature}
+    {v : Var} {name' : String}
+    (hσ : σ.wfIn Δ_base Δ_use)
+    (hfresh_range : name' ∉ σ.range.allNames)
+    (hfresh_use : name' ∉ Δ_use.allNames) :
+    (σ.rename v name').wfIn Δ_base (Δ_use.addConst ⟨name', v.sort⟩) := by
+  rcases hσ with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+  have hrange_add_wf : (σ.range.addConst ⟨name', v.sort⟩).wf :=
+    Signature.wf_addConst hrangewf hfresh_range
+  have huse_add_wf : (Δ_use.addConst ⟨name', v.sort⟩).wf :=
+    Signature.wf_addConst husewf hfresh_use
+  have hconst_wf :
+      (Term.const (.uninterpreted name' v.sort)).wfIn
+        (σ.range.addConst ⟨name', v.sort⟩) :=
+    const_wfIn_addConst hrangewf hfresh_range
+  have hremove :
+      (σ.subst.remove v.name).wfIn
+        ((Δ_base.declVars σ.dom).remove v.name).vars
+        (σ.range.addConst ⟨name', v.sort⟩) := by
+    exact Subst.wfIn_mono (Subst.wfIn_remove hsubst)
+      (Signature.Subset.subset_addConst _ _) hrange_add_wf
+  have hupdate :
+      ((σ.subst.remove v.name).update v.sort v.name
+        (Term.const (.uninterpreted name' v.sort))).wfIn
+        ((Δ_base.declVars σ.dom).declVar v).vars
+        (σ.range.addConst ⟨name', v.sort⟩) := by
+    simpa [Signature.declVar, Signature.addVar] using
+      (Subst.wfIn_update (σ := σ.subst.remove v.name)
+        (dom := ((Δ_base.declVars σ.dom).remove v.name).vars)
+        (x := v.name) hremove hconst_wf)
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, hbasevars⟩
+  · have hsub₁ :
+        (Δ_base.declVars (σ.rename v name').dom).vars ⊆
+          ((Δ_base.declVars σ.dom).declVar v).vars :=
+      (FiniteSubst.rename_source_subset_rev σ Δ_base v name').vars
+    have hsub₂ :
+        ((Δ_base.declVars σ.dom).declVar v).vars ⊆
+          (Δ_base.declVars (σ.rename v name').dom).vars :=
+      (FiniteSubst.rename_source_subset σ Δ_base v name').vars
+    simpa [FiniteSubst.rename] using subst_wfIn_dom_congr hupdate hsub₁ hsub₂
+  · exact Signature.SymbolSubset.trans hbase (Signature.SymbolSubset.subset_addConst _ _)
+  · exact subset_addConst_same huse ⟨name', v.sort⟩
+  · exact FiniteSubst.rename_source_wf hsrcwf
+  · exact hrange_add_wf
+  · exact huse_add_wf
 
-theorem FiniteSubst.eval_update_fresh {σ : FiniteSubst} {ρ : Env} {τ : Srt} {name' : String}
-    {u : τ.denote} (hσ : σ.subst.wfIn σ.dom σ.range) (hfresh : name' ∉ σ.range.allNames) :
-    Env.agreeOn (Signature.ofVars σ.dom) (σ.subst.eval ρ) (σ.subst.eval (ρ.updateConst τ name' u)) := by
-  constructor
-  · intro v hv
-    exact Term.eval_env_agree (hσ.1 v hv) (Env.agreeOn_update_fresh_const (c := ⟨name', τ⟩) hfresh)
-  · simp [Signature.ofVars]
+theorem declVars_symbolSubset {Δ_base : Signature} {vs : List Var} :
+    (Δ_base.declVars vs).SymbolSubset Δ_base := by
+  induction vs generalizing Δ_base with
+  | nil =>
+    simpa [Signature.declVars] using Signature.SymbolSubset.refl Δ_base
+  | cons v vs ih =>
+    simpa [Signature.declVars] using
+      Signature.SymbolSubset.trans (ih (Δ_base := Δ_base.declVar v))
+        (Signature.SymbolSubset.declVar (Signature.SymbolSubset.refl Δ_base) v)
 
-theorem FiniteSubst.subst_wfIn_formula {σ : FiniteSubst} {φ : Formula} {Δ : Signature}
-    (hσ : σ.wf Δ) (hφ : φ.wfIn (Signature.ofVars σ.dom)) (hwfΔ : Δ.wf) :
-    (φ.subst σ.subst σ.range.allNames).wfIn Δ := by
-  rcases hσ with ⟨hsubst, hrange, hwfRange⟩
-  have hwf_range : (φ.subst σ.subst σ.range.allNames).wfIn σ.range := by
-    simpa using
-      (Formula.subst_wfIn (Δ := Signature.ofVars σ.dom) (Δ' := σ.range) hφ hsubst
-        (Signature.SymbolSubset.ofVars _ _) hwfRange)
-  exact Formula.wfIn_mono _ hwf_range hrange hwfΔ
+theorem FiniteSubst.subst_wfIn_formula_range {σ : FiniteSubst} {φ : Formula}
+    {Δ_base Δ_use : Signature}
+    (hσ : σ.wfIn Δ_base Δ_use)
+    (hφ : φ.wfIn (Δ_base.declVars σ.dom)) :
+    (φ.subst σ.subst σ.range.allNames).wfIn σ.range := by
+  rcases hσ with ⟨hsubst, hbase, _huse, _hsrcwf, hrangewf, _husewf, _hbasevars⟩
+  exact Formula.subst_wfIn hφ hsubst
+    (Signature.SymbolSubset.trans declVars_symbolSubset hbase) hrangewf
+
+theorem FiniteSubst.subst_wfIn_formula {σ : FiniteSubst} {φ : Formula}
+    {Δ_base Δ_use : Signature}
+    (hσ : σ.wfIn Δ_base Δ_use)
+    (hφ : φ.wfIn (Δ_base.declVars σ.dom)) :
+    (φ.subst σ.subst σ.range.allNames).wfIn Δ_use := by
+  have hrange := FiniteSubst.subst_wfIn_formula_range hσ hφ
+  rcases hσ with ⟨_hsubst, _hbase, huse, _hsrcwf, _hrangewf, husewf, _hbasevars⟩
+  exact Formula.wfIn_mono _ hrange huse husewf
+
+theorem FiniteSubst.subst_wfIn_term_range {σ : FiniteSubst} {t : Term τ}
+    {Δ_base Δ_use : Signature}
+    (hσ : σ.wfIn Δ_base Δ_use)
+    (ht : t.wfIn (Δ_base.declVars σ.dom)) :
+    (t.subst σ.subst).wfIn σ.range := by
+  rcases hσ with ⟨hsubst, hbase, _huse, _hsrcwf, hrangewf, _husewf, _hbasevars⟩
+  exact Term.subst_wfIn ht hsubst (by intro x hx; exact hx)
+    (Signature.SymbolSubset.trans declVars_symbolSubset hbase) hrangewf
+
+theorem FiniteSubst.subst_wfIn_term {σ : FiniteSubst} {t : Term τ}
+    {Δ_base Δ_use : Signature}
+    (hσ : σ.wfIn Δ_base Δ_use)
+    (ht : t.wfIn (Δ_base.declVars σ.dom)) :
+    (t.subst σ.subst).wfIn Δ_use := by
+  have hrange := FiniteSubst.subst_wfIn_term_range hσ ht
+  rcases hσ with ⟨_hsubst, _hbase, huse, _hsrcwf, _hrangewf, husewf, _hbasevars⟩
+  exact Term.wfIn_mono _ hrange huse husewf
 
 theorem FiniteSubst.eval_subst_formula {σ : FiniteSubst} {φ : Formula} {ρ : Env}
-    (hφ : φ.wfIn (Signature.ofVars σ.dom)) (hσ : σ.subst.wfIn σ.dom σ.range)
-    (hdomwf : (Signature.ofVars σ.dom).wf) :
-    σ.range.wf →
+    {Δ_base Δ_use : Signature}
+    (hσ : σ.wfIn Δ_base Δ_use)
+    (hφ : φ.wfIn (Δ_base.declVars σ.dom)) :
     ((φ.subst σ.subst σ.range.allNames).eval ρ ↔ φ.eval (σ.subst.eval ρ)) := by
-  intro hwf
-  exact Formula.eval_subst (ρ := ρ) hφ hσ (Signature.SymbolSubset.ofVars _ _) hdomwf hwf
+  rcases hσ with ⟨hsubst, hbase, _huse, hsrcwf, hrangewf, _husewf, _hbasevars⟩
+  exact Formula.eval_subst hφ hsubst
+    (Signature.SymbolSubset.trans declVars_symbolSubset hbase) hsrcwf hrangewf
 
-theorem FiniteSubst.id_wf (Δ : Signature) : FiniteSubst.id.wf Δ := by
-  constructor
-  · apply Subst.id_wfIn
-    · intro x hx; cases hx
-    · exact Signature.wf_empty
-  · constructor
-    · constructor
-      · intro _ h; cases h
-      · intro _ h; cases h
-      · intro _ h; cases h
-      · intro _ h; cases h
-      · intro _ h; cases h
-      · intro _ h; cases h
-    · exact Signature.wf_empty
+theorem FiniteSubst.eval_subst_term {σ : FiniteSubst} {t : Term τ} {ρ : Env}
+    {Δ_base Δ_use : Signature}
+    (hσ : σ.wfIn Δ_base Δ_use)
+    (ht : t.wfIn (Δ_base.declVars σ.dom)) :
+    Term.eval ρ (t.subst σ.subst) = Term.eval (σ.subst.eval ρ) t := by
+  rcases hσ with ⟨hsubst, _hbase, _huse, _hsrcwf, hrangewf, _husewf, _hbasevars⟩
+  exact Term.eval_subst ht hsubst hrangewf
 
 theorem FiniteSubst.eval_agreeOn {σ : FiniteSubst} {ρ ρ' : Env}
-    (hσ : σ.subst.wfIn σ.dom σ.range) (hagree : Env.agreeOn σ.range ρ ρ') :
-    Env.agreeOn (Signature.ofVars σ.dom) (σ.subst.eval ρ) (σ.subst.eval ρ') := by
+    {Δ_base Δ_use : Signature}
+    (hσ : σ.wfIn Δ_base Δ_use)
+    (hagree : Env.agreeOn Δ_use ρ ρ') :
+    Env.agreeOn (Δ_base.declVars σ.dom) (σ.subst.eval ρ) (σ.subst.eval ρ') := by
+  rcases hσ with ⟨hsubst, hbase, huse, hsrcwf, _hrangewf, _husewf, _hbasevars⟩
+  have hagree_range : Env.agreeOn σ.range ρ ρ' := Env.agreeOn_mono huse hagree
+  have hsymbols : (Δ_base.declVars σ.dom).SymbolSubset σ.range :=
+    Signature.SymbolSubset.trans declVars_symbolSubset hbase
   constructor
   · intro v hv
-    exact Term.eval_env_agree (hσ.1 v hv) hagree
-  · simp [Signature.ofVars]
+    exact Term.eval_env_agree (hsubst.1 v hv) hagree_range
+  · constructor
+    · intro c hc
+      have hc' : c ∈ σ.range.consts := hsymbols.consts c hc
+      have hnot : ⟨c.name, c.sort⟩ ∉ (Δ_base.declVars σ.dom).vars := by
+        intro hv
+        exact Signature.wf_no_var_of_const hsrcwf hc hv
+      have hvar : σ.subst.apply c.sort c.name = Term.var c.sort c.name := hsubst.2 _ hnot
+      simp [Subst.eval, Term.eval, hvar]
+      exact hagree_range.2.1 c hc'
+    · constructor
+      · intro u hu
+        have hu' : u ∈ σ.range.unary := hsymbols.unary u hu
+        exact hagree_range.2.2.1 u hu'
+      · constructor
+        · intro b hb
+          have hb' : b ∈ σ.range.binary := hsymbols.binary b hb
+          exact hagree_range.2.2.2.1 b hb'
+        · constructor
+          · intro u hu
+            have hu' : u ∈ σ.range.unaryRel := hsymbols.unaryRel u hu
+            exact hagree_range.2.2.2.2.1 u hu'
+          · intro b hb
+            have hb' : b ∈ σ.range.binaryRel := hsymbols.binaryRel b hb
+            exact hagree_range.2.2.2.2.2 b hb'
+
+theorem FiniteSubst.eval_update_fresh {σ : FiniteSubst} {ρ : Env} {τ : Srt} {name' : String}
+    {u : τ.denote} {Δ_base Δ_use : Signature}
+    (hσ : σ.wfIn Δ_base Δ_use) (hfresh : name' ∉ σ.range.allNames) :
+    Env.agreeOn (Δ_base.declVars σ.dom) (σ.subst.eval ρ) (σ.subst.eval (ρ.updateConst τ name' u)) := by
+  rcases hσ with ⟨hsubst, hbase, _huse, hsrcwf, _hrangewf, _husewf, _hbasevars⟩
+  have hagree_range : Env.agreeOn σ.range ρ (ρ.updateConst τ name' u) :=
+    Env.agreeOn_update_fresh_const (c := ⟨name', τ⟩) hfresh
+  have hsymbols : (Δ_base.declVars σ.dom).SymbolSubset σ.range :=
+    Signature.SymbolSubset.trans declVars_symbolSubset hbase
+  constructor
+  · intro v hv
+    exact Term.eval_env_agree (hsubst.1 v hv) hagree_range
+  · constructor
+    · intro c hc
+      have hc' : c ∈ σ.range.consts := hsymbols.consts c hc
+      have hnot : ⟨c.name, c.sort⟩ ∉ (Δ_base.declVars σ.dom).vars := by
+        intro hv
+        exact Signature.wf_no_var_of_const hsrcwf hc hv
+      have hvar : σ.subst.apply c.sort c.name = Term.var c.sort c.name := hsubst.2 _ hnot
+      simp [Subst.eval, Term.eval, hvar]
+      exact hagree_range.2.1 c hc'
+    · constructor
+      · intro u' hu
+        exact hagree_range.2.2.1 u' (hsymbols.unary u' hu)
+      · constructor
+        · intro b hb
+          exact hagree_range.2.2.2.1 b (hsymbols.binary b hb)
+        · constructor
+          · intro u' hu
+            exact hagree_range.2.2.2.2.1 u' (hsymbols.unaryRel u' hu)
+          · intro b hb
+            exact hagree_range.2.2.2.2.2 b (hsymbols.binaryRel b hb)
+
+/-- After `rename`, evaluating the renamed substitution in an environment containing the
+    fresh verifier constant agrees with evaluating the old substitution and updating the
+    source-level variable. -/
+theorem FiniteSubst.rename_agreeOn {σ : FiniteSubst} {Δ_base Δ_use : Signature}
+    {v : Var} {name' : String} {ρ : Env} {u : v.sort.denote}
+    (hσ : σ.wfIn Δ_base Δ_use) (hfresh : name' ∉ σ.range.allNames) :
+    Env.agreeOn (Δ_base.declVars (σ.rename v name').dom)
+      ((σ.rename v name').subst.eval (ρ.updateConst v.sort name' u))
+      ((σ.subst.eval ρ).updateConst v.sort v.name u) := by
+  rcases hσ with ⟨hsubst, hbase, huse, hsrcwf, hrangewf, husewf, hbasevars⟩
+  have hsymbols : (Δ_base.declVars σ.dom).SymbolSubset σ.range :=
+    Signature.SymbolSubset.trans declVars_symbolSubset hbase
+  have hlarge :
+      Env.agreeOn ((Δ_base.declVars σ.dom).declVar v)
+        ((σ.rename v name').subst.eval (ρ.updateConst v.sort name' u))
+        ((σ.subst.eval ρ).updateConst v.sort v.name u) := by
+    constructor
+    · intro w hw
+      simp [Signature.declVar, Signature.addVar] at hw
+      rcases hw with rfl | hw
+      · simp [FiniteSubst.rename, Subst.eval, Env.updateConst, Subst.apply,
+          Subst.update, Term.eval, Const.denote]
+      · rcases hw with ⟨hwsrc, hwne⟩
+        have hwne' : w.name ≠ v.name := hwne
+        change Term.eval (ρ.updateConst v.sort name' u)
+            (((σ.subst.remove v.name).update v.sort v.name
+              (Term.const (Const.uninterpreted name' v.sort))).apply w.sort w.name) =
+          ((σ.subst.eval ρ).updateConst v.sort v.name u).lookupConst w.sort w.name
+        rw [Subst.apply_update_ne (Or.inl hwne'), Subst.apply_remove_ne hwne',
+          Env.lookupConst_updateConst_ne' (Or.inl hwne'), Subst.eval_lookup]
+        exact (Term.eval_env_agree (hsubst.1 w hwsrc)
+          (Env.agreeOn_update_fresh_const (c := ⟨name', v.sort⟩) hfresh)).symm
+    · constructor
+      · intro c hc
+        simp [Signature.declVar, Signature.addVar] at hc
+        rcases hc with ⟨hcsrc, hcne⟩
+        have hnotvar : ⟨c.name, c.sort⟩ ∉ (Δ_base.declVars σ.dom).vars := by
+          intro hv
+          exact Signature.wf_no_var_of_const hsrcwf hcsrc hv
+        have hvar : σ.subst.apply c.sort c.name = Term.var c.sort c.name := hsubst.2 _ hnotvar
+        have hcne' : c.name ≠ v.name := hcne
+        have hc_range : c ∈ σ.range.consts := hsymbols.consts c hcsrc
+        have hname : c.name ≠ name' := by
+          intro heq
+          exact hfresh (by
+            rw [← heq]
+            exact Signature.mem_allNames_of_const hc_range)
+        change Term.eval (ρ.updateConst v.sort name' u)
+            (((σ.subst.remove v.name).update v.sort v.name
+              (Term.const (Const.uninterpreted name' v.sort))).apply c.sort c.name) =
+          ((σ.subst.eval ρ).updateConst v.sort v.name u).lookupConst c.sort c.name
+        rw [Subst.apply_update_ne (Or.inl hcne'), Subst.apply_remove_ne hcne',
+          Env.lookupConst_updateConst_ne' (Or.inl hcne'), Subst.eval_lookup, hvar]
+        simp only [Term.eval, Env.lookupConst]
+        by_cases hs : c.sort = v.sort
+        · cases c
+          simp only at hs hname
+          subst hs
+          simp [Env.updateConst, hname]
+        · simp [Env.updateConst, hs]
+      · constructor
+        · intro unary hunary
+          simp [Subst.eval, Env.updateConst]
+        · constructor
+          · intro binary hbinary
+            simp [Subst.eval, Env.updateConst]
+          · constructor
+            · intro unaryRel hunaryRel
+              simp [Subst.eval, Env.updateConst]
+            · intro binaryRel hbinaryRel
+              simp [Subst.eval, Env.updateConst]
+  exact Env.agreeOn_mono (FiniteSubst.rename_source_subset_rev σ Δ_base v name') hlarge
+
+theorem FiniteSubst.id_wf {Δ_use : Signature}
+    (husewf : Δ_use.wf) :
+    FiniteSubst.id.wfIn Signature.empty Δ_use := by
+  refine ⟨?_, ?_, ?_, ?_, Signature.wf_empty, husewf, rfl⟩
+  · apply Subst.id_wfIn
+    · intro x hx
+      cases hx
+    · exact Signature.wf_empty
+  · constructor
+    · intro c hc
+      cases hc
+    · intro u hu
+      cases hu
+    · intro b hb
+      cases hb
+    · intro u hu
+      cases hu
+    · intro b hb
+      cases hb
+  · constructor
+    · intro x hx
+      cases hx
+    · intro c hc
+      cases hc
+    · intro u hu
+      cases hu
+    · intro b hb
+      cases hb
+    · intro u hu
+      cases hu
+    · intro b hb
+      cases hb
+  · simp [FiniteSubst.id, Signature.empty, Signature.declVars, Signature.wf, Signature.allNames]
+
+theorem FiniteSubst.base_wfIn {Δ_base Δ_use : Signature}
+    (hbase : Δ_base.Subset Δ_use) (hbasewf : Δ_base.wf) (husewf : Δ_use.wf)
+    (hvars : Δ_base.vars = []) :
+    (FiniteSubst.base Δ_base).wfIn Δ_base Δ_use := by
+  refine ⟨?_, Signature.SymbolSubset.refl Δ_base, hbase, ?_, hbasewf, husewf, hvars⟩
+  · apply Subst.id_wfIn
+    · intro v hv
+      simp [FiniteSubst.base, Signature.declVars, hvars] at hv
+    · exact hbasewf
+  · simpa [FiniteSubst.base, Signature.declVars] using hbasewf

--- a/Mica/Verifier/Utils.lean
+++ b/Mica/Verifier/Utils.lean
@@ -246,15 +246,6 @@ theorem FiniteSubst.subst_wfIn_formula_range {σ : FiniteSubst} {φ : Formula}
   exact Formula.subst_wfIn hφ hsubst
     (Signature.SymbolSubset.trans declVars_symbolSubset hbase) hrangewf
 
-theorem FiniteSubst.subst_wfIn_formula {σ : FiniteSubst} {φ : Formula}
-    {Δ_base Δ_use : Signature}
-    (hσ : σ.wfIn Δ_base Δ_use)
-    (hφ : φ.wfIn (Δ_base.declVars σ.dom)) :
-    (φ.subst σ.subst σ.range.allNames).wfIn Δ_use := by
-  have hrange := FiniteSubst.subst_wfIn_formula_range hσ hφ
-  rcases hσ with ⟨_hsubst, _hbase, huse, _hsrcwf, _hrangewf, husewf, _hbasevars⟩
-  exact Formula.wfIn_mono _ hrange huse husewf
-
 theorem FiniteSubst.subst_wfIn_term_range {σ : FiniteSubst} {t : Term τ}
     {Δ_base Δ_use : Signature}
     (hσ : σ.wfIn Δ_base Δ_use)
@@ -432,40 +423,6 @@ theorem FiniteSubst.rename_agreeOn {σ : FiniteSubst} {Δ_base Δ_use : Signatur
             · intro binaryRel hbinaryRel
               simp [Subst.eval, Env.updateConst]
   exact Env.agreeOn_mono (FiniteSubst.rename_source_subset_rev σ Δ_base v name') hlarge
-
-theorem FiniteSubst.id_wf {Δ_use : Signature}
-    (husewf : Δ_use.wf) :
-    FiniteSubst.id.wfIn Signature.empty Δ_use := by
-  refine ⟨?_, ?_, ?_, ?_, Signature.wf_empty, husewf, rfl⟩
-  · apply Subst.id_wfIn
-    · intro x hx
-      cases hx
-    · exact Signature.wf_empty
-  · constructor
-    · intro c hc
-      cases hc
-    · intro u hu
-      cases hu
-    · intro b hb
-      cases hb
-    · intro u hu
-      cases hu
-    · intro b hb
-      cases hb
-  · constructor
-    · intro x hx
-      cases hx
-    · intro c hc
-      cases hc
-    · intro u hu
-      cases hu
-    · intro b hb
-      cases hb
-    · intro u hu
-      cases hu
-    · intro b hb
-      cases hb
-  · simp [FiniteSubst.id, Signature.empty, Signature.declVars, Signature.wf, Signature.allNames]
 
 theorem FiniteSubst.base_wfIn {Δ_base Δ_use : Signature}
     (hbase : Δ_base.Subset Δ_use) (hbasewf : Δ_base.wf) (husewf : Δ_use.wf)


### PR DESCRIPTION
This PR generalizes the signature that is threaded through the verifier. It used to be entirely empty and now we support declaring some initial constants. This has required some redesign of the notion of a finite substitution.