### PR TITLE
Unary and binary predicates in first-order logic

### DIFF
--- a/Mica/Engine/Command.lean
+++ b/Mica/Engine/Command.lean
@@ -6,6 +6,7 @@ import Mica.Engine.State
 An SMT command, indexed by its response type -- Unit for no meaningful response
 - push, pop, assert: Unit
 - declareConst, declareUnary, declareBinary : Unit
+- declareUnaryRel, declareBinaryRel : Unit
 - checkSat: returns sat/unsat/unknown — Smt.Result -/
 
 namespace Smt
@@ -16,6 +17,8 @@ inductive Command : Type → Type where
   | declareConst (name : String) (sort : Srt) : Command Unit
   | declareUnary (name : String) (arg ret : Srt) : Command Unit
   | declareBinary (name : String) (arg1 arg2 ret : Srt) : Command Unit
+  | declareUnaryRel (name : String) (arg : Srt) : Command Unit
+  | declareBinaryRel (name : String) (arg1 arg2 : Srt) : Command Unit
   | assert (expr : Formula) : Command Unit
   | checkSat : Command Result
 
@@ -30,6 +33,8 @@ def toSMTLIB : Command α → String
   | .declareConst n s => s!"(declare-const {n} {s.toSMTLIB})"
   | .declareUnary n a r => s!"(declare-fun {n} ({a.toSMTLIB}) {r.toSMTLIB})"
   | .declareBinary n a1 a2 r => s!"(declare-fun {n} ({a1.toSMTLIB} {a2.toSMTLIB}) {r.toSMTLIB})"
+  | .declareUnaryRel n a => s!"(declare-fun {n} ({a.toSMTLIB}) Bool)"
+  | .declareBinaryRel n a1 a2 => s!"(declare-fun {n} ({a1.toSMTLIB} {a2.toSMTLIB}) Bool)"
   | .assert e => s!"(assert {e.toSMTLIB})"
   | .checkSat => "(check-sat)"
 
@@ -40,6 +45,8 @@ def parse : (cmd : Command α) → String → Option α
   | .declareConst _ _, s => if s == "success" then some () else none
   | .declareUnary _ _ _, s => if s == "success" then some () else none
   | .declareBinary _ _ _ _, s => if s == "success" then some () else none
+  | .declareUnaryRel _ _, s => if s == "success" then some () else none
+  | .declareBinaryRel _ _ _, s => if s == "success" then some () else none
   | .assert _, s => if s == "success" then some () else none
   | .checkSat, s =>
     if s == "sat" then some .sat
@@ -60,6 +67,8 @@ def step : Command β → β → State → State
   | .declareConst n sort, (), s => s.addConst ⟨n, sort⟩
   | .declareUnary n arg ret, (), s => s.addUnary ⟨n, arg, ret⟩
   | .declareBinary n arg1 arg2 ret, (), s => s.addBinary ⟨n, arg1, arg2, ret⟩
+  | .declareUnaryRel n arg, (), s => Smt.State.addUnaryRel s ⟨n, arg⟩
+  | .declareBinaryRel n arg1 arg2, (), s => Smt.State.addBinaryRel s ⟨n, arg1, arg2⟩
   | .assert e, (), s => s.addAssert e
   | .checkSat, _, s => s
 

--- a/Mica/Engine/State.lean
+++ b/Mica/Engine/State.lean
@@ -20,41 +20,53 @@ structure State where
 /-! ## Frame Extension -/
 
 def Frame.Extends (f f' : Frame) : Prop :=
-  ∃ vs cs us bs as,
+  ∃ vs cs us bs urs brs as,
     f'.decls.vars   = vs ++ f.decls.vars ∧
     f'.decls.consts = cs ++ f.decls.consts ∧
     f'.decls.unary  = us ++ f.decls.unary ∧
     f'.decls.binary = bs ++ f.decls.binary ∧
+    f'.decls.unaryRel = urs ++ f.decls.unaryRel ∧
+    f'.decls.binaryRel = brs ++ f.decls.binaryRel ∧
     f'.asserts = as ++ f.asserts
 
 theorem Frame.Extends.refl (f : Frame) : f.Extends f :=
-  ⟨[], [], [], [], [], rfl, rfl, rfl, rfl, rfl⟩
+  ⟨[], [], [], [], [], [], [], rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 theorem Frame.Extends.addConst (f : Frame) (c : FOL.Const) :
     f.Extends ⟨f.decls.addConst c, f.asserts⟩ :=
-  ⟨[], [c], [], [], [], rfl, rfl, rfl, rfl, rfl⟩
+  ⟨[], [c], [], [], [], [], [], rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 theorem Frame.Extends.addUnary (f : Frame) (u : FOL.Unary) :
     f.Extends ⟨f.decls.addUnary u, f.asserts⟩ :=
-  ⟨[], [], [u], [], [], rfl, rfl, rfl, rfl, rfl⟩
+  ⟨[], [], [u], [], [], [], [], rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 theorem Frame.Extends.addBinary (f : Frame) (b : FOL.Binary) :
     f.Extends ⟨f.decls.addBinary b, f.asserts⟩ :=
-  ⟨[], [], [], [b], [], rfl, rfl, rfl, rfl, rfl⟩
+  ⟨[], [], [], [b], [], [], [], rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+theorem Frame.Extends.addUnaryRel (f : Frame) (u : FOL.UnaryRel) :
+    f.Extends ⟨f.decls.addUnaryRel u, f.asserts⟩ :=
+  ⟨[], [], [], [], [u], [], [], rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+
+theorem Frame.Extends.addBinaryRel (f : Frame) (b : FOL.BinaryRel) :
+    f.Extends ⟨f.decls.addBinaryRel b, f.asserts⟩ :=
+  ⟨[], [], [], [], [], [b], [], rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 theorem Frame.Extends.addAssert (f : Frame) (φ : Formula) :
     f.Extends ⟨f.decls, φ :: f.asserts⟩ :=
-  ⟨[], [], [], [], [φ], rfl, rfl, rfl, rfl, rfl⟩
+  ⟨[], [], [], [], [], [], [φ], rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 theorem Frame.Extends.trans {f₁ f₂ f₃ : Frame}
     (h₁₂ : f₁.Extends f₂) (h₂₃ : f₂.Extends f₃) : f₁.Extends f₃ := by
-  obtain ⟨vs₁, cs₁, us₁, bs₁, as₁, hv₁, hc₁, hu₁, hb₁, ha₁⟩ := h₁₂
-  obtain ⟨vs₂, cs₂, us₂, bs₂, as₂, hv₂, hc₂, hu₂, hb₂, ha₂⟩ := h₂₃
-  exact ⟨vs₂ ++ vs₁, cs₂ ++ cs₁, us₂ ++ us₁, bs₂ ++ bs₁, as₂ ++ as₁,
+  obtain ⟨vs₁, cs₁, us₁, bs₁, urs₁, brs₁, as₁, hv₁, hc₁, hu₁, hb₁, hur₁, hbr₁, ha₁⟩ := h₁₂
+  obtain ⟨vs₂, cs₂, us₂, bs₂, urs₂, brs₂, as₂, hv₂, hc₂, hu₂, hb₂, hur₂, hbr₂, ha₂⟩ := h₂₃
+  exact ⟨vs₂ ++ vs₁, cs₂ ++ cs₁, us₂ ++ us₁, bs₂ ++ bs₁, urs₂ ++ urs₁, brs₂ ++ brs₁, as₂ ++ as₁,
     by simp [hv₂, hv₁, List.append_assoc],
     by simp [hc₂, hc₁, List.append_assoc],
     by simp [hu₂, hu₁, List.append_assoc],
     by simp [hb₂, hb₁, List.append_assoc],
+    by simp [hur₂, hur₁, List.append_assoc],
+    by simp [hbr₂, hbr₁, List.append_assoc],
     by simp [ha₂, ha₁, List.append_assoc]⟩
 
 /-! ## Smt.Result -/
@@ -105,6 +117,12 @@ def addUnary (s : State) (u : FOL.Unary) : State :=
 
 def addBinary (s : State) (b : FOL.Binary) : State :=
   s.modifyDecls (·.addBinary b)
+
+def addUnaryRel (s : State) (u : FOL.UnaryRel) : State :=
+  s.modifyDecls (·.addUnaryRel u)
+
+def addBinaryRel (s : State) (b : FOL.BinaryRel) : State :=
+  s.modifyDecls (·.addBinaryRel b)
 
 def addAssert (s : State) (φ : Formula) : State :=
   match s.frames with

--- a/Mica/Engine/Strategy.lean
+++ b/Mica/Engine/Strategy.lean
@@ -84,6 +84,8 @@ theorem bind_traceSound {s : Strategy α} {k : α → Strategy β}
         | declareConst => cases r; trivial
         | declareUnary => cases r; trivial
         | declareBinary => cases r; trivial
+        | declareUnaryRel => cases r; trivial
+        | declareBinaryRel => cases r; trivial
         | assert => cases r; trivial
         | checkSat => cases r with
           | sat => trivial

--- a/Mica/Engine/Trace.lean
+++ b/Mica/Engine/Trace.lean
@@ -42,6 +42,8 @@ def isSound : State → Trace α → Prop
   | s, .step (.declareConst n sort) () rest => isSound (s.addConst ⟨n, sort⟩) rest
   | s, .step (.declareUnary n arg ret) () rest => isSound (s.addUnary ⟨n, arg, ret⟩) rest
   | s, .step (.declareBinary n arg1 arg2 ret) () rest => isSound (s.addBinary ⟨n, arg1, arg2, ret⟩) rest
+  | s, .step (.declareUnaryRel n arg) () rest => isSound (s.addUnaryRel ⟨n, arg⟩) rest
+  | s, .step (.declareBinaryRel n arg1 arg2) () rest => isSound (s.addBinaryRel ⟨n, arg1, arg2⟩) rest
   | s, .step (.assert e) () rest => isSound (s.addAssert e) rest
   | s, .step .checkSat .unsat rest =>
       ¬ State.satisfiable s.allDecls s.allAsserts ∧ isSound s rest
@@ -58,6 +60,8 @@ theorem isSound.step_rest {cmd : Command β} {r : β} {rest : Trace α} {st : St
   | declareConst n sort => cases r; exact h
   | declareUnary n arg ret => cases r; exact h
   | declareBinary n arg1 arg2 ret => cases r; exact h
+  | declareUnaryRel n arg => cases r; exact h
+  | declareBinaryRel n arg1 arg2 => cases r; exact h
   | assert e => cases r; exact h
   | checkSat => cases r with | sat => exact h | unsat => exact h.2 | unknown => exact h
 
@@ -74,6 +78,8 @@ theorem isSound.step_cons {cmd : Command β} {r : β} {rest : Trace α} {st : St
   | declareConst n sort => cases r; exact hrest
   | declareUnary n arg ret => cases r; exact hrest
   | declareBinary n arg1 arg2 ret => cases r; exact hrest
+  | declareUnaryRel n arg => cases r; exact hrest
+  | declareBinaryRel n arg1 arg2 => cases r; exact hrest
   | assert e => cases r; exact hrest
   | checkSat => cases r with | sat => exact hrest | unsat => exact ⟨hstep, hrest⟩ | unknown => exact hrest
 

--- a/Mica/FOL/Variables.lean
+++ b/Mica/FOL/Variables.lean
@@ -645,40 +645,30 @@ remains absent after adding that unary function. -/
 theorem not_mem_allNames_addUnary {Δ : Signature} {u : FOL.Unary} {x : String}
     (hΔ : x ∉ Δ.allNames) (hu : x ≠ u.name) :
     x ∉ (Δ.addUnary u).allNames := by
-  intro hmem
-  have : x ∈ Δ.allNames := by
-    simp only [Signature.allNames, Signature.addUnary,
-      List.map_cons, List.append_assoc, List.mem_append, List.mem_cons] at hmem ⊢
-    rcases hmem with h | h | h | h | h | h
-    · exact Or.inl h
-    · exact Or.inr (Or.inl h)
-    · rcases h with h | h
-      · exact (hu h).elim
-      · exact Or.inr (Or.inr (Or.inl h))
-    · exact Or.inr (Or.inr (Or.inr (Or.inl h)))
-    · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h))))
-    · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h))))
-  exact hΔ this
+  intro h
+  simp [Signature.allNames, Signature.addUnary] at h
+  rcases h with h | h | h | h | h | h
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hu h
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
 
 /-- A name absent from a signature and distinct from a new unary relation name
 remains absent after adding that unary relation. -/
 theorem not_mem_allNames_addUnaryRel {Δ : Signature} {u : FOL.UnaryRel} {x : String}
     (hΔ : x ∉ Δ.allNames) (hu : x ≠ u.name) :
     x ∉ (Δ.addUnaryRel u).allNames := by
-  intro hmem
-  have : x ∈ Δ.allNames := by
-    simp only [Signature.allNames, Signature.addUnaryRel,
-      List.map_cons, List.append_assoc, List.mem_append, List.mem_cons] at hmem ⊢
-    rcases hmem with h | h | h | h | h | h
-    · exact Or.inl h
-    · exact Or.inr (Or.inl h)
-    · exact Or.inr (Or.inr (Or.inl h))
-    · exact Or.inr (Or.inr (Or.inr (Or.inl h)))
-    · rcases h with h | h
-      · exact (hu h).elim
-      · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h))))
-    · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h))))
-  exact hΔ this
+  intro h
+  simp [Signature.allNames, Signature.addUnaryRel] at h
+  rcases h with h | h | h | h | h | h
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hu h
+  · exact hΔ (by simp [Signature.allNames, h])
 
 /-- Declaring a variable whose name is fresh for the signature extends it. -/
 theorem subset_declVar_of_fresh {Δ : Signature} {v : Var}

--- a/Mica/FOL/Variables.lean
+++ b/Mica/FOL/Variables.lean
@@ -241,6 +241,83 @@ theorem wf_addVar {Δ : Signature} {v : Var}
     Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
   simp
 
+theorem wf_addUnaryRel {Δ : Signature} {u : FOL.UnaryRel}
+    (hΔ : Δ.wf) (hfresh : u.name ∉ Δ.allNames) : (Δ.addUnaryRel u).wf := by
+  unfold wf at hΔ ⊢
+  suffices h : (Δ.addUnaryRel u).allNames.Perm (u.name :: Δ.allNames) from
+    h.nodup_iff.mpr (List.nodup_cons.mpr ⟨hfresh, hΔ⟩)
+  show (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    (u.name :: Δ.unaryRel.map FOL.UnaryRel.name) ++ Δ.binaryRel.map FOL.BinaryRel.name).Perm
+    (u.name :: (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
+  change ((Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    u.name :: Δ.unaryRel.map FOL.UnaryRel.name) ++
+    Δ.binaryRel.map FOL.BinaryRel.name).Perm
+    (u.name :: ((Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name) ++ Δ.binaryRel.map FOL.BinaryRel.name))
+  exact List.perm_middle.append_right _
+
+theorem wf_addBinaryRel {Δ : Signature} {b : FOL.BinaryRel}
+    (hΔ : Δ.wf) (hfresh : b.name ∉ Δ.allNames) : (Δ.addBinaryRel b).wf := by
+  unfold wf at hΔ ⊢
+  suffices h : (Δ.addBinaryRel b).allNames.Perm (b.name :: Δ.allNames) from
+    h.nodup_iff.mpr (List.nodup_cons.mpr ⟨hfresh, hΔ⟩)
+  show (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ (b.name :: Δ.binaryRel.map FOL.BinaryRel.name)).Perm
+    (b.name :: (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
+  change ((Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name) ++ b.name :: Δ.binaryRel.map FOL.BinaryRel.name).Perm
+    (b.name :: ((Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name) ++ Δ.binaryRel.map FOL.BinaryRel.name))
+  exact List.perm_middle
+
+theorem wf_addUnary {Δ : Signature} {u : FOL.Unary}
+    (hΔ : Δ.wf) (hfresh : u.name ∉ Δ.allNames) : (Δ.addUnary u).wf := by
+  unfold wf at hΔ ⊢
+  suffices h : (Δ.addUnary u).allNames.Perm (u.name :: Δ.allNames) from
+    h.nodup_iff.mpr (List.nodup_cons.mpr ⟨hfresh, hΔ⟩)
+  show (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    (u.name :: Δ.unary.map FOL.Unary.name) ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name).Perm
+    (u.name :: (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
+  change ((Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    u.name :: Δ.unary.map FOL.Unary.name) ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name).Perm
+    (u.name :: (((Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name) ++ Δ.binary.map FOL.Binary.name) ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
+  exact ((List.perm_middle.append_right _).append_right _).append_right _
+
+theorem wf_addBinary {Δ : Signature} {b : FOL.Binary}
+    (hΔ : Δ.wf) (hfresh : b.name ∉ Δ.allNames) : (Δ.addBinary b).wf := by
+  unfold wf at hΔ ⊢
+  suffices h : (Δ.addBinary b).allNames.Perm (b.name :: Δ.allNames) from
+    h.nodup_iff.mpr (List.nodup_cons.mpr ⟨hfresh, hΔ⟩)
+  show (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ (b.name :: Δ.binary.map FOL.Binary.name) ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name).Perm
+    (b.name :: (Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ Δ.binary.map FOL.Binary.name ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
+  change ((Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name ++ b.name :: Δ.binary.map FOL.Binary.name) ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name).Perm
+    (b.name :: (((Δ.vars.map Var.name ++ Δ.consts.map FOL.Const.name ++
+    Δ.unary.map FOL.Unary.name) ++ Δ.binary.map FOL.Binary.name) ++
+    Δ.unaryRel.map FOL.UnaryRel.name ++ Δ.binaryRel.map FOL.BinaryRel.name))
+  exact (List.perm_middle.append_right _).append_right _
+
 def ofVars (vars : VarCtx) : Signature := ⟨vars, [], [], [], [], []⟩
 
 @[simp] theorem ofVars_vars (vars : VarCtx) : (ofVars vars).vars = vars := rfl
@@ -533,6 +610,88 @@ theorem wf_declVars {Δ : Signature} {vs : List Var} (hΔ : Δ.wf) : (Δ.declVar
     simpa [declVars] using hΔ
   | cons v vs ih =>
     simpa [declVars] using ih (wf_declVar (Δ := Δ) (v := v) hΔ)
+
+/-- A name absent from a signature and distinct from a new binary relation name
+remains absent after adding that binary relation. -/
+theorem not_mem_allNames_addBinaryRel {Δ : Signature} {b : FOL.BinaryRel} {x : String}
+    (hΔ : x ∉ Δ.allNames) (hb : x ≠ b.name) :
+    x ∉ (Δ.addBinaryRel b).allNames := by
+  intro h
+  simp [Signature.allNames, Signature.addBinaryRel] at h
+  rcases h with h | h | h | h | h | h
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · exact hΔ (by simp [Signature.allNames, h])
+  · rcases h with h | h
+    · exact hb h
+    · exact hΔ (by simp [Signature.allNames, h])
+
+/-- A name absent from a signature and distinct from a new variable name remains
+absent after declaring that variable. -/
+theorem not_mem_allNames_declVar {Δ : Signature} {v : Var} {x : String}
+    (hΔ : x ∉ Δ.allNames) (hv : x ≠ v.name) :
+    x ∉ (Δ.declVar v).allNames := by
+  intro h
+  have h' : x ∈ v.name :: (Δ.remove v.name).allNames := by
+    simpa [Signature.declVar, Signature.addVar, Signature.allNames] using h
+  cases h' with
+  | head => exact hv rfl
+  | tail _ htail => exact hΔ (Signature.remove_allNames_subset htail)
+
+/-- A name absent from a signature and distinct from a new unary function name
+remains absent after adding that unary function. -/
+theorem not_mem_allNames_addUnary {Δ : Signature} {u : FOL.Unary} {x : String}
+    (hΔ : x ∉ Δ.allNames) (hu : x ≠ u.name) :
+    x ∉ (Δ.addUnary u).allNames := by
+  intro hmem
+  have : x ∈ Δ.allNames := by
+    simp only [Signature.allNames, Signature.addUnary,
+      List.map_cons, List.append_assoc, List.mem_append, List.mem_cons] at hmem ⊢
+    rcases hmem with h | h | h | h | h | h
+    · exact Or.inl h
+    · exact Or.inr (Or.inl h)
+    · rcases h with h | h
+      · exact (hu h).elim
+      · exact Or.inr (Or.inr (Or.inl h))
+    · exact Or.inr (Or.inr (Or.inr (Or.inl h)))
+    · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h))))
+    · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h))))
+  exact hΔ this
+
+/-- A name absent from a signature and distinct from a new unary relation name
+remains absent after adding that unary relation. -/
+theorem not_mem_allNames_addUnaryRel {Δ : Signature} {u : FOL.UnaryRel} {x : String}
+    (hΔ : x ∉ Δ.allNames) (hu : x ≠ u.name) :
+    x ∉ (Δ.addUnaryRel u).allNames := by
+  intro hmem
+  have : x ∈ Δ.allNames := by
+    simp only [Signature.allNames, Signature.addUnaryRel,
+      List.map_cons, List.append_assoc, List.mem_append, List.mem_cons] at hmem ⊢
+    rcases hmem with h | h | h | h | h | h
+    · exact Or.inl h
+    · exact Or.inr (Or.inl h)
+    · exact Or.inr (Or.inr (Or.inl h))
+    · exact Or.inr (Or.inr (Or.inr (Or.inl h)))
+    · rcases h with h | h
+      · exact (hu h).elim
+      · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h))))
+    · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h))))
+  exact hΔ this
+
+/-- Declaring a variable whose name is fresh for the signature extends it. -/
+theorem subset_declVar_of_fresh {Δ : Signature} {v : Var}
+    (hfresh : v.name ∉ Δ.allNames) : Δ.Subset (Δ.declVar v) := by
+  have heq : Δ.declVar v = Δ.addVar v := by
+    show (Δ.remove v.name).addVar v = Δ.addVar v
+    rw [Signature.remove_eq_of_not_in hfresh]
+  rw [heq]
+  exact Signature.Subset.subset_addVar Δ v
+
+/-- A freshly declared variable is in the resulting signature's variables. -/
+theorem var_mem_declVar (Δ : Signature) (v : Var) : v ∈ (Δ.declVar v).vars :=
+  List.Mem.head _
 
 theorem allNames_remove_addVar_of_not_in {Δ : Signature} {x : String} {τ : Srt}
     (h : x ∉ Δ.allNames) : ((Δ.remove x).addVar ⟨x, τ⟩).allNames = x :: Δ.allNames := by
@@ -877,6 +1036,10 @@ def Env.agreeOn (Δ : Signature) (ρ ρ' : Env) : Prop :=
 theorem Env.agreeOn_refl : Env.agreeOn Δ ρ ρ :=
   ⟨fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl⟩
 
+/-- Any two environments agree on the empty signature. -/
+theorem Env.agreeOn_empty (ρ ρ' : Env) : Env.agreeOn Signature.empty ρ ρ' := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;> intro x hx <;> simp [Signature.empty] at hx
+
 theorem Env.agreeOn_mono {Δ₁ Δ₂ : Signature} (hsub : Δ₁.Subset Δ₂)
     (h : Env.agreeOn Δ₂ ρ ρ') : Env.agreeOn Δ₁ ρ ρ' :=
   ⟨fun x hx => h.1 x (hsub.vars x hx),
@@ -973,6 +1136,73 @@ theorem Env.agreeOn_update_fresh_const {ρ : Env} {c : FOL.Const} {u : c.sort.de
             rw [Env.updateConst_unaryRel]
           · intro b' hb'
             rw [Env.updateConst_binaryRel]
+
+theorem Env.agreeOn_update_fresh_unary {ρ : Env} {u : FOL.Unary}
+    {f : u.arg.denote → u.ret.denote}
+    {Δ : Signature} (hfresh : u.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.updateUnary u.arg u.ret u.name f) :=
+  ⟨fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun u' hu' => by
+     have hne : u'.name ≠ u.name := by
+       intro heq; apply hfresh; rw [← heq]; exact Signature.mem_allNames_of_unary hu'
+     simp only [Env.updateUnary]
+     split
+     · next h => exact absurd h.2.2 hne
+     · rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl⟩
+
+theorem Env.agreeOn_update_fresh_binary {ρ : Env} {b : FOL.Binary}
+    {f : b.arg1.denote → b.arg2.denote → b.ret.denote}
+    {Δ : Signature} (hfresh : b.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.updateBinary b.arg1 b.arg2 b.ret b.name f) :=
+  ⟨fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun b' hb' => by
+     have hne : b'.name ≠ b.name := by
+       intro heq; apply hfresh; rw [← heq]; exact Signature.mem_allNames_of_binary hb'
+     simp only [Env.updateBinary]
+     split
+     · next h => exact absurd h.2.2.2 hne
+     · rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl⟩
+
+theorem Env.agreeOn_update_fresh_unaryRel {ρ : Env} {u : FOL.UnaryRel} {f : u.arg.denote → Prop}
+    {Δ : Signature} (hfresh : u.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.updateUnaryRel u.arg u.name f) :=
+  ⟨fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun u' hu' => by
+     have hne : u'.name ≠ u.name := by
+       intro heq; apply hfresh; rw [← heq]; exact Signature.mem_allNames_of_unaryRel hu'
+     simp only [Env.updateUnaryRel]
+     split
+     · next h => exact absurd h.2 hne
+     · rfl,
+   fun _ _ => rfl⟩
+
+theorem Env.agreeOn_update_fresh_binaryRel {ρ : Env} {b : FOL.BinaryRel}
+    {f : b.arg1.denote → b.arg2.denote → Prop}
+    {Δ : Signature} (hfresh : b.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.updateBinaryRel b.arg1 b.arg2 b.name f) :=
+  ⟨fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun _ _ => rfl,
+   fun b' hb' => by
+     have hne : b'.name ≠ b.name := by
+       intro heq; apply hfresh; rw [← heq]; exact Signature.mem_allNames_of_binaryRel hb'
+     simp only [Env.updateBinaryRel]
+     split
+     · next h => exact absurd h.2.2 hne
+     · rfl⟩
 
 /-- Double update with the same variable - second update wins. -/
 @[simp] theorem Env.updateConst_updateConst_same {ρ : Env} {τ : Srt} {x : String} {v w : τ.denote} :

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -25,6 +25,14 @@ inductive VerifM : Type → Type 1 where
   | bind : VerifM α → (α → VerifM β) → VerifM β
   /-- Declare a fresh SMT constant. -/
   | decl : Option String → Srt → VerifM FOL.Const
+  /-- Declare a fresh unary relation symbol with the given hint and argument sort. -/
+  | declUnaryRel : String → Srt → VerifM FOL.UnaryRel
+  /-- Declare a fresh binary relation symbol with the given hint and argument sorts. -/
+  | declBinaryRel : String → Srt → Srt → VerifM FOL.BinaryRel
+  /-- Declare a fresh unary function symbol with the given hint, argument and result sorts. -/
+  | declUnary : String → Srt → Srt → VerifM FOL.Unary
+  /-- Declare a fresh binary function symbol with the given hint, argument and result sorts. -/
+  | declBinary : String → Srt → Srt → Srt → VerifM FOL.Binary
   /-- Add a context item to the verifier state (permanent, no check). -/
   | assume : CtxItem → VerifM Unit
   /-- Check whether φ is provable from the current context.
@@ -73,6 +81,26 @@ def VerifM.expectSome (msg : String) (x : Option α) : VerifM α := do
   | some x => pure x
   | none => VerifM.fatal msg
 
+/-- Declare a unary relation with a specific name, failing if a different name was assigned. -/
+def VerifM.declUnaryRelExact (u : FOL.UnaryRel) : VerifM Unit := do
+  let u' ← VerifM.declUnaryRel u.name u.arg
+  VerifM.expectEq "declUnaryRelExact" u'.name u.name
+
+/-- Declare a binary relation with a specific name, failing if a different name was assigned. -/
+def VerifM.declBinaryRelExact (b : FOL.BinaryRel) : VerifM Unit := do
+  let b' ← VerifM.declBinaryRel b.name b.arg1 b.arg2
+  VerifM.expectEq "declBinaryRelExact" b'.name b.name
+
+/-- Declare a unary function with a specific name, failing if a different name was assigned. -/
+def VerifM.declUnaryExact (u : FOL.Unary) : VerifM Unit := do
+  let u' ← VerifM.declUnary u.name u.arg u.ret
+  VerifM.expectEq "declUnaryExact" u'.name u.name
+
+/-- Declare a binary function with a specific name, failing if a different name was assigned. -/
+def VerifM.declBinaryExact (b : FOL.Binary) : VerifM Unit := do
+  let b' ← VerifM.declBinary b.name b.arg1 b.arg2 b.ret
+  VerifM.expectEq "declBinaryExact" b'.name b.name
+
 /-- Assume all formulas in a list via `VerifM.assume`. -/
 def VerifM.assumeAll : List Formula → VerifM Unit
   | [] => pure ()
@@ -111,6 +139,22 @@ def VerifM.translate :
       let c := st.freshConst hint t
       .declareConst c.name t (fun () =>
         k (.ok c) { st with decls := st.decls.addConst c })
+  | .declUnaryRel hint τ, st, k =>
+      let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ⟩
+      .declareUnaryRel u.name u.arg (fun () =>
+        k (.ok u) { st with decls := st.decls.addUnaryRel u })
+  | .declBinaryRel hint τ₁ τ₂, st, k =>
+      let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+      .declareBinaryRel b.name b.arg1 b.arg2 (fun () =>
+        k (.ok b) { st with decls := st.decls.addBinaryRel b })
+  | .declUnary hint τ₁ τ₂, st, k =>
+      let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+      .declareUnary u.name u.arg u.ret (fun () =>
+        k (.ok u) { st with decls := st.decls.addUnary u })
+  | .declBinary hint τ₁ τ₂ τ₃, st, k =>
+      let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂, τ₃⟩
+      .declareBinary b.name b.arg1 b.arg2 b.ret (fun () =>
+        k (.ok b) { st with decls := st.decls.addBinary b })
   | .assume item, st, k =>
       match item with
       | .pure φ =>
@@ -147,6 +191,18 @@ private def VerifM.eval_rec : VerifM α → TransState → VerifM.Env → (α �
   | .decl hint t, st, ρ, P =>
       let c := st.freshConst hint t
       ∀ u, P c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u)
+  | .declUnaryRel hint τ, st, ρ, P =>
+      let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ⟩
+      ∀ f, P u { st with decls := st.decls.addUnaryRel u } (ρ.updateUnaryRel τ u.name f)
+  | .declBinaryRel hint τ₁ τ₂, st, ρ, P =>
+      let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+      ∀ f, P b { st with decls := st.decls.addBinaryRel b } (ρ.updateBinaryRel τ₁ τ₂ b.name f)
+  | .declUnary hint τ₁ τ₂, st, ρ, P =>
+      let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+      ∀ f, P u { st with decls := st.decls.addUnary u } (ρ.updateUnary τ₁ τ₂ u.name f)
+  | .declBinary hint τ₁ τ₂ τ₃, st, ρ, P =>
+      let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂, τ₃⟩
+      ∀ f, P b { st with decls := st.decls.addBinary b } (ρ.updateBinary τ₁ τ₂ τ₃ b.name f)
   | .assume item, st, ρ, P =>
       match item with
       | .pure φ => φ.wfIn st.decls → φ.eval ρ.env → P () { st with asserts := φ :: st.asserts } ρ
@@ -178,6 +234,34 @@ private theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : VerifM.Env) (st : Tr
     exact VerifM.Env.agreeOn_update_fresh
       (c := ⟨Fresh.freshNumbers (hint.getD "_v") st.decls.allNames, t⟩)
       (Fresh.freshNumbers_not_mem (hint.getD "_v") st.decls.allNames)
+  | declUnaryRel hint τ =>
+    simp only [VerifM.eval_rec] at h ⊢
+    intro f
+    refine hPQ _ _ _ (Signature.Subset.subset_addUnaryRel _ _) ?_ (h f)
+    exact VerifM.Env.agreeOn_update_fresh_unaryRel
+      (u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ⟩)
+      (Fresh.freshNumbers_not_mem hint st.decls.allNames)
+  | declBinaryRel hint τ₁ τ₂ =>
+    simp only [VerifM.eval_rec] at h ⊢
+    intro f
+    refine hPQ _ _ _ (Signature.Subset.subset_addBinaryRel _ _) ?_ (h f)
+    exact VerifM.Env.agreeOn_update_fresh_binaryRel
+      (b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩)
+      (Fresh.freshNumbers_not_mem hint st.decls.allNames)
+  | declUnary hint τ₁ τ₂ =>
+    simp only [VerifM.eval_rec] at h ⊢
+    intro f
+    refine hPQ _ _ _ (Signature.Subset.subset_addUnary _ _) ?_ (h f)
+    exact VerifM.Env.agreeOn_update_fresh_unary
+      (u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩)
+      (Fresh.freshNumbers_not_mem hint st.decls.allNames)
+  | declBinary hint τ₁ τ₂ τ₃ =>
+    simp only [VerifM.eval_rec] at h ⊢
+    intro f
+    refine hPQ _ _ _ (Signature.Subset.subset_addBinary _ _) ?_ (h f)
+    exact VerifM.Env.agreeOn_update_fresh_binary
+      (b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂, τ₃⟩)
+      (Fresh.freshNumbers_not_mem hint st.decls.allNames)
   | assume item =>
     cases item with
     | pure φ =>
@@ -239,6 +323,54 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     · intro φ hφ
       exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
     · exact ⟨TransState.freshConst.wf _ hwf, h⟩
+  | declUnaryRel hint τ =>
+    simp only [VerifM.eval_rec] at h
+    simp only [VerifM.eval_rec]
+    intro f
+    specialize h f
+    let w := Fresh.freshNumbers hint st.decls.allNames
+    have hfresh := Fresh.freshNumbers_not_mem hint st.decls.allNames
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnaryRel τ w f) := by
+      exact VerifM.Env.agreeOn_update_fresh_unaryRel (u := ⟨w, τ⟩) hfresh
+    refine ⟨?_, TransState.addUnaryRel.wf st _ hwf hfresh, h⟩
+    intro φ hφ
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
+  | declBinaryRel hint τ₁ τ₂ =>
+    simp only [VerifM.eval_rec] at h
+    simp only [VerifM.eval_rec]
+    intro f
+    specialize h f
+    let w := Fresh.freshNumbers hint st.decls.allNames
+    have hfresh := Fresh.freshNumbers_not_mem hint st.decls.allNames
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinaryRel τ₁ τ₂ w f) := by
+      exact VerifM.Env.agreeOn_update_fresh_binaryRel (b := ⟨w, τ₁, τ₂⟩) hfresh
+    refine ⟨?_, TransState.addBinaryRel.wf st _ hwf hfresh, h⟩
+    intro φ hφ
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
+  | declUnary hint τ₁ τ₂ =>
+    simp only [VerifM.eval_rec] at h
+    simp only [VerifM.eval_rec]
+    intro f
+    specialize h f
+    let w := Fresh.freshNumbers hint st.decls.allNames
+    have hfresh := Fresh.freshNumbers_not_mem hint st.decls.allNames
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnary τ₁ τ₂ w f) := by
+      exact VerifM.Env.agreeOn_update_fresh_unary (u := ⟨w, τ₁, τ₂⟩) hfresh
+    refine ⟨?_, TransState.addUnary.wf st _ hwf hfresh, h⟩
+    intro φ hφ
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
+  | declBinary hint τ₁ τ₂ τ₃ =>
+    simp only [VerifM.eval_rec] at h
+    simp only [VerifM.eval_rec]
+    intro f
+    specialize h f
+    let w := Fresh.freshNumbers hint st.decls.allNames
+    have hfresh := Fresh.freshNumbers_not_mem hint st.decls.allNames
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinary τ₁ τ₂ τ₃ w f) := by
+      exact VerifM.Env.agreeOn_update_fresh_binary (b := ⟨w, τ₁, τ₂, τ₃⟩) hfresh
+    refine ⟨?_, TransState.addBinary.wf st _ hwf hfresh, h⟩
+    intro φ hφ
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
   | assume item =>
     cases item with
     | pure φ =>
@@ -347,6 +479,30 @@ private theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ:
     have h := ScopedM.eval_declareConst h
     simp only [VerifM.eval_rec]
     intro u
+    exact ⟨_, h⟩
+  | declUnaryRel hint τ =>
+    simp only [VerifM.translate] at h
+    have h := ScopedM.eval_declareUnaryRel h
+    simp only [VerifM.eval_rec]
+    intro _
+    exact ⟨_, h⟩
+  | declBinaryRel hint τ₁ τ₂ =>
+    simp only [VerifM.translate] at h
+    have h := ScopedM.eval_declareBinaryRel h
+    simp only [VerifM.eval_rec]
+    intro _
+    exact ⟨_, h⟩
+  | declUnary hint τ₁ τ₂ =>
+    simp only [VerifM.translate] at h
+    have h := ScopedM.eval_declareUnary h
+    simp only [VerifM.eval_rec]
+    intro _
+    exact ⟨_, h⟩
+  | declBinary hint τ₁ τ₂ τ₃ =>
+    simp only [VerifM.translate] at h
+    have h := ScopedM.eval_declareBinary h
+    simp only [VerifM.eval_rec]
+    intro _
     exact ⟨_, h⟩
   | assume item =>
     cases item with
@@ -479,6 +635,38 @@ theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ 
     ∀ u, Q c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u) :=
   fun u => (h.2.2 u).2.2
 
+theorem VerifM.eval_declUnaryRel {hint : String} {τ : Srt} {st : TransState} {ρ : VerifM.Env}
+    {Q : FOL.UnaryRel → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (.declUnaryRel hint τ) st ρ Q) :
+    let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ⟩
+    u.name ∉ st.decls.allNames ∧
+    ∀ f, Q u { st with decls := st.decls.addUnaryRel u } (ρ.updateUnaryRel τ u.name f) :=
+  ⟨Fresh.freshNumbers_not_mem hint st.decls.allNames, fun f => (h.2.2 f).2.2⟩
+
+theorem VerifM.eval_declBinaryRel {hint : String} {τ₁ τ₂ : Srt} {st : TransState} {ρ : VerifM.Env}
+    {Q : FOL.BinaryRel → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (.declBinaryRel hint τ₁ τ₂) st ρ Q) :
+    let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+    b.name ∉ st.decls.allNames ∧
+    ∀ f, Q b { st with decls := st.decls.addBinaryRel b } (ρ.updateBinaryRel τ₁ τ₂ b.name f) :=
+  ⟨Fresh.freshNumbers_not_mem hint st.decls.allNames, fun f => (h.2.2 f).2.2⟩
+
+theorem VerifM.eval_declUnary {hint : String} {τ₁ τ₂ : Srt} {st : TransState} {ρ : VerifM.Env}
+    {Q : FOL.Unary → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (.declUnary hint τ₁ τ₂) st ρ Q) :
+    let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+    u.name ∉ st.decls.allNames ∧
+    ∀ f, Q u { st with decls := st.decls.addUnary u } (ρ.updateUnary τ₁ τ₂ u.name f) :=
+  ⟨Fresh.freshNumbers_not_mem hint st.decls.allNames, fun f => (h.2.2 f).2.2⟩
+
+theorem VerifM.eval_declBinary {hint : String} {τ₁ τ₂ τ₃ : Srt} {st : TransState} {ρ : VerifM.Env}
+    {Q : FOL.Binary → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (.declBinary hint τ₁ τ₂ τ₃) st ρ Q) :
+    let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂, τ₃⟩
+    b.name ∉ st.decls.allNames ∧
+    ∀ f, Q b { st with decls := st.decls.addBinary b } (ρ.updateBinary τ₁ τ₂ τ₃ b.name f) :=
+  ⟨Fresh.freshNumbers_not_mem hint st.decls.allNames, fun f => (h.2.2 f).2.2⟩
+
 theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : VerifM.Env}
     {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.assume (.pure φ)) st ρ Q) :
@@ -556,6 +744,82 @@ theorem VerifM.eval_expectSome
   | some y =>
     simp [hx] at h
     exact ⟨y, rfl, VerifM.eval_ret h⟩
+
+theorem VerifM.eval_declUnaryRelExact {u : FOL.UnaryRel} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (VerifM.declUnaryRelExact u) st ρ Q) :
+    u.name ∉ st.decls.allNames ∧
+    ∀ f, Q () { st with decls := st.decls.addUnaryRel u } (ρ.updateUnaryRel u.arg u.name f) := by
+  simp only [VerifM.declUnaryRelExact] at h
+  obtain ⟨hfresh, hcont⟩ := VerifM.eval_declUnaryRel (VerifM.eval_bind _ _ _ _ h)
+  have hname : Fresh.freshNumbers u.name st.decls.allNames = u.name := by
+    have hcont0 := hcont (fun _ => True)
+    obtain ⟨heq, _⟩ := VerifM.eval_expectEq hcont0
+    simpa using heq
+  refine ⟨hname ▸ hfresh, ?_⟩
+  intro f
+  obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hcont f)
+  have hueq : (⟨Fresh.freshNumbers u.name st.decls.allNames, u.arg⟩ : FOL.UnaryRel) = u := by
+    cases u; simp [hname]
+  rw [hueq] at hq
+  exact hq
+
+theorem VerifM.eval_declBinaryRelExact {b : FOL.BinaryRel} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (VerifM.declBinaryRelExact b) st ρ Q) :
+    b.name ∉ st.decls.allNames ∧
+    ∀ f, Q () { st with decls := st.decls.addBinaryRel b } (ρ.updateBinaryRel b.arg1 b.arg2 b.name f) := by
+  simp only [VerifM.declBinaryRelExact] at h
+  obtain ⟨hfresh, hcont⟩ := VerifM.eval_declBinaryRel (VerifM.eval_bind _ _ _ _ h)
+  have hname : Fresh.freshNumbers b.name st.decls.allNames = b.name := by
+    have hcont0 := hcont (fun _ _ => True)
+    obtain ⟨heq, _⟩ := VerifM.eval_expectEq hcont0
+    simpa using heq
+  refine ⟨hname ▸ hfresh, ?_⟩
+  intro f
+  obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hcont f)
+  have hbeq : (⟨Fresh.freshNumbers b.name st.decls.allNames, b.arg1, b.arg2⟩ : FOL.BinaryRel) = b := by
+    cases b; simp [hname]
+  rw [hbeq] at hq
+  exact hq
+
+theorem VerifM.eval_declUnaryExact {u : FOL.Unary} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (VerifM.declUnaryExact u) st ρ Q) :
+    u.name ∉ st.decls.allNames ∧
+    ∀ f, Q () { st with decls := st.decls.addUnary u } (ρ.updateUnary u.arg u.ret u.name f) := by
+  simp only [VerifM.declUnaryExact] at h
+  obtain ⟨hfresh, hcont⟩ := VerifM.eval_declUnary (VerifM.eval_bind _ _ _ _ h)
+  have hname : Fresh.freshNumbers u.name st.decls.allNames = u.name := by
+    have hcont0 := hcont (fun _ => default)
+    obtain ⟨heq, _⟩ := VerifM.eval_expectEq hcont0
+    simpa using heq
+  refine ⟨hname ▸ hfresh, ?_⟩
+  intro f
+  obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hcont f)
+  have hueq : (⟨Fresh.freshNumbers u.name st.decls.allNames, u.arg, u.ret⟩ : FOL.Unary) = u := by
+    cases u; simp [hname]
+  rw [hueq] at hq
+  exact hq
+
+theorem VerifM.eval_declBinaryExact {b : FOL.Binary} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (VerifM.declBinaryExact b) st ρ Q) :
+    b.name ∉ st.decls.allNames ∧
+    ∀ f, Q () { st with decls := st.decls.addBinary b } (ρ.updateBinary b.arg1 b.arg2 b.ret b.name f) := by
+  simp only [VerifM.declBinaryExact] at h
+  obtain ⟨hfresh, hcont⟩ := VerifM.eval_declBinary (VerifM.eval_bind _ _ _ _ h)
+  have hname : Fresh.freshNumbers b.name st.decls.allNames = b.name := by
+    have hcont0 := hcont (fun _ _ => default)
+    obtain ⟨heq, _⟩ := VerifM.eval_expectEq hcont0
+    simpa using heq
+  refine ⟨hname ▸ hfresh, ?_⟩
+  intro f
+  obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hcont f)
+  have hbeq : (⟨Fresh.freshNumbers b.name st.decls.allNames, b.arg1, b.arg2, b.ret⟩ : FOL.Binary) = b := by
+    cases b; simp [hname]
+  rw [hbeq] at hq
+  exact hq
 
 theorem VerifM.eval_bind_expectEq [DecidableEq α] [Repr α]
     {msg : String} {actual expected : α} {β : Type _} {k : Unit → VerifM β}

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -26,13 +26,13 @@ inductive VerifM : Type → Type 1 where
   /-- Declare a fresh SMT constant. -/
   | decl : Option String → Srt → VerifM FOL.Const
   /-- Declare a fresh unary relation symbol with the given hint and argument sort. -/
-  | declUnaryRel : String → Srt → VerifM FOL.UnaryRel
+  | declUnaryRel : Option String → Srt → VerifM FOL.UnaryRel
   /-- Declare a fresh binary relation symbol with the given hint and argument sorts. -/
-  | declBinaryRel : String → Srt → Srt → VerifM FOL.BinaryRel
+  | declBinaryRel : Option String → Srt → Srt → VerifM FOL.BinaryRel
   /-- Declare a fresh unary function symbol with the given hint, argument and result sorts. -/
-  | declUnary : String → Srt → Srt → VerifM FOL.Unary
+  | declUnary : Option String → Srt → Srt → VerifM FOL.Unary
   /-- Declare a fresh binary function symbol with the given hint, argument and result sorts. -/
-  | declBinary : String → Srt → Srt → Srt → VerifM FOL.Binary
+  | declBinary : Option String → Srt → Srt → Srt → VerifM FOL.Binary
   /-- Add a context item to the verifier state (permanent, no check). -/
   | assume : CtxItem → VerifM Unit
   /-- Check whether φ is provable from the current context.
@@ -83,22 +83,22 @@ def VerifM.expectSome (msg : String) (x : Option α) : VerifM α := do
 
 /-- Declare a unary relation with a specific name, failing if a different name was assigned. -/
 def VerifM.declUnaryRelExact (u : FOL.UnaryRel) : VerifM Unit := do
-  let u' ← VerifM.declUnaryRel u.name u.arg
+  let u' ← VerifM.declUnaryRel (some u.name) u.arg
   VerifM.expectEq "declUnaryRelExact" u'.name u.name
 
 /-- Declare a binary relation with a specific name, failing if a different name was assigned. -/
 def VerifM.declBinaryRelExact (b : FOL.BinaryRel) : VerifM Unit := do
-  let b' ← VerifM.declBinaryRel b.name b.arg1 b.arg2
+  let b' ← VerifM.declBinaryRel (some b.name) b.arg1 b.arg2
   VerifM.expectEq "declBinaryRelExact" b'.name b.name
 
 /-- Declare a unary function with a specific name, failing if a different name was assigned. -/
 def VerifM.declUnaryExact (u : FOL.Unary) : VerifM Unit := do
-  let u' ← VerifM.declUnary u.name u.arg u.ret
+  let u' ← VerifM.declUnary (some u.name) u.arg u.ret
   VerifM.expectEq "declUnaryExact" u'.name u.name
 
 /-- Declare a binary function with a specific name, failing if a different name was assigned. -/
 def VerifM.declBinaryExact (b : FOL.Binary) : VerifM Unit := do
-  let b' ← VerifM.declBinary b.name b.arg1 b.arg2 b.ret
+  let b' ← VerifM.declBinary (some b.name) b.arg1 b.arg2 b.ret
   VerifM.expectEq "declBinaryExact" b'.name b.name
 
 /-- Assume all formulas in a list via `VerifM.assume`. -/
@@ -140,19 +140,19 @@ def VerifM.translate :
       .declareConst c.name t (fun () =>
         k (.ok c) { st with decls := st.decls.addConst c })
   | .declUnaryRel hint τ, st, k =>
-      let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ⟩
+      let u := st.freshUnaryRel hint τ
       .declareUnaryRel u.name u.arg (fun () =>
         k (.ok u) { st with decls := st.decls.addUnaryRel u })
   | .declBinaryRel hint τ₁ τ₂, st, k =>
-      let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+      let b := st.freshBinaryRel hint τ₁ τ₂
       .declareBinaryRel b.name b.arg1 b.arg2 (fun () =>
         k (.ok b) { st with decls := st.decls.addBinaryRel b })
   | .declUnary hint τ₁ τ₂, st, k =>
-      let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+      let u := st.freshUnary hint τ₁ τ₂
       .declareUnary u.name u.arg u.ret (fun () =>
         k (.ok u) { st with decls := st.decls.addUnary u })
   | .declBinary hint τ₁ τ₂ τ₃, st, k =>
-      let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂, τ₃⟩
+      let b := st.freshBinary hint τ₁ τ₂ τ₃
       .declareBinary b.name b.arg1 b.arg2 b.ret (fun () =>
         k (.ok b) { st with decls := st.decls.addBinary b })
   | .assume item, st, k =>
@@ -192,16 +192,16 @@ private def VerifM.eval_rec : VerifM α → TransState → VerifM.Env → (α �
       let c := st.freshConst hint t
       ∀ u, P c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u)
   | .declUnaryRel hint τ, st, ρ, P =>
-      let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ⟩
+      let u := st.freshUnaryRel hint τ
       ∀ f, P u { st with decls := st.decls.addUnaryRel u } (ρ.updateUnaryRel τ u.name f)
   | .declBinaryRel hint τ₁ τ₂, st, ρ, P =>
-      let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+      let b := st.freshBinaryRel hint τ₁ τ₂
       ∀ f, P b { st with decls := st.decls.addBinaryRel b } (ρ.updateBinaryRel τ₁ τ₂ b.name f)
   | .declUnary hint τ₁ τ₂, st, ρ, P =>
-      let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+      let u := st.freshUnary hint τ₁ τ₂
       ∀ f, P u { st with decls := st.decls.addUnary u } (ρ.updateUnary τ₁ τ₂ u.name f)
   | .declBinary hint τ₁ τ₂ τ₃, st, ρ, P =>
-      let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂, τ₃⟩
+      let b := st.freshBinary hint τ₁ τ₂ τ₃
       ∀ f, P b { st with decls := st.decls.addBinary b } (ρ.updateBinary τ₁ τ₂ τ₃ b.name f)
   | .assume item, st, ρ, P =>
       match item with
@@ -239,29 +239,29 @@ private theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : VerifM.Env) (st : Tr
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addUnaryRel _ _) ?_ (h f)
     exact VerifM.Env.agreeOn_update_fresh_unaryRel
-      (u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ⟩)
-      (Fresh.freshNumbers_not_mem hint st.decls.allNames)
+      (u := st.freshUnaryRel hint τ)
+      (st.freshUnaryRel_fresh hint τ)
   | declBinaryRel hint τ₁ τ₂ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addBinaryRel _ _) ?_ (h f)
     exact VerifM.Env.agreeOn_update_fresh_binaryRel
-      (b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩)
-      (Fresh.freshNumbers_not_mem hint st.decls.allNames)
+      (b := st.freshBinaryRel hint τ₁ τ₂)
+      (st.freshBinaryRel_fresh hint τ₁ τ₂)
   | declUnary hint τ₁ τ₂ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addUnary _ _) ?_ (h f)
     exact VerifM.Env.agreeOn_update_fresh_unary
-      (u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩)
-      (Fresh.freshNumbers_not_mem hint st.decls.allNames)
+      (u := st.freshUnary hint τ₁ τ₂)
+      (st.freshUnary_fresh hint τ₁ τ₂)
   | declBinary hint τ₁ τ₂ τ₃ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addBinary _ _) ?_ (h f)
     exact VerifM.Env.agreeOn_update_fresh_binary
-      (b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂, τ₃⟩)
-      (Fresh.freshNumbers_not_mem hint st.decls.allNames)
+      (b := st.freshBinary hint τ₁ τ₂ τ₃)
+      (st.freshBinary_fresh hint τ₁ τ₂ τ₃)
   | assume item =>
     cases item with
     | pure φ =>
@@ -328,10 +328,10 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     simp only [VerifM.eval_rec]
     intro f
     specialize h f
-    let w := Fresh.freshNumbers hint st.decls.allNames
-    have hfresh := Fresh.freshNumbers_not_mem hint st.decls.allNames
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnaryRel τ w f) := by
-      exact VerifM.Env.agreeOn_update_fresh_unaryRel (u := ⟨w, τ⟩) hfresh
+    let u := st.freshUnaryRel hint τ
+    have hfresh := st.freshUnaryRel_fresh hint τ
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnaryRel τ u.name f) := by
+      exact VerifM.Env.agreeOn_update_fresh_unaryRel (u := u) hfresh
     refine ⟨?_, TransState.addUnaryRel.wf st _ hwf hfresh, h⟩
     intro φ hφ
     exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
@@ -340,10 +340,10 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     simp only [VerifM.eval_rec]
     intro f
     specialize h f
-    let w := Fresh.freshNumbers hint st.decls.allNames
-    have hfresh := Fresh.freshNumbers_not_mem hint st.decls.allNames
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinaryRel τ₁ τ₂ w f) := by
-      exact VerifM.Env.agreeOn_update_fresh_binaryRel (b := ⟨w, τ₁, τ₂⟩) hfresh
+    let b := st.freshBinaryRel hint τ₁ τ₂
+    have hfresh := st.freshBinaryRel_fresh hint τ₁ τ₂
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinaryRel τ₁ τ₂ b.name f) := by
+      exact VerifM.Env.agreeOn_update_fresh_binaryRel (b := b) hfresh
     refine ⟨?_, TransState.addBinaryRel.wf st _ hwf hfresh, h⟩
     intro φ hφ
     exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
@@ -352,10 +352,10 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     simp only [VerifM.eval_rec]
     intro f
     specialize h f
-    let w := Fresh.freshNumbers hint st.decls.allNames
-    have hfresh := Fresh.freshNumbers_not_mem hint st.decls.allNames
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnary τ₁ τ₂ w f) := by
-      exact VerifM.Env.agreeOn_update_fresh_unary (u := ⟨w, τ₁, τ₂⟩) hfresh
+    let u := st.freshUnary hint τ₁ τ₂
+    have hfresh := st.freshUnary_fresh hint τ₁ τ₂
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnary τ₁ τ₂ u.name f) := by
+      exact VerifM.Env.agreeOn_update_fresh_unary (u := u) hfresh
     refine ⟨?_, TransState.addUnary.wf st _ hwf hfresh, h⟩
     intro φ hφ
     exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
@@ -364,10 +364,10 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     simp only [VerifM.eval_rec]
     intro f
     specialize h f
-    let w := Fresh.freshNumbers hint st.decls.allNames
-    have hfresh := Fresh.freshNumbers_not_mem hint st.decls.allNames
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinary τ₁ τ₂ τ₃ w f) := by
-      exact VerifM.Env.agreeOn_update_fresh_binary (b := ⟨w, τ₁, τ₂, τ₃⟩) hfresh
+    let b := st.freshBinary hint τ₁ τ₂ τ₃
+    have hfresh := st.freshBinary_fresh hint τ₁ τ₂ τ₃
+    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinary τ₁ τ₂ τ₃ b.name f) := by
+      exact VerifM.Env.agreeOn_update_fresh_binary (b := b) hfresh
     refine ⟨?_, TransState.addBinary.wf st _ hwf hfresh, h⟩
     intro φ hφ
     exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
@@ -635,37 +635,37 @@ theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ 
     ∀ u, Q c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u) :=
   fun u => (h.2.2 u).2.2
 
-theorem VerifM.eval_declUnaryRel {hint : String} {τ : Srt} {st : TransState} {ρ : VerifM.Env}
+theorem VerifM.eval_declUnaryRel {hint : Option String} {τ : Srt} {st : TransState} {ρ : VerifM.Env}
     {Q : FOL.UnaryRel → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.declUnaryRel hint τ) st ρ Q) :
-    let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ⟩
+    let u := st.freshUnaryRel hint τ
     u.name ∉ st.decls.allNames ∧
     ∀ f, Q u { st with decls := st.decls.addUnaryRel u } (ρ.updateUnaryRel τ u.name f) :=
-  ⟨Fresh.freshNumbers_not_mem hint st.decls.allNames, fun f => (h.2.2 f).2.2⟩
+  ⟨st.freshUnaryRel_fresh hint τ, fun f => (h.2.2 f).2.2⟩
 
-theorem VerifM.eval_declBinaryRel {hint : String} {τ₁ τ₂ : Srt} {st : TransState} {ρ : VerifM.Env}
-    {Q : FOL.BinaryRel → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declBinaryRel {hint : Option String} {τ₁ τ₂ : Srt} {st : TransState}
+    {ρ : VerifM.Env} {Q : FOL.BinaryRel → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.declBinaryRel hint τ₁ τ₂) st ρ Q) :
-    let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+    let b := st.freshBinaryRel hint τ₁ τ₂
     b.name ∉ st.decls.allNames ∧
     ∀ f, Q b { st with decls := st.decls.addBinaryRel b } (ρ.updateBinaryRel τ₁ τ₂ b.name f) :=
-  ⟨Fresh.freshNumbers_not_mem hint st.decls.allNames, fun f => (h.2.2 f).2.2⟩
+  ⟨st.freshBinaryRel_fresh hint τ₁ τ₂, fun f => (h.2.2 f).2.2⟩
 
-theorem VerifM.eval_declUnary {hint : String} {τ₁ τ₂ : Srt} {st : TransState} {ρ : VerifM.Env}
-    {Q : FOL.Unary → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declUnary {hint : Option String} {τ₁ τ₂ : Srt} {st : TransState}
+    {ρ : VerifM.Env} {Q : FOL.Unary → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.declUnary hint τ₁ τ₂) st ρ Q) :
-    let u := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂⟩
+    let u := st.freshUnary hint τ₁ τ₂
     u.name ∉ st.decls.allNames ∧
     ∀ f, Q u { st with decls := st.decls.addUnary u } (ρ.updateUnary τ₁ τ₂ u.name f) :=
-  ⟨Fresh.freshNumbers_not_mem hint st.decls.allNames, fun f => (h.2.2 f).2.2⟩
+  ⟨st.freshUnary_fresh hint τ₁ τ₂, fun f => (h.2.2 f).2.2⟩
 
-theorem VerifM.eval_declBinary {hint : String} {τ₁ τ₂ τ₃ : Srt} {st : TransState} {ρ : VerifM.Env}
-    {Q : FOL.Binary → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declBinary {hint : Option String} {τ₁ τ₂ τ₃ : Srt} {st : TransState}
+    {ρ : VerifM.Env} {Q : FOL.Binary → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (.declBinary hint τ₁ τ₂ τ₃) st ρ Q) :
-    let b := ⟨Fresh.freshNumbers hint st.decls.allNames, τ₁, τ₂, τ₃⟩
+    let b := st.freshBinary hint τ₁ τ₂ τ₃
     b.name ∉ st.decls.allNames ∧
     ∀ f, Q b { st with decls := st.decls.addBinary b } (ρ.updateBinary τ₁ τ₂ τ₃ b.name f) :=
-  ⟨Fresh.freshNumbers_not_mem hint st.decls.allNames, fun f => (h.2.2 f).2.2⟩
+  ⟨st.freshBinary_fresh hint τ₁ τ₂ τ₃, fun f => (h.2.2 f).2.2⟩
 
 theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : VerifM.Env}
     {Q : Unit → TransState → VerifM.Env → Prop}
@@ -759,8 +759,8 @@ theorem VerifM.eval_declUnaryRelExact {u : FOL.UnaryRel} {st : TransState} {ρ :
   refine ⟨hname ▸ hfresh, ?_⟩
   intro f
   obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hcont f)
-  have hueq : (⟨Fresh.freshNumbers u.name st.decls.allNames, u.arg⟩ : FOL.UnaryRel) = u := by
-    cases u; simp [hname]
+  have hueq : st.freshUnaryRel (some u.name) u.arg = u := by
+    cases u; simp [TransState.freshUnaryRel, hname]
   rw [hueq] at hq
   exact hq
 
@@ -778,8 +778,8 @@ theorem VerifM.eval_declBinaryRelExact {b : FOL.BinaryRel} {st : TransState} {ρ
   refine ⟨hname ▸ hfresh, ?_⟩
   intro f
   obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hcont f)
-  have hbeq : (⟨Fresh.freshNumbers b.name st.decls.allNames, b.arg1, b.arg2⟩ : FOL.BinaryRel) = b := by
-    cases b; simp [hname]
+  have hbeq : st.freshBinaryRel (some b.name) b.arg1 b.arg2 = b := by
+    cases b; simp [TransState.freshBinaryRel, hname]
   rw [hbeq] at hq
   exact hq
 
@@ -797,8 +797,8 @@ theorem VerifM.eval_declUnaryExact {u : FOL.Unary} {st : TransState} {ρ : Verif
   refine ⟨hname ▸ hfresh, ?_⟩
   intro f
   obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hcont f)
-  have hueq : (⟨Fresh.freshNumbers u.name st.decls.allNames, u.arg, u.ret⟩ : FOL.Unary) = u := by
-    cases u; simp [hname]
+  have hueq : st.freshUnary (some u.name) u.arg u.ret = u := by
+    cases u; simp [TransState.freshUnary, hname]
   rw [hueq] at hq
   exact hq
 
@@ -816,8 +816,8 @@ theorem VerifM.eval_declBinaryExact {b : FOL.Binary} {st : TransState} {ρ : Ver
   refine ⟨hname ▸ hfresh, ?_⟩
   intro f
   obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hcont f)
-  have hbeq : (⟨Fresh.freshNumbers b.name st.decls.allNames, b.arg1, b.arg2, b.ret⟩ : FOL.Binary) = b := by
-    cases b; simp [hname]
+  have hbeq : st.freshBinary (some b.name) b.arg1 b.arg2 b.ret = b := by
+    cases b; simp [TransState.freshBinary, hname]
   rw [hbeq] at hq
   exact hq
 

--- a/Mica/Verifier/Scoped.lean
+++ b/Mica/Verifier/Scoped.lean
@@ -14,6 +14,8 @@ inductive ScopedM : Type → Type 1 where
   | declareConst : String → Srt → (Unit → ScopedM α) → ScopedM α
   | declareUnary : String → Srt → Srt → (Unit → ScopedM α) → ScopedM α
   | declareBinary : String → Srt → Srt → Srt → (Unit → ScopedM α) → ScopedM α
+  | declareUnaryRel : String → Srt → (Unit → ScopedM α) → ScopedM α
+  | declareBinaryRel : String → Srt → Srt → (Unit → ScopedM α) → ScopedM α
   | assert : Formula → (Unit → ScopedM α) → ScopedM α
   | checkSat : (Result → ScopedM α) → ScopedM α
   | bracket : ScopedM β → (β → ScopedM α) → ScopedM α
@@ -25,6 +27,8 @@ def ScopedM.translate : ScopedM α → Strategy α
   | .declareConst n s k => .exec (.declareConst n s) (fun r => translate (k r))
   | .declareUnary n a r k => .exec (.declareUnary n a r) (fun resp => translate (k resp))
   | .declareBinary n a1 a2 r k => .exec (.declareBinary n a1 a2 r) (fun resp => translate (k resp))
+  | .declareUnaryRel n a k => .exec (.declareUnaryRel n a) (fun resp => translate (k resp))
+  | .declareBinaryRel n a1 a2 k => .exec (.declareBinaryRel n a1 a2) (fun resp => translate (k resp))
   | .assert e k => .exec (.assert e) (fun r => translate (k r))
   | .checkSat k => .exec .checkSat (fun r => translate (k r))
   | .bracket body k =>
@@ -53,6 +57,12 @@ def addUnary (ctx : FlatCtx) (n : String) (arg ret : Srt) : FlatCtx :=
 
 def addBinary (ctx : FlatCtx) (n : String) (arg1 arg2 ret : Srt) : FlatCtx :=
   ⟨ctx.decls.addBinary ⟨n, arg1, arg2, ret⟩, ctx.asserts⟩
+
+def addUnaryRel (ctx : FlatCtx) (n : String) (arg : Srt) : FlatCtx :=
+  ⟨ctx.decls.addUnaryRel ⟨n, arg⟩, ctx.asserts⟩
+
+def addBinaryRel (ctx : FlatCtx) (n : String) (arg1 arg2 : Srt) : FlatCtx :=
+  ⟨ctx.decls.addBinaryRel ⟨n, arg1, arg2⟩, ctx.asserts⟩
 
 def addAssert (ctx : FlatCtx) (φ : Formula) : FlatCtx :=
   ⟨ctx.decls, φ :: ctx.asserts⟩
@@ -99,6 +109,30 @@ theorem flatten_addBinary (s : State) (b : FOL.Binary) :
     | mk decls asserts =>
       cases decls
       simp [Signature.addBinary, List.flatMap, List.cons_append]
+
+theorem flatten_addUnaryRel (s : State) (u : FOL.UnaryRel) :
+    (s.addUnaryRel u).flatten = s.flatten.addUnaryRel u.name u.arg := by
+  simp only [State.flatten, State.allDecls, State.allAsserts,
+             State.modifyDecls, State.addUnaryRel, FlatCtx.addUnaryRel]
+  cases s.frames with
+  | nil => simp [Signature.addUnaryRel]
+  | cons hd tl =>
+    cases hd with
+    | mk decls asserts =>
+      cases decls
+      simp [Signature.addUnaryRel, List.flatMap, List.cons_append]
+
+theorem flatten_addBinaryRel (s : State) (b : FOL.BinaryRel) :
+    (s.addBinaryRel b).flatten = s.flatten.addBinaryRel b.name b.arg1 b.arg2 := by
+  simp only [State.flatten, State.allDecls, State.allAsserts,
+             State.modifyDecls, State.addBinaryRel, FlatCtx.addBinaryRel]
+  cases s.frames with
+  | nil => simp [Signature.addBinaryRel]
+  | cons hd tl =>
+    cases hd with
+    | mk decls asserts =>
+      cases decls
+      simp [Signature.addBinaryRel, List.flatMap, List.cons_append]
 
 theorem flatten_addAssert (s : State) (φ : Formula) :
     (s.addAssert φ).flatten = s.flatten.addAssert φ := by
@@ -149,6 +183,22 @@ theorem ScopedM.translate_preservesFrames {m : ScopedM α} {f : Frame} {fs : Lis
       (f := ⟨f.decls.addBinary ⟨n, a1, a2, r⟩, f.asserts⟩) (fs := fs)
     refine ⟨f', (Frame.Extends.addBinary f ⟨n, a1, a2, r⟩).trans hext, ?_⟩
     simp [Trace.finalState, State.step, State.addBinary]; exact hfin
+  | declareUnaryRel n a k ih =>
+    cases hgen; rename_i rest resp hrest
+    cases resp
+    dsimp only at hrest
+    have ⟨f', hext, hfin⟩ := ih () hrest
+      (f := ⟨f.decls.addUnaryRel ⟨n, a⟩, f.asserts⟩) (fs := fs)
+    refine ⟨f', (Frame.Extends.addUnaryRel f ⟨n, a⟩).trans hext, ?_⟩
+    simp [Trace.finalState, State.step, State.addUnaryRel]; exact hfin
+  | declareBinaryRel n a1 a2 k ih =>
+    cases hgen; rename_i rest resp hrest
+    cases resp
+    dsimp only at hrest
+    have ⟨f', hext, hfin⟩ := ih () hrest
+      (f := ⟨f.decls.addBinaryRel ⟨n, a1, a2⟩, f.asserts⟩) (fs := fs)
+    refine ⟨f', (Frame.Extends.addBinaryRel f ⟨n, a1, a2⟩).trans hext, ?_⟩
+    simp [Trace.finalState, State.step, State.addBinaryRel]; exact hfin
   | assert e k ih =>
     cases hgen; rename_i rest resp hrest
     cases resp
@@ -248,6 +298,30 @@ theorem ScopedM.eval_declareBinary {n : String} {arg1 arg2 ret : Srt}
   refine ⟨st.addBinary ⟨n, arg1, arg2, ret⟩, st', ?_, hflat', rest, hrest, hsound, hst', hret⟩
   simp only [State.flatten_addBinary, hflat]
 
+theorem ScopedM.eval_declareUnaryRel {n : String} {arg : Srt}
+    {k : Unit → ScopedM α} {ctx : FlatCtx} {r : α} {ctx' : FlatCtx} :
+    ScopedM.eval (.declareUnaryRel n arg k) ctx r ctx' →
+      ScopedM.eval (k ()) (ctx.addUnaryRel n arg) r ctx' := by
+  simp only [ScopedM.eval, translate, Strategy.eval]
+  rintro ⟨st, st', hflat, hflat', t, hgen, hsound, hst', hret⟩
+  cases hgen; rename_i rest resp hrest
+  cases resp
+  simp only [Trace.finalState, State.step, Trace.result] at hsound hst' hret
+  refine ⟨st.addUnaryRel ⟨n, arg⟩, st', ?_, hflat', rest, hrest, hsound, hst', hret⟩
+  simp only [State.flatten_addUnaryRel, hflat]
+
+theorem ScopedM.eval_declareBinaryRel {n : String} {arg1 arg2 : Srt}
+    {k : Unit → ScopedM α} {ctx : FlatCtx} {r : α} {ctx' : FlatCtx} :
+    ScopedM.eval (.declareBinaryRel n arg1 arg2 k) ctx r ctx' →
+      ScopedM.eval (k ()) (ctx.addBinaryRel n arg1 arg2) r ctx' := by
+  simp only [ScopedM.eval, translate, Strategy.eval]
+  rintro ⟨st, st', hflat, hflat', t, hgen, hsound, hst', hret⟩
+  cases hgen; rename_i rest resp hrest
+  cases resp
+  simp only [Trace.finalState, State.step, Trace.result] at hsound hst' hret
+  refine ⟨st.addBinaryRel ⟨n, arg1, arg2⟩, st', ?_, hflat', rest, hrest, hsound, hst', hret⟩
+  simp only [State.flatten_addBinaryRel, hflat]
+
 theorem ScopedM.eval_assert {e : Formula}
     {k : Unit → ScopedM α} {ctx : FlatCtx} {ret : α} {ctx' : FlatCtx} :
     ScopedM.eval (.assert e k) ctx ret ctx' →
@@ -329,6 +403,8 @@ def ScopedM.bind : ScopedM α → (α → ScopedM β) → ScopedM β
   | .declareConst n s cont, k => .declareConst n s (fun r => (cont r).bind k)
   | .declareUnary n a r cont, k => .declareUnary n a r (fun resp => (cont resp).bind k)
   | .declareBinary n a1 a2 r cont, k => .declareBinary n a1 a2 r (fun resp => (cont resp).bind k)
+  | .declareUnaryRel n a cont, k => .declareUnaryRel n a (fun resp => (cont resp).bind k)
+  | .declareBinaryRel n a1 a2 cont, k => .declareBinaryRel n a1 a2 (fun resp => (cont resp).bind k)
   | .assert e cont, k => .assert e (fun r => (cont r).bind k)
   | .checkSat cont, k => .checkSat (fun r => (cont r).bind k)
   | .bracket body cont, k => .bracket body (fun x => (cont x).bind k)
@@ -342,6 +418,10 @@ theorem ScopedM.translate_bind (m : ScopedM α) (k : α → ScopedM β) :
   | declareUnary n a r cont ih =>
     simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext resp; exact ih resp k
   | declareBinary n a1 a2 r cont ih =>
+    simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext resp; exact ih resp k
+  | declareUnaryRel n a cont ih =>
+    simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext resp; exact ih resp k
+  | declareBinaryRel n a1 a2 cont ih =>
     simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext resp; exact ih resp k
   | assert e cont ih =>
     simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext r; exact ih r k
@@ -404,6 +484,16 @@ theorem ScopedM.eval_extends {α} s Δ (r : α) Δ' :
     have h' := ScopedM.eval_declareBinary h
     have ⟨hdecls, hasserts⟩ := ih () (Δ.addBinary n arg1 arg2 ret) r Δ' h'
     exact ⟨(Signature.Subset.subset_addBinary _ _).trans hdecls, hasserts⟩
+  | declareUnaryRel n arg k ih =>
+    intro h
+    have h' := ScopedM.eval_declareUnaryRel h
+    have ⟨hdecls, hasserts⟩ := ih () (Δ.addUnaryRel n arg) r Δ' h'
+    exact ⟨(Signature.Subset.subset_addUnaryRel _ _).trans hdecls, hasserts⟩
+  | declareBinaryRel n arg1 arg2 k ih =>
+    intro h
+    have h' := ScopedM.eval_declareBinaryRel h
+    have ⟨hdecls, hasserts⟩ := ih () (Δ.addBinaryRel n arg1 arg2) r Δ' h'
+    exact ⟨(Signature.Subset.subset_addBinaryRel _ _).trans hdecls, hasserts⟩
   | assert φ k ih =>
     intro h
     have h := ScopedM.eval_assert h

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -39,6 +39,34 @@ def Env.updateConst (ρ : Env) (t : Srt) (x : String) (u : t.denote) : Env :=
 @[simp] theorem Env.updateConst_env (ρ : Env) (t : Srt) (x : String) (u : t.denote) :
     (ρ.updateConst t x u).env = ρ.env.updateConst t x u := rfl
 
+def Env.updateUnary (ρ : Env) (τ₁ τ₂ : Srt) (x : String) (f : τ₁.denote → τ₂.denote) : Env :=
+  { ρ with env := _root_.Env.updateUnary ρ.env τ₁ τ₂ x f }
+
+@[simp] theorem Env.updateUnary_env (ρ : Env) (τ₁ τ₂ : Srt) (x : String) (f : τ₁.denote → τ₂.denote) :
+    (ρ.updateUnary τ₁ τ₂ x f).env = ρ.env.updateUnary τ₁ τ₂ x f := rfl
+
+def Env.updateBinary (ρ : Env) (τ₁ τ₂ τ₃ : Srt) (x : String)
+    (f : τ₁.denote → τ₂.denote → τ₃.denote) : Env :=
+  { ρ with env := _root_.Env.updateBinary ρ.env τ₁ τ₂ τ₃ x f }
+
+@[simp] theorem Env.updateBinary_env (ρ : Env) (τ₁ τ₂ τ₃ : Srt) (x : String)
+    (f : τ₁.denote → τ₂.denote → τ₃.denote) :
+    (ρ.updateBinary τ₁ τ₂ τ₃ x f).env = ρ.env.updateBinary τ₁ τ₂ τ₃ x f := rfl
+
+def Env.updateUnaryRel (ρ : Env) (τ : Srt) (x : String) (f : τ.denote → Prop) : Env :=
+  { ρ with env := _root_.Env.updateUnaryRel ρ.env τ x f }
+
+@[simp] theorem Env.updateUnaryRel_env (ρ : Env) (τ : Srt) (x : String) (f : τ.denote → Prop) :
+    (ρ.updateUnaryRel τ x f).env = ρ.env.updateUnaryRel τ x f := rfl
+
+def Env.updateBinaryRel (ρ : Env) (τ₁ τ₂ : Srt) (x : String)
+    (f : τ₁.denote → τ₂.denote → Prop) : Env :=
+  { ρ with env := _root_.Env.updateBinaryRel ρ.env τ₁ τ₂ x f }
+
+@[simp] theorem Env.updateBinaryRel_env (ρ : Env) (τ₁ τ₂ : Srt) (x : String)
+    (f : τ₁.denote → τ₂.denote → Prop) :
+    (ρ.updateBinaryRel τ₁ τ₂ x f).env = ρ.env.updateBinaryRel τ₁ τ₂ x f := rfl
+
 def Env.withEnv (ρ : Env) (env' : _root_.Env) : Env :=
   { ρ with env := env' }
 
@@ -76,6 +104,34 @@ theorem Env.agreeOn_update_fresh {ρ : Env} {c : FOL.Const} {u : c.sort.denote}
     Env.agreeOn Δ ρ (ρ.updateConst c.sort c.name u) := by
   simpa [Env.agreeOn, Env.updateConst] using
     (Env.agreeOn_update_fresh_const (ρ := ρ.env) (c := c) (u := u) (Δ := Δ) hfresh)
+
+theorem Env.agreeOn_update_fresh_unary {ρ : Env} {u : FOL.Unary}
+    {f : u.arg.denote → u.ret.denote}
+    {Δ : Signature} (hfresh : u.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.updateUnary u.arg u.ret u.name f) := by
+  simpa [Env.agreeOn, Env.updateUnary] using
+    (_root_.Env.agreeOn_update_fresh_unary (ρ := ρ.env) (u := u) (f := f) (Δ := Δ) hfresh)
+
+theorem Env.agreeOn_update_fresh_binary {ρ : Env} {b : FOL.Binary}
+    {f : b.arg1.denote → b.arg2.denote → b.ret.denote}
+    {Δ : Signature} (hfresh : b.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.updateBinary b.arg1 b.arg2 b.ret b.name f) := by
+  simpa [Env.agreeOn, Env.updateBinary] using
+    (_root_.Env.agreeOn_update_fresh_binary (ρ := ρ.env) (b := b) (f := f) (Δ := Δ) hfresh)
+
+theorem Env.agreeOn_update_fresh_unaryRel {ρ : Env} {u : FOL.UnaryRel}
+    {f : u.arg.denote → Prop}
+    {Δ : Signature} (hfresh : u.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.updateUnaryRel u.arg u.name f) := by
+  simpa [Env.agreeOn, Env.updateUnaryRel] using
+    (_root_.Env.agreeOn_update_fresh_unaryRel (ρ := ρ.env) (u := u) (f := f) (Δ := Δ) hfresh)
+
+theorem Env.agreeOn_update_fresh_binaryRel {ρ : Env} {b : FOL.BinaryRel}
+    {f : b.arg1.denote → b.arg2.denote → Prop}
+    {Δ : Signature} (hfresh : b.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.updateBinaryRel b.arg1 b.arg2 b.name f) := by
+  simpa [Env.agreeOn, Env.updateBinaryRel] using
+    (_root_.Env.agreeOn_update_fresh_binaryRel (ρ := ρ.env) (b := b) (f := f) (Δ := Δ) hfresh)
 
 end VerifM
 
@@ -126,6 +182,26 @@ def TransState.toFlatCtx (st : TransState) : FlatCtx :=
     { st with decls := st.decls.addConst c }.toFlatCtx = st.toFlatCtx.addConst c.name c.sort := by
   simp [toFlatCtx, FlatCtx.addConst]
 
+@[simp] theorem TransState.toFlatCtx_addUnary (st : TransState) (u : FOL.Unary) :
+    { st with decls := st.decls.addUnary u }.toFlatCtx =
+      st.toFlatCtx.addUnary u.name u.arg u.ret := by
+  simp [toFlatCtx, FlatCtx.addUnary]
+
+@[simp] theorem TransState.toFlatCtx_addBinary (st : TransState) (b : FOL.Binary) :
+    { st with decls := st.decls.addBinary b }.toFlatCtx =
+      st.toFlatCtx.addBinary b.name b.arg1 b.arg2 b.ret := by
+  simp [toFlatCtx, FlatCtx.addBinary]
+
+@[simp] theorem TransState.toFlatCtx_addUnaryRel (st : TransState) (u : FOL.UnaryRel) :
+    { st with decls := st.decls.addUnaryRel u }.toFlatCtx =
+      st.toFlatCtx.addUnaryRel u.name u.arg := by
+  simp [toFlatCtx, FlatCtx.addUnaryRel]
+
+@[simp] theorem TransState.toFlatCtx_addBinaryRel (st : TransState) (b : FOL.BinaryRel) :
+    { st with decls := st.decls.addBinaryRel b }.toFlatCtx =
+      st.toFlatCtx.addBinaryRel b.name b.arg1 b.arg2 := by
+  simp [toFlatCtx, FlatCtx.addBinaryRel]
+
 @[simp] theorem TransState.toFlatCtx_addAssert (st : TransState) (φ : Formula) :
     { st with asserts := φ :: st.asserts }.toFlatCtx = st.toFlatCtx.addAssert φ := by
   simp [toFlatCtx, FlatCtx.addAssert]
@@ -166,6 +242,50 @@ theorem TransState.freshConst.wf {hint t} (st : TransState) :
   · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addConst _ _) hwf'
   · exact Signature.nodup_allNames_addConst hwf.namesDisjoint hfresh
   · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addConst _ _) hwf'
+
+theorem TransState.addUnary.wf (st : TransState) (u : FOL.Unary) :
+    TransState.wf st →
+    u.name ∉ st.decls.allNames →
+    TransState.wf { st with decls := st.decls.addUnary u } := by
+  intro hwf hfresh
+  have hwf' := Signature.wf_addUnary hwf.namesDisjoint hfresh
+  constructor
+  · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addUnary _ _) hwf'
+  · exact hwf'
+  · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addUnary _ _) hwf'
+
+theorem TransState.addBinary.wf (st : TransState) (b : FOL.Binary) :
+    TransState.wf st →
+    b.name ∉ st.decls.allNames →
+    TransState.wf { st with decls := st.decls.addBinary b } := by
+  intro hwf hfresh
+  have hwf' := Signature.wf_addBinary hwf.namesDisjoint hfresh
+  constructor
+  · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addBinary _ _) hwf'
+  · exact hwf'
+  · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addBinary _ _) hwf'
+
+theorem TransState.addUnaryRel.wf (st : TransState) (u : FOL.UnaryRel) :
+    TransState.wf st →
+    u.name ∉ st.decls.allNames →
+    TransState.wf { st with decls := st.decls.addUnaryRel u } := by
+  intro hwf hfresh
+  have hwf' := Signature.wf_addUnaryRel hwf.namesDisjoint hfresh
+  constructor
+  · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addUnaryRel _ _) hwf'
+  · exact hwf'
+  · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addUnaryRel _ _) hwf'
+
+theorem TransState.addBinaryRel.wf (st : TransState) (b : FOL.BinaryRel) :
+    TransState.wf st →
+    b.name ∉ st.decls.allNames →
+    TransState.wf { st with decls := st.decls.addBinaryRel b } := by
+  intro hwf hfresh
+  have hwf' := Signature.wf_addBinaryRel hwf.namesDisjoint hfresh
+  constructor
+  · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addBinaryRel _ _) hwf'
+  · exact hwf'
+  · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addBinaryRel _ _) hwf'
 
 /-- The name produced by `freshConst` is not in the existing decls. -/
 theorem TransState.freshConst_fresh (st : TransState) (hint : Option String) (τ : Srt) :

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -226,6 +226,20 @@ def TransState.freshConst (hint : Option String) (t : Srt) (st : TransState) : F
   let x' := Fresh.freshNumbers base st.decls.allNames
   ⟨x', t⟩
 
+def TransState.freshUnaryRel (st : TransState) (hint : Option String) (τ : Srt) : FOL.UnaryRel :=
+  ⟨Fresh.freshNumbers (hint.getD "_p") st.decls.allNames, τ⟩
+
+def TransState.freshBinaryRel (st : TransState) (hint : Option String) (τ₁ τ₂ : Srt) :
+    FOL.BinaryRel :=
+  ⟨Fresh.freshNumbers (hint.getD "_r") st.decls.allNames, τ₁, τ₂⟩
+
+def TransState.freshUnary (st : TransState) (hint : Option String) (τ₁ τ₂ : Srt) : FOL.Unary :=
+  ⟨Fresh.freshNumbers (hint.getD "_f") st.decls.allNames, τ₁, τ₂⟩
+
+def TransState.freshBinary (st : TransState) (hint : Option String) (τ₁ τ₂ τ₃ : Srt) :
+    FOL.Binary :=
+  ⟨Fresh.freshNumbers (hint.getD "_g") st.decls.allNames, τ₁, τ₂, τ₃⟩
+
 def TransState.addItem (st : TransState) (item : CtxItem) :=
   match item with
   | .pure φ => { st with asserts := φ :: st.asserts }
@@ -291,6 +305,22 @@ theorem TransState.addBinaryRel.wf (st : TransState) (b : FOL.BinaryRel) :
 theorem TransState.freshConst_fresh (st : TransState) (hint : Option String) (τ : Srt) :
     (st.freshConst hint τ).name ∉ st.decls.allNames :=
   Fresh.freshNumbers_not_mem (hint.getD "_v") st.decls.allNames
+
+theorem TransState.freshUnaryRel_fresh (st : TransState) (hint : Option String) (τ : Srt) :
+    (st.freshUnaryRel hint τ).name ∉ st.decls.allNames :=
+  Fresh.freshNumbers_not_mem (hint.getD "_p") st.decls.allNames
+
+theorem TransState.freshBinaryRel_fresh (st : TransState) (hint : Option String) (τ₁ τ₂ : Srt) :
+    (st.freshBinaryRel hint τ₁ τ₂).name ∉ st.decls.allNames :=
+  Fresh.freshNumbers_not_mem (hint.getD "_r") st.decls.allNames
+
+theorem TransState.freshUnary_fresh (st : TransState) (hint : Option String) (τ₁ τ₂ : Srt) :
+    (st.freshUnary hint τ₁ τ₂).name ∉ st.decls.allNames :=
+  Fresh.freshNumbers_not_mem (hint.getD "_f") st.decls.allNames
+
+theorem TransState.freshBinary_fresh (st : TransState) (hint : Option String) (τ₁ τ₂ τ₃ : Srt) :
+    (st.freshBinary hint τ₁ τ₂ τ₃).name ∉ st.decls.allNames :=
+  Fresh.freshNumbers_not_mem (hint.getD "_g") st.decls.allNames
 
 theorem TransState.addAssert.wf (st : TransState) :
     TransState.wf st →


### PR DESCRIPTION
This PR adds verifier support for declaring uninterpreted first-order logic predicates (unary and binary). 

It also adds a few small helper lemmas.