### PR TITLE
Foundations for spec-level functions

### DIFF
--- a/Mica/FOL/Terms.lean
+++ b/Mica/FOL/Terms.lean
@@ -390,14 +390,6 @@ theorem Term.eval_env_agree {t : Term τ} {ρ ρ' : Env} {Δ : Signature} :
     simp [Term.eval]
     rw [ihc hwf.1, iht hwf.2.1, ihe hwf.2.2]
 
-/-- A variable's value depends only on the environment components named by a
-signature it belongs to. -/
-theorem Term.eval_var_agreeOn {τ : Srt} {x : String} {Δ : Signature} {ρ ρ' : Env}
-    (hmem : (⟨x, τ⟩ : Var) ∈ Δ.vars) (hag : Env.agreeOn Δ ρ ρ') :
-    Term.eval ρ (.var τ x) = Term.eval ρ' (.var τ x) := by
-  simp [Term.eval, Env.lookupConst]
-  exact hag.1 ⟨x, τ⟩ hmem
-
 /-- Agreement on the environment components used by term evaluation. Relation
 interpretations are intentionally ignored. -/
 def Env.termAgree (Δ : Signature) (ρ₁ ρ₂ : Env) : Prop :=

--- a/Mica/FOL/Terms.lean
+++ b/Mica/FOL/Terms.lean
@@ -390,6 +390,92 @@ theorem Term.eval_env_agree {t : Term τ} {ρ ρ' : Env} {Δ : Signature} :
     simp [Term.eval]
     rw [ihc hwf.1, iht hwf.2.1, ihe hwf.2.2]
 
+/-- A variable's value depends only on the environment components named by a
+signature it belongs to. -/
+theorem Term.eval_var_agreeOn {τ : Srt} {x : String} {Δ : Signature} {ρ ρ' : Env}
+    (hmem : (⟨x, τ⟩ : Var) ∈ Δ.vars) (hag : Env.agreeOn Δ ρ ρ') :
+    Term.eval ρ (.var τ x) = Term.eval ρ' (.var τ x) := by
+  simp [Term.eval, Env.lookupConst]
+  exact hag.1 ⟨x, τ⟩ hmem
+
+/-- Agreement on the environment components used by term evaluation. Relation
+interpretations are intentionally ignored. -/
+def Env.termAgree (Δ : Signature) (ρ₁ ρ₂ : Env) : Prop :=
+  (∀ v ∈ Δ.vars, ρ₁.consts v.sort v.name = ρ₂.consts v.sort v.name) ∧
+  (∀ c ∈ Δ.consts, ρ₁.consts c.sort c.name = ρ₂.consts c.sort c.name) ∧
+  (∀ u ∈ Δ.unary, ρ₁.unary u.arg u.ret u.name = ρ₂.unary u.arg u.ret u.name) ∧
+  (∀ b ∈ Δ.binary, ρ₁.binary b.arg1 b.arg2 b.ret b.name =
+    ρ₂.binary b.arg1 b.arg2 b.ret b.name)
+
+theorem Env.termAgree_of_agreeOn {Δ : Signature} {ρ₁ ρ₂ : Env}
+    (h : Env.agreeOn Δ ρ₁ ρ₂) : Env.termAgree Δ ρ₁ ρ₂ :=
+  ⟨h.1, h.2.1, h.2.2.1, h.2.2.2.1⟩
+
+theorem Env.termAgree_declVar {Δ : Signature} {ρ₁ ρ₂ : Env}
+    {x : String} {τ : Srt} {v : τ.denote}
+    (h : Env.termAgree Δ ρ₁ ρ₂) :
+    Env.termAgree (Δ.declVar ⟨x, τ⟩)
+      (ρ₁.updateConst τ x v) (ρ₂.updateConst τ x v) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · intro w hw
+    have hw' : w ∈ ⟨x, τ⟩ :: (Δ.remove x).vars := by
+      simpa [Signature.declVar, Signature.addVar] using hw
+    cases hw' with
+    | head => simp [Env.updateConst]
+    | tail _ htail =>
+      by_cases hn : w.name = x <;> by_cases ht : w.sort = τ
+      · cases w; simp only at hn ht; subst hn ht; simp [Env.updateConst]
+      · simp [Env.updateConst, ht, h.1 w (Signature.remove_subset Δ x |>.vars w htail)]
+      · simp [Env.updateConst, hn, h.1 w (Signature.remove_subset Δ x |>.vars w htail)]
+      · simp [Env.updateConst, hn, h.1 w (Signature.remove_subset Δ x |>.vars w htail)]
+  · intro c hc
+    have hcΔ : c ∈ Δ.consts :=
+      Signature.remove_subset Δ x |>.consts c (by
+        simpa [Signature.declVar, Signature.addVar] using hc)
+    by_cases hn : c.name = x <;> by_cases ht : c.sort = τ
+    · cases c; simp only at hn ht; subst hn ht; simp [Env.updateConst]
+    · simp [Env.updateConst, ht, h.2.1 c hcΔ]
+    · simp [Env.updateConst, hn, h.2.1 c hcΔ]
+    · simp [Env.updateConst, hn, h.2.1 c hcΔ]
+  · intro u hu
+    rw [Env.updateConst_unary, Env.updateConst_unary]
+    exact h.2.2.1 u (Signature.remove_subset Δ x |>.unary u (by
+      simpa [Signature.declVar, Signature.addVar] using hu))
+  · intro b hb
+    rw [Env.updateConst_binary, Env.updateConst_binary]
+    exact h.2.2.2 b (Signature.remove_subset Δ x |>.binary b (by
+      simpa [Signature.declVar, Signature.addVar] using hb))
+
+theorem Term.eval_termAgree {t : Term τ} {ρ₁ ρ₂ : Env} {Δ : Signature} :
+    t.wfIn Δ → Env.termAgree Δ ρ₁ ρ₂ → Term.eval ρ₁ t = Term.eval ρ₂ t := by
+  intro hwf hagree
+  induction t with
+  | var τ y => simp [Term.eval, Env.lookupConst]; exact hagree.1 ⟨y, τ⟩ hwf.1
+  | const c =>
+    simp only [Term.eval]
+    cases c with
+    | uninterpreted name _ => exact hagree.2.1 ⟨name, _⟩ hwf.1
+    | _ => rfl
+  | unop op a iha =>
+    simp only [Term.eval]
+    rw [iha hwf.2]
+    cases op with
+    | uninterpreted name _ _ =>
+      simp only [UnOp.eval]
+      exact congrFun (hagree.2.2.1 ⟨name, _, _⟩ hwf.1.1) _
+    | _ => rfl
+  | binop op a b iha ihb =>
+    simp only [Term.eval]
+    rw [iha hwf.2.1, ihb hwf.2.2]
+    cases op with
+    | uninterpreted name _ _ _ =>
+      simp only [BinOp.eval]
+      exact congrFun (congrFun (hagree.2.2.2 ⟨name, _, _, _⟩ hwf.1.1) _) _
+    | _ => rfl
+  | ite c t e ihc iht ihe =>
+    simp [Term.eval]
+    rw [ihc hwf.1, iht hwf.2.1, ihe hwf.2.2]
+
 theorem Term.eval_update_fresh {t : Term τ'} {x : String} {τ : Srt} {v : τ.denote} {ρ : Env}
     {Δ : Signature} (hwf : t.wfIn Δ) (hfresh : x ∉ Δ.allNames) :
     Term.eval (ρ.updateConst τ x v) t = Term.eval ρ t :=

--- a/Mica/Verifier.lean
+++ b/Mica/Verifier.lean
@@ -6,6 +6,7 @@ import Mica.Verifier.Bindings
 import Mica.Verifier.Utils
 import Mica.Verifier.Assertions
 import Mica.Verifier.Expressions
+import Mica.Verifier.RelationalEncoding
 import Mica.Verifier.Functions
 import Mica.Verifier.Specifications
 import Mica.Verifier.SpecMaps

--- a/Mica/Verifier/OUTLINE.md
+++ b/Mica/Verifier/OUTLINE.md
@@ -8,6 +8,7 @@
 - `Monad.lean` — Verification monad with SMT operations, branching, and its operational and semantic correctness interfaces.
 - `PredicateTransformers.lean` — Predicate transformers for function specifications, together with their semantics and call and implementation protocols.
 - `Programs.lean` — End-to-end preparation and verification of programs, from typed elaboration to program-level soundness.
+- `RelationalEncoding.lean` — Bundle for RelationalEncoding/, the two-stage encoding of recursive functions into FOL axioms.
 - `Scoped.lean` — Scoped SMT command language and its translation to solver strategies and flat contexts.
 - `SpecMaps.lean` — Finite maps of function specifications, together with satisfaction, update, and well-formedness lemmas.
 - `SpecTranslation.lean` — Sort-checked translation from frontend specifications into verifier terms, formulas, assertions, and predicate transformers.

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -9,6 +9,7 @@ import Mica.Verifier.SpecTranslation
 import Mica.Verifier.PredicateTransformers
 import Mica.Verifier.Specifications
 import Mica.Engine.Driver
+import Mica.Verifier.RelationalEncoding
 
 open Iris Iris.BI
 open Typed

--- a/Mica/Verifier/RelationalEncoding.lean
+++ b/Mica/Verifier/RelationalEncoding.lean
@@ -1,0 +1,8 @@
+-- SUMMARY: Bundle for RelationalEncoding/, the two-stage encoding of recursive functions into FOL axioms.
+import Mica.Verifier.RelationalEncoding.Monad
+import Mica.Verifier.RelationalEncoding.Variables
+import Mica.Verifier.RelationalEncoding.Relation
+import Mica.Verifier.RelationalEncoding.SkolemizeCommon
+import Mica.Verifier.RelationalEncoding.SkolemizeSoundness
+import Mica.Verifier.RelationalEncoding.SkolemizeCompleteness
+import Mica.Verifier.RelationalEncoding.Axioms

--- a/Mica/Verifier/RelationalEncoding/Axioms.lean
+++ b/Mica/Verifier/RelationalEncoding/Axioms.lean
@@ -5,7 +5,7 @@ import Mica.Verifier.RelationalEncoding.SkolemizeCompleteness
 /-!
 # Split Encoding Axioms
 
-For each fn-œmarked recursive function, Skolemization exposes the
+For each relation-marked recursive function, Skolemization exposes the
 relational graph through two solver-facing symbols:
 
 * `f_def(x)` says the function is defined on input `x`;
@@ -53,36 +53,36 @@ open Relation
 -- Axioms
 
 /-- If the encoded body is defined on input `x`, the function is defined on `x`. -/
-def definedIntroAxiom (rel x : TinyML.Var) (body : DefVal) : Formula :=
+def definedIntroAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
-    (.implies body.defined (SpecFn.isDefined rel (.var .value x)))
+    (.implies body.defined (SpecFn.isDefined fn (.var .value x)))
 
 /-- If the function is defined on input `x`, its solver-facing value equals the
 encoded body value. -/
-def valueAxiom (rel x : TinyML.Var) (body : DefVal) : Formula :=
+def valueAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
     (.implies
-      (SpecFn.isDefined rel (.var .value x))
-      (.eq .value (SpecFn.call rel (.var .value x)) body.value))
+      (SpecFn.isDefined fn (.var .value x))
+      (.eq .value (SpecFn.call fn (.var .value x)) body.value))
 
 /-- Converse of `definedIntroAxiom`: if the function is defined on `x`, then the
 encoded body is defined on `x`.  Experimental — exposing this lets the SMT
 backend propagate definedness from a parent call into its recursive subterms. -/
-def definedElimAxiom (rel x : TinyML.Var) (body : DefVal) : Formula :=
+def definedElimAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
-    (.implies (SpecFn.isDefined rel (.var .value x)) body.defined)
+    (.implies (SpecFn.isDefined fn (.var .value x)) body.defined)
 
 /-- The solver-facing axioms emitted for a relation-marked function. -/
-def axioms (rel x : TinyML.Var) (body : DefVal) : List Formula :=
-  [definedIntroAxiom rel x body, valueAxiom rel x body,
-   definedElimAxiom rel x body]
+def axioms (fn x : TinyML.Var) (body : DefVal) : List Formula :=
+  [definedIntroAxiom fn x body, valueAxiom fn x body,
+   definedElimAxiom fn x body]
 
-theorem axioms_wfIn {Δ : Signature} {rel x : String} {body : DefVal}
+theorem axioms_wfIn {Δ : Signature} {fn x : String} {body : DefVal}
     (hΔx : (Δ.declVar ⟨x, .value⟩).wf)
     (hbody : body.wfIn (Δ.declVar ⟨x, .value⟩))
-    (hfun : SpecFn.func rel ∈ (Δ.declVar ⟨x, .value⟩).unary)
-    (hrel : SpecFn.defined rel ∈ (Δ.declVar ⟨x, .value⟩).unaryRel) :
-    ∀ ax ∈ axioms rel x body, ax.wfIn Δ := by
+    (hfun : SpecFn.func fn ∈ (Δ.declVar ⟨x, .value⟩).unary)
+    (hrel : SpecFn.defined fn ∈ (Δ.declVar ⟨x, .value⟩).unaryRel) :
+    ∀ ax ∈ axioms fn x body, ax.wfIn Δ := by
   intro ax hmem
   simp [axioms] at hmem
   rcases hmem with rfl | rfl | rfl
@@ -105,12 +105,12 @@ theorem axioms_wfIn {Δ : Signature} {rel x : String} {body : DefVal}
 of the split definedness predicate and the epsilon-selected value function. -/
 def GraphCompatible
     (Γ : FunCtx) (Δ : Signature) (ρ : Env)
-    (f : TinyML.Var) (rel : String) (x res : TinyML.Var) (e : Typed.Expr)
+    (f : TinyML.Var) (fn : SpecFn) (x res : TinyML.Var) (e : Typed.Expr)
     (body : DefVal) : Prop :=
   ∀ vin vout,
-    semrel Γ Δ ρ f rel x res e vin vout ↔
-      semdef Γ Δ ρ f rel x res e body vin ∧
-        semFunc (semrel Γ Δ ρ f rel x res e) vin = vout
+    semrel Γ Δ ρ f fn x res e vin vout ↔
+      semdef Γ Δ ρ f fn x res e body vin ∧
+        semFunc (semrel Γ Δ ρ f fn x res e) vin = vout
 
 
 /-- The definedness-introduction axiom is valid under the semantic definedness
@@ -118,17 +118,17 @@ least fixpoint. This is the first solver-facing axiom and does not require the
 eventual relation/graph equivalence. -/
 theorem definedIntroAxiom_eval
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body) :
-    (definedIntroAxiom rel x body).eval
-      (defInterpEnv Γ Δ ρ f rel x res e body) := by
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body) :
+    (definedIntroAxiom fn x body).eval
+      (defInterpEnv Γ Δ ρ f fn x res e body) := by
   simp only [definedIntroAxiom, Formula.eval]
   intro vin hbody
   have hsem :
-      semdef Γ Δ ρ f rel x res e body vin := by
+      semdef Γ Δ ρ f fn x res e body vin := by
     exact (semdef_unfold_of_encode (ρ := ρ) (x := x) (res := res) henc vin).mpr hbody
   exact (definedCall_eval_defInterpEnv (Γ := Γ) (Δ := Δ) (ρ := ρ)
-    (f := f) (fn := rel) (x := x) (res := res) (e := e) (body := body) vin).mpr hsem
+    (f := f) (fn := fn) (x := x) (res := res) (e := e) (body := body) vin).mpr hsem
 
 /-- The semantic relation induced by the relational encoding agrees with the
 graph induced by the split definedness fixpoint and epsilon-selected value
@@ -138,103 +138,103 @@ symbols from clobbering them, and the paired-encoding completeness/soundness pro
 recursive body. -/
 theorem semrel_compatible
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ) :
-    GraphCompatible Γ Δ ρ f rel x res e body := by
+    GraphCompatible Γ Δ ρ f fn x res e body := by
   intro vin vout
   constructor
   · intro hrel
     have hsplit :=
-      semrel_complete henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+      semrel_complete henc hΓ hΓwf hΔ hheadFresh hρdet
         vin vout hrel
-    have hdefined : semDefined (semrel Γ Δ ρ f rel x res e) vin := ⟨vout, hrel⟩
+    have hdefined : semDefined (semrel Γ Δ ρ f fn x res e) vin := ⟨vout, hrel⟩
     have hfun :
-      semFunc (semrel Γ Δ ρ f rel x res e) vin = vout :=
-      relation_semrel_functional_of_encodeBody henc hΔ hΓrel hΓdef hheadFresh hρdet vin
-        (semFunc (semrel Γ Δ ρ f rel x res e) vin) vout
+      semFunc (semrel Γ Δ ρ f fn x res e) vin = vout :=
+      relation_semrel_functional_of_encodeBody henc hΔ hΓwf hheadFresh hρdet vin
+        (semFunc (semrel Γ Δ ρ f fn x res e) vin) vout
         (semFunc_spec hdefined) hrel
     exact ⟨hsplit.1, hfun⟩
   · intro hgraph
     rcases hgraph with ⟨hdef, hfun⟩
     let vbody :=
       body.value.eval
-        ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin)
+        ((defInterpEnv Γ Δ ρ f fn x res e body).updateConst .value x vin)
     have hrelBody :
-        semrel Γ Δ ρ f rel x res e vin vbody :=
-      semrel_sound henc hΓ hΓrel hΓdef hΔ hheadFresh vin vbody
+        semrel Γ Δ ρ f fn x res e vin vbody :=
+      semrel_sound henc hΓ hΓwf hΔ hheadFresh vin vbody
         hdef rfl
-    have hdefined : semDefined (semrel Γ Δ ρ f rel x res e) vin := ⟨vbody, hrelBody⟩
+    have hdefined : semDefined (semrel Γ Δ ρ f fn x res e) vin := ⟨vbody, hrelBody⟩
     have hchosen :
-        vbody = semFunc (semrel Γ Δ ρ f rel x res e) vin :=
-      relation_semrel_functional_of_encodeBody henc hΔ hΓrel hΓdef hheadFresh hρdet vin vbody
-        (semFunc (semrel Γ Δ ρ f rel x res e) vin)
+        vbody = semFunc (semrel Γ Δ ρ f fn x res e) vin :=
+      relation_semrel_functional_of_encodeBody henc hΔ hΓwf hheadFresh hρdet vin vbody
+        (semFunc (semrel Γ Δ ρ f fn x res e) vin)
         hrelBody (semFunc_spec hdefined)
-    exact semrel_sound henc hΓ hΓrel hΓdef hΔ hheadFresh vin vout
+    exact semrel_sound henc hΓ hΓwf hΔ hheadFresh vin vout
       hdef (hchosen.trans hfun)
 
 /-- The value axiom is valid under the canonical split interpretation extracted
 from the relational semantics. -/
 theorem valueAxiom_eval
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ) :
-    (valueAxiom rel x body).eval
-      (defInterpEnv Γ Δ ρ f rel x res e body) := by
+    (valueAxiom fn x body).eval
+      (defInterpEnv Γ Δ ρ f fn x res e body) := by
   simp only [valueAxiom, Formula.eval]
   intro vin hdef
   have hsem := (definedCall_eval_defInterpEnv (Γ := Γ) (Δ := Δ) (ρ := ρ)
-    (f := f) (fn := rel) (x := x) (res := res) (e := e) (body := body) vin).mp hdef
+    (f := f) (fn := fn) (x := x) (res := res) (e := e) (body := body) vin).mp hdef
   rw [valueCall_eval_defInterpEnv (Γ := Γ) (Δ := Δ) (ρ := ρ)
-    (f := f) (fn := rel) (x := x) (res := res) (e := e) (body := body) vin]
-  have hgraph := semrel_compatible henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+    (f := f) (fn := fn) (x := x) (res := res) (e := e) (body := body) vin]
+  have hgraph := semrel_compatible henc hΓ hΓwf hΔ hheadFresh hρdet
   have hrel :
-      semrel Γ Δ ρ f rel x res e vin
-        (semFunc (semrel Γ Δ ρ f rel x res e) vin) :=
-    (hgraph vin (semFunc (semrel Γ Δ ρ f rel x res e) vin)).mpr ⟨hsem, rfl⟩
-  exact (semrel_complete henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
-    vin (semFunc (semrel Γ Δ ρ f rel x res e) vin) hrel).2.symm
+      semrel Γ Δ ρ f fn x res e vin
+        (semFunc (semrel Γ Δ ρ f fn x res e) vin) :=
+    (hgraph vin (semFunc (semrel Γ Δ ρ f fn x res e) vin)).mpr ⟨hsem, rfl⟩
+  exact (semrel_complete henc hΓ hΓwf hΔ hheadFresh hρdet
+    vin (semFunc (semrel Γ Δ ρ f fn x res e) vin) hrel).2.symm
 
 /-- Semantic validity of the converse definedness axiom: under the least
 fixpoint of `semdef`, the `semdef`/`defBody` unfolding goes both ways, so
-`isDefined rel x` implies `body.defined` on `x`. -/
+`isDefined fn x` implies `body.defined` on `x`. -/
 theorem definedElimAxiom_eval
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body) :
-    (definedElimAxiom rel x body).eval
-      (defInterpEnv Γ Δ ρ f rel x res e body) := by
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body) :
+    (definedElimAxiom fn x body).eval
+      (defInterpEnv Γ Δ ρ f fn x res e body) := by
   simp only [definedElimAxiom, Formula.eval]
   intro vin hdef
-  have hsem : semdef Γ Δ ρ f rel x res e body vin :=
+  have hsem : semdef Γ Δ ρ f fn x res e body vin :=
     (definedCall_eval_defInterpEnv (Γ := Γ) (Δ := Δ) (ρ := ρ)
-      (f := f) (fn := rel) (x := x) (res := res) (e := e) (body := body) vin).mp hdef
+      (f := f) (fn := fn) (x := x) (res := res) (e := e) (body := body) vin).mp hdef
   exact (semdef_unfold_of_encode (ρ := ρ) (x := x) (res := res) henc vin).mp hsem
 
 /-- Semantic validity of the split axioms under the canonical split
 interpretation. -/
 theorem axioms_eval
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ) :
-    ∀ ax ∈ axioms rel x body,
-      ax.eval (defInterpEnv Γ Δ ρ f rel x res e body) := by
+    ∀ ax ∈ axioms fn x body,
+      ax.eval (defInterpEnv Γ Δ ρ f fn x res e body) := by
   intro ax hmem
   simp [axioms] at hmem
   rcases hmem with rfl | rfl | rfl
   · exact definedIntroAxiom_eval henc
-  · exact valueAxiom_eval henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+  · exact valueAxiom_eval henc hΓ hΓwf hΔ hheadFresh hρdet
   · exact definedElimAxiom_eval henc
 
 /-! ## Verifier-facing bundle
@@ -252,23 +252,23 @@ level. -/
 /-- Bundle of independent freshness premises sufficient to derive
 `HeadFresh` once a fresh result variable is chosen. The verifier discharges
 these per step. -/
-structure InfoFresh (Δ : Signature) (rel arg : String) : Prop where
-  relFresh : rel ∉ Δ.allNames
-  funFresh : SpecFn.funcName rel ∉ Δ.allNames
-  defFresh : SpecFn.defName rel ∉ Δ.allNames
-  argFresh : arg ∉ Δ.allNames
-  argNeRel : arg ≠ rel
-  argNeFun : arg ≠ SpecFn.funcName rel
-  argNeDef : arg ≠ SpecFn.defName rel
+structure InfoFresh (Δ : Signature) (fn x : String) : Prop where
+  relFresh : fn ∉ Δ.allNames
+  funFresh : SpecFn.funcName fn ∉ Δ.allNames
+  defFresh : SpecFn.defName fn ∉ Δ.allNames
+  argFresh : x ∉ Δ.allNames
+  argNeRel : x ≠ fn
+  argNeFun : x ≠ SpecFn.funcName fn
+  argNeDef : x ≠ SpecFn.defName fn
 
 theorem freshName_avoid_props
-    (Δ : Signature) (arg rel : String) :
+    (Δ : Signature) (x fn : SpecFn) :
     let res := Fresh.freshName
-      (Δ.allNames ++ [arg, rel, SpecFn.funcName rel, SpecFn.defName rel]) "r"
-    res ∉ Δ.allNames ∧ res ≠ arg ∧ res ≠ rel ∧
-      res ≠ SpecFn.funcName rel ∧ res ≠ SpecFn.defName rel := by
+      (Δ.allNames ++ [x, fn, SpecFn.funcName fn, SpecFn.defName fn]) "r"
+    res ∉ Δ.allNames ∧ res ≠ x ∧ res ≠ fn ∧
+      res ≠ SpecFn.funcName fn ∧ res ≠ SpecFn.defName fn := by
   have hres := Fresh.freshName_not_in_avoid
-    (Δ.allNames ++ [arg, rel, SpecFn.funcName rel, SpecFn.defName rel]) "r"
+    (Δ.allNames ++ [x, fn, SpecFn.funcName fn, SpecFn.defName fn]) "r"
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · intro h; exact hres (List.mem_append_left _ h)
   · intro h; apply hres; rw [h]; simp
@@ -279,22 +279,22 @@ theorem freshName_avoid_props
 /-- Derive `HeadFresh` from independent freshness hypotheses on each of the
 solver-facing names. -/
 theorem headFresh_of_fresh
-    {Δ : Signature} {rel x res : String}
-    (hf : InfoFresh Δ rel x)
+    {Δ : Signature} {fn x res : String}
+    (hf : InfoFresh Δ fn x)
     (hresΔ : res ∉ Δ.allNames)
-    (hresRel : res ≠ rel) (hresFun : res ≠ SpecFn.funcName rel)
-    (hresDef : res ≠ SpecFn.defName rel) (hresx : res ≠ x) :
-    HeadFresh Δ rel x res := by
+    (hresRel : res ≠ fn) (hresFun : res ≠ SpecFn.funcName fn)
+    (hresDef : res ≠ SpecFn.defName fn) (hresx : res ≠ x) :
+    HeadFresh Δ fn x res := by
   refine
     { relFresh := hf.relFresh
       funFresh := ?_
       defFresh := ?_
       argFresh := ?_
       resFresh := ?_ }
-  · exact Signature.not_mem_allNames_addBinaryRel hf.funFresh (SpecFn.funcName_ne_fn rel)
+  · exact Signature.not_mem_allNames_addBinaryRel hf.funFresh (SpecFn.funcName_ne_fn fn)
   · exact Signature.not_mem_allNames_addUnary
-      (Signature.not_mem_allNames_addBinaryRel hf.defFresh (SpecFn.defName_ne_fn rel))
-      (SpecFn.defName_ne_funcName rel)
+      (Signature.not_mem_allNames_addBinaryRel hf.defFresh (SpecFn.defName_ne_fn fn))
+      (SpecFn.defName_ne_funcName fn)
   · exact Signature.not_mem_allNames_addUnaryRel
       (Signature.not_mem_allNames_addUnary
         (Signature.not_mem_allNames_addBinaryRel hf.argFresh hf.argNeRel)
@@ -314,36 +314,36 @@ level), the solver-facing value function, the definedness predicate, the
 canonical pinned-result variable, the encoded body, and the list of
 solver-emitted axioms. -/
 def bundle
-    (Γ : FunCtx) (Δ : Signature) (name rel arg : String) (body : Typed.Expr) :
+    (Γ : FunCtx) (Δ : Signature) (f fn x : String) (e : Typed.Expr) :
     Except String
       (FOL.BinaryRel × FOL.Unary × FOL.UnaryRel × String × DefVal × List Formula) := do
   let res := Fresh.freshName
-    (Δ.allNames ++ [arg, rel, SpecFn.funcName rel, SpecFn.defName rel]) "r"
-  let bv ← encodeBody Γ Δ name rel arg res body
-  pure (⟨rel, .value, .value⟩, SpecFn.func rel, SpecFn.defined rel, res, bv,
-        axioms rel arg bv)
+    (Δ.allNames ++ [x, fn, SpecFn.funcName fn, SpecFn.defName fn]) "r"
+  let bv ← encodeBody Γ Δ f fn x res e
+  pure (⟨fn, .value, .value⟩, SpecFn.func fn, SpecFn.defined fn, res, bv,
+        axioms fn x bv)
 
 theorem bundle_headFresh
-    {Δ : Signature} {arg rel : String}
-    (hf : InfoFresh Δ rel arg) :
-    HeadFresh Δ rel arg
+    {Δ : Signature} {x fn : SpecFn}
+    (hf : InfoFresh Δ fn x) :
+    HeadFresh Δ fn x
       (Fresh.freshName
-        (Δ.allNames ++ [arg, rel, SpecFn.funcName rel, SpecFn.defName rel]) "r") := by
+        (Δ.allNames ++ [x, fn, SpecFn.funcName fn, SpecFn.defName fn]) "r") := by
   obtain ⟨hresΔ, hresArg, hresRel, hresFun, hresDef⟩ :=
-    freshName_avoid_props Δ arg rel
+    freshName_avoid_props Δ x fn
   exact headFresh_of_fresh hf hresΔ hresRel hresFun hresDef hresArg
 
 theorem bundle_wfIn
-    {Γ : FunCtx} {Δ : Signature} {name rel arg : String} {body : Typed.Expr}
-    {sym : FOL.BinaryRel} {fn : FOL.Unary} {drel : FOL.UnaryRel}
+    {Γ : FunCtx} {Δ : Signature} {f fn x : String} {e : Typed.Expr}
+    {sym : FOL.BinaryRel} {fnSym : FOL.Unary} {drel : FOL.UnaryRel}
     {res : String} {bv : DefVal} {axs : List Formula}
-    (hinfo : bundle Γ Δ name rel arg body
-              = .ok (sym, fn, drel, res, bv, axs))
-    (hΔ : Δ.wf) (hΓdef : Γ.defWfIn Δ)
-    (hf : InfoFresh Δ rel arg) :
-    sym = ⟨rel, .value, .value⟩ ∧ fn = SpecFn.func rel ∧ drel = SpecFn.defined rel ∧
+    (hinfo : bundle Γ Δ f fn x e
+              = .ok (sym, fnSym, drel, res, bv, axs))
+    (hΔ : Δ.wf) (hΓwf : Γ.wfIn Δ)
+    (hf : InfoFresh Δ fn x) :
+    sym = ⟨fn, .value, .value⟩ ∧ fnSym = SpecFn.func fn ∧ drel = SpecFn.defined fn ∧
       ∀ ax ∈ axs,
-        ax.wfIn (((Δ.addBinaryRel sym).addUnary fn).addUnaryRel drel) := by
+        ax.wfIn (((Δ.addBinaryRel sym).addUnary fnSym).addUnaryRel drel) := by
   unfold bundle at hinfo
   simp only [bind, Except.bind] at hinfo
   split at hinfo
@@ -351,93 +351,93 @@ theorem bundle_wfIn
   rename_i bv' henc
   cases hinfo
   refine ⟨rfl, rfl, rfl, ?_⟩
-  have hheadFresh := bundle_headFresh (Δ := Δ) (arg := arg) (rel := rel) hf
+  have hheadFresh := bundle_headFresh (Δ := Δ) (x := x) (fn := fn) hf
   set Δext : Signature :=
-    ((Δ.addBinaryRel ⟨rel, .value, .value⟩).addUnary (SpecFn.func rel)).addUnaryRel
-      (SpecFn.defined rel) with hΔext_def
-  have hΔx_wf : (Δext.declVar ⟨arg, .value⟩).wf := by
+    ((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (SpecFn.func fn)).addUnaryRel
+      (SpecFn.defined fn) with hΔext_def
+  have hΔx_wf : (Δext.declVar ⟨x, .value⟩).wf := by
     simpa [Δext, bodySig] using bodySig_wf_of_headFresh hΔ hheadFresh
-  have hbody_x : bv.wfIn (Δext.declVar ⟨arg, .value⟩) := by
-    show bv.wfIn (bodySig Δ rel arg)
-    exact encode_wfIn (Γ := Relation.ctx Γ name rel)
-      (Δ := bodySig Δ rel arg) body
+  have hbody_x : bv.wfIn (Δext.declVar ⟨x, .value⟩) := by
+    show bv.wfIn (bodySig Δ fn x)
+    exact encode_wfIn (Γ := Relation.ctx Γ f fn)
+      (Δ := bodySig Δ fn x) e
       (bodySig_wf_of_headFresh hΔ hheadFresh)
-      (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh)
+      (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
       (encodeBody_def_bodySig henc)
-  have hfun_mem : SpecFn.func rel ∈ (Δext.declVar ⟨arg, .value⟩).unary :=
+  have hfun_mem : SpecFn.func fn ∈ (Δext.declVar ⟨x, .value⟩).unary :=
     Signature.mem_remove_unary.mpr ⟨List.Mem.head _, fun heq => hf.argNeFun heq.symm⟩
-  have hrel_mem : SpecFn.defined rel ∈ (Δext.declVar ⟨arg, .value⟩).unaryRel :=
+  have hrel_mem : SpecFn.defined fn ∈ (Δext.declVar ⟨x, .value⟩).unaryRel :=
     Signature.mem_remove_unaryRel.mpr ⟨List.Mem.head _, fun heq => hf.argNeDef heq.symm⟩
   intro ax hmem
   exact axioms_wfIn (Δ := Δext) hΔx_wf hbody_x hfun_mem hrel_mem ax hmem
 
 
 /-- The split axioms remain valid under any choice of binary relation
-interpretation for `rel`. The body and axiom shapes only mention the
-solver-facing split symbols, never `rel` as a binary predicate, so updating
-`rel`'s binary interpretation is irrelevant. -/
+interpretation for `fn`. The body and axiom shapes only mention the
+solver-facing split symbols, never `fn` as a binary predicate, so updating
+`fn`'s binary interpretation is irrelevant. -/
 theorem axioms_eval_updateBinaryRel
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (R : ValRel) :
-    ∀ ax ∈ axioms rel x body,
-      ax.eval ((defInterpEnv Γ Δ ρ f rel x res e body).updateBinaryRel
-        .value .value rel R) := by
+    ∀ ax ∈ axioms fn x body,
+      ax.eval ((defInterpEnv Γ Δ ρ f fn x res e body).updateBinaryRel
+        .value .value fn R) := by
   intro ax hmem
-  have hbase := axioms_eval henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet ax hmem
+  have hbase := axioms_eval henc hΓ hΓwf hΔ hheadFresh hρdet ax hmem
   set Δsmall : Signature :=
-    (Δ.addUnary (SpecFn.func rel)).addUnaryRel (SpecFn.defined rel) with hΔsmall_def
+    (Δ.addUnary (SpecFn.func fn)).addUnaryRel (SpecFn.defined fn) with hΔsmall_def
   have hΔbig_wf : (Δsmall.declVar ⟨x, .value⟩).wf := by
-    show (defvalBodySig Δ rel x).wf
+    show (defvalBodySig Δ fn x).wf
     exact defvalBodySig_wf_of_headFresh hΔ hheadFresh
   have hbody_wf : body.wfIn (Δsmall.declVar ⟨x, .value⟩) := by
-    show body.wfIn (defvalBodySig Δ rel x)
-    exact encodeBody_wfIn_defvalBodySig hΔ hΓdef hheadFresh henc
-  have hxNeFun : x ≠ SpecFn.funcName rel := fun heq =>
+    show body.wfIn (defvalBodySig Δ fn x)
+    exact encodeBody_wfIn_defvalBodySig hΔ hΓwf.split hheadFresh henc
+  have hxNeFun : x ≠ SpecFn.funcName fn := fun heq =>
     var_fresh_splitBase_of_headFresh hheadFresh (heq ▸ Signature.mem_allNames_of_unary
-      (Δ := Δsmall) (u := SpecFn.func rel) (List.Mem.head _))
-  have hxNeDef : x ≠ SpecFn.defName rel := fun heq =>
+      (Δ := Δsmall) (u := SpecFn.func fn) (List.Mem.head _))
+  have hxNeDef : x ≠ SpecFn.defName fn := fun heq =>
     var_fresh_splitBase_of_headFresh hheadFresh (heq ▸ Signature.mem_allNames_of_unaryRel
-      (Δ := Δsmall) (u := SpecFn.defined rel) (List.Mem.head _))
-  have hfun_mem : SpecFn.func rel ∈ (Δsmall.declVar ⟨x, .value⟩).unary :=
+      (Δ := Δsmall) (u := SpecFn.defined fn) (List.Mem.head _))
+  have hfun_mem : SpecFn.func fn ∈ (Δsmall.declVar ⟨x, .value⟩).unary :=
     Signature.mem_remove_unary.mpr ⟨List.Mem.head _, fun heq => hxNeFun heq.symm⟩
-  have hrel_mem : SpecFn.defined rel ∈ (Δsmall.declVar ⟨x, .value⟩).unaryRel :=
+  have hrel_mem : SpecFn.defined fn ∈ (Δsmall.declVar ⟨x, .value⟩).unaryRel :=
     Signature.mem_remove_unaryRel.mpr ⟨List.Mem.head _, fun heq => hxNeDef heq.symm⟩
   have hax_wf : ax.wfIn Δsmall :=
     axioms_wfIn (Δ := Δsmall) hΔbig_wf hbody_wf hfun_mem hrel_mem ax hmem
-  have hrelFresh_small : (⟨rel, .value, .value⟩ : FOL.BinaryRel).name ∉ Δsmall.allNames :=
+  have hrelFresh_small : (⟨fn, .value, .value⟩ : FOL.BinaryRel).name ∉ Δsmall.allNames :=
     Signature.not_mem_allNames_addUnaryRel
       (Signature.not_mem_allNames_addUnary hheadFresh.relFresh
-        (show rel ≠ (SpecFn.func rel).name from (SpecFn.funcName_ne_fn rel).symm))
-      (show rel ≠ (SpecFn.defined rel).name from (SpecFn.defName_ne_fn rel).symm)
+        (show fn ≠ (SpecFn.func fn).name from (SpecFn.funcName_ne_fn fn).symm))
+      (show fn ≠ (SpecFn.defined fn).name from (SpecFn.defName_ne_fn fn).symm)
   have hagree :
       Env.agreeOn Δsmall
-        (defInterpEnv Γ Δ ρ f rel x res e body)
-        ((defInterpEnv Γ Δ ρ f rel x res e body).updateBinaryRel
-          .value .value rel R) :=
+        (defInterpEnv Γ Δ ρ f fn x res e body)
+        ((defInterpEnv Γ Δ ρ f fn x res e body).updateBinaryRel
+          .value .value fn R) :=
     Env.agreeOn_update_fresh_binaryRel
-      (b := ⟨rel, .value, .value⟩) hrelFresh_small
+      (b := ⟨fn, .value, .value⟩) hrelFresh_small
   exact (Formula.eval_env_agree hax_wf hagree).mp hbase
 
 /-- Verifier-facing combined functionality: `semrel` is single-valued. -/
 theorem bundle_semrel_functional
     {Γ : FunCtx} {Δ : Signature}
-    {name rel arg : String} {body : Typed.Expr}
-    {sym : FOL.BinaryRel} {fn : FOL.Unary} {drel : FOL.UnaryRel}
+    {f fn x : String} {e : Typed.Expr}
+    {sym : FOL.BinaryRel} {fnSym : FOL.Unary} {drel : FOL.UnaryRel}
     {res : String} {bv : DefVal} {axs : List Formula}
-    (hinfo : bundle Γ Δ name rel arg body
-              = .ok (sym, fn, drel, res, bv, axs))
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hf : InfoFresh Δ rel arg)
+    (hinfo : bundle Γ Δ f fn x e
+              = .ok (sym, fnSym, drel, res, bv, axs))
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hf : InfoFresh Δ fn x)
     (ρ : Env) (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (vin : Srt.value.denote) (y₁ y₂ : Srt.value.denote)
-    (h₁ : semrel Γ Δ ρ name rel arg res body vin y₁)
-    (h₂ : semrel Γ Δ ρ name rel arg res body vin y₂) :
+    (h₁ : semrel Γ Δ ρ f fn x res e vin y₁)
+    (h₂ : semrel Γ Δ ρ f fn x res e vin y₂) :
     y₁ = y₂ := by
   unfold bundle at hinfo
   simp only [bind, Except.bind] at hinfo
@@ -445,60 +445,60 @@ theorem bundle_semrel_functional
   · cases hinfo
   rename_i bv' henc
   cases hinfo
-  have hheadFresh := bundle_headFresh (Δ := Δ) (arg := arg) (rel := rel) hf
-  exact relation_semrel_functional_of_encodeBody henc hΔ hΓrel hΓdef hheadFresh hρdet vin y₁ y₂ h₁ h₂
+  have hheadFresh := bundle_headFresh (Δ := Δ) (x := x) (fn := fn) hf
+  exact relation_semrel_functional_of_encodeBody henc hΔ hΓwf hheadFresh hρdet vin y₁ y₂ h₁ h₂
 
 /-- Verifier-facing semrel/split graph compatibility for the new relation. -/
 theorem bundle_semrel_compatible
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {name rel arg : String} {body : Typed.Expr}
-    {sym : FOL.BinaryRel} {fn : FOL.Unary} {drel : FOL.UnaryRel}
+    {f fn x : String} {e : Typed.Expr}
+    {sym : FOL.BinaryRel} {fnSym : FOL.Unary} {drel : FOL.UnaryRel}
     {res : String} {bv : DefVal} {axs : List Formula}
-    (hinfo : bundle Γ Δ name rel arg body
-              = .ok (sym, fn, drel, res, bv, axs))
+    (hinfo : bundle Γ Δ f fn x e
+              = .ok (sym, fnSym, drel, res, bv, axs))
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hf : InfoFresh Δ rel arg)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hf : InfoFresh Δ fn x)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (vin vout : Srt.value.denote) :
-    semrel Γ Δ ρ name rel arg res body vin vout ↔
-      semdef Γ Δ ρ name rel arg res body bv vin ∧
-        semFunc (semrel Γ Δ ρ name rel arg res body) vin = vout := by
+    semrel Γ Δ ρ f fn x res e vin vout ↔
+      semdef Γ Δ ρ f fn x res e bv vin ∧
+        semFunc (semrel Γ Δ ρ f fn x res e) vin = vout := by
   unfold bundle at hinfo
   simp only [bind, Except.bind] at hinfo
   split at hinfo
   · cases hinfo
   rename_i bv' henc
   cases hinfo
-  have hheadFresh := bundle_headFresh (Δ := Δ) (arg := arg) (rel := rel) hf
-  exact semrel_compatible henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet vin vout
+  have hheadFresh := bundle_headFresh (Δ := Δ) (x := x) (fn := fn) hf
+  exact semrel_compatible henc hΓ hΓwf hΔ hheadFresh hρdet vin vout
 
 /-- Verifier-facing variant of `axioms_eval_updateBinaryRel`: the axioms emitted
 by `bundle` evaluate to true under any choice of binary-relation
-interpretation for the freshly declared `rel` symbol. -/
+interpretation for the freshly declared `fn` symbol. -/
 theorem bundle_eval_updateBinaryRel
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {name rel arg : String} {body : Typed.Expr}
-    {sym : FOL.BinaryRel} {fn : FOL.Unary} {drel : FOL.UnaryRel}
+    {f fn x : String} {e : Typed.Expr}
+    {sym : FOL.BinaryRel} {fnSym : FOL.Unary} {drel : FOL.UnaryRel}
     {res : String} {bv : DefVal} {axs : List Formula}
-    (hinfo : bundle Γ Δ name rel arg body
-              = .ok (sym, fn, drel, res, bv, axs))
+    (hinfo : bundle Γ Δ f fn x e
+              = .ok (sym, fnSym, drel, res, bv, axs))
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hf : InfoFresh Δ rel arg)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hf : InfoFresh Δ fn x)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (R : ValRel) :
     ∀ ax ∈ axs,
-      ax.eval ((defInterpEnv Γ Δ ρ name rel arg res body bv).updateBinaryRel
-        .value .value rel R) := by
+      ax.eval ((defInterpEnv Γ Δ ρ f fn x res e bv).updateBinaryRel
+        .value .value fn R) := by
   unfold bundle at hinfo
   simp only [bind, Except.bind] at hinfo
   split at hinfo
   · cases hinfo
   rename_i bv' henc
   cases hinfo
-  have hheadFresh := bundle_headFresh (Δ := Δ) (arg := arg) (rel := rel) hf
-  exact axioms_eval_updateBinaryRel henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet R
+  have hheadFresh := bundle_headFresh (Δ := Δ) (x := x) (fn := fn) hf
+  exact axioms_eval_updateBinaryRel henc hΓ hΓwf hΔ hheadFresh hρdet R
 
 end Skolemize
 end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/Axioms.lean
+++ b/Mica/Verifier/RelationalEncoding/Axioms.lean
@@ -53,13 +53,13 @@ open Relation
 -- Axioms
 
 /-- If the encoded body is defined on input `x`, the function is defined on `x`. -/
-def definedIntroAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
+def definedIntroAxiom (fn : SpecFn) (x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
     (.implies body.defined (fn.isDefined (.var .value x)))
 
 /-- If the function is defined on input `x`, its solver-facing value equals the
 encoded body value. -/
-def valueAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
+def valueAxiom (fn : SpecFn) (x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
     (.implies
       (fn.isDefined (.var .value x))
@@ -68,16 +68,16 @@ def valueAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
 /-- Converse of `definedIntroAxiom`: if the function is defined on `x`, then the
 encoded body is defined on `x`.  Experimental — exposing this lets the SMT
 backend propagate definedness from a parent call into its recursive subterms. -/
-def definedElimAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
+def definedElimAxiom (fn : SpecFn) (x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
     (.implies (fn.isDefined (.var .value x)) body.defined)
 
 /-- The solver-facing axioms emitted for a relation-marked function. -/
-def axioms (fn x : TinyML.Var) (body : DefVal) : List Formula :=
+def axioms (fn : SpecFn) (x : TinyML.Var) (body : DefVal) : List Formula :=
   [definedIntroAxiom fn x body, valueAxiom fn x body,
    definedElimAxiom fn x body]
 
-theorem axioms_wfIn {Δ : Signature} {fn x : String} {body : DefVal}
+theorem axioms_wfIn {Δ : Signature} {fn : SpecFn} {x : String} {body : DefVal}
     (hΔx : (Δ.declVar ⟨x, .value⟩).wf)
     (hbody : body.wfIn (Δ.declVar ⟨x, .value⟩))
     (hfun : fn.func ∈ (Δ.declVar ⟨x, .value⟩).unary)
@@ -252,7 +252,7 @@ level. -/
 /-- Bundle of independent freshness premises sufficient to derive
 `HeadFresh` once a fresh result variable is chosen. The verifier discharges
 these per step. -/
-structure InfoFresh (Δ : Signature) (fn x : String) : Prop where
+structure InfoFresh (Δ : Signature) (fn : SpecFn) (x : String) : Prop where
   relFresh : fn.relName ∉ Δ.allNames
   funFresh : fn.funcName ∉ Δ.allNames
   defFresh : fn.defName ∉ Δ.allNames
@@ -279,7 +279,7 @@ theorem freshName_avoid_props
 /-- Derive `HeadFresh` from independent freshness hypotheses on each of the
 solver-facing names. -/
 theorem headFresh_of_fresh
-    {Δ : Signature} {fn x res : String}
+    {Δ : Signature} {fn : SpecFn} {x res : String}
     (hf : InfoFresh Δ fn x)
     (hresΔ : res ∉ Δ.allNames)
     (hresRel : res ≠ fn.relName) (hresFun : res ≠ fn.funcName)
@@ -314,13 +314,13 @@ level), the solver-facing value function, the definedness predicate, the
 canonical pinned-result variable, the encoded body, and the list of
 solver-emitted axioms. -/
 def bundle
-    (Γ : FunCtx) (Δ : Signature) (f fn x : String) (e : Typed.Expr) :
+    (Γ : FunCtx) (Δ : Signature) (f : TinyML.Var) (fn : SpecFn) (x : String) (e : Typed.Expr) :
     Except String
       (FOL.BinaryRel × FOL.Unary × FOL.UnaryRel × String × DefVal × List Formula) := do
   let res := Fresh.freshName
     (Δ.allNames ++ [x, fn.relName, fn.funcName, fn.defName]) "r"
   let bv ← encodeBody Γ Δ f fn x res e
-  pure (⟨fn.relName, .value, .value⟩, fn.func, fn.defined, res, bv,
+  pure (fn.rel, fn.func, fn.defined, res, bv,
         axioms fn x bv)
 
 theorem bundle_headFresh
@@ -328,20 +328,20 @@ theorem bundle_headFresh
     (hf : InfoFresh Δ fn x) :
     HeadFresh Δ fn x
       (Fresh.freshName
-        (Δ.allNames ++ [x, fn, fn.funcName, fn.defName]) "r") := by
+        (Δ.allNames ++ [x, fn.relName, fn.funcName, fn.defName]) "r") := by
   obtain ⟨hresΔ, hresArg, hresRel, hresFun, hresDef⟩ :=
     freshName_avoid_props Δ x fn
   exact headFresh_of_fresh hf hresΔ hresRel hresFun hresDef hresArg
 
 theorem bundle_wfIn
-    {Γ : FunCtx} {Δ : Signature} {f fn x : String} {e : Typed.Expr}
+    {Γ : FunCtx} {Δ : Signature} {f : TinyML.Var} {fn : SpecFn} {x : String} {e : Typed.Expr}
     {sym : FOL.BinaryRel} {fnSym : FOL.Unary} {drel : FOL.UnaryRel}
     {res : String} {bv : DefVal} {axs : List Formula}
     (hinfo : bundle Γ Δ f fn x e
               = .ok (sym, fnSym, drel, res, bv, axs))
     (hΔ : Δ.wf) (hΓwf : Γ.wfIn Δ)
     (hf : InfoFresh Δ fn x) :
-    sym = ⟨fn.relName, .value, .value⟩ ∧ fnSym = fn.func ∧ drel = fn.defined ∧
+    sym = fn.rel ∧ fnSym = fn.func ∧ drel = fn.defined ∧
       ∀ ax ∈ axs,
         ax.wfIn (((Δ.addBinaryRel sym).addUnary fnSym).addUnaryRel drel) := by
   unfold bundle at hinfo
@@ -353,7 +353,7 @@ theorem bundle_wfIn
   refine ⟨rfl, rfl, rfl, ?_⟩
   have hheadFresh := bundle_headFresh (Δ := Δ) (x := x) (fn := fn) hf
   set Δext : Signature :=
-    ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+    ((Δ.addBinaryRel fn.rel).addUnary (fn.func)).addUnaryRel
       (fn.defined) with hΔext_def
   have hΔx_wf : (Δext.declVar ⟨x, .value⟩).wf := by
     simpa [Δext, bodySig] using bodySig_wf_of_headFresh hΔ hheadFresh
@@ -387,7 +387,7 @@ theorem axioms_eval_updateBinaryRel
     (R : ValRel) :
     ∀ ax ∈ axioms fn x body,
       ax.eval ((defInterpEnv Γ Δ ρ f fn x res e body).updateBinaryRel
-        .value .value fn R) := by
+        .value .value fn.relName R) := by
   intro ax hmem
   have hbase := axioms_eval henc hΓ hΓwf hΔ hheadFresh hρdet ax hmem
   set Δsmall : Signature :=
@@ -410,18 +410,18 @@ theorem axioms_eval_updateBinaryRel
     Signature.mem_remove_unaryRel.mpr ⟨List.Mem.head _, fun heq => hxNeDef heq.symm⟩
   have hax_wf : ax.wfIn Δsmall :=
     axioms_wfIn (Δ := Δsmall) hΔbig_wf hbody_wf hfun_mem hrel_mem ax hmem
-  have hrelFresh_small : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel).name ∉ Δsmall.allNames :=
+  have hrelFresh_small : fn.rel.name ∉ Δsmall.allNames :=
     Signature.not_mem_allNames_addUnaryRel
       (Signature.not_mem_allNames_addUnary hheadFresh.relFresh
-        (show fn ≠ (fn.func).name from (SpecFn.funcName_ne_fn fn).symm))
-      (show fn ≠ (fn.defined).name from (SpecFn.defName_ne_fn fn).symm)
+        (show fn.relName ≠ (fn.func).name from (SpecFn.funcName_ne_relName fn).symm))
+      (show fn.relName ≠ (fn.defined).name from (SpecFn.defName_ne_relName fn).symm)
   have hagree :
       Env.agreeOn Δsmall
         (defInterpEnv Γ Δ ρ f fn x res e body)
         ((defInterpEnv Γ Δ ρ f fn x res e body).updateBinaryRel
-          .value .value fn R) :=
+          .value .value fn.relName R) :=
     Env.agreeOn_update_fresh_binaryRel
-      (b := ⟨fn.relName, .value, .value⟩) hrelFresh_small
+      (b := fn.rel) hrelFresh_small
   exact (Formula.eval_env_agree hax_wf hagree).mp hbase
 
 /-- Verifier-facing combined functionality: `semrel` is single-valued. -/
@@ -478,7 +478,7 @@ by `bundle` evaluate to true under any choice of binary-relation
 interpretation for the freshly declared `fn` symbol. -/
 theorem bundle_eval_updateBinaryRel
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f fn x : String} {e : Typed.Expr}
+    {f : TinyML.Var} {fn : SpecFn} {x : String} {e : Typed.Expr}
     {sym : FOL.BinaryRel} {fnSym : FOL.Unary} {drel : FOL.UnaryRel}
     {res : String} {bv : DefVal} {axs : List Formula}
     (hinfo : bundle Γ Δ f fn x e
@@ -490,7 +490,7 @@ theorem bundle_eval_updateBinaryRel
     (R : ValRel) :
     ∀ ax ∈ axs,
       ax.eval ((defInterpEnv Γ Δ ρ f fn x res e bv).updateBinaryRel
-        .value .value fn R) := by
+        .value .value fn.relName R) := by
   unfold bundle at hinfo
   simp only [bind, Except.bind] at hinfo
   split at hinfo

--- a/Mica/Verifier/RelationalEncoding/Axioms.lean
+++ b/Mica/Verifier/RelationalEncoding/Axioms.lean
@@ -55,22 +55,22 @@ open Relation
 /-- If the encoded body is defined on input `x`, the function is defined on `x`. -/
 def definedIntroAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
-    (.implies body.defined (SpecFn.isDefined fn (.var .value x)))
+    (.implies body.defined (fn.isDefined (.var .value x)))
 
 /-- If the function is defined on input `x`, its solver-facing value equals the
 encoded body value. -/
 def valueAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
     (.implies
-      (SpecFn.isDefined fn (.var .value x))
-      (.eq .value (SpecFn.call fn (.var .value x)) body.value))
+      (fn.isDefined (.var .value x))
+      (.eq .value (fn.call (.var .value x)) body.value))
 
 /-- Converse of `definedIntroAxiom`: if the function is defined on `x`, then the
 encoded body is defined on `x`.  Experimental — exposing this lets the SMT
 backend propagate definedness from a parent call into its recursive subterms. -/
 def definedElimAxiom (fn x : TinyML.Var) (body : DefVal) : Formula :=
   .forall_ x .value
-    (.implies (SpecFn.isDefined fn (.var .value x)) body.defined)
+    (.implies (fn.isDefined (.var .value x)) body.defined)
 
 /-- The solver-facing axioms emitted for a relation-marked function. -/
 def axioms (fn x : TinyML.Var) (body : DefVal) : List Formula :=
@@ -80,8 +80,8 @@ def axioms (fn x : TinyML.Var) (body : DefVal) : List Formula :=
 theorem axioms_wfIn {Δ : Signature} {fn x : String} {body : DefVal}
     (hΔx : (Δ.declVar ⟨x, .value⟩).wf)
     (hbody : body.wfIn (Δ.declVar ⟨x, .value⟩))
-    (hfun : SpecFn.func fn ∈ (Δ.declVar ⟨x, .value⟩).unary)
-    (hrel : SpecFn.defined fn ∈ (Δ.declVar ⟨x, .value⟩).unaryRel) :
+    (hfun : fn.func ∈ (Δ.declVar ⟨x, .value⟩).unary)
+    (hrel : fn.defined ∈ (Δ.declVar ⟨x, .value⟩).unaryRel) :
     ∀ ax ∈ axioms fn x body, ax.wfIn Δ := by
   intro ax hmem
   simp [axioms] at hmem
@@ -253,22 +253,22 @@ level. -/
 `HeadFresh` once a fresh result variable is chosen. The verifier discharges
 these per step. -/
 structure InfoFresh (Δ : Signature) (fn x : String) : Prop where
-  relFresh : fn ∉ Δ.allNames
-  funFresh : SpecFn.funcName fn ∉ Δ.allNames
-  defFresh : SpecFn.defName fn ∉ Δ.allNames
+  relFresh : fn.relName ∉ Δ.allNames
+  funFresh : fn.funcName ∉ Δ.allNames
+  defFresh : fn.defName ∉ Δ.allNames
   argFresh : x ∉ Δ.allNames
-  argNeRel : x ≠ fn
-  argNeFun : x ≠ SpecFn.funcName fn
-  argNeDef : x ≠ SpecFn.defName fn
+  argNeRel : x ≠ fn.relName
+  argNeFun : x ≠ fn.funcName
+  argNeDef : x ≠ fn.defName
 
 theorem freshName_avoid_props
     (Δ : Signature) (x fn : SpecFn) :
     let res := Fresh.freshName
-      (Δ.allNames ++ [x, fn, SpecFn.funcName fn, SpecFn.defName fn]) "r"
-    res ∉ Δ.allNames ∧ res ≠ x ∧ res ≠ fn ∧
-      res ≠ SpecFn.funcName fn ∧ res ≠ SpecFn.defName fn := by
+      (Δ.allNames ++ [x, fn.relName, fn.funcName, fn.defName]) "r"
+    res ∉ Δ.allNames ∧ res ≠ x ∧ res ≠ fn.relName ∧
+      res ≠ fn.funcName ∧ res ≠ fn.defName := by
   have hres := Fresh.freshName_not_in_avoid
-    (Δ.allNames ++ [x, fn, SpecFn.funcName fn, SpecFn.defName fn]) "r"
+    (Δ.allNames ++ [x, fn.relName, fn.funcName, fn.defName]) "r"
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · intro h; exact hres (List.mem_append_left _ h)
   · intro h; apply hres; rw [h]; simp
@@ -282,8 +282,8 @@ theorem headFresh_of_fresh
     {Δ : Signature} {fn x res : String}
     (hf : InfoFresh Δ fn x)
     (hresΔ : res ∉ Δ.allNames)
-    (hresRel : res ≠ fn) (hresFun : res ≠ SpecFn.funcName fn)
-    (hresDef : res ≠ SpecFn.defName fn) (hresx : res ≠ x) :
+    (hresRel : res ≠ fn.relName) (hresFun : res ≠ fn.funcName)
+    (hresDef : res ≠ fn.defName) (hresx : res ≠ x) :
     HeadFresh Δ fn x res := by
   refine
     { relFresh := hf.relFresh
@@ -291,9 +291,9 @@ theorem headFresh_of_fresh
       defFresh := ?_
       argFresh := ?_
       resFresh := ?_ }
-  · exact Signature.not_mem_allNames_addBinaryRel hf.funFresh (SpecFn.funcName_ne_fn fn)
+  · exact Signature.not_mem_allNames_addBinaryRel hf.funFresh (SpecFn.funcName_ne_relName fn)
   · exact Signature.not_mem_allNames_addUnary
-      (Signature.not_mem_allNames_addBinaryRel hf.defFresh (SpecFn.defName_ne_fn fn))
+      (Signature.not_mem_allNames_addBinaryRel hf.defFresh (SpecFn.defName_ne_relName fn))
       (SpecFn.defName_ne_funcName fn)
   · exact Signature.not_mem_allNames_addUnaryRel
       (Signature.not_mem_allNames_addUnary
@@ -318,9 +318,9 @@ def bundle
     Except String
       (FOL.BinaryRel × FOL.Unary × FOL.UnaryRel × String × DefVal × List Formula) := do
   let res := Fresh.freshName
-    (Δ.allNames ++ [x, fn, SpecFn.funcName fn, SpecFn.defName fn]) "r"
+    (Δ.allNames ++ [x, fn.relName, fn.funcName, fn.defName]) "r"
   let bv ← encodeBody Γ Δ f fn x res e
-  pure (⟨fn, .value, .value⟩, SpecFn.func fn, SpecFn.defined fn, res, bv,
+  pure (⟨fn.relName, .value, .value⟩, fn.func, fn.defined, res, bv,
         axioms fn x bv)
 
 theorem bundle_headFresh
@@ -328,7 +328,7 @@ theorem bundle_headFresh
     (hf : InfoFresh Δ fn x) :
     HeadFresh Δ fn x
       (Fresh.freshName
-        (Δ.allNames ++ [x, fn, SpecFn.funcName fn, SpecFn.defName fn]) "r") := by
+        (Δ.allNames ++ [x, fn, fn.funcName, fn.defName]) "r") := by
   obtain ⟨hresΔ, hresArg, hresRel, hresFun, hresDef⟩ :=
     freshName_avoid_props Δ x fn
   exact headFresh_of_fresh hf hresΔ hresRel hresFun hresDef hresArg
@@ -341,7 +341,7 @@ theorem bundle_wfIn
               = .ok (sym, fnSym, drel, res, bv, axs))
     (hΔ : Δ.wf) (hΓwf : Γ.wfIn Δ)
     (hf : InfoFresh Δ fn x) :
-    sym = ⟨fn, .value, .value⟩ ∧ fnSym = SpecFn.func fn ∧ drel = SpecFn.defined fn ∧
+    sym = ⟨fn.relName, .value, .value⟩ ∧ fnSym = fn.func ∧ drel = fn.defined ∧
       ∀ ax ∈ axs,
         ax.wfIn (((Δ.addBinaryRel sym).addUnary fnSym).addUnaryRel drel) := by
   unfold bundle at hinfo
@@ -353,8 +353,8 @@ theorem bundle_wfIn
   refine ⟨rfl, rfl, rfl, ?_⟩
   have hheadFresh := bundle_headFresh (Δ := Δ) (x := x) (fn := fn) hf
   set Δext : Signature :=
-    ((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (SpecFn.func fn)).addUnaryRel
-      (SpecFn.defined fn) with hΔext_def
+    ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+      (fn.defined) with hΔext_def
   have hΔx_wf : (Δext.declVar ⟨x, .value⟩).wf := by
     simpa [Δext, bodySig] using bodySig_wf_of_headFresh hΔ hheadFresh
   have hbody_x : bv.wfIn (Δext.declVar ⟨x, .value⟩) := by
@@ -364,9 +364,9 @@ theorem bundle_wfIn
       (bodySig_wf_of_headFresh hΔ hheadFresh)
       (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
       (encodeBody_def_bodySig henc)
-  have hfun_mem : SpecFn.func fn ∈ (Δext.declVar ⟨x, .value⟩).unary :=
+  have hfun_mem : fn.func ∈ (Δext.declVar ⟨x, .value⟩).unary :=
     Signature.mem_remove_unary.mpr ⟨List.Mem.head _, fun heq => hf.argNeFun heq.symm⟩
-  have hrel_mem : SpecFn.defined fn ∈ (Δext.declVar ⟨x, .value⟩).unaryRel :=
+  have hrel_mem : fn.defined ∈ (Δext.declVar ⟨x, .value⟩).unaryRel :=
     Signature.mem_remove_unaryRel.mpr ⟨List.Mem.head _, fun heq => hf.argNeDef heq.symm⟩
   intro ax hmem
   exact axioms_wfIn (Δ := Δext) hΔx_wf hbody_x hfun_mem hrel_mem ax hmem
@@ -391,37 +391,37 @@ theorem axioms_eval_updateBinaryRel
   intro ax hmem
   have hbase := axioms_eval henc hΓ hΓwf hΔ hheadFresh hρdet ax hmem
   set Δsmall : Signature :=
-    (Δ.addUnary (SpecFn.func fn)).addUnaryRel (SpecFn.defined fn) with hΔsmall_def
+    (Δ.addUnary (fn.func)).addUnaryRel (fn.defined) with hΔsmall_def
   have hΔbig_wf : (Δsmall.declVar ⟨x, .value⟩).wf := by
     show (defvalBodySig Δ fn x).wf
     exact defvalBodySig_wf_of_headFresh hΔ hheadFresh
   have hbody_wf : body.wfIn (Δsmall.declVar ⟨x, .value⟩) := by
     show body.wfIn (defvalBodySig Δ fn x)
     exact encodeBody_wfIn_defvalBodySig hΔ hΓwf.split hheadFresh henc
-  have hxNeFun : x ≠ SpecFn.funcName fn := fun heq =>
+  have hxNeFun : x ≠ fn.funcName := fun heq =>
     var_fresh_splitBase_of_headFresh hheadFresh (heq ▸ Signature.mem_allNames_of_unary
-      (Δ := Δsmall) (u := SpecFn.func fn) (List.Mem.head _))
-  have hxNeDef : x ≠ SpecFn.defName fn := fun heq =>
+      (Δ := Δsmall) (u := fn.func) (List.Mem.head _))
+  have hxNeDef : x ≠ fn.defName := fun heq =>
     var_fresh_splitBase_of_headFresh hheadFresh (heq ▸ Signature.mem_allNames_of_unaryRel
-      (Δ := Δsmall) (u := SpecFn.defined fn) (List.Mem.head _))
-  have hfun_mem : SpecFn.func fn ∈ (Δsmall.declVar ⟨x, .value⟩).unary :=
+      (Δ := Δsmall) (u := fn.defined) (List.Mem.head _))
+  have hfun_mem : fn.func ∈ (Δsmall.declVar ⟨x, .value⟩).unary :=
     Signature.mem_remove_unary.mpr ⟨List.Mem.head _, fun heq => hxNeFun heq.symm⟩
-  have hrel_mem : SpecFn.defined fn ∈ (Δsmall.declVar ⟨x, .value⟩).unaryRel :=
+  have hrel_mem : fn.defined ∈ (Δsmall.declVar ⟨x, .value⟩).unaryRel :=
     Signature.mem_remove_unaryRel.mpr ⟨List.Mem.head _, fun heq => hxNeDef heq.symm⟩
   have hax_wf : ax.wfIn Δsmall :=
     axioms_wfIn (Δ := Δsmall) hΔbig_wf hbody_wf hfun_mem hrel_mem ax hmem
-  have hrelFresh_small : (⟨fn, .value, .value⟩ : FOL.BinaryRel).name ∉ Δsmall.allNames :=
+  have hrelFresh_small : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel).name ∉ Δsmall.allNames :=
     Signature.not_mem_allNames_addUnaryRel
       (Signature.not_mem_allNames_addUnary hheadFresh.relFresh
-        (show fn ≠ (SpecFn.func fn).name from (SpecFn.funcName_ne_fn fn).symm))
-      (show fn ≠ (SpecFn.defined fn).name from (SpecFn.defName_ne_fn fn).symm)
+        (show fn ≠ (fn.func).name from (SpecFn.funcName_ne_fn fn).symm))
+      (show fn ≠ (fn.defined).name from (SpecFn.defName_ne_fn fn).symm)
   have hagree :
       Env.agreeOn Δsmall
         (defInterpEnv Γ Δ ρ f fn x res e body)
         ((defInterpEnv Γ Δ ρ f fn x res e body).updateBinaryRel
           .value .value fn R) :=
     Env.agreeOn_update_fresh_binaryRel
-      (b := ⟨fn, .value, .value⟩) hrelFresh_small
+      (b := ⟨fn.relName, .value, .value⟩) hrelFresh_small
   exact (Formula.eval_env_agree hax_wf hagree).mp hbase
 
 /-- Verifier-facing combined functionality: `semrel` is single-valued. -/

--- a/Mica/Verifier/RelationalEncoding/Axioms.lean
+++ b/Mica/Verifier/RelationalEncoding/Axioms.lean
@@ -1,0 +1,504 @@
+-- SUMMARY: Solver-facing axioms and validity theorems for skolemized relational encoding.
+import Mica.Verifier.RelationalEncoding.SkolemizeCompleteness
+
+
+/-!
+# Split Encoding Axioms
+
+For each fn-œmarked recursive function, Skolemization exposes the
+relational graph through two solver-facing symbols:
+
+* `f_def(x)` says the function is defined on input `x`;
+* `f_val(x)` is the value returned at `x` when it is defined.
+
+If `body_def(x)` and `body_val(x)` are the definedness and value expressions
+computed by the split body encoding, this file emits and proves valid three
+axioms:
+
+1. `body_def(x) -> f_def(x)` (`definedIntroAxiom`);
+2. `f_def(x) -> f_val(x) = body_val(x)` (`valueAxiom`);
+3. `f_def(x) -> body_def(x)` (`definedElimAxiom`).
+
+Together, the two definedness implications make `f_def(x)` equivalent to the
+body being defined, and the value axiom pins `f_val(x)` to the encoded body
+value on that domain.
+
+For a fibonacci-style definition
+
+```text
+fib n = if n <= 1 then n else fib (n - 1) + fib (n - 2)
+```
+
+the split body has a definedness condition like
+
+```text
+n <= 1 || (fib_def(n - 1) && fib_def(n - 2))
+```
+
+and a value expression like
+
+```text
+if n <= 1 then n else fib_val(n - 1) + fib_val(n - 2)
+```
+
+so the emitted axioms state that the recursive-call definedness condition is
+exactly `fib_def(n)`, and that `fib_val(n)` equals the conditional value
+expression whenever `fib_def(n)` holds.
+-/
+
+namespace Verifier.RelationalEncoding
+namespace Skolemize
+open Relation
+
+-- Axioms
+
+/-- If the encoded body is defined on input `x`, the function is defined on `x`. -/
+def definedIntroAxiom (rel x : TinyML.Var) (body : DefVal) : Formula :=
+  .forall_ x .value
+    (.implies body.defined (SpecFn.isDefined rel (.var .value x)))
+
+/-- If the function is defined on input `x`, its solver-facing value equals the
+encoded body value. -/
+def valueAxiom (rel x : TinyML.Var) (body : DefVal) : Formula :=
+  .forall_ x .value
+    (.implies
+      (SpecFn.isDefined rel (.var .value x))
+      (.eq .value (SpecFn.call rel (.var .value x)) body.value))
+
+/-- Converse of `definedIntroAxiom`: if the function is defined on `x`, then the
+encoded body is defined on `x`.  Experimental — exposing this lets the SMT
+backend propagate definedness from a parent call into its recursive subterms. -/
+def definedElimAxiom (rel x : TinyML.Var) (body : DefVal) : Formula :=
+  .forall_ x .value
+    (.implies (SpecFn.isDefined rel (.var .value x)) body.defined)
+
+/-- The solver-facing axioms emitted for a relation-marked function. -/
+def axioms (rel x : TinyML.Var) (body : DefVal) : List Formula :=
+  [definedIntroAxiom rel x body, valueAxiom rel x body,
+   definedElimAxiom rel x body]
+
+theorem axioms_wfIn {Δ : Signature} {rel x : String} {body : DefVal}
+    (hΔx : (Δ.declVar ⟨x, .value⟩).wf)
+    (hbody : body.wfIn (Δ.declVar ⟨x, .value⟩))
+    (hfun : SpecFn.func rel ∈ (Δ.declVar ⟨x, .value⟩).unary)
+    (hrel : SpecFn.defined rel ∈ (Δ.declVar ⟨x, .value⟩).unaryRel) :
+    ∀ ax ∈ axioms rel x body, ax.wfIn Δ := by
+  intro ax hmem
+  simp [axioms] at hmem
+  rcases hmem with rfl | rfl | rfl
+  · simp only [definedIntroAxiom, Formula.wfIn]
+    exact ⟨hbody.2,
+      SpecFn.isDefined_wfIn hrel hΔx
+        (var_value_wfIn hΔx (Signature.var_mem_declVar Δ ⟨x, .value⟩))⟩
+  · simp only [valueAxiom, Formula.wfIn]
+    have hx : (Term.var .value x).wfIn (Δ.declVar ⟨x, .value⟩) :=
+      var_value_wfIn hΔx (Signature.var_mem_declVar Δ ⟨x, .value⟩)
+    exact ⟨SpecFn.isDefined_wfIn hrel hΔx hx,
+      SpecFn.call_wfIn hfun hΔx hx, hbody.1⟩
+  · simp only [definedElimAxiom, Formula.wfIn]
+    exact ⟨SpecFn.isDefined_wfIn hrel hΔx
+        (var_value_wfIn hΔx (Signature.var_mem_declVar Δ ⟨x, .value⟩)),
+      hbody.2⟩
+
+
+/-- The semantic relation for the current recursive body is exactly the graph
+of the split definedness predicate and the epsilon-selected value function. -/
+def GraphCompatible
+    (Γ : FunCtx) (Δ : Signature) (ρ : Env)
+    (f : TinyML.Var) (rel : String) (x res : TinyML.Var) (e : Typed.Expr)
+    (body : DefVal) : Prop :=
+  ∀ vin vout,
+    semrel Γ Δ ρ f rel x res e vin vout ↔
+      semdef Γ Δ ρ f rel x res e body vin ∧
+        semFunc (semrel Γ Δ ρ f rel x res e) vin = vout
+
+
+/-- The definedness-introduction axiom is valid under the semantic definedness
+least fixpoint. This is the first solver-facing axiom and does not require the
+eventual relation/graph equivalence. -/
+theorem definedIntroAxiom_eval
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body) :
+    (definedIntroAxiom rel x body).eval
+      (defInterpEnv Γ Δ ρ f rel x res e body) := by
+  simp only [definedIntroAxiom, Formula.eval]
+  intro vin hbody
+  have hsem :
+      semdef Γ Δ ρ f rel x res e body vin := by
+    exact (semdef_unfold_of_encode (ρ := ρ) (x := x) (res := res) henc vin).mpr hbody
+  exact (definedCall_eval_defInterpEnv (Γ := Γ) (Δ := Δ) (ρ := ρ)
+    (f := f) (fn := rel) (x := x) (res := res) (e := e) (body := body) vin).mpr hsem
+
+/-- The semantic relation induced by the relational encoding agrees with the
+graph induced by the split definedness fixpoint and epsilon-selected value
+function. This is a theorem of the two encodings, not an external invariant:
+tail compatibility handles old function symbols, freshness prevents the new
+symbols from clobbering them, and the paired-encoding completeness/soundness proof handles the
+recursive body. -/
+theorem semrel_compatible
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ) :
+    GraphCompatible Γ Δ ρ f rel x res e body := by
+  intro vin vout
+  constructor
+  · intro hrel
+    have hsplit :=
+      semrel_complete henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+        vin vout hrel
+    have hdefined : semDefined (semrel Γ Δ ρ f rel x res e) vin := ⟨vout, hrel⟩
+    have hfun :
+      semFunc (semrel Γ Δ ρ f rel x res e) vin = vout :=
+      relation_semrel_functional_of_encodeBody henc hΔ hΓrel hΓdef hheadFresh hρdet vin
+        (semFunc (semrel Γ Δ ρ f rel x res e) vin) vout
+        (semFunc_spec hdefined) hrel
+    exact ⟨hsplit.1, hfun⟩
+  · intro hgraph
+    rcases hgraph with ⟨hdef, hfun⟩
+    let vbody :=
+      body.value.eval
+        ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin)
+    have hrelBody :
+        semrel Γ Δ ρ f rel x res e vin vbody :=
+      semrel_sound henc hΓ hΓrel hΓdef hΔ hheadFresh vin vbody
+        hdef rfl
+    have hdefined : semDefined (semrel Γ Δ ρ f rel x res e) vin := ⟨vbody, hrelBody⟩
+    have hchosen :
+        vbody = semFunc (semrel Γ Δ ρ f rel x res e) vin :=
+      relation_semrel_functional_of_encodeBody henc hΔ hΓrel hΓdef hheadFresh hρdet vin vbody
+        (semFunc (semrel Γ Δ ρ f rel x res e) vin)
+        hrelBody (semFunc_spec hdefined)
+    exact semrel_sound henc hΓ hΓrel hΓdef hΔ hheadFresh vin vout
+      hdef (hchosen.trans hfun)
+
+/-- The value axiom is valid under the canonical split interpretation extracted
+from the relational semantics. -/
+theorem valueAxiom_eval
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ) :
+    (valueAxiom rel x body).eval
+      (defInterpEnv Γ Δ ρ f rel x res e body) := by
+  simp only [valueAxiom, Formula.eval]
+  intro vin hdef
+  have hsem := (definedCall_eval_defInterpEnv (Γ := Γ) (Δ := Δ) (ρ := ρ)
+    (f := f) (fn := rel) (x := x) (res := res) (e := e) (body := body) vin).mp hdef
+  rw [valueCall_eval_defInterpEnv (Γ := Γ) (Δ := Δ) (ρ := ρ)
+    (f := f) (fn := rel) (x := x) (res := res) (e := e) (body := body) vin]
+  have hgraph := semrel_compatible henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+  have hrel :
+      semrel Γ Δ ρ f rel x res e vin
+        (semFunc (semrel Γ Δ ρ f rel x res e) vin) :=
+    (hgraph vin (semFunc (semrel Γ Δ ρ f rel x res e) vin)).mpr ⟨hsem, rfl⟩
+  exact (semrel_complete henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+    vin (semFunc (semrel Γ Δ ρ f rel x res e) vin) hrel).2.symm
+
+/-- Semantic validity of the converse definedness axiom: under the least
+fixpoint of `semdef`, the `semdef`/`defBody` unfolding goes both ways, so
+`isDefined rel x` implies `body.defined` on `x`. -/
+theorem definedElimAxiom_eval
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body) :
+    (definedElimAxiom rel x body).eval
+      (defInterpEnv Γ Δ ρ f rel x res e body) := by
+  simp only [definedElimAxiom, Formula.eval]
+  intro vin hdef
+  have hsem : semdef Γ Δ ρ f rel x res e body vin :=
+    (definedCall_eval_defInterpEnv (Γ := Γ) (Δ := Δ) (ρ := ρ)
+      (f := f) (fn := rel) (x := x) (res := res) (e := e) (body := body) vin).mp hdef
+  exact (semdef_unfold_of_encode (ρ := ρ) (x := x) (res := res) henc vin).mp hsem
+
+/-- Semantic validity of the split axioms under the canonical split
+interpretation. -/
+theorem axioms_eval
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ) :
+    ∀ ax ∈ axioms rel x body,
+      ax.eval (defInterpEnv Γ Δ ρ f rel x res e body) := by
+  intro ax hmem
+  simp [axioms] at hmem
+  rcases hmem with rfl | rfl | rfl
+  · exact definedIntroAxiom_eval henc
+  · exact valueAxiom_eval henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+  · exact definedElimAxiom_eval henc
+
+/-! ## Verifier-facing bundle
+
+`bundle` is the top-level entry point for the verifier: given a relation-marked
+function and its body, it returns the data needed to declare solver symbols
+and assume axioms (the binary relation symbol, the value function, the
+definedness predicate, a fresh pinned result variable, the encoded body, and
+the list of axioms). Stage 2 emits two unary axioms (over the value and
+definedness symbols) instead of stage 1's single binary defining axiom.
+
+The lemmas below lift the corresponding `axioms_*` results to the `bundle`
+level. -/
+
+/-- Bundle of independent freshness premises sufficient to derive
+`HeadFresh` once a fresh result variable is chosen. The verifier discharges
+these per step. -/
+structure InfoFresh (Δ : Signature) (rel arg : String) : Prop where
+  relFresh : rel ∉ Δ.allNames
+  funFresh : SpecFn.funcName rel ∉ Δ.allNames
+  defFresh : SpecFn.defName rel ∉ Δ.allNames
+  argFresh : arg ∉ Δ.allNames
+  argNeRel : arg ≠ rel
+  argNeFun : arg ≠ SpecFn.funcName rel
+  argNeDef : arg ≠ SpecFn.defName rel
+
+theorem freshName_avoid_props
+    (Δ : Signature) (arg rel : String) :
+    let res := Fresh.freshName
+      (Δ.allNames ++ [arg, rel, SpecFn.funcName rel, SpecFn.defName rel]) "r"
+    res ∉ Δ.allNames ∧ res ≠ arg ∧ res ≠ rel ∧
+      res ≠ SpecFn.funcName rel ∧ res ≠ SpecFn.defName rel := by
+  have hres := Fresh.freshName_not_in_avoid
+    (Δ.allNames ++ [arg, rel, SpecFn.funcName rel, SpecFn.defName rel]) "r"
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · intro h; exact hres (List.mem_append_left _ h)
+  · intro h; apply hres; rw [h]; simp
+  · intro h; apply hres; rw [h]; simp
+  · intro h; apply hres; rw [h]; simp
+  · intro h; apply hres; rw [h]; simp
+
+/-- Derive `HeadFresh` from independent freshness hypotheses on each of the
+solver-facing names. -/
+theorem headFresh_of_fresh
+    {Δ : Signature} {rel x res : String}
+    (hf : InfoFresh Δ rel x)
+    (hresΔ : res ∉ Δ.allNames)
+    (hresRel : res ≠ rel) (hresFun : res ≠ SpecFn.funcName rel)
+    (hresDef : res ≠ SpecFn.defName rel) (hresx : res ≠ x) :
+    HeadFresh Δ rel x res := by
+  refine
+    { relFresh := hf.relFresh
+      funFresh := ?_
+      defFresh := ?_
+      argFresh := ?_
+      resFresh := ?_ }
+  · exact Signature.not_mem_allNames_addBinaryRel hf.funFresh (SpecFn.funcName_ne_fn rel)
+  · exact Signature.not_mem_allNames_addUnary
+      (Signature.not_mem_allNames_addBinaryRel hf.defFresh (SpecFn.defName_ne_fn rel))
+      (SpecFn.defName_ne_funcName rel)
+  · exact Signature.not_mem_allNames_addUnaryRel
+      (Signature.not_mem_allNames_addUnary
+        (Signature.not_mem_allNames_addBinaryRel hf.argFresh hf.argNeRel)
+        hf.argNeFun)
+      hf.argNeDef
+  · exact Signature.not_mem_allNames_declVar
+      (Signature.not_mem_allNames_addUnaryRel
+        (Signature.not_mem_allNames_addUnary
+          (Signature.not_mem_allNames_addBinaryRel hresΔ hresRel)
+          hresFun)
+        hresDef)
+      hresx
+
+/-- Verifier-facing helper bundle for the split (definedness/value) encoding.
+Returns the binary relation symbol (declared but unconstrained at the SMT
+level), the solver-facing value function, the definedness predicate, the
+canonical pinned-result variable, the encoded body, and the list of
+solver-emitted axioms. -/
+def bundle
+    (Γ : FunCtx) (Δ : Signature) (name rel arg : String) (body : Typed.Expr) :
+    Except String
+      (FOL.BinaryRel × FOL.Unary × FOL.UnaryRel × String × DefVal × List Formula) := do
+  let res := Fresh.freshName
+    (Δ.allNames ++ [arg, rel, SpecFn.funcName rel, SpecFn.defName rel]) "r"
+  let bv ← encodeBody Γ Δ name rel arg res body
+  pure (⟨rel, .value, .value⟩, SpecFn.func rel, SpecFn.defined rel, res, bv,
+        axioms rel arg bv)
+
+theorem bundle_headFresh
+    {Δ : Signature} {arg rel : String}
+    (hf : InfoFresh Δ rel arg) :
+    HeadFresh Δ rel arg
+      (Fresh.freshName
+        (Δ.allNames ++ [arg, rel, SpecFn.funcName rel, SpecFn.defName rel]) "r") := by
+  obtain ⟨hresΔ, hresArg, hresRel, hresFun, hresDef⟩ :=
+    freshName_avoid_props Δ arg rel
+  exact headFresh_of_fresh hf hresΔ hresRel hresFun hresDef hresArg
+
+theorem bundle_wfIn
+    {Γ : FunCtx} {Δ : Signature} {name rel arg : String} {body : Typed.Expr}
+    {sym : FOL.BinaryRel} {fn : FOL.Unary} {drel : FOL.UnaryRel}
+    {res : String} {bv : DefVal} {axs : List Formula}
+    (hinfo : bundle Γ Δ name rel arg body
+              = .ok (sym, fn, drel, res, bv, axs))
+    (hΔ : Δ.wf) (hΓdef : Γ.defWfIn Δ)
+    (hf : InfoFresh Δ rel arg) :
+    sym = ⟨rel, .value, .value⟩ ∧ fn = SpecFn.func rel ∧ drel = SpecFn.defined rel ∧
+      ∀ ax ∈ axs,
+        ax.wfIn (((Δ.addBinaryRel sym).addUnary fn).addUnaryRel drel) := by
+  unfold bundle at hinfo
+  simp only [bind, Except.bind] at hinfo
+  split at hinfo
+  · cases hinfo
+  rename_i bv' henc
+  cases hinfo
+  refine ⟨rfl, rfl, rfl, ?_⟩
+  have hheadFresh := bundle_headFresh (Δ := Δ) (arg := arg) (rel := rel) hf
+  set Δext : Signature :=
+    ((Δ.addBinaryRel ⟨rel, .value, .value⟩).addUnary (SpecFn.func rel)).addUnaryRel
+      (SpecFn.defined rel) with hΔext_def
+  have hΔx_wf : (Δext.declVar ⟨arg, .value⟩).wf := by
+    simpa [Δext, bodySig] using bodySig_wf_of_headFresh hΔ hheadFresh
+  have hbody_x : bv.wfIn (Δext.declVar ⟨arg, .value⟩) := by
+    show bv.wfIn (bodySig Δ rel arg)
+    exact encode_wfIn (Γ := Relation.ctx Γ name rel)
+      (Δ := bodySig Δ rel arg) body
+      (bodySig_wf_of_headFresh hΔ hheadFresh)
+      (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh)
+      (encodeBody_def_bodySig henc)
+  have hfun_mem : SpecFn.func rel ∈ (Δext.declVar ⟨arg, .value⟩).unary :=
+    Signature.mem_remove_unary.mpr ⟨List.Mem.head _, fun heq => hf.argNeFun heq.symm⟩
+  have hrel_mem : SpecFn.defined rel ∈ (Δext.declVar ⟨arg, .value⟩).unaryRel :=
+    Signature.mem_remove_unaryRel.mpr ⟨List.Mem.head _, fun heq => hf.argNeDef heq.symm⟩
+  intro ax hmem
+  exact axioms_wfIn (Δ := Δext) hΔx_wf hbody_x hfun_mem hrel_mem ax hmem
+
+
+/-- The split axioms remain valid under any choice of binary relation
+interpretation for `rel`. The body and axiom shapes only mention the
+solver-facing split symbols, never `rel` as a binary predicate, so updating
+`rel`'s binary interpretation is irrelevant. -/
+theorem axioms_eval_updateBinaryRel
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ)
+    (R : ValRel) :
+    ∀ ax ∈ axioms rel x body,
+      ax.eval ((defInterpEnv Γ Δ ρ f rel x res e body).updateBinaryRel
+        .value .value rel R) := by
+  intro ax hmem
+  have hbase := axioms_eval henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet ax hmem
+  set Δsmall : Signature :=
+    (Δ.addUnary (SpecFn.func rel)).addUnaryRel (SpecFn.defined rel) with hΔsmall_def
+  have hΔbig_wf : (Δsmall.declVar ⟨x, .value⟩).wf := by
+    show (defvalBodySig Δ rel x).wf
+    exact defvalBodySig_wf_of_headFresh hΔ hheadFresh
+  have hbody_wf : body.wfIn (Δsmall.declVar ⟨x, .value⟩) := by
+    show body.wfIn (defvalBodySig Δ rel x)
+    exact encodeBody_wfIn_defvalBodySig hΔ hΓdef hheadFresh henc
+  have hxNeFun : x ≠ SpecFn.funcName rel := fun heq =>
+    var_fresh_splitBase_of_headFresh hheadFresh (heq ▸ Signature.mem_allNames_of_unary
+      (Δ := Δsmall) (u := SpecFn.func rel) (List.Mem.head _))
+  have hxNeDef : x ≠ SpecFn.defName rel := fun heq =>
+    var_fresh_splitBase_of_headFresh hheadFresh (heq ▸ Signature.mem_allNames_of_unaryRel
+      (Δ := Δsmall) (u := SpecFn.defined rel) (List.Mem.head _))
+  have hfun_mem : SpecFn.func rel ∈ (Δsmall.declVar ⟨x, .value⟩).unary :=
+    Signature.mem_remove_unary.mpr ⟨List.Mem.head _, fun heq => hxNeFun heq.symm⟩
+  have hrel_mem : SpecFn.defined rel ∈ (Δsmall.declVar ⟨x, .value⟩).unaryRel :=
+    Signature.mem_remove_unaryRel.mpr ⟨List.Mem.head _, fun heq => hxNeDef heq.symm⟩
+  have hax_wf : ax.wfIn Δsmall :=
+    axioms_wfIn (Δ := Δsmall) hΔbig_wf hbody_wf hfun_mem hrel_mem ax hmem
+  have hrelFresh_small : (⟨rel, .value, .value⟩ : FOL.BinaryRel).name ∉ Δsmall.allNames :=
+    Signature.not_mem_allNames_addUnaryRel
+      (Signature.not_mem_allNames_addUnary hheadFresh.relFresh
+        (show rel ≠ (SpecFn.func rel).name from (SpecFn.funcName_ne_fn rel).symm))
+      (show rel ≠ (SpecFn.defined rel).name from (SpecFn.defName_ne_fn rel).symm)
+  have hagree :
+      Env.agreeOn Δsmall
+        (defInterpEnv Γ Δ ρ f rel x res e body)
+        ((defInterpEnv Γ Δ ρ f rel x res e body).updateBinaryRel
+          .value .value rel R) :=
+    Env.agreeOn_update_fresh_binaryRel
+      (b := ⟨rel, .value, .value⟩) hrelFresh_small
+  exact (Formula.eval_env_agree hax_wf hagree).mp hbase
+
+/-- Verifier-facing combined functionality: `semrel` is single-valued. -/
+theorem bundle_semrel_functional
+    {Γ : FunCtx} {Δ : Signature}
+    {name rel arg : String} {body : Typed.Expr}
+    {sym : FOL.BinaryRel} {fn : FOL.Unary} {drel : FOL.UnaryRel}
+    {res : String} {bv : DefVal} {axs : List Formula}
+    (hinfo : bundle Γ Δ name rel arg body
+              = .ok (sym, fn, drel, res, bv, axs))
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hf : InfoFresh Δ rel arg)
+    (ρ : Env) (hρdet : Relation.BinaryRelDet Γ ρ ρ)
+    (vin : Srt.value.denote) (y₁ y₂ : Srt.value.denote)
+    (h₁ : semrel Γ Δ ρ name rel arg res body vin y₁)
+    (h₂ : semrel Γ Δ ρ name rel arg res body vin y₂) :
+    y₁ = y₂ := by
+  unfold bundle at hinfo
+  simp only [bind, Except.bind] at hinfo
+  split at hinfo
+  · cases hinfo
+  rename_i bv' henc
+  cases hinfo
+  have hheadFresh := bundle_headFresh (Δ := Δ) (arg := arg) (rel := rel) hf
+  exact relation_semrel_functional_of_encodeBody henc hΔ hΓrel hΓdef hheadFresh hρdet vin y₁ y₂ h₁ h₂
+
+/-- Verifier-facing semrel/split graph compatibility for the new relation. -/
+theorem bundle_semrel_compatible
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {name rel arg : String} {body : Typed.Expr}
+    {sym : FOL.BinaryRel} {fn : FOL.Unary} {drel : FOL.UnaryRel}
+    {res : String} {bv : DefVal} {axs : List Formula}
+    (hinfo : bundle Γ Δ name rel arg body
+              = .ok (sym, fn, drel, res, bv, axs))
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hf : InfoFresh Δ rel arg)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ)
+    (vin vout : Srt.value.denote) :
+    semrel Γ Δ ρ name rel arg res body vin vout ↔
+      semdef Γ Δ ρ name rel arg res body bv vin ∧
+        semFunc (semrel Γ Δ ρ name rel arg res body) vin = vout := by
+  unfold bundle at hinfo
+  simp only [bind, Except.bind] at hinfo
+  split at hinfo
+  · cases hinfo
+  rename_i bv' henc
+  cases hinfo
+  have hheadFresh := bundle_headFresh (Δ := Δ) (arg := arg) (rel := rel) hf
+  exact semrel_compatible henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet vin vout
+
+/-- Verifier-facing variant of `axioms_eval_updateBinaryRel`: the axioms emitted
+by `bundle` evaluate to true under any choice of binary-relation
+interpretation for the freshly declared `rel` symbol. -/
+theorem bundle_eval_updateBinaryRel
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {name rel arg : String} {body : Typed.Expr}
+    {sym : FOL.BinaryRel} {fn : FOL.Unary} {drel : FOL.UnaryRel}
+    {res : String} {bv : DefVal} {axs : List Formula}
+    (hinfo : bundle Γ Δ name rel arg body
+              = .ok (sym, fn, drel, res, bv, axs))
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hf : InfoFresh Δ rel arg)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ)
+    (R : ValRel) :
+    ∀ ax ∈ axs,
+      ax.eval ((defInterpEnv Γ Δ ρ name rel arg res body bv).updateBinaryRel
+        .value .value rel R) := by
+  unfold bundle at hinfo
+  simp only [bind, Except.bind] at hinfo
+  split at hinfo
+  · cases hinfo
+  rename_i bv' henc
+  cases hinfo
+  have hheadFresh := bundle_headFresh (Δ := Δ) (arg := arg) (rel := rel) hf
+  exact axioms_eval_updateBinaryRel henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet R
+
+end Skolemize
+end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/Monad.lean
+++ b/Mica/Verifier/RelationalEncoding/Monad.lean
@@ -1,0 +1,1346 @@
+-- SUMMARY: Generic monadic skeleton for TinyML-to-FOL encoders.
+import Mica.FOL.Formulas
+import Mica.FOL.Fixpoint
+import Mica.TinyML.Typed
+import Mica.Base.Fresh
+import Mica.Verifier.RelationalEncoding.Variables
+
+/-!
+# Generic monadic skeleton for TinyML-to-FOL encoders
+
+An *encoder* is parameterized by a carrier `M` together with three operations
+(`call`, `ite`, `error`) packaged as `EncoderOps M`. Error handling lives in
+`M`: every failure path goes through `ops.error`. The traversal
+is in continuation-passing style: every leaf hands its value term to the
+continuation; `call` consumes a continuation explicitly; for `ite` the
+continuation is pushed into both branches before they are combined.
+
+Three generic induction principles are proved once:
+
+* **plain induction** — `encodeWith_ind`, for any carrier-side predicate
+  closed under the operations (`EncoderOpsInd`);
+* **signature-indexed induction** — `encodeWith_indWithSig`, for any
+  signature-indexed carrier predicate closed under the operations
+  (`EncoderOpsSig`). Well-formedness is the canonical instance, but
+  determinism in a designated result variable is another;
+* **paired-encoding binary** — `encodeWith_bind_binary`, lifting an
+  operation-level binary relation between two encoders (`EncoderOpsBinary`)
+  to their full traversals.
+-/
+
+namespace Verifier.RelationalEncoding
+
+/-! ## Per-operation encoders for constants and primitives -/
+
+/-- Encode a TinyML constant into a value-sorted FOL term. -/
+def encodeConst : TinyML.Const → Term .value
+  | .int  n => .unop .ofInt  (.const (.i n))
+  | .bool b => .unop .ofBool (.const (.b b))
+  | .unit   => .const .unit
+
+/-- Encode a TinyML unary op acting on a value-sorted argument. -/
+def encodeUnOp : TinyML.UnOp → Term .value → Except String (Term .value)
+  | .neg,    v => .ok (.unop .ofInt  (.unop .neg (.unop .toInt  v)))
+  | .not,    v => .ok (.unop .ofBool (.unop .not (.unop .toBool v)))
+  | .proj n, v => .ok (.unop .vhead (vtailN (.unop .toValList v) n))
+
+/-- Encode a TinyML binary op acting on two value-sorted arguments. -/
+def encodeBinOp : TinyML.BinOp → Term .value → Term .value → Except String (Term .value)
+  | .add, a, b => .ok (.unop .ofInt  (.binop .add  (.unop .toInt a) (.unop .toInt b)))
+  | .sub, a, b => .ok (.unop .ofInt  (.binop .sub  (.unop .toInt a) (.unop .toInt b)))
+  | .mul, a, b => .ok (.unop .ofInt  (.binop .mul  (.unop .toInt a) (.unop .toInt b)))
+  | .div, a, b => .ok (.unop .ofInt  (.binop .div  (.unop .toInt a) (.unop .toInt b)))
+  | .mod, a, b => .ok (.unop .ofInt  (.binop .mod  (.unop .toInt a) (.unop .toInt b)))
+  | .lt,  a, b => .ok (.unop .ofBool (.binop .less (.unop .toInt a) (.unop .toInt b)))
+  | .le,  a, b => .ok (.unop .ofBool (.binop .ge   (.unop .toInt b) (.unop .toInt a)))
+  | .gt,  a, b => .ok (.unop .ofBool (.binop .gt   (.unop .toInt a) (.unop .toInt b)))
+  | .ge,  a, b => .ok (.unop .ofBool (.binop .ge   (.unop .toInt a) (.unop .toInt b)))
+  | .eq,  a, b => .ok (.unop .ofBool (.binop .eq             a              b))
+  | .and, a, b => .ok (.unop .ofBool (.ite (.unop .toBool a) (.unop .toBool b) (.const (.b false))))
+  | .or,  a, b => .ok (.unop .ofBool (.ite (.unop .toBool a) (.const (.b true)) (.unop .toBool b)))
+
+/-! ## Well-formedness lemmas for primitive encoders -/
+
+theorem encodeConst_wfIn (c : TinyML.Const) (Δ : Signature) :
+    (encodeConst c).wfIn Δ := by
+  cases c <;> simp [encodeConst, Term.wfIn, UnOp.wfIn, Const.wfIn]
+
+theorem encodeUnOp_wfIn {op : TinyML.UnOp} {v v' : Term .value} {Δ : Signature}
+    (h : encodeUnOp op v = .ok v') (hv : v.wfIn Δ) : v'.wfIn Δ := by
+  cases op with
+  | neg =>
+    simp only [encodeUnOp, Except.ok.injEq] at h; subst h
+    exact ⟨trivial, trivial, trivial, hv⟩
+  | not =>
+    simp only [encodeUnOp, Except.ok.injEq] at h; subst h
+    exact ⟨trivial, trivial, trivial, hv⟩
+  | proj n =>
+    simp only [encodeUnOp, Except.ok.injEq] at h; subst h
+    have ht : (vtailN (.unop .toValList v) n).wfIn Δ := by
+      apply vtailN_wfIn
+      change UnOp.toValList.wfIn Δ ∧ v.wfIn Δ
+      exact ⟨trivial, hv⟩
+    change UnOp.vhead.wfIn Δ ∧ (vtailN (.unop .toValList v) n).wfIn Δ
+    exact ⟨trivial, ht⟩
+
+theorem encodeBinOp_wfIn {op : TinyML.BinOp} {v1 v2 v : Term .value} {Δ : Signature}
+    (h : encodeBinOp op v1 v2 = .ok v) (h1 : v1.wfIn Δ) (h2 : v2.wfIn Δ) :
+    v.wfIn Δ := by
+  cases op
+  case add | sub | mul | div | mod | lt | gt | ge =>
+    simp only [encodeBinOp, Except.ok.injEq] at h; subst h
+    exact ⟨trivial, trivial, ⟨trivial, h1⟩, ⟨trivial, h2⟩⟩
+  case le =>
+    simp only [encodeBinOp, Except.ok.injEq] at h; subst h
+    exact ⟨trivial, trivial, ⟨trivial, h2⟩, ⟨trivial, h1⟩⟩
+  case eq =>
+    simp only [encodeBinOp, Except.ok.injEq] at h; subst h
+    exact ⟨trivial, trivial, h1, h2⟩
+  case and =>
+    simp only [encodeBinOp, Except.ok.injEq] at h; subst h
+    change UnOp.ofBool.wfIn Δ ∧
+      (Term.ite (.unop .toBool v1) (.unop .toBool v2) (.const (.b false))).wfIn Δ
+    exact ⟨trivial, ⟨⟨trivial, h1⟩, ⟨trivial, h2⟩, trivial⟩⟩
+  case or =>
+    simp only [encodeBinOp, Except.ok.injEq] at h; subst h
+    change UnOp.ofBool.wfIn Δ ∧
+      (Term.ite (.unop .toBool v1) (.const (.b true)) (.unop .toBool v2)).wfIn Δ
+    exact ⟨trivial, ⟨⟨trivial, h1⟩, trivial, ⟨trivial, h2⟩⟩⟩
+
+/-! ## Generic encoder operations -/
+
+/-- Generic operations needed to encode a TinyML expression in
+continuation-passing style. The shared traversal `encodeWith`
+pattern-matches on the syntax and delegates everything else to these.
+
+* `call` encodes a unary call to a relation-marked function, threading the
+  result through the continuation;
+* `ite` combines two branches — each already obtained by encoding under the
+  outer continuation — into a single carrier guarded by a boolean;
+* `error` produces a failure carrier with the given message. Concrete carriers
+  decide what "failure" means (e.g. an `Except`-valued thunk, or a top-level
+  `Except`). -/
+structure EncoderOps (M : Type) where
+  call  : String → Term .value → (Term .value → M) → M
+  ite   : Term .bool → M → M → M
+  error : String → M
+
+mutual
+/-- Shared structural traversal of a typed TinyML expression in
+continuation-passing style, parametric in the encoder operations. The only
+place that pattern-matches on `Typed.Expr`. Errors are reported via
+`ops.error`; the traversal itself is total in `M`. -/
+def encodeWith {M : Type} (ops : EncoderOps M)
+    (Γ : FunCtx) (δ : VarEnv) : Typed.Expr → (Term .value → M) → M
+  | .const c, k => k (encodeConst c)
+  | .var x _, k =>
+    match δ.lookup x with
+    | some v => k v
+    | none => ops.error s!"unbound variable: {x}"
+  | .unop op e _, k =>
+    encodeWith ops Γ δ e fun v =>
+      match encodeUnOp op v with
+      | .ok v'    => k v'
+      | .error msg => ops.error msg
+  | .binop op e1 e2 _, k =>
+    encodeWith ops Γ δ e1 fun v1 =>
+      encodeWith ops Γ δ e2 fun v2 =>
+        match encodeBinOp op v1 v2 with
+        | .ok v     => k v
+        | .error msg => ops.error msg
+  | .ifThenElse c t e _, k =>
+    encodeWith ops Γ δ c fun b =>
+      ops.ite (.unop .toBool b) (encodeWith ops Γ δ t k) (encodeWith ops Γ δ e k)
+  | .tuple es, k =>
+    encodeListWith ops Γ δ es fun vs =>
+      k (.unop .ofValList (Terms.toValList vs))
+  | .app (.var f _) [arg] _, k =>
+    match FunCtx.lookup Γ f with
+    | none     => ops.error s!"unknown function: {f}"
+    | some rel =>
+      encodeWith ops Γ δ arg fun v => ops.call rel v k
+  | .cast e _, k  => encodeWith ops Γ δ e k
+  | .letIn b bound body, k =>
+    encodeWith ops Γ δ bound fun v =>
+      encodeWith ops Γ (VarEnv.bindBinder δ b v) body k
+  | .inj tag arity payload, k =>
+    encodeWith ops Γ δ payload fun v =>
+      k (.unop (.mkInj tag arity) v)
+  | .match_ scrut branches _, k =>
+    encodeWith ops Γ δ scrut fun v =>
+      encodeMatchWith ops Γ δ v branches 0 k
+  | .app _ _ _, _ => ops.error "relational encoding: only unary calls to named top-level functions are supported"
+  | .fix .., _    => ops.error "relational encoding: nested `fix` is not supported"
+  | .ref _, _     => ops.error "relational encoding: heap allocation (`ref`) is not supported"
+  | .deref .., _  => ops.error "relational encoding: heap dereference is not supported"
+  | .store .., _  => ops.error "relational encoding: heap store is not supported"
+  | .assert _, _  => ops.error "relational encoding: `assert` is not supported"
+
+/-- Encode a list of expressions left-to-right, collecting their value terms.
+This is the list companion to `encodeWith`, needed by tuple syntax and later
+other n-ary constructs. -/
+def encodeListWith {M : Type} (ops : EncoderOps M)
+    (Γ : FunCtx) (δ : VarEnv) : List Typed.Expr → (List (Term .value) → M) → M
+  | [], k => k []
+  | e :: es, k =>
+    encodeWith ops Γ δ e fun v =>
+      encodeListWith ops Γ δ es fun vs => k (v :: vs)
+
+/-- Encode a `match_` as an if-let chain. For each non-final branch
+`(b, body)` at index `i`, the carrier tests whether the scrutinee
+value's tag equals `i`; on the true branch the binder is bound to the
+payload projection before encoding `body`; on the false branch the
+remaining branches are tried. The final branch is dispatched
+unconditionally — the elaborator guarantees an exhaustive list, so the
+trailing case must hold. An empty list (which the elaborator never
+produces) is conservatively encoded as `ops.error`. -/
+def encodeMatchWith {M : Type} (ops : EncoderOps M)
+    (Γ : FunCtx) (δ : VarEnv) (scrut : Term .value) :
+    List (Typed.Binder × Typed.Expr) → Nat → (Term .value → M) → M
+  | [], _, _ => ops.error "match: non-exhaustive"
+  | (b, body) :: rest, i, k =>
+    let δ' := VarEnv.bindBinder δ b (.unop .payloadOf scrut)
+    match rest with
+    | [] => encodeWith ops Γ δ' body k
+    | _ :: _ =>
+      ops.ite
+        (.binop .eq (.unop .tagOf scrut) (.const (.i (i : Int))))
+        (encodeWith ops Γ δ' body k)
+        (encodeMatchWith ops Γ δ scrut rest (i + 1) k)
+end
+
+/-! ## Semantic interpretation of carriers
+
+A semantic predicate `sem : M → Env → Prop` explains how a carrier is
+interpreted in an environment. Downstream constructions (e.g. the relational
+encoder's least fixpoint) use these notions on top of the traversal. -/
+
+/-- Semantic interpretation of an encoded carrier in an environment. -/
+abbrev SemPred (M : Type) := M → Env → Prop
+
+/-- A carrier is monotone when its semantic interpretation is stable under
+`Fix.Env.le`. -/
+def SemanticMono {M : Type} (sem : SemPred M) (m : M) : Prop :=
+  ∀ {ρ ρ' : Env}, Fix.Env.le ρ ρ' → sem m ρ → sem m ρ'
+
+/-! ## Generic carrier predicates
+
+Some properties of encodings are independent of signatures and function-context
+well-formedness. `EncoderOpsInd` packages per-operation preservation of
+an arbitrary carrier predicate; `encodeWith_ind` lifts those assumptions
+through the shared traversal. -/
+
+/-- Per-operation preservation assumptions for an arbitrary carrier predicate. -/
+structure EncoderOpsInd {M : Type} (ops : EncoderOps M) (P : M → Prop) where
+  /-- Calls preserve the predicate when their continuation does. -/
+  call_ind : ∀ {rel arg k},
+    (∀ v, P (k v)) → P (ops.call rel arg k)
+  /-- Conditionals preserve the predicate when both branches do. -/
+  ite_ind : ∀ {cond t e},
+    P t → P e → P (ops.ite cond t e)
+  /-- The error carrier satisfies the predicate. -/
+  error_ind : ∀ {msg}, P (ops.error msg)
+
+/-- Per-expression statement of `encodeWith_ind`. -/
+def EncodeWithInd (e : Typed.Expr) : Prop :=
+  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop}
+    {Γ : FunCtx} {δ : VarEnv} {k : Term .value → M},
+    EncoderOpsInd ops P → (∀ v, P (k v)) →
+    P (encodeWith ops Γ δ e k)
+
+/-- Per-list statement of `encodeWith_ind`. -/
+def EncodeListWithInd (es : List Typed.Expr) : Prop :=
+  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop}
+    {Γ : FunCtx} {δ : VarEnv} {k : List (Term .value) → M},
+    EncoderOpsInd ops P → (∀ vs, P (k vs)) →
+    P (encodeListWith ops Γ δ es k)
+
+/-- Per-branch-list statement of `encodeWith_ind`, mirroring `EncodeWithInd`
+but parametric in the scrutinee value and the index offset. -/
+def EncodeMatchWithInd (branches : List (Typed.Binder × Typed.Expr)) : Prop :=
+  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop}
+    {Γ : FunCtx} {δ : VarEnv} {scrut : Term .value} {i : Nat}
+    {k : Term .value → M},
+    EncoderOpsInd ops P → (∀ v, P (k v)) →
+    P (encodeMatchWith ops Γ δ scrut branches i k)
+
+/-! ## Per-case helpers for `encodeWith_ind` -/
+
+namespace Ind
+
+theorem const (c : TinyML.Const) : EncodeWithInd (.const c) := by
+  intro _ _ _ _ _ _ _ hk; simp only [encodeWith]; exact hk _
+
+theorem var (x : String) (ty : TinyML.Typ) : EncodeWithInd (.var x ty) := by
+  intro _ _ _ _ δ _ hops hk
+  cases hlookup : δ.lookup x with
+  | none => simp only [encodeWith, hlookup]; exact hops.error_ind
+  | some v => simp only [encodeWith, hlookup]; exact hk v
+
+theorem unop (op : TinyML.UnOp) (e : Typed.Expr) (ty : TinyML.Typ)
+    (ih : EncodeWithInd e) : EncodeWithInd (.unop op e ty) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeWith]
+  refine ih hops ?_
+  intro v
+  cases encodeUnOp op v with
+  | error _ => simp; exact hops.error_ind
+  | ok _    => simp; exact hk _
+
+theorem binop (op : TinyML.BinOp) (e1 e2 : Typed.Expr) (ty : TinyML.Typ)
+    (ih1 : EncodeWithInd e1) (ih2 : EncodeWithInd e2) :
+    EncodeWithInd (.binop op e1 e2 ty) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeWith]
+  refine ih1 hops ?_
+  intro v1
+  refine ih2 hops ?_
+  intro v2
+  cases encodeBinOp op v1 v2 with
+  | error _ => simp; exact hops.error_ind
+  | ok _    => simp; exact hk _
+
+theorem ifThenElse (c t e : Typed.Expr) (ty : TinyML.Typ)
+    (ihc : EncodeWithInd c) (iht : EncodeWithInd t) (ihe : EncodeWithInd e) :
+    EncodeWithInd (.ifThenElse c t e ty) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeWith]
+  refine ihc hops ?_
+  intro _
+  exact hops.ite_ind (iht hops hk) (ihe hops hk)
+
+theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
+    (ihArgs : ∀ a ∈ args, EncodeWithInd a) : EncodeWithInd (.app fn args ty) := by
+  intro _ _ _ Γ _ _ hops hk
+  match fn, args with
+  | .var f _, [arg] =>
+      simp only [encodeWith]
+      cases FunCtx.lookup Γ f with
+      | none => exact hops.error_ind
+      | some _ =>
+          simp only
+          refine ihArgs arg (List.mem_singleton.mpr rfl) hops ?_
+          intro _
+          exact hops.call_ind hk
+  | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
+  | .ifThenElse .., _ | .letIn .., _ | .ref _, _ | .deref .., _ | .store .., _
+  | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
+  | .var _ _, [] | .var _ _, _ :: _ :: _ =>
+      simp only [encodeWith]; exact hops.error_ind
+
+theorem cast (e : Typed.Expr) (ty : TinyML.Typ) (ih : EncodeWithInd e) :
+    EncodeWithInd (.cast e ty) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeWith]; exact ih hops hk
+
+theorem fix (self : Typed.Binder) (args : List Typed.Binder) (retTy : TinyML.Typ)
+    (body : Typed.Expr) : EncodeWithInd (.fix self args retTy body) :=
+  fun hops _ => hops.error_ind
+
+theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
+    (ihBound : EncodeWithInd bound) (ihBody : EncodeWithInd body) :
+    EncodeWithInd (.letIn name bound body) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeWith]
+  exact ihBound hops fun _ => ihBody hops hk
+
+theorem ref (e : Typed.Expr) : EncodeWithInd (.ref e) :=
+  fun hops _ => hops.error_ind
+
+theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithInd (.deref e ty) :=
+  fun hops _ => hops.error_ind
+
+theorem store (loc val : Typed.Expr) : EncodeWithInd (.store loc val) :=
+  fun hops _ => hops.error_ind
+
+theorem assert (e : Typed.Expr) : EncodeWithInd (.assert e) :=
+  fun hops _ => hops.error_ind
+
+theorem tuple (es : List Typed.Expr) (ih : EncodeListWithInd es) :
+    EncodeWithInd (.tuple es) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeWith]
+  exact ih hops (fun vs => hk (.unop .ofValList (Terms.toValList vs)))
+
+theorem inj (tag arity : Nat) (payload : Typed.Expr)
+    (ih : EncodeWithInd payload) : EncodeWithInd (.inj tag arity payload) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeWith]
+  refine ih hops ?_
+  intro v; exact hk _
+
+theorem match_ (scrut : Typed.Expr) (branches : List (Typed.Binder × Typed.Expr))
+    (ty : TinyML.Typ) (ihScrut : EncodeWithInd scrut)
+    (ihBranches : EncodeMatchWithInd branches) :
+    EncodeWithInd (.match_ scrut branches ty) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeWith]
+  refine ihScrut hops ?_
+  intro _; exact ihBranches hops hk
+
+theorem match_nil : EncodeMatchWithInd [] := by
+  intro _ _ _ _ _ _ _ _ hops _; simp only [encodeMatchWith]; exact hops.error_ind
+
+theorem match_cons (b : Typed.Binder) (body : Typed.Expr)
+    (rest : List (Typed.Binder × Typed.Expr))
+    (ihBody : EncodeWithInd body) (ihRest : EncodeMatchWithInd rest) :
+    EncodeMatchWithInd ((b, body) :: rest) := by
+  intro _ _ _ _ _ _ _ _ hops hk
+  simp only [encodeMatchWith]
+  cases rest with
+  | nil =>
+    cases b.name <;> exact ihBody hops hk
+  | cons _ _ =>
+    refine hops.ite_ind ?_ ?_
+    · cases b.name <;> exact ihBody hops hk
+    · exact ihRest hops hk
+
+theorem list_nil : EncodeListWithInd [] := by
+  intro _ _ _ _ _ _ _ hk; simp only [encodeListWith]; exact hk []
+
+theorem list_cons (e : Typed.Expr) (es : List Typed.Expr)
+    (ih : EncodeWithInd e) (ihs : EncodeListWithInd es) :
+    EncodeListWithInd (e :: es) := by
+  intro _ _ _ _ _ _ hops hk
+  simp only [encodeListWith]
+  refine ih hops ?_
+  intro v
+  refine ihs hops ?_
+  intro vs
+  exact hk (v :: vs)
+
+end Ind
+
+mutual
+/-- Generic preservation theorem for the shared traversal: under per-operation
+preservation assumptions, every encoded expression yields a carrier satisfying
+the predicate. -/
+theorem encodeWith_ind_def : ∀ (e : Typed.Expr), EncodeWithInd e
+  | .const c => Ind.const c
+  | .var x ty => Ind.var x ty
+  | .unop op e ty => Ind.unop op e ty (encodeWith_ind_def e)
+  | .binop op e1 e2 ty =>
+      Ind.binop op e1 e2 ty (encodeWith_ind_def e1) (encodeWith_ind_def e2)
+  | .ifThenElse c t e ty =>
+      Ind.ifThenElse c t e ty (encodeWith_ind_def c)
+        (encodeWith_ind_def t) (encodeWith_ind_def e)
+  | .app fn args ty =>
+      Ind.app fn args ty (fun a _ => encodeWith_ind_def a)
+  | .cast e ty => Ind.cast e ty (encodeWith_ind_def e)
+  | .fix self args retTy body => Ind.fix self args retTy body
+  | .letIn name bound body =>
+      Ind.letIn name bound body (encodeWith_ind_def bound) (encodeWith_ind_def body)
+  | .ref e => Ind.ref e
+  | .deref e ty => Ind.deref e ty
+  | .store loc val => Ind.store loc val
+  | .assert e => Ind.assert e
+  | .tuple es => Ind.tuple es (encodeListWith_ind_def es)
+  | .inj tag arity payload => Ind.inj tag arity payload (encodeWith_ind_def payload)
+  | .match_ scrut branches ty =>
+      Ind.match_ scrut branches ty
+        (encodeWith_ind_def scrut) (encodeMatchWith_ind_def branches)
+
+theorem encodeListWith_ind_def : ∀ (es : List Typed.Expr), EncodeListWithInd es
+  | [] => Ind.list_nil
+  | e :: es => Ind.list_cons e es (encodeWith_ind_def e) (encodeListWith_ind_def es)
+
+theorem encodeMatchWith_ind_def :
+    ∀ (branches : List (Typed.Binder × Typed.Expr)), EncodeMatchWithInd branches
+  | [] => Ind.match_nil
+  | (b, body) :: rest =>
+      Ind.match_cons b body rest (encodeWith_ind_def body)
+        (encodeMatchWith_ind_def rest)
+end
+
+/-- Compatibility wrapper preserving the original signature. -/
+theorem encodeWith_ind {M : Type} {ops : EncoderOps M} {P : M → Prop}
+    (hops : EncoderOpsInd ops P)
+    {Γ : FunCtx} {δ : VarEnv} (e : Typed.Expr)
+    {k : Term .value → M}
+    (hk : ∀ v, P (k v)) :
+    P (encodeWith ops Γ δ e k) :=
+  encodeWith_ind_def e hops hk
+
+/-! ## Signature-indexed induction
+
+Each instance supplies its own signature-indexed carrier predicate `P` and its
+own function-context predicate `Pctx`. Given the per-operation assumptions
+packaged in `EncoderOpsSig`, the shared traversal preserves `P`. Well-formedness
+is the canonical instance; determinism in a designated result variable is
+another. -/
+
+/-- Continuation contract for signature-indexed induction: a continuation `k`
+takes a value term well-formed in any signature extending `Δ` to a carrier
+satisfying `P` in that extension. -/
+abbrev SigCont {M : Type} (P : Signature → M → Prop)
+    (Δ : Signature) (k : Term .value → M) : Prop :=
+  ∀ {Δ'}, Δ.Subset Δ' → Δ'.wf →
+    ∀ v, v.wfIn Δ' → P Δ' (k v)
+
+/-- Per-operation closure assumptions for a signature-indexed carrier
+predicate `P`, with a function-context predicate `Pctx` for `call`
+(instantiated e.g. by `FunCtx.wfIn` for well-formedness, or pinned to a
+specific `Γ` for determinism). The shared traversal preserves `P` whenever
+`ops` satisfies these (`encodeWith_indWithSig`). -/
+structure EncoderOpsSig {M : Type} (ops : EncoderOps M)
+    (P : Signature → M → Prop) (Pctx : FunCtx → Signature → Prop) where
+  /-- The function-context predicate is stable under signature extension. -/
+  ctx_mono : ∀ {Γ Δ Δ'}, Pctx Γ Δ → Δ.Subset Δ' → Pctx Γ Δ'
+  /-- A call to a function registered in `Γ` satisfies `P` at `Δ` provided its
+  continuation does. -/
+  call_ind : ∀ {Γ Δ f rel arg k},
+    Δ.wf → Pctx Γ Δ → (f, rel) ∈ Γ → arg.wfIn Δ →
+    SigCont P Δ k →
+    P Δ (ops.call rel arg k)
+  /-- A conditional with a well-formed condition and both branches satisfying
+  `P` satisfies `P`. -/
+  ite_ind : ∀ {Δ cond t e},
+    Δ.wf → cond.wfIn Δ → P Δ t → P Δ e →
+    P Δ (ops.ite cond t e)
+  /-- The error carrier satisfies `P` at every signature. -/
+  error_ind : ∀ {Δ msg}, P Δ (ops.error msg)
+
+/-- Per-expression statement of `encodeWith_indWithSig`. -/
+def EncodeWithIndSig (e : Typed.Expr) : Prop :=
+  ∀ {M : Type} {ops : EncoderOps M}
+    {P : Signature → M → Prop} {Pctx : FunCtx → Signature → Prop}
+    {Γ : FunCtx} {Δ Δ' : Signature} {δ : VarEnv} {k : Term .value → M},
+    EncoderOpsSig ops P Pctx →
+    Δ.Subset Δ' → Δ'.wf → Pctx Γ Δ' → δ.wfIn Δ' →
+    SigCont P Δ' k →
+    P Δ' (encodeWith ops Γ δ e k)
+
+/-- Per-list statement of `encodeWith_indWithSig`. -/
+def EncodeListWithIndSig (es : List Typed.Expr) : Prop :=
+  ∀ {M : Type} {ops : EncoderOps M}
+    {P : Signature → M → Prop} {Pctx : FunCtx → Signature → Prop}
+    {Γ : FunCtx} {Δ Δ' : Signature} {δ : VarEnv} {k : List (Term .value) → M},
+    EncoderOpsSig ops P Pctx →
+    Δ.Subset Δ' → Δ'.wf → Pctx Γ Δ' → δ.wfIn Δ' →
+    (∀ {Δ''}, Δ'.Subset Δ'' → Δ''.wf →
+      ∀ vs, (∀ v ∈ vs, v.wfIn Δ'') → P Δ'' (k vs)) →
+    P Δ' (encodeListWith ops Γ δ es k)
+
+/-- Per-branch-list statement of `encodeWith_indWithSig`, parametric in the
+scrutinee value and starting index. The scrutinee must be well-formed at the
+current signature so the tag-check and payload projection are. -/
+def EncodeMatchWithIndSig (branches : List (Typed.Binder × Typed.Expr)) : Prop :=
+  ∀ {M : Type} {ops : EncoderOps M}
+    {P : Signature → M → Prop} {Pctx : FunCtx → Signature → Prop}
+    {Γ : FunCtx} {Δ Δ' : Signature} {δ : VarEnv}
+    {scrut : Term .value} {i : Nat} {k : Term .value → M},
+    EncoderOpsSig ops P Pctx →
+    Δ.Subset Δ' → Δ'.wf → Pctx Γ Δ' → δ.wfIn Δ' →
+    scrut.wfIn Δ' →
+    SigCont P Δ' k →
+    P Δ' (encodeMatchWith ops Γ δ scrut branches i k)
+
+/-! ## Per-case helpers for `encodeWith_indWithSig` -/
+
+namespace IndSig
+
+theorem const (c : TinyML.Const) : EncodeWithIndSig (.const c) := by
+  intro _ _ _ _ _ _ _ _ _ _ _ hΔ' _ _ hk
+  simp only [encodeWith]
+  exact hk (Signature.Subset.refl _) hΔ' _ (encodeConst_wfIn c _)
+
+theorem var (x : String) (ty : TinyML.Typ) : EncodeWithIndSig (.var x ty) := by
+  intro _ _ _ _ _ _ _ δ _ hops _ hΔ' _ hδ hk
+  cases hlookup : δ.lookup x with
+  | none => simp only [encodeWith, hlookup]; exact hops.error_ind
+  | some v =>
+      simp only [encodeWith, hlookup]
+      exact hk (Signature.Subset.refl _) hΔ' v (hδ x v hlookup)
+
+theorem unop (op : TinyML.UnOp) (e : Typed.Expr) (ty : TinyML.Typ)
+    (ih : EncodeWithIndSig e) : EncodeWithIndSig (.unop op e ty) := by
+  intro M ops P Pctx Γ Δ Δ' δ k hops hsub hΔ' hΓ hδ hk
+  simp only [encodeWith]
+  refine ih hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' v hv
+  cases hraw : encodeUnOp op v with
+  | error _ => simp [hraw]; exact hops.error_ind
+  | ok _ =>
+      simp [hraw]
+      exact hk hsub'' hΔ'' _ (encodeUnOp_wfIn hraw hv)
+
+theorem binop (op : TinyML.BinOp) (e1 e2 : Typed.Expr) (ty : TinyML.Typ)
+    (ih1 : EncodeWithIndSig e1) (ih2 : EncodeWithIndSig e2) :
+    EncodeWithIndSig (.binop op e1 e2 ty) := by
+  intro _ _ _ _ _ _ _ δ _ hops hsub hΔ' hΓ hδ hk
+  simp only [encodeWith]
+  refine ih1 hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' v1 hv1
+  have hΓ'' := hops.ctx_mono hΓ hsub''
+  refine ih2 hops (hsub.trans hsub'') hΔ'' hΓ''
+    (fun x v h => Term.wfIn_mono v (hδ x v h) hsub'' hΔ'') ?_
+  intro Δ''' hsub''' hΔ''' v2 hv2
+  cases hraw : encodeBinOp op v1 v2 with
+  | error _ => simp [hraw]; exact hops.error_ind
+  | ok _ =>
+      simp [hraw]
+      have hv1' := Term.wfIn_mono _ hv1 hsub''' hΔ'''
+      exact hk (hsub''.trans hsub''') hΔ''' _ (encodeBinOp_wfIn hraw hv1' hv2)
+
+theorem ifThenElse (c t e : Typed.Expr) (ty : TinyML.Typ)
+    (ihc : EncodeWithIndSig c) (iht : EncodeWithIndSig t) (ihe : EncodeWithIndSig e) :
+    EncodeWithIndSig (.ifThenElse c t e ty) := by
+  intro M ops P Pctx Γ Δ Δ' δ k hops hsub hΔ' hΓ hδ hk
+  simp only [encodeWith]
+  refine ihc hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' b hb
+  have hΓ'' := hops.ctx_mono hΓ hsub''
+  have hkmono : SigCont P Δ'' k := fun hsub''' hΔ''' v hv =>
+    hk (hsub''.trans hsub''') hΔ''' v hv
+  have hδ'' : δ.wfIn Δ'' :=
+    fun x v h => Term.wfIn_mono v (hδ x v h) hsub'' hΔ''
+  have hmtP := iht hops (hsub.trans hsub'') hΔ'' hΓ'' hδ'' hkmono
+  have hmeP := ihe hops (hsub.trans hsub'') hΔ'' hΓ'' hδ'' hkmono
+  have hbWf : (Term.unop UnOp.toBool b).wfIn Δ'' := ⟨trivial, hb⟩
+  exact hops.ite_ind hΔ'' hbWf hmtP hmeP
+
+theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
+    (ihArgs : ∀ a ∈ args, EncodeWithIndSig a) : EncodeWithIndSig (.app fn args ty) := by
+  intro _ _ _ _ Γ _ _ δ _ hops hsub hΔ' hΓ hδ hk
+  match fn, args with
+  | .var f _, [arg] =>
+      simp only [encodeWith]
+      cases hlk : FunCtx.lookup Γ f with
+      | none => exact hops.error_ind
+      | some _ =>
+          simp only
+          have hmem := FunCtx.mem_of_lookup hlk
+          refine ihArgs arg (List.mem_singleton.mpr rfl) hops hsub hΔ' hΓ hδ ?_
+          intro Δ'' hsub'' hΔ'' v hv
+          refine hops.call_ind hΔ'' (hops.ctx_mono hΓ hsub'') hmem hv ?_
+          intro Δ''' hsub''' hΔ''' v' hv'
+          exact hk (hsub''.trans hsub''') hΔ''' v' hv'
+  | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
+  | .ifThenElse .., _ | .letIn .., _ | .ref _, _ | .deref .., _ | .store .., _
+  | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
+  | .var _ _, [] | .var _ _, _ :: _ :: _ =>
+      simp only [encodeWith]; exact hops.error_ind
+
+theorem cast (e : Typed.Expr) (ty : TinyML.Typ) (ih : EncodeWithIndSig e) :
+    EncodeWithIndSig (.cast e ty) := by
+  intro _ _ _ _ _ _ _ _ _ hops hsub hΔ' hΓ hδ hk
+  simpa [encodeWith] using ih hops hsub hΔ' hΓ hδ hk
+
+theorem fix (self : Typed.Binder) (args : List Typed.Binder) (retTy : TinyML.Typ)
+    (body : Typed.Expr) : EncodeWithIndSig (.fix self args retTy body) :=
+  fun hops _ _ _ _ _ => hops.error_ind
+
+theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
+    (ihBound : EncodeWithIndSig bound) (ihBody : EncodeWithIndSig body) :
+    EncodeWithIndSig (.letIn name bound body) := by
+  intro _ _ _ _ _ _ _ δ _ hops hsub hΔ' hΓ hδ hk
+  simp only [encodeWith]
+  refine ihBound hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' v hv
+  have hΓ'' := hops.ctx_mono hΓ hsub''
+  exact ihBody hops (hsub.trans hsub'') hΔ'' hΓ''
+    (VarEnv.wfIn.bindBinder
+      (fun y w h => Term.wfIn_mono w (hδ y w h) hsub'' hΔ'') hv)
+    (fun hsub''' hΔ''' w hw => hk (hsub''.trans hsub''') hΔ''' w hw)
+
+theorem ref (e : Typed.Expr) : EncodeWithIndSig (.ref e) :=
+  fun hops _ _ _ _ _ => hops.error_ind
+
+theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithIndSig (.deref e ty) :=
+  fun hops _ _ _ _ _ => hops.error_ind
+
+theorem store (loc val : Typed.Expr) : EncodeWithIndSig (.store loc val) :=
+  fun hops _ _ _ _ _ => hops.error_ind
+
+theorem assert (e : Typed.Expr) : EncodeWithIndSig (.assert e) :=
+  fun hops _ _ _ _ _ => hops.error_ind
+
+theorem tuple (es : List Typed.Expr) (ih : EncodeListWithIndSig es) :
+    EncodeWithIndSig (.tuple es) := by
+  intro _ _ _ _ _ _ _ δ _ hops hsub hΔ' hΓ hδ hk
+  simp only [encodeWith]
+  refine ih hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' vs hvs
+  exact hk hsub'' hΔ'' _ ⟨trivial, Terms.toValList_wfIn hvs⟩
+
+theorem inj (tag arity : Nat) (payload : Typed.Expr)
+    (ih : EncodeWithIndSig payload) :
+    EncodeWithIndSig (.inj tag arity payload) := by
+  intro _ _ _ _ _ _ _ _ _ hops hsub hΔ' hΓ hδ hk
+  simp only [encodeWith]
+  refine ih hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' v hv
+  exact hk hsub'' hΔ'' _ ⟨trivial, hv⟩
+
+theorem match_ (scrut : Typed.Expr) (branches : List (Typed.Binder × Typed.Expr))
+    (ty : TinyML.Typ) (ihScrut : EncodeWithIndSig scrut)
+    (ihBranches : EncodeMatchWithIndSig branches) :
+    EncodeWithIndSig (.match_ scrut branches ty) := by
+  intro _ _ _ _ _ _ _ δ k hops hsub hΔ' hΓ hδ hk
+  simp only [encodeWith]
+  refine ihScrut hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' v hv
+  have hΓ'' := hops.ctx_mono hΓ hsub''
+  have hδ'' : δ.wfIn Δ'' :=
+    fun y w h => Term.wfIn_mono w (hδ y w h) hsub'' hΔ''
+  have hkmono : SigCont _ Δ'' k :=
+    fun hs hΔ''' v hv => hk (hsub''.trans hs) hΔ''' v hv
+  exact ihBranches hops (hsub.trans hsub'') hΔ'' hΓ'' hδ'' hv hkmono
+
+theorem match_nil : EncodeMatchWithIndSig [] := by
+  intro _ _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _
+  simp only [encodeMatchWith]
+  exact hops.error_ind
+
+theorem match_cons (b : Typed.Binder) (body : Typed.Expr)
+    (rest : List (Typed.Binder × Typed.Expr))
+    (ihBody : EncodeWithIndSig body)
+    (ihRest : EncodeMatchWithIndSig rest) :
+    EncodeMatchWithIndSig ((b, body) :: rest) := by
+  intro _ _ _ _ _ _ Δ' _ scrut _ _ hops hsub hΔ' hΓ hδ hscrut hk
+  simp only [encodeMatchWith]
+  have hpay : (Term.unop UnOp.payloadOf scrut).wfIn Δ' := ⟨trivial, hscrut⟩
+  cases rest with
+  | nil => exact ihBody hops hsub hΔ' hΓ (VarEnv.wfIn.bindBinder hδ hpay) hk
+  | cons _ _ =>
+    exact hops.ite_ind hΔ' ⟨trivial, ⟨trivial, hscrut⟩, trivial⟩
+      (ihBody hops hsub hΔ' hΓ (VarEnv.wfIn.bindBinder hδ hpay) hk)
+      (ihRest hops hsub hΔ' hΓ hδ hscrut hk)
+
+theorem list_nil : EncodeListWithIndSig [] := by
+  intro _ _ _ _ _ _ _ _ _ _ _ hΔ' _ _ hk
+  simp only [encodeListWith]
+  exact hk (Signature.Subset.refl _) hΔ' [] (by simp)
+
+theorem list_cons (e : Typed.Expr) (es : List Typed.Expr)
+    (ih : EncodeWithIndSig e) (ihs : EncodeListWithIndSig es) :
+    EncodeListWithIndSig (e :: es) := by
+  intro _ _ _ _ Γ Δ Δ' δ k hops hsub hΔ' hΓ hδ hk
+  simp only [encodeListWith]
+  refine ih hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' v hv
+  have hΓ'' := hops.ctx_mono hΓ hsub''
+  refine ihs hops (hsub.trans hsub'') hΔ'' hΓ''
+    (fun x v h => Term.wfIn_mono v (hδ x v h) hsub'' hΔ'') ?_
+  intro Δ''' hsub''' hΔ''' vs hvs
+  have hwfs : ∀ q ∈ v :: vs, q.wfIn Δ''' := by
+    intro q hq
+    simp only [List.mem_cons] at hq
+    rcases hq with hq | hq
+    · subst q
+      exact Term.wfIn_mono v hv hsub''' hΔ'''
+    · exact hvs q hq
+  exact hk (hsub''.trans hsub''') hΔ''' (v :: vs) hwfs
+
+end IndSig
+
+mutual
+/-- Generic signature-indexed induction theorem for the shared traversal:
+under the per-operation closure assumptions in `EncoderOpsSig`, every encoded
+expression yields a carrier satisfying `P`. -/
+theorem encodeWith_indWithSig_def : ∀ (e : Typed.Expr), EncodeWithIndSig e
+  | .const c => IndSig.const c
+  | .var x ty => IndSig.var x ty
+  | .unop op e ty => IndSig.unop op e ty (encodeWith_indWithSig_def e)
+  | .binop op e1 e2 ty =>
+      IndSig.binop op e1 e2 ty (encodeWith_indWithSig_def e1) (encodeWith_indWithSig_def e2)
+  | .ifThenElse c t e ty =>
+      IndSig.ifThenElse c t e ty (encodeWith_indWithSig_def c)
+        (encodeWith_indWithSig_def t) (encodeWith_indWithSig_def e)
+  | .app fn args ty =>
+      IndSig.app fn args ty (fun a _ => encodeWith_indWithSig_def a)
+  | .cast e ty => IndSig.cast e ty (encodeWith_indWithSig_def e)
+  | .fix self args retTy body => IndSig.fix self args retTy body
+  | .letIn name bound body =>
+      IndSig.letIn name bound body
+        (encodeWith_indWithSig_def bound) (encodeWith_indWithSig_def body)
+  | .ref e => IndSig.ref e
+  | .deref e ty => IndSig.deref e ty
+  | .store loc val => IndSig.store loc val
+  | .assert e => IndSig.assert e
+  | .tuple es => IndSig.tuple es (encodeListWith_indWithSig_def es)
+  | .inj tag arity payload =>
+      IndSig.inj tag arity payload (encodeWith_indWithSig_def payload)
+  | .match_ scrut branches ty =>
+      IndSig.match_ scrut branches ty
+        (encodeWith_indWithSig_def scrut)
+        (encodeMatchWith_indWithSig_def branches)
+
+theorem encodeListWith_indWithSig_def : ∀ (es : List Typed.Expr), EncodeListWithIndSig es
+  | [] => IndSig.list_nil
+  | e :: es =>
+      IndSig.list_cons e es (encodeWith_indWithSig_def e) (encodeListWith_indWithSig_def es)
+
+theorem encodeMatchWith_indWithSig_def :
+    ∀ (branches : List (Typed.Binder × Typed.Expr)),
+      EncodeMatchWithIndSig branches
+  | [] => IndSig.match_nil
+  | (b, body) :: rest =>
+      IndSig.match_cons b body rest
+        (encodeWith_indWithSig_def body)
+        (encodeMatchWith_indWithSig_def rest)
+end
+
+theorem encodeWith_indWithSig {M : Type} {ops : EncoderOps M}
+    {P : Signature → M → Prop} {Pctx : FunCtx → Signature → Prop}
+    (hops : EncoderOpsSig ops P Pctx)
+    {Γ : FunCtx} {Δ Δ' : Signature} {δ : VarEnv} (e : Typed.Expr)
+    {k : Term .value → M}
+    (hsub : Δ.Subset Δ') (hΔ' : Δ'.wf) (hΓ : Pctx Γ Δ')
+    (hδ : δ.wfIn Δ')
+    (hk : SigCont P Δ' k) :
+    P Δ' (encodeWith ops Γ δ e k) :=
+  encodeWith_indWithSig_def e hops hsub hΔ' hΓ hδ hk
+
+/-! ## Generic paired-encoding binary
+
+When two encoders are run on the same TinyML expression, a binary relation `B`
+between their carriers can be lifted from operation-level binary data. The
+primary theorem is stated in bind position, so recursive continuations remain
+in scope throughout the induction. -/
+
+/-- Generic continuation contract for bind-position proofs. The two
+continuations are paired by `B` whenever they are fed value terms that are
+`Term.eval`-equal in some pair of *future* states extending the base
+`(Δ₁, ρ₁)` / `(Δ₂, ρ₂)`. "Future" means the signature only grew
+(`Δ.Subset`) and the environment still agrees on the old symbols
+(`Env.agreeOn`); the fed terms must be well-formed in the future
+signatures. Future quantification is needed because each carrier's `call`
+op declares its own fresh symbols as the monad runs, so the two sides may
+extend to different signatures. -/
+abbrev EncoderContSpec {M₁ M₂ : Type}
+    (B : Signature → Signature → Env → Env → M₁ → M₂ → Prop)
+    (Δ₁ Δ₂ : Signature) (ρ₁ ρ₂ : Env)
+    (k₁ : Term .value → M₁) (k₂ : Term .value → M₂) : Prop :=
+  ∀ {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env},
+    Δ₁.Subset Δ₁' → Δ₂.Subset Δ₂' →
+    Δ₁'.wf → Δ₂'.wf →
+    Env.agreeOn Δ₁ ρ₁ ρ₁' → Env.agreeOn Δ₂ ρ₂ ρ₂' →
+    ∀ v₁ v₂,
+      v₁.wfIn Δ₁' → v₂.wfIn Δ₂' →
+      Term.eval ρ₁' v₁ = Term.eval ρ₂' v₂ →
+      B Δ₁' Δ₂' ρ₁' ρ₂' (k₁ v₁) (k₂ v₂)
+
+/-- Weakening of the continuation contract: a contract at base `(Δ₁, ρ₁)` /
+`(Δ₂, ρ₂)` restricts to any future state, since futures of the future are
+futures of the base. -/
+theorem EncoderContSpec.mono {M₁ M₂ : Type}
+    {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop}
+    {Δ₁ Δ₂ Δ₁' Δ₂' : Signature} {ρ₁ ρ₂ ρ₁' ρ₂' : Env}
+    {k₁ : Term .value → M₁} {k₂ : Term .value → M₂}
+    (hsub₁ : Δ₁.Subset Δ₁') (hsub₂ : Δ₂.Subset Δ₂')
+    (ha₁ : Env.agreeOn Δ₁ ρ₁ ρ₁') (ha₂ : Env.agreeOn Δ₂ ρ₂ ρ₂')
+    (hk : EncoderContSpec B Δ₁ Δ₂ ρ₁ ρ₂ k₁ k₂) :
+    EncoderContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂ := by
+  intro Δ₁'' Δ₂'' ρ₁'' ρ₂'' hs₁ hs₂ hw₁ hw₂ hag₁ hag₂ v₁ v₂ hv₁ hv₂ heval
+  exact hk (hsub₁.trans hs₁) (hsub₂.trans hs₂) hw₁ hw₂
+    (Env.agreeOn_trans ha₁ (Env.agreeOn_mono hsub₁ hag₁))
+    (Env.agreeOn_trans ha₂ (Env.agreeOn_mono hsub₂ hag₂))
+    v₁ v₂ hv₁ hv₂ heval
+
+/-- Operation-level binary data for the CPS induction theorem. The relation
+`B` is now indexed by the pair of signatures and environments the carriers
+are interpreted in. -/
+structure EncoderOpsBinary {M₁ M₂ : Type} (Γ : FunCtx)
+    (ops₁ : EncoderOps M₁) (ops₂ : EncoderOps M₂)
+    (B : Signature → Signature → Env → Env → M₁ → M₂ → Prop) where
+  /-- A call to a function registered in `Γ` is related when its (well-formed)
+  arguments evaluate equally and its continuations are paired by the
+  continuation contract. -/
+  call_binary : ∀ {Δ₁ Δ₂ ρ₁ ρ₂ f rel arg₁ arg₂ k₁ k₂}, (f, rel) ∈ Γ →
+    arg₁.wfIn Δ₁ → arg₂.wfIn Δ₂ →
+    Term.eval ρ₁ arg₁ = Term.eval ρ₂ arg₂ →
+    EncoderContSpec B Δ₁ Δ₂ ρ₁ ρ₂ k₁ k₂ →
+    B Δ₁ Δ₂ ρ₁ ρ₂ (ops₁.call rel arg₁ k₁) (ops₂.call rel arg₂ k₂)
+  /-- Conditionals preserve the binary property when the conditions evaluate
+  equally and both branches are related. -/
+  ite_binary : ∀ {Δ₁ Δ₂ ρ₁ ρ₂ c₁ c₂ t₁ t₂ e₁ e₂},
+    Term.eval ρ₁ c₁ = Term.eval ρ₂ c₂ →
+    B Δ₁ Δ₂ ρ₁ ρ₂ t₁ t₂ → B Δ₁ Δ₂ ρ₁ ρ₂ e₁ e₂ →
+    B Δ₁ Δ₂ ρ₁ ρ₂ (ops₁.ite c₁ t₁ e₁) (ops₂.ite c₂ t₂ e₂)
+  /-- Error carriers are related in every state. -/
+  error_binary : ∀ {Δ₁ Δ₂ ρ₁ ρ₂ msg}, B Δ₁ Δ₂ ρ₁ ρ₂ (ops₁.error msg) (ops₂.error msg)
+
+/-- Generic continuation contract for list encodings. It is the list-valued
+analogue of `EncoderContSpec`: the continuation may be invoked in any future
+state, provided the paired value lists are well-formed and evaluate
+pointwise equally. -/
+abbrev EncoderListContSpec {M₁ M₂ : Type}
+    (B : Signature → Signature → Env → Env → M₁ → M₂ → Prop)
+    (Δ₁ Δ₂ : Signature) (ρ₁ ρ₂ : Env)
+    (k₁ : List (Term .value) → M₁) (k₂ : List (Term .value) → M₂) : Prop :=
+  ∀ {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env},
+    Δ₁.Subset Δ₁' → Δ₂.Subset Δ₂' →
+    Δ₁'.wf → Δ₂'.wf →
+    Env.agreeOn Δ₁ ρ₁ ρ₁' → Env.agreeOn Δ₂ ρ₂ ρ₂' →
+    ∀ vs₁ vs₂,
+      (∀ v ∈ vs₁, v.wfIn Δ₁') → (∀ v ∈ vs₂, v.wfIn Δ₂') →
+      vs₁.map (fun v => Term.eval ρ₁' v) =
+        vs₂.map (fun v => Term.eval ρ₂' v) →
+      B Δ₁' Δ₂' ρ₁' ρ₂' (k₁ vs₁) (k₂ vs₂)
+
+/-- Per-expression statement of `encodeWith_bind_binary`. -/
+def EncodeWithBindBinary (e : Typed.Expr) : Prop :=
+  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ₁ Δ₂ : Signature} {δ₁ δ₂ : VarEnv}
+    {ops₁ : EncoderOps M₁} {ops₂ : EncoderOps M₂}
+    {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop},
+    EncoderOpsBinary Γ ops₁ ops₂ B →
+    ∀ {k₁ : Term .value → M₁}
+      {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env} {k₂ : Term .value → M₂},
+      Δ₁.Subset Δ₁' → Δ₂.Subset Δ₂' →
+      Δ₁'.wf → Δ₂'.wf →
+      VarEnv.Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂ →
+      EncoderContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂ →
+      B Δ₁' Δ₂' ρ₁' ρ₂'
+        (encodeWith ops₁ Γ δ₁ e k₁) (encodeWith ops₂ Γ δ₂ e k₂)
+
+/-- Per-list statement of `encodeWith_bind_binary`. -/
+def EncodeListWithBindBinary (es : List Typed.Expr) : Prop :=
+  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ₁ Δ₂ : Signature} {δ₁ δ₂ : VarEnv}
+    {ops₁ : EncoderOps M₁} {ops₂ : EncoderOps M₂}
+    {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop},
+    EncoderOpsBinary Γ ops₁ ops₂ B →
+    ∀ {k₁ : List (Term .value) → M₁}
+      {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env} {k₂ : List (Term .value) → M₂},
+      Δ₁.Subset Δ₁' → Δ₂.Subset Δ₂' →
+      Δ₁'.wf → Δ₂'.wf →
+      VarEnv.Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂ →
+      EncoderListContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂ →
+      B Δ₁' Δ₂' ρ₁' ρ₂'
+        (encodeListWith ops₁ Γ δ₁ es k₁) (encodeListWith ops₂ Γ δ₂ es k₂)
+
+/-- Per-branch-list statement of `encodeWith_bind_binary`, parametric in two
+scrutinee values whose evaluations agree, the starting index, and the
+continuations. -/
+def EncodeMatchWithBindBinary (branches : List (Typed.Binder × Typed.Expr)) : Prop :=
+  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ₁ Δ₂ : Signature} {δ₁ δ₂ : VarEnv}
+    {ops₁ : EncoderOps M₁} {ops₂ : EncoderOps M₂}
+    {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop},
+    EncoderOpsBinary Γ ops₁ ops₂ B →
+    ∀ {k₁ : Term .value → M₁}
+      {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env} {k₂ : Term .value → M₂}
+      {scrut₁ scrut₂ : Term .value} {i : Nat},
+      Δ₁.Subset Δ₁' → Δ₂.Subset Δ₂' →
+      Δ₁'.wf → Δ₂'.wf →
+      VarEnv.Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂ →
+      scrut₁.wfIn Δ₁' → scrut₂.wfIn Δ₂' →
+      Term.eval ρ₁' scrut₁ = Term.eval ρ₂' scrut₂ →
+      EncoderContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂ →
+      B Δ₁' Δ₂' ρ₁' ρ₂'
+        (encodeMatchWith ops₁ Γ δ₁ scrut₁ branches i k₁)
+        (encodeMatchWith ops₂ Γ δ₂ scrut₂ branches i k₂)
+
+
+/-! ### Eval helpers for the paired-encoding binary -/
+
+/-- `encodeConst` produces closed terms, so their value is environment
+independent. -/
+private theorem encodeConst_eval (c : TinyML.Const) (ρ ρ' : Env) :
+    Term.eval ρ (encodeConst c) = Term.eval ρ' (encodeConst c) :=
+  Term.eval_env_agree (encodeConst_wfIn c Signature.empty) (Env.agreeOn_empty ρ ρ')
+
+/-- `encodeUnOp` is a pure syntactic wrapper: equal arguments yield equal
+results. -/
+private theorem encodeUnOp_eval {op : TinyML.UnOp} {v v' w w' : Term .value}
+    {ρ ρ' : Env} (hv : encodeUnOp op v = .ok v') (hw : encodeUnOp op w = .ok w')
+    (h : Term.eval ρ v = Term.eval ρ' w) :
+    Term.eval ρ v' = Term.eval ρ' w' := by
+  cases op with
+  | neg | not =>
+      simp only [encodeUnOp, Except.ok.injEq] at hv hw
+      subst hv; subst hw
+      simp only [Term.eval, UnOp.eval]; rw [h]
+  | proj n =>
+      simp only [encodeUnOp, Except.ok.injEq] at hv hw
+      subst hv; subst hw
+      simp only [Term.eval, UnOp.eval, vtailN_eval]
+      rw [h]
+
+/-- `encodeBinOp` is a pure syntactic wrapper: equal arguments yield equal
+results. -/
+private theorem encodeBinOp_eval {op : TinyML.BinOp} {a a' b b' c c' : Term .value}
+    {ρ ρ' : Env}
+    (h1 : encodeBinOp op a b = .ok c) (h2 : encodeBinOp op a' b' = .ok c')
+    (ha : Term.eval ρ a = Term.eval ρ' a') (hb : Term.eval ρ b = Term.eval ρ' b') :
+    Term.eval ρ c = Term.eval ρ' c' := by
+  cases op with
+  | add | sub | mul | div | mod | lt | le | gt | ge | eq | and | or =>
+      simp only [encodeBinOp, Except.ok.injEq] at h1 h2
+      subst h1; subst h2
+      simp [Term.eval, UnOp.eval, BinOp.eval, Const.denote, ha, hb, ge_iff_le]
+
+private theorem toValList_eval_eq {ts₁ ts₂ : List (Term .value)} {ρ₁ ρ₂ : Env}
+    (h : ts₁.map (fun t => Term.eval ρ₁ t) = ts₂.map (fun t => Term.eval ρ₂ t)) :
+    Term.eval ρ₁ (Terms.toValList ts₁) = Term.eval ρ₂ (Terms.toValList ts₂) := by
+  induction ts₁ generalizing ts₂ with
+  | nil =>
+      cases ts₂ <;> simp [Terms.toValList, Term.eval, Const.denote] at h ⊢
+  | cons t ts ih =>
+      cases ts₂ with
+      | nil => simp at h
+      | cons u us =>
+          simp only [List.map_cons, List.cons.injEq] at h
+          rcases h with ⟨hhead, htail⟩
+          simp [Terms.toValList, Term.eval, BinOp.eval, hhead, ih htail]
+
+/-- The shape of an `encodeUnOp` result (error, with message) depends only on
+the operator, not the argument. -/
+private theorem encodeUnOp_error_irrel {op : TinyML.UnOp} {v v' : Term .value}
+    {msg : String} (h : encodeUnOp op v = .error msg) :
+    encodeUnOp op v' = .error msg := by
+  cases op <;> simp_all [encodeUnOp]
+
+/-- The shape of an `encodeUnOp` result (success) depends only on the
+operator, not the argument. -/
+private theorem encodeUnOp_ok_irrel {op : TinyML.UnOp} {v v' w : Term .value}
+    (h : encodeUnOp op v = .ok w) : ∃ w', encodeUnOp op v' = .ok w' := by
+  cases op <;> simp_all [encodeUnOp]
+
+/-- The shape of an `encodeBinOp` result (error, with message) depends only on
+the operator, not the arguments. -/
+private theorem encodeBinOp_error_irrel {op : TinyML.BinOp} {a b a' b' : Term .value}
+    {msg : String} (h : encodeBinOp op a b = .error msg) :
+    encodeBinOp op a' b' = .error msg := by
+  cases op <;> simp_all [encodeBinOp]
+
+/-- The shape of an `encodeBinOp` result (success) depends only on the
+operator, not the arguments. -/
+private theorem encodeBinOp_ok_irrel {op : TinyML.BinOp} {a b a' b' c : Term .value}
+    (h : encodeBinOp op a b = .ok c) : ∃ c', encodeBinOp op a' b' = .ok c' := by
+  cases op <;> simp_all [encodeBinOp]
+
+/-! ## Per-case helpers for `encodeWith_bind_binary` -/
+
+namespace BindBinary
+
+theorem const (c : TinyML.Const) : EncodeWithBindBinary (.const c) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ _ hk
+  simp only [encodeWith]
+  exact hk (Signature.Subset.refl _) (Signature.Subset.refl _) hwf₁ hwf₂
+    Env.agreeOn_refl Env.agreeOn_refl (encodeConst c) (encodeConst c)
+    (encodeConst_wfIn c _) (encodeConst_wfIn c _) (encodeConst_eval c _ _)
+
+theorem var (x : String) (ty : TinyML.Typ) : EncodeWithBindBinary (.var x ty) := by
+  intro _ _ _ _ _ δ₁ δ₂ _ _ _ hops _ _ _ ρ₁' ρ₂' _ _ _ hwf₁ hwf₂ henv hk
+  cases h₁ : δ₁.lookup x with
+  | none =>
+      have h₂ : δ₂.lookup x = none := by
+        cases h₂ : δ₂.lookup x with
+        | none => rfl
+        | some v₂ =>
+            have : ∃ v₁, δ₁.lookup x = some v₁ := (henv.sameDomain x).mpr ⟨v₂, h₂⟩
+            rcases this with ⟨v₁, hv₁⟩
+            rw [h₁] at hv₁
+            cases hv₁
+      simp only [encodeWith, h₁, h₂]
+      exact hops.error_binary
+  | some v₁ =>
+      obtain ⟨v₂, h₂⟩ := (henv.sameDomain x).mp ⟨v₁, h₁⟩
+      rcases henv.agree x v₁ v₂ h₁ h₂ with ⟨hv₁, hv₂, heval⟩
+      simp only [encodeWith, h₁, h₂]
+      exact hk (Signature.Subset.refl _) (Signature.Subset.refl _) hwf₁ hwf₂
+        Env.agreeOn_refl Env.agreeOn_refl v₁ v₂ hv₁ hv₂ heval
+
+theorem unop (op : TinyML.UnOp) (e : Typed.Expr) (ty : TinyML.Typ)
+    (ih : EncodeWithBindBinary e) : EncodeWithBindBinary (.unop op e ty) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simp only [encodeWith]
+  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
+  cases hraw₁ : encodeUnOp op v₁ with
+  | error msg =>
+      have hraw₂ := encodeUnOp_error_irrel (v' := v₂) hraw₁
+      simp only [hraw₁, hraw₂]
+      exact hops.error_binary
+  | ok v₁' =>
+      obtain ⟨v₂', hraw₂⟩ := encodeUnOp_ok_irrel (v' := v₂) hraw₁
+      simp only [hraw₁, hraw₂]
+      exact hk hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁' v₂'
+        (encodeUnOp_wfIn hraw₁ hv₁) (encodeUnOp_wfIn hraw₂ hv₂)
+        (encodeUnOp_eval hraw₁ hraw₂ hevalv)
+
+theorem binop (op : TinyML.BinOp) (e1 e2 : Typed.Expr) (ty : TinyML.Typ)
+    (ih1 : EncodeWithBindBinary e1) (ih2 : EncodeWithBindBinary e2) :
+    EncodeWithBindBinary (.binop op e1 e2 ty) := by
+  intro _ _ _ Δ₁ Δ₂ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simp only [encodeWith]
+  refine ih1 hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v1₁ v1₂ hv1₁ hv1₂ heval1
+  refine ih2 hops
+    (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
+    (VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv) ?_
+  intro Δb₁ Δb₂ ρb₁ ρb₂ hsb₁ hsb₂ hwb₁ hwb₂ hab₁ hab₂ v2₁ v2₂ hv2₁ hv2₂ heval2
+  have hev1 : Term.eval ρb₁ v1₁ = Term.eval ρb₂ v1₂ := by
+    rw [← Term.eval_env_agree hv1₁ hab₁, heval1,
+        Term.eval_env_agree hv1₂ hab₂]
+  cases hraw₁ : encodeBinOp op v1₁ v2₁ with
+  | error msg =>
+      have hraw₂ := encodeBinOp_error_irrel (a' := v1₂) (b' := v2₂) hraw₁
+      simp only [hraw₁, hraw₂]
+      exact hops.error_binary
+  | ok v₁' =>
+      obtain ⟨v₂', hraw₂⟩ := encodeBinOp_ok_irrel (a' := v1₂) (b' := v2₂) hraw₁
+      simp only [hraw₁, hraw₂]
+      exact hk (hsa₁.trans hsb₁) (hsa₂.trans hsb₂) hwb₁ hwb₂
+        (Env.agreeOn_trans haa₁ (Env.agreeOn_mono hsa₁ hab₁))
+        (Env.agreeOn_trans haa₂ (Env.agreeOn_mono hsa₂ hab₂))
+        v₁' v₂'
+        (encodeBinOp_wfIn hraw₁ (Term.wfIn_mono v1₁ hv1₁ hsb₁ hwb₁) hv2₁)
+        (encodeBinOp_wfIn hraw₂ (Term.wfIn_mono v1₂ hv1₂ hsb₂ hwb₂) hv2₂)
+        (encodeBinOp_eval hraw₁ hraw₂ hev1 heval2)
+
+theorem ifThenElse (c t e : Typed.Expr) (ty : TinyML.Typ)
+    (ihc : EncodeWithBindBinary c) (iht : EncodeWithBindBinary t)
+    (ihe : EncodeWithBindBinary e) :
+    EncodeWithBindBinary (.ifThenElse c t e ty) := by
+  intro _ _ _ Δ₁ Δ₂ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simp only [encodeWith]
+  refine ihc hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ b₁ b₂ hb₁ hb₂ hevalb
+  have hsub₁a : Δ₁.Subset Δa₁ := hsub₁.trans hsa₁
+  have hsub₂a : Δ₂.Subset Δa₂ := hsub₂.trans hsa₂
+  have henv_a := VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv
+  have hka : EncoderContSpec _ Δa₁ Δa₂ ρa₁ ρa₂ _ _ :=
+    EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk
+  refine hops.ite_binary ?_
+    (iht hops hsub₁a hsub₂a hwa₁ hwa₂ henv_a hka)
+    (ihe hops hsub₁a hsub₂a hwa₁ hwa₂ henv_a hka)
+  simp only [Term.eval, UnOp.eval]; rw [hevalb]
+
+theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
+    (ihArgs : ∀ a ∈ args, EncodeWithBindBinary a) :
+    EncodeWithBindBinary (.app fn args ty) := by
+  intro _ _ Γ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  match fn, args with
+  | .var f _, [arg] =>
+      simp only [encodeWith]
+      cases hlk : FunCtx.lookup Γ f with
+      | none => exact hops.error_binary
+      | some _ =>
+          simp only
+          refine ihArgs arg (List.mem_singleton.mpr rfl) hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+          intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ _ _ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
+          exact hops.call_binary (FunCtx.mem_of_lookup hlk) hv₁ hv₂ hevalv
+            (EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk)
+  | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
+  | .ifThenElse .., _ | .letIn .., _ | .ref _, _ | .deref .., _ | .store .., _
+  | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
+  | .var _ _, [] | .var _ _, _ :: _ :: _ =>
+      simp only [encodeWith]; exact hops.error_binary
+
+theorem cast (e : Typed.Expr) (ty : TinyML.Typ) (ih : EncodeWithBindBinary e) :
+    EncodeWithBindBinary (.cast e ty) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simpa only [encodeWith] using ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+
+theorem fix (self : Typed.Binder) (args : List Typed.Binder) (retTy : TinyML.Typ)
+    (body : Typed.Expr) : EncodeWithBindBinary (.fix self args retTy body) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+
+theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
+    (ihBound : EncodeWithBindBinary bound) (ihBody : EncodeWithBindBinary body) :
+    EncodeWithBindBinary (.letIn name bound body) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simp only [encodeWith]
+  refine ihBound hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
+  have henv_a := VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv
+  have hka : EncoderContSpec _ Δa₁ Δa₂ ρa₁ ρa₂ _ _ :=
+    EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk
+  exact ihBody hops (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
+    (VarEnv.Agree.bindBinder henv_a hv₁ hv₂ hevalv) hka
+
+theorem ref (e : Typed.Expr) : EncodeWithBindBinary (.ref e) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+
+theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithBindBinary (.deref e ty) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+
+theorem store (loc val : Typed.Expr) : EncodeWithBindBinary (.store loc val) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+
+theorem assert (e : Typed.Expr) : EncodeWithBindBinary (.assert e) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+
+theorem tuple (es : List Typed.Expr) (ih : EncodeListWithBindBinary es) :
+    EncodeWithBindBinary (.tuple es) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simp only [encodeWith]
+  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ vs₁ vs₂ hvs₁ hvs₂ hevals
+  exact hk hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂
+    (.unop .ofValList (Terms.toValList vs₁)) (.unop .ofValList (Terms.toValList vs₂))
+    ⟨trivial, Terms.toValList_wfIn hvs₁⟩
+    ⟨trivial, Terms.toValList_wfIn hvs₂⟩
+    (by simp [Term.eval, UnOp.eval, toValList_eval_eq hevals])
+
+theorem inj (tag arity : Nat) (payload : Typed.Expr)
+    (ih : EncodeWithBindBinary payload) :
+    EncodeWithBindBinary (.inj tag arity payload) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simp only [encodeWith]
+  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
+  exact hk hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂
+    (.unop (.mkInj tag arity) v₁) (.unop (.mkInj tag arity) v₂)
+    ⟨trivial, hv₁⟩ ⟨trivial, hv₂⟩
+    (by simp [Term.eval, UnOp.eval, hevalv])
+
+theorem match_ (scrut : Typed.Expr) (branches : List (Typed.Binder × Typed.Expr))
+    (ty : TinyML.Typ) (ihScrut : EncodeWithBindBinary scrut)
+    (ihBranches : EncodeMatchWithBindBinary branches) :
+    EncodeWithBindBinary (.match_ scrut branches ty) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simp only [encodeWith]
+  refine ihScrut hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
+  have henv_a := VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv
+  have hka : EncoderContSpec _ Δa₁ Δa₂ ρa₁ ρa₂ _ _ :=
+    EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk
+  exact ihBranches hops (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
+    henv_a hv₁ hv₂ hevalv hka
+
+/-- Empty match branch lists encode as the shared match error. -/
+theorem match_nil : EncodeMatchWithBindBinary [] := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+  simp only [encodeMatchWith]; exact hops.error_binary
+
+/-- Binary preservation for a non-empty match branch list. -/
+theorem match_cons (b : Typed.Binder) (body : Typed.Expr)
+    (rest : List (Typed.Binder × Typed.Expr))
+    (ihBody : EncodeWithBindBinary body)
+    (ihRest : EncodeMatchWithBindBinary rest) :
+    EncodeMatchWithBindBinary ((b, body) :: rest) := by
+  intro _ _ _ _ _ _ _ _ _ _ hops _ Δ₁' Δ₂' ρ₁' ρ₂' _ scrut₁ scrut₂ _
+        hsub₁ hsub₂ hwf₁ hwf₂ henv hscrut₁ hscrut₂ hevalScrut hk
+  simp only [encodeMatchWith]
+  have hpay₁ : (Term.unop UnOp.payloadOf scrut₁).wfIn Δ₁' := ⟨trivial, hscrut₁⟩
+  have hpay₂ : (Term.unop UnOp.payloadOf scrut₂).wfIn Δ₂' := ⟨trivial, hscrut₂⟩
+  have hpayEval : Term.eval ρ₁' (.unop UnOp.payloadOf scrut₁) =
+      Term.eval ρ₂' (.unop UnOp.payloadOf scrut₂) := by
+    simp [Term.eval, UnOp.eval, hevalScrut]
+  cases rest with
+  | nil =>
+    exact ihBody hops hsub₁ hsub₂ hwf₁ hwf₂
+      (VarEnv.Agree.bindBinder henv hpay₁ hpay₂ hpayEval) hk
+  | cons _ _ =>
+    refine hops.ite_binary ?_
+      (ihBody hops hsub₁ hsub₂ hwf₁ hwf₂
+        (VarEnv.Agree.bindBinder henv hpay₁ hpay₂ hpayEval) hk)
+      (ihRest hops hsub₁ hsub₂ hwf₁ hwf₂ henv hscrut₁ hscrut₂ hevalScrut hk)
+    simp [Term.eval, UnOp.eval, BinOp.eval, hevalScrut]
+
+/-- Empty expression lists feed matching empty value lists to their
+continuations. -/
+theorem list_nil : EncodeListWithBindBinary [] := by
+  intro _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ _ hk
+  simp only [encodeListWith]
+  exact hk (Signature.Subset.refl _) (Signature.Subset.refl _) hwf₁ hwf₂
+    Env.agreeOn_refl Env.agreeOn_refl [] [] (by simp) (by simp) (by simp)
+
+/-- Binary preservation for expression lists, threading the head value into the
+tail list continuation. -/
+theorem list_cons (e : Typed.Expr) (es : List Typed.Expr)
+    (ih : EncodeWithBindBinary e) (ihs : EncodeListWithBindBinary es) :
+    EncodeListWithBindBinary (e :: es) := by
+  intro _ _ _ Δ₁ Δ₂ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  simp only [encodeListWith]
+  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
+  refine ihs hops
+    (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
+    (VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv) ?_
+  intro Δb₁ Δb₂ ρb₁ ρb₂ hsb₁ hsb₂ hwb₁ hwb₂ hab₁ hab₂ vs₁ vs₂ hvs₁ hvs₂ hevals
+  have hevHead : Term.eval ρb₁ v₁ = Term.eval ρb₂ v₂ := by
+    rw [← Term.eval_env_agree hv₁ hab₁, hevalv,
+        Term.eval_env_agree hv₂ hab₂]
+  have hwfs₁ : ∀ q ∈ v₁ :: vs₁, q.wfIn Δb₁ := by
+    intro q hq
+    simp only [List.mem_cons] at hq
+    rcases hq with hq | hq
+    · subst q
+      exact Term.wfIn_mono v₁ hv₁ hsb₁ hwb₁
+    · exact hvs₁ q hq
+  have hwfs₂ : ∀ q ∈ v₂ :: vs₂, q.wfIn Δb₂ := by
+    intro q hq
+    simp only [List.mem_cons] at hq
+    rcases hq with hq | hq
+    · subst q
+      exact Term.wfIn_mono v₂ hv₂ hsb₂ hwb₂
+    · exact hvs₂ q hq
+  exact hk (hsa₁.trans hsb₁) (hsa₂.trans hsb₂) hwb₁ hwb₂
+    (Env.agreeOn_trans haa₁ (Env.agreeOn_mono hsa₁ hab₁))
+    (Env.agreeOn_trans haa₂ (Env.agreeOn_mono hsa₂ hab₂))
+    (v₁ :: vs₁) (v₂ :: vs₂) hwfs₁ hwfs₂ (by simp [hevHead, hevals])
+
+end BindBinary
+
+mutual
+/-- Generic paired-encoding theorem for the shared traversal. -/
+theorem encodeWith_bind_binary_def : ∀ (e : Typed.Expr), EncodeWithBindBinary e
+  | .const c => BindBinary.const c
+  | .var x ty => BindBinary.var x ty
+  | .unop op e ty => BindBinary.unop op e ty (encodeWith_bind_binary_def e)
+  | .binop op e1 e2 ty =>
+      BindBinary.binop op e1 e2 ty (encodeWith_bind_binary_def e1)
+        (encodeWith_bind_binary_def e2)
+  | .ifThenElse c t e ty =>
+      BindBinary.ifThenElse c t e ty (encodeWith_bind_binary_def c)
+        (encodeWith_bind_binary_def t) (encodeWith_bind_binary_def e)
+  | .app fn args ty =>
+      BindBinary.app fn args ty (fun a _ => encodeWith_bind_binary_def a)
+  | .cast e ty => BindBinary.cast e ty (encodeWith_bind_binary_def e)
+  | .fix self args retTy body => BindBinary.fix self args retTy body
+  | .letIn name bound body =>
+      BindBinary.letIn name bound body
+        (encodeWith_bind_binary_def bound) (encodeWith_bind_binary_def body)
+  | .ref e => BindBinary.ref e
+  | .deref e ty => BindBinary.deref e ty
+  | .store loc val => BindBinary.store loc val
+  | .assert e => BindBinary.assert e
+  | .tuple es => BindBinary.tuple es (encodeListWith_bind_binary_def es)
+  | .inj tag arity payload =>
+      BindBinary.inj tag arity payload (encodeWith_bind_binary_def payload)
+  | .match_ scrut branches ty =>
+      BindBinary.match_ scrut branches ty
+        (encodeWith_bind_binary_def scrut)
+        (encodeMatchWith_bind_binary_def branches)
+
+theorem encodeListWith_bind_binary_def : ∀ (es : List Typed.Expr), EncodeListWithBindBinary es
+  | [] => BindBinary.list_nil
+  | e :: es =>
+      BindBinary.list_cons e es (encodeWith_bind_binary_def e)
+        (encodeListWith_bind_binary_def es)
+
+theorem encodeMatchWith_bind_binary_def :
+    ∀ (branches : List (Typed.Binder × Typed.Expr)),
+      EncodeMatchWithBindBinary branches
+  | [] => BindBinary.match_nil
+  | (b, body) :: rest =>
+      BindBinary.match_cons b body rest
+        (encodeWith_bind_binary_def body)
+        (encodeMatchWith_bind_binary_def rest)
+end
+
+/-- Bind-position paired-encoding theorem. The two encoders are run on the
+same syntax `e` but with independent local environments related by
+`VarEnv.Agree`. The conclusion is quantified over arbitrary *states*
+`(Δ₁', ρ₁')`, `(Δ₂', ρ₂')` extending the initial signatures, so the induction
+can chain inner continuation contracts off the future state reached by the
+outer one. -/
+theorem encodeWith_bind_binary {M₁ M₂ : Type} {Γ : FunCtx} {Δ₁ Δ₂ : Signature}
+    {δ₁ δ₂ : VarEnv}
+    {ops₁ : EncoderOps M₁} {ops₂ : EncoderOps M₂}
+    {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop}
+    (hops : EncoderOpsBinary Γ ops₁ ops₂ B)
+    (e : Typed.Expr) {k₁ : Term .value → M₁}
+    {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env} {k₂ : Term .value → M₂}
+    (hsub₁ : Δ₁.Subset Δ₁') (hsub₂ : Δ₂.Subset Δ₂')
+    (hwf₁ : Δ₁'.wf) (hwf₂ : Δ₂'.wf)
+    (henv : VarEnv.Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂)
+    (hk : EncoderContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂) :
+    B Δ₁' Δ₂' ρ₁' ρ₂' (encodeWith ops₁ Γ δ₁ e k₁) (encodeWith ops₂ Γ δ₂ e k₂) :=
+  encodeWith_bind_binary_def e hops hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+
+
+end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/OUTLINE.md
+++ b/Mica/Verifier/RelationalEncoding/OUTLINE.md
@@ -1,0 +1,9 @@
+**Mica/Verifier/RelationalEncoding**
+
+- `Axioms.lean` — Solver-facing axioms and validity theorems for skolemized relational encoding.
+- `Monad.lean` — Generic monadic skeleton for TinyML-to-FOL encoders.
+- `Relation.lean` — Stage 1 — encode a recursive TinyML body as a binary FOL relation defined by least fixpoint.
+- `SkolemizeCommon.lean` — Shared split encoding and semantic infrastructure for Skolemization.
+- `SkolemizeCompleteness.lean` — Completeness of Skolemization: relational encoding implies split definedness/value.
+- `SkolemizeSoundness.lean` — Soundness of Skolemization: split definedness/value implies the relational encoding.
+- `Variables.lean` — Shared names, signatures, and freshness helpers for relational encoding.

--- a/Mica/Verifier/RelationalEncoding/Relation.lean
+++ b/Mica/Verifier/RelationalEncoding/Relation.lean
@@ -1,0 +1,590 @@
+-- SUMMARY: Stage 1 — encode a recursive TinyML body as a binary FOL relation defined by least fixpoint.
+import Mica.Verifier.RelationalEncoding.Monad
+
+/-!
+# Relational encoding of recursive TinyML bodies
+
+First stage of the encoding. A recursive definition `rec f x := e` becomes a
+binary FOL relation, interpreted as the least fixpoint of the encoded body
+operator. Diverging inputs are absent from the relation.
+-/
+/-- Uninterpreted binary predicate `rel ⊆ value × value` applied to `arg, res`. -/
+def Formula.funcall (rel : String) (arg res : Term .value) : Formula :=
+  .binpred (.uninterpreted rel .value .value) arg res
+
+theorem Formula.funcall_wfIn {rel : String} {arg res : Term .value} {Δ : Signature}
+    (hrel : (⟨rel, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
+    (hΔ : Δ.wf)
+    (harg : arg.wfIn Δ) (hres : res.wfIn Δ) :
+    (Formula.funcall rel arg res).wfIn Δ := by
+  refine ⟨?_, harg, hres⟩
+  refine ⟨hrel, ?_, ?_⟩
+  · intro τ₁ τ₂ τ₃ hb
+    exact Signature.wf_no_binaryRel_of_binary hΔ hb hrel
+  · intro τ₁ τ₂ hb
+    exact Signature.wf_unique_binaryRel hΔ hrel hb
+
+def Formula.iteBool (cond : Term .bool) (φ ψ : Formula) : Formula :=
+  .and (.implies (.eq .bool cond (.const (.b true)))  φ)
+       (.implies (.eq .bool cond (.const (.b false))) ψ)
+
+theorem Formula.iteBool_wfIn {cond : Term .bool} {φ ψ : Formula} {Δ : Signature}
+    (hc : cond.wfIn Δ) (hφ : φ.wfIn Δ) (hψ : ψ.wfIn Δ) :
+    (Formula.iteBool cond φ ψ).wfIn Δ := by
+  simp [Formula.iteBool, Formula.wfIn, Term.wfIn, Const.wfIn, hc, hφ, hψ]
+
+namespace Verifier.RelationalEncoding
+namespace Relation
+
+abbrev ValRel : Type := Fix.Rel Srt.value.denote Srt.value.denote
+
+def relEnv (ρ : Env) (rel : String) (x r : TinyML.Var)
+    (self : ValRel) (vin vout : Srt.value.denote) : Env :=
+  let ρ1 := ρ.updateBinaryRel .value .value rel self
+  let ρ2 := ρ1.updateConst .value x vin
+  ρ2.updateConst .value r vout
+
+def semanticBody {M : Type} (sem : SemPred M)
+    (ρ : Env) (rel : String) (x r : TinyML.Var) (m : M) : ValRel → ValRel :=
+  fun self vin vout => sem m (relEnv ρ rel x r self vin vout)
+
+def semanticFixpoint {M : Type} (encoded : Except String M) (sem : SemPred M)
+    (ρ : Env) (rel : String) (x r : TinyML.Var) : ValRel :=
+  match encoded with
+  | .error _ => fun _ _ => False
+  | .ok m    => Fix.lfp (semanticBody sem ρ rel x r m)
+
+theorem semanticBody_mono_of_semanticMono {M : Type} {sem : SemPred M}
+    {ρ : Env} {rel : String} {x r : TinyML.Var} {m : M}
+    (hm : SemanticMono sem m) :
+    Fix.Mono (semanticBody sem ρ rel x r m) := by
+  intro S S' hSS' vin vout hF
+  have hle : Fix.Env.le (relEnv ρ rel x r S vin vout)
+                    (relEnv ρ rel x r S' vin vout) := by
+    refine Fix.Env.le.updateConst (Fix.Env.le.updateConst ?_ _ _ _) _ _ _
+    refine ⟨rfl, rfl, rfl, fun _ _ _ h => h, ?_⟩
+    intro τ₁ τ₂ name a b
+    simp only [Env.updateBinaryRel]
+    split
+    · rename_i heq; rcases heq with ⟨rfl, rfl, rfl⟩
+      intro h; exact hSS' a b h
+    · intro h; exact h
+  exact hm hle hF
+
+abbrev Rel : Type := NameSupply → Except String Formula
+
+def Rel.error (msg : String) : Rel := fun _ => .error msg
+
+def Rel.call (rel : String) (arg : Term .value) (k : Term .value → Rel) : Rel :=
+  fun s =>
+    let r := s.fresh "r"
+    let s' := s.reserve r
+    do
+      let φ ← k (.var .value r) s'
+      .ok (.exists_ r .value (.and (Formula.funcall rel arg (.var .value r)) φ))
+
+def Rel.ite (cond : Term .bool) (thenEnc elseEnc : Rel) : Rel :=
+  fun s => do
+    let φt ← thenEnc s
+    let φe ← elseEnc s
+    .ok (Formula.iteBool cond φt φe)
+
+def encoderOps : EncoderOps Rel where
+  call  := Rel.call
+  ite   := Rel.ite
+  error := Rel.error
+
+def Rel.wfIn (Δ : Signature) (m : Rel) : Prop :=
+  ∀ Δ' s φ, Δ.Subset Δ' → Δ'.wf → s.Covers Δ' →
+    m s = .ok φ → φ.wfIn Δ'
+
+theorem Rel.error_wfIn {Δ : Signature} {msg : String} :
+    Rel.wfIn Δ (Rel.error msg) := by
+  intro Δ' s φ _ _ _ hrun
+  simp [Rel.error] at hrun
+
+theorem Rel.call_wfIn {Δ : Signature} {rel : String} {arg : Term .value}
+    (hrel : (⟨rel, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
+    (harg : arg.wfIn Δ)
+    {k : Term .value → Rel}
+    (hk : ∀ {Δ'}, Δ.Subset Δ' → Δ'.wf →
+      ∀ v, v.wfIn Δ' → Rel.wfIn Δ' (k v)) :
+    Rel.wfIn Δ (Rel.call rel arg k) := by
+  intro Δ' s φ hsub hΔ' hcov hrun
+  simp only [Rel.call] at hrun
+  set r := s.fresh "r" with hr
+  set s' := s.reserve r with hs'
+  set Δ'' := Δ'.declVar ⟨r, .value⟩ with hΔ''
+  have hfresh_avoid : r ∉ s.avoid := by
+    simpa [hr] using NameSupply.fresh_not_in_avoid s "r"
+  have hfresh : r ∉ Δ'.allNames := fun hmem => hfresh_avoid (hcov r hmem)
+  have hΔ''wf : Δ''.wf := by simpa [hΔ''] using Signature.wf_declVar hΔ'
+  have hsub'' : Δ'.Subset Δ'' := by
+    simpa [hΔ''] using (Signature.subset_declVar_of_fresh (Δ := Δ') (v := ⟨r, .value⟩) hfresh)
+  have hsubt : Δ.Subset Δ'' := hsub.trans hsub''
+  have harg'' : arg.wfIn Δ'' :=
+    Term.wfIn_mono _ harg hsubt hΔ''wf
+  have hrvar : (Term.var .value r).wfIn Δ'' :=
+    var_value_wfIn hΔ''wf (by simpa [hΔ''] using Signature.var_mem_declVar Δ' ⟨r, .value⟩)
+  have hrel'' : (⟨rel, .value, .value⟩ : FOL.BinaryRel) ∈ Δ''.binaryRel :=
+    hsub''.binaryRel _ (hsub.binaryRel _ hrel)
+  have hcov' : s'.Covers Δ'' := by
+    simpa [hΔ'', hs'] using NameSupply.Covers.declVar hcov r .value
+  cases hinner : k (.var .value r) s' with
+  | error msg => simp [hinner, bind, Except.bind] at hrun
+  | ok inner =>
+    simp [hinner, bind, Except.bind] at hrun
+    subst hrun
+    have hkWf : Rel.wfIn Δ'' (k (.var .value r)) :=
+      hk hsubt hΔ''wf _ hrvar
+    have hinnerWf : inner.wfIn Δ'' :=
+      hkWf Δ'' s' inner (Signature.Subset.refl _) hΔ''wf hcov' hinner
+    exact ⟨Formula.funcall_wfIn hrel'' hΔ''wf harg'' hrvar, hinnerWf⟩
+
+theorem Rel.ite_wfIn {Δ : Signature} {cond : Term .bool}
+    {thenEnc elseEnc : Rel}
+    (hcond : cond.wfIn Δ) (ht : Rel.wfIn Δ thenEnc) (he : Rel.wfIn Δ elseEnc) :
+    Rel.wfIn Δ (Rel.ite cond thenEnc elseEnc) := by
+  intro Δ' s φ hsub hΔ' hcov hrun
+  simp only [Rel.ite, Bind.bind, Except.bind] at hrun
+  cases htRun : thenEnc s with
+  | error msg => simp only [htRun] at hrun; cases hrun
+  | ok φt =>
+    cases heRun : elseEnc s with
+    | error msg => simp only [htRun, heRun] at hrun; cases hrun
+    | ok φe =>
+      simp only [htRun, heRun, Except.ok.injEq] at hrun
+      subst hrun
+      have hφt := ht Δ' s φt hsub hΔ' hcov htRun
+      have hφe := he Δ' s φe hsub hΔ' hcov heRun
+      exact Formula.iteBool_wfIn (Term.wfIn_mono _ hcond hsub hΔ') hφt hφe
+
+def encoderOps_wf : EncoderOpsSig encoderOps Rel.wfIn FunCtx.wfIn where
+  ctx_mono := fun hΓ hsub => FunCtx.wfIn_mono hΓ hsub
+  call_ind := by
+    intro Γ Δ f rel arg k hΔ hΓ hmem harg hk
+    exact Rel.call_wfIn (hΓ f rel hmem) harg hk
+  ite_ind := by
+    intro Δ cond t e _ hcond ht he
+    exact Rel.ite_wfIn hcond ht he
+  error_ind := Rel.error_wfIn
+
+def Formula.sem (φ : Formula) (ρ : Env) : Prop :=
+  φ.eval ρ
+
+def Rel.Mono (m : Rel) : Prop :=
+  ∀ s φ, m s = .ok φ → SemanticMono Formula.sem φ
+
+theorem Rel.error_mono {msg : String} : Rel.Mono (Rel.error msg) := by
+  intro _ _ hrun; simp [Rel.error] at hrun
+
+theorem Rel.call_mono {rel : String} {arg : Term .value}
+    {k : Term .value → Rel}
+    (hk : ∀ v, Rel.Mono (k v)) :
+    Rel.Mono (Rel.call rel arg k) := by
+  intro s φ hrun ρ ρ' hle hφ
+  simp only [Rel.call, Bind.bind, Except.bind] at hrun
+  set r : String := s.fresh "r" with hr
+  set s' : NameSupply := s.reserve r with hs'
+  cases hinner : k (.var .value r) s' with
+  | error msg => simp [hinner] at hrun
+  | ok inner =>
+    simp [hinner] at hrun
+    subst hrun
+    have hkMono := hk (.var .value r)
+    unfold Formula.sem at hφ ⊢
+    simp only [Formula.eval] at hφ ⊢
+    rcases hφ with ⟨w, hcall_ev, hbody⟩
+    refine ⟨w, ?_, ?_⟩
+    · simp only [Formula.funcall, Formula.eval, BinPred.eval] at hcall_ev ⊢
+      have hleU : Fix.Env.le (ρ.updateConst .value r w) (ρ'.updateConst .value r w) :=
+        Fix.Env.le.updateConst hle .value r w
+      rw [← Fix.Term.eval_le hleU, ← Fix.Term.eval_le hleU]
+      exact hleU.2.2.2.2 _ _ _ _ _ hcall_ev
+    · exact hkMono s' inner hinner (hle.updateConst .value r w) hbody
+
+theorem Rel.ite_mono {cond : Term .bool} {t e : Rel}
+    (ht : Rel.Mono t) (he : Rel.Mono e) :
+    Rel.Mono (Rel.ite cond t e) := by
+  intro s φ hrun ρ ρ' hle hφ
+  simp only [Rel.ite, Bind.bind, Except.bind] at hrun
+  cases htRun : t s with
+  | error msg => simp [htRun] at hrun
+  | ok φt =>
+    cases heRun : e s with
+    | error msg => simp [htRun, heRun] at hrun
+    | ok φe =>
+      simp [htRun, heRun] at hrun
+      subst hrun
+      unfold Formula.sem at hφ ⊢
+      simp only [Formula.iteBool, Formula.eval] at hφ ⊢
+      constructor
+      · intro hcond
+        have hcond' : cond.eval ρ = true := by
+          rw [Fix.Term.eval_le hle]; exact hcond
+        exact ht s φt htRun hle (hφ.1 hcond')
+      · intro hcond
+        have hcond' : cond.eval ρ = false := by
+          rw [Fix.Term.eval_le hle]; exact hcond
+        exact he s φe heRun hle (hφ.2 hcond')
+
+def encoderOps_preservesMono :
+    EncoderOpsInd encoderOps Rel.Mono where
+  call_ind := Rel.call_mono
+  ite_ind  := Rel.ite_mono
+  error_ind := Rel.error_mono
+
+def kEq (r : String) : Term .value → Rel :=
+  fun v _ => .ok (.eq .value v (.var .value r))
+
+theorem kEq_wfCont {Δ : Signature} {r : String}
+    (hr : (⟨r, .value⟩ : Var) ∈ Δ.vars) :
+    ∀ {Δ'}, Δ.Subset Δ' → Δ'.wf →
+      ∀ v, v.wfIn Δ' → Rel.wfIn Δ' (kEq r v) := by
+  intro Δ' hsub hΔ' v hv Δ'' s φ hsub' hΔ'' _ hrun
+  simp only [kEq, Except.ok.injEq] at hrun
+  subst hrun
+  exact ⟨Term.wfIn_mono _ hv hsub' hΔ'',
+    var_value_wfIn hΔ'' ((hsub.trans hsub').vars _ hr)⟩
+
+theorem kEq_mono (r : String) :
+    ∀ v, Rel.Mono (kEq r v) := by
+  intro v s φ hrun ρ ρ' hle
+  simp only [kEq, Except.ok.injEq] at hrun
+  subst hrun
+  intro h
+  unfold Formula.sem at h ⊢
+  simp only [Formula.eval] at h ⊢
+  rw [← Fix.Term.eval_le hle, ← Fix.Term.eval_le hle]; exact h
+
+/-- Extend the function context so recursive calls to `f` resolve to `rel`. -/
+def ctx (Γ : FunCtx) (f : TinyML.Var) (rel : String) : FunCtx :=
+  (f, rel) :: Γ
+
+/-- Relational body encoding: encodes `rec f x := e` into a closed FOL formula
+pinned at result variable `res`. -/
+def relEncodeBody (Γ : FunCtx) (Δ : Signature)
+    (f : TinyML.Var) (rel : String) (x res : TinyML.Var) (e : Typed.Expr) :
+    Except String Formula :=
+  encodeWith encoderOps (ctx Γ f rel) (VarEnv.ofSignature (bodySig Δ rel x)) e (kEq res)
+    (relBodySupply Δ rel x res)
+
+/-- Least-fixpoint relational interpretation of `rec f x := e`. -/
+def semrel
+    (Γ : FunCtx) (Δ : Signature) (ρ : Env)
+    (f : TinyML.Var) (rel : String) (x res : TinyML.Var) (e : Typed.Expr) :
+    ValRel :=
+  semanticFixpoint (relEncodeBody Γ Δ f rel x res e) Formula.sem ρ rel x res
+
+/-- Cross-environment determinism for the relation symbols registered in `Γ`. -/
+def BinaryRelDet (Γ : FunCtx) (ρ₁ ρ₂ : Env) : Prop :=
+  ∀ f rel, (f, rel) ∈ Γ →
+    ∀ vin y₁ y₂,
+      ρ₁.binaryRel .value .value rel vin y₁ →
+      ρ₂.binaryRel .value .value rel vin y₂ →
+      y₁ = y₂
+
+/-- A relational carrier is deterministic in `res` at any extension of its
+view signature. -/
+def Rel.Det (Γ : FunCtx) (res : String) (Δview : Signature) (m : Rel) : Prop :=
+  ∀ Δ s φ ρ₁ ρ₂,
+    Δview.Subset Δ → Δ.wf → s.Covers Δ → res ∈ s.avoid →
+    m s = .ok φ →
+    BinaryRelDet Γ ρ₁ ρ₂ →
+    Env.termAgree Δ ρ₁ ρ₂ →
+    φ.eval ρ₁ → φ.eval ρ₂ →
+    ρ₁.lookupConst .value res = ρ₂.lookupConst .value res
+
+theorem Rel.error_det {Γ : FunCtx} {res : String} {Δview : Signature}
+    {msg : String} : Rel.Det Γ res Δview (Rel.error msg) := by
+  intro Δ s φ ρ₁ ρ₂ _ _ _ _ hrun _ _ _ _
+  simp [Rel.error] at hrun
+
+theorem kEq_det {Γ : FunCtx} {res : String} {Δview : Signature}
+    {v : Term .value} (hv : v.wfIn Δview) :
+    Rel.Det Γ res Δview (kEq res v) := by
+  intro Δ s φ ρ₁ ρ₂ hsub hΔ _ _ hrun _ hagree hφ₁ hφ₂
+  simp only [kEq, Except.ok.injEq] at hrun
+  subst hrun
+  have hvWf : v.wfIn Δ := Term.wfIn_mono _ hv hsub hΔ
+  simp only [Formula.eval, Term.eval] at hφ₁ hφ₂
+  have hveq : v.eval ρ₁ = v.eval ρ₂ := Term.eval_termAgree hvWf hagree
+  rw [← hφ₁, ← hφ₂, hveq]
+
+theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
+    {f : TinyML.Var} {rel : String} {arg : Term .value}
+    (hmem : (f, rel) ∈ Γ) (harg : arg.wfIn Δview)
+    {k : Term .value → Rel}
+    (hk : ∀ {Δ : Signature} {v : Term .value},
+            Δview.Subset Δ → Δ.wf → v.wfIn Δ → Rel.Det Γ res Δ (k v)) :
+    Rel.Det Γ res Δview (Rel.call rel arg k) := by
+  intro Δ s φ ρ₁ ρ₂ hsubView hΔ hcov hresA hrun hrel hagree hφ₁ hφ₂
+  simp only [Rel.call, Bind.bind, Except.bind] at hrun
+  set r : String := s.fresh "r" with hr
+  set s' : NameSupply := s.reserve r with hs'
+  set Δ' : Signature := Δ.declVar ⟨r, .value⟩ with hΔ'def
+  have hfresh_avoid : r ∉ s.avoid := by
+    simpa [hr] using NameSupply.fresh_not_in_avoid s "r"
+  have hfresh : r ∉ Δ.allNames := fun hmem => hfresh_avoid (hcov r hmem)
+  have hΔ'wf : Δ'.wf := by simpa [hΔ'def] using Signature.wf_declVar hΔ
+  have hsub' : Δ.Subset Δ' := by
+    simpa [hΔ'def] using
+      (Signature.subset_declVar_of_fresh (Δ := Δ) (v := ⟨r, .value⟩) hfresh)
+  have hsubView' : Δview.Subset Δ' := hsubView.trans hsub'
+  have hcov' : s'.Covers Δ' := by
+    simpa [hΔ'def, hs'] using NameSupply.Covers.declVar hcov r .value
+  have hresA' : res ∈ s'.avoid := by
+    simp [hs', NameSupply.reserve, hresA]
+  have hres_ne_r : res ≠ r := by
+    intro heq; exact hfresh_avoid (by simpa [heq] using hresA)
+  have hrvar : (Term.var .value r).wfIn Δ' :=
+    var_value_wfIn hΔ'wf (by simpa [hΔ'def] using Signature.var_mem_declVar Δ ⟨r, .value⟩)
+  have hargΔ : arg.wfIn Δ := Term.wfIn_mono _ harg hsubView hΔ
+  have hargΔ' : arg.wfIn Δ' := Term.wfIn_mono _ hargΔ hsub' hΔ'wf
+  cases hinner : k (.var .value r) s' with
+  | error msg => simp [hinner] at hrun
+  | ok inner =>
+    simp [hinner] at hrun
+    subst hrun
+    simp only [Formula.eval] at hφ₁ hφ₂
+    rcases hφ₁ with ⟨w₁, hcall₁, hbody₁⟩
+    rcases hφ₂ with ⟨w₂, hcall₂, hbody₂⟩
+    have hagree' : Env.termAgree Δ'
+        (ρ₁.updateConst .value r w₁) (ρ₂.updateConst .value r w₁) :=
+      Env.termAgree_declVar (x := r) (τ := .value) (v := w₁) hagree
+    have hargEval :
+        arg.eval (ρ₁.updateConst .value r w₁) =
+          arg.eval (ρ₂.updateConst .value r w₁) :=
+      Term.eval_termAgree hargΔ' hagree'
+    simp only [Formula.funcall, Formula.eval, BinPred.eval, Term.eval] at hcall₁ hcall₂
+    have hargEq₂ :
+        arg.eval (ρ₂.updateConst .value r w₁) =
+          arg.eval (ρ₂.updateConst .value r w₂) := by
+      have hag : Env.termAgree Δ
+          (ρ₂.updateConst .value r w₁) (ρ₂.updateConst .value r w₂) :=
+        Env.termAgree_of_agreeOn (Env.agreeOn_trans
+          (Env.agreeOn_symm
+            (Env.agreeOn_update_fresh_const (ρ := ρ₂) (c := ⟨r, .value⟩) (u := w₁) hfresh))
+          (Env.agreeOn_update_fresh_const (ρ := ρ₂) (c := ⟨r, .value⟩) (u := w₂) hfresh))
+      exact Term.eval_termAgree hargΔ hag
+    have hw : w₁ = w₂ := by
+      have hcall₁base :
+          ρ₁.binaryRel .value .value rel
+            (arg.eval (ρ₁.updateConst .value r w₁)) w₁ := by
+        simpa [Env.updateConst_binaryRel, Env.lookupConst_updateConst_same] using hcall₁
+      have hcall₂base :
+          ρ₂.binaryRel .value .value rel
+            (arg.eval (ρ₂.updateConst .value r w₂)) w₂ := by
+        simpa [Env.updateConst_binaryRel, Env.lookupConst_updateConst_same] using hcall₂
+      apply hrel f rel hmem (arg.eval (ρ₁.updateConst .value r w₁))
+      · exact hcall₁base
+      · rw [hargEval, hargEq₂]
+        exact hcall₂base
+    subst w₂
+    have hrelUpd :
+        BinaryRelDet Γ
+          (ρ₁.updateConst .value r w₁) (ρ₂.updateConst .value r w₁) := by
+      intro f' rel' hmem' vin y₁ y₂ hy₁ hy₂
+      simp only [Env.updateConst_binaryRel] at hy₁ hy₂
+      exact hrel f' rel' hmem' vin y₁ y₂ hy₁ hy₂
+    have hkDet : Rel.Det Γ res Δ' (k (.var .value r)) :=
+      hk hsubView' hΔ'wf hrvar
+    have hresEqUpd :=
+      hkDet Δ' s' inner
+        (ρ₁.updateConst .value r w₁) (ρ₂.updateConst .value r w₁)
+        (Signature.Subset.refl _) hΔ'wf hcov' hresA' hinner
+        hrelUpd hagree' hbody₁ hbody₂
+    simpa [Env.lookupConst_updateConst_ne hres_ne_r] using hresEqUpd
+
+theorem Rel.ite_det {Γ : FunCtx} {res : String} {Δview : Signature}
+    {cond : Term .bool} {t e : Rel}
+    (hcond : cond.wfIn Δview)
+    (ht : Rel.Det Γ res Δview t) (he : Rel.Det Γ res Δview e) :
+    Rel.Det Γ res Δview (Rel.ite cond t e) := by
+  intro Δ s φ ρ₁ ρ₂ hsubView hΔ hcov hresA hrun hrel hagree hφ₁ hφ₂
+  simp only [Rel.ite, Bind.bind, Except.bind] at hrun
+  cases htRun : t s with
+  | error msg => simp [htRun] at hrun
+  | ok φt =>
+    cases heRun : e s with
+    | error msg => simp [htRun, heRun] at hrun
+    | ok φe =>
+      simp [htRun, heRun] at hrun
+      subst hrun
+      have hcondΔ : cond.wfIn Δ := Term.wfIn_mono _ hcond hsubView hΔ
+      simp only [Formula.iteBool, Formula.eval] at hφ₁ hφ₂
+      have hcondEq : cond.eval ρ₁ = cond.eval ρ₂ :=
+        Term.eval_termAgree hcondΔ hagree
+      cases hc : cond.eval ρ₁
+      · have hc₂ : cond.eval ρ₂ = false := by simpa [hcondEq] using hc
+        exact he Δ s φe ρ₁ ρ₂ hsubView hΔ hcov hresA heRun hrel hagree
+          (hφ₁.2 hc) (hφ₂.2 hc₂)
+      · have hc₂ : cond.eval ρ₂ = true := by simpa [hcondEq] using hc
+        exact ht Δ s φt ρ₁ ρ₂ hsubView hΔ hcov hresA htRun hrel hagree
+          (hφ₁.1 hc) (hφ₂.1 hc₂)
+
+private def encoderOps_det (Γ : FunCtx) (res : String) :
+    EncoderOpsSig encoderOps (fun Δview m => Rel.Det Γ res Δview m)
+      (fun Γ' _ => Γ' = Γ) where
+  ctx_mono := fun h _ => h
+  call_ind := by
+    intro Γ' _ _ _ _ _ _ hΓeq hmem harg hk
+    subst hΓeq
+    exact Rel.call_det hmem harg (fun hsub hΔ hv => hk hsub hΔ _ hv)
+  ite_ind := fun _ hcond ht he => Rel.ite_det hcond ht he
+  error_ind := Rel.error_det
+
+/-- Successful relational encodings produce deterministic carriers. -/
+theorem encodeWith_det {Γ : FunCtx} {Δenc : Signature} {res : String}
+    {e : Typed.Expr} {Δview : Signature} {δ : VarEnv} {k : Term .value → Rel}
+    (hsubView : Δenc.Subset Δview) (hΔview : Δview.wf)
+    (hδ : δ.wfIn Δview)
+    (hk : ∀ {Δ : Signature} {v : Term .value},
+        Δview.Subset Δ → Δ.wf → v.wfIn Δ → Rel.Det Γ res Δ (k v)) :
+    Rel.Det Γ res Δview (encodeWith encoderOps Γ δ e k) :=
+  encodeWith_indWithSig (encoderOps_det Γ res) e hsubView hΔview rfl
+    hδ
+    (fun hsub hΔ' _ hv => hk hsub hΔ' hv)
+
+/-- The relational semantics induced by an encoded pure body is functional. -/
+theorem semrel_functional
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : Formula}
+    (henc : relEncodeBody Γ Δ f rel x res e = .ok body)
+    (hΓ : Γ.wfIn Δ)
+    (hrelFresh : rel ∉ Δ.allNames)
+    (hΔbody : (bodySig Δ rel x).wf)
+    (hresFresh : res ∉ (bodySig Δ rel x).allNames)
+    (hρdet : BinaryRelDet Γ ρ ρ)
+    (vin y₁ y₂ : Srt.value.denote) :
+    semrel Γ Δ ρ f rel x res e vin y₁ →
+      semrel Γ Δ ρ f rel x res e vin y₂ →
+      y₁ = y₂ := by
+  let F : ValRel → ValRel := semanticBody Formula.sem ρ rel x res body
+  let R : ValRel := semrel Γ Δ ρ f rel x res e
+  set δ := VarEnv.ofSignature (bodySig Δ rel x) with hδ_def
+  set m := encodeWith encoderOps (ctx Γ f rel) δ e (kEq res) with hm_def
+  have hrun : m (relBodySupply Δ rel x res) = .ok body := by
+    simpa [relEncodeBody, hm_def] using henc
+  have hR : R = Fix.lfp F := by simp [R, F, semrel, semanticFixpoint, henc]
+  have hmMono : Rel.Mono m :=
+    encodeWith_ind encoderOps_preservesMono e (kEq_mono res)
+  have hmonoBody : SemanticMono Formula.sem body :=
+    hmMono (relBodySupply Δ rel x res) body hrun
+  have hmono : Fix.Mono F := by
+    simpa [F] using
+      (semanticBody_mono_of_semanticMono
+        (ρ := ρ) (rel := rel) (x := x) (r := res) hmonoBody)
+  have hdetM : Rel.Det (ctx Γ f rel) res (bodySig Δ rel x) m :=
+    by
+      simpa [hm_def] using
+        encodeWith_det (Γ := ctx Γ f rel) (Δenc := bodySig Δ rel x)
+          (res := res) (e := e) (Δview := bodySig Δ rel x) (δ := δ)
+          (Signature.Subset.refl _) hΔbody
+          (by simpa [hδ_def] using VarEnv.ofSignature_wfIn hΔbody)
+          (fun _ _ hv => kEq_det hv)
+  have hxres : x ≠ res := by
+    intro h
+    exact hresFresh (by
+      simp [bodySig, Signature.declVar, Signature.addVar, Signature.allNames, h])
+  have hcovBody : (relBodySupply Δ rel x res).Covers (bodySig Δ rel x) := by
+    intro n hn
+    by_contra hnAvoid
+    have hnΔ : n ∉ Δ.allNames := fun h => hnAvoid (by simp [relBodySupply, h])
+    have hnRel : n ≠ rel := fun h => hnAvoid (by simp [relBodySupply, h])
+    have hnX : n ≠ x := fun h => hnAvoid (by simp [relBodySupply, h])
+    exact (Signature.not_mem_allNames_declVar
+      (Signature.not_mem_allNames_addBinaryRel hnΔ hnRel) hnX)
+      (by simpa [bodySig] using hn)
+  have hresAvoid : res ∈ (relBodySupply Δ rel x res).avoid := by simp [relBodySupply]
+  let S : ValRel := fun a b => R a b ∧ ∀ b', R a b' → b = b'
+  have hSleR : Fix.le S R := fun _ _ h => h.1
+  have hpre : Fix.le (F S) S := by
+    intro a b hFS
+    constructor
+    · rw [hR]
+      have hFR : F R a b := hmono hSleR a b hFS
+      rw [hR] at hFR
+      exact Fix.lfp_prefixed hmono a b hFR
+    · intro b' hRb'
+      have hFR : F R a b' := by
+        have hFRlfp : F (Fix.lfp F) a b' := by
+          rw [hR] at hRb'
+          exact (Fix.lfp_unfold hmono a b').mp hRb'
+        simpa [hR] using hFRlfp
+      have hrelDet :
+          BinaryRelDet (ctx Γ f rel)
+            (relEnv ρ rel x res S a b)
+            (relEnv ρ rel x res R a b') := by
+        intro f' rel' hmem' vin' z₁ z₂ hz₁ hz₂
+        cases hmem' with
+        | head =>
+            simp [relEnv, Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
+            exact hz₁.2 z₂ hz₂
+        | tail _ htail =>
+            have hrel'_mem : (⟨rel', .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel :=
+              hΓ f' rel' htail
+            have hne : rel' ≠ rel := fun h =>
+              hrelFresh (h ▸ Signature.mem_allNames_of_binaryRel hrel'_mem)
+            simp only [relEnv, Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
+            simp [hne] at hz₁ hz₂
+            exact hρdet f' rel' htail vin' z₁ z₂ hz₁ hz₂
+      have htermAgree :
+          Env.termAgree (bodySig Δ rel x)
+            (relEnv ρ rel x res S a b)
+            (relEnv ρ rel x res R a b') := by
+        unfold bodySig relEnv
+        refine ⟨?_, ?_, ?_, ?_⟩
+        · intro v hv
+          have hv' : v ∈ ⟨x, .value⟩ ::
+              ((Δ.addBinaryRel ⟨rel, .value, .value⟩).remove x).vars := by
+            simpa [Signature.declVar, Signature.addVar] using hv
+          cases hv' with
+          | head =>
+              simp [Env.updateConst, Env.updateBinaryRel, hxres]
+          | tail _ htail =>
+              have hneX : v.name ≠ x := by
+                intro hxv
+                have hmem : v.name ∈
+                    ((Δ.addBinaryRel ⟨rel, .value, .value⟩).remove x).allNames :=
+                  Signature.mem_allNames_of_var htail
+                exact Signature.remove_allNames hmem hxv
+              have hneRes : v.name ≠ res := by
+                intro hres
+                have hmem : v.name ∈ (bodySig Δ rel x).allNames := by
+                  exact Signature.mem_allNames_of_var hv
+                exact hresFresh (hres ▸ hmem)
+              simp [Env.updateConst, Env.updateBinaryRel, hneX, hneRes]
+        · intro c hc
+          have hneX : c.name ≠ x := by
+            intro hcx
+            have hmem : c.name ∈
+                ((Δ.addBinaryRel ⟨rel, .value, .value⟩).remove x).allNames :=
+              Signature.mem_allNames_of_const (by
+                simpa [bodySig, Signature.declVar, Signature.addVar] using hc)
+            exact Signature.remove_allNames hmem hcx
+          have hneRes : c.name ≠ res := by
+            intro hres
+            have hmem : c.name ∈ (bodySig Δ rel x).allNames :=
+              Signature.mem_allNames_of_const hc
+            exact hresFresh (hres ▸ hmem)
+          simp [Env.updateConst, Env.updateBinaryRel, hneX, hneRes]
+        · intro u hu
+          simp [Env.updateConst_unary, Env.updateBinaryRel]
+        · intro bin hbin
+          simp [Env.updateConst_binary, Env.updateBinaryRel]
+      have hresEq :=
+        hdetM (bodySig Δ rel x) (relBodySupply Δ rel x res) body
+        (relEnv ρ rel x res S a b) (relEnv ρ rel x res R a b')
+        (Signature.Subset.refl _) hΔbody hcovBody hresAvoid hrun
+        hrelDet htermAgree hFS hFR
+      simpa [relEnv, Env.lookupConst_updateConst_same] using hresEq
+  intro hy₁ hy₂
+  have hy₁S : S vin y₁ := by
+    change R vin y₁ at hy₁
+    rw [hR] at hy₁
+    exact Fix.lfp_le_of_prefixed hpre vin y₁ hy₁
+  exact hy₁S.2 y₂ hy₂
+end Relation
+end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/Relation.lean
+++ b/Mica/Verifier/RelationalEncoding/Relation.lean
@@ -8,22 +8,6 @@ First stage of the encoding. A recursive definition `rec f x := e` becomes a
 binary FOL relation, interpreted as the least fixpoint of the encoded body
 operator. Diverging inputs are absent from the relation.
 -/
-/-- Uninterpreted binary predicate `rel ⊆ value × value` applied to `arg, res`. -/
-def Formula.funcall (rel : String) (arg res : Term .value) : Formula :=
-  .binpred (.uninterpreted rel .value .value) arg res
-
-theorem Formula.funcall_wfIn {rel : String} {arg res : Term .value} {Δ : Signature}
-    (hrel : (⟨rel, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
-    (hΔ : Δ.wf)
-    (harg : arg.wfIn Δ) (hres : res.wfIn Δ) :
-    (Formula.funcall rel arg res).wfIn Δ := by
-  refine ⟨?_, harg, hres⟩
-  refine ⟨hrel, ?_, ?_⟩
-  · intro τ₁ τ₂ τ₃ hb
-    exact Signature.wf_no_binaryRel_of_binary hΔ hb hrel
-  · intro τ₁ τ₂ hb
-    exact Signature.wf_unique_binaryRel hΔ hrel hb
-
 def Formula.iteBool (cond : Term .bool) (φ ψ : Formula) : Formula :=
   .and (.implies (.eq .bool cond (.const (.b true)))  φ)
        (.implies (.eq .bool cond (.const (.b false))) ψ)
@@ -40,7 +24,7 @@ abbrev ValRel : Type := Fix.Rel Srt.value.denote Srt.value.denote
 
 def relEnv (ρ : Env) (fn : SpecFn) (x res : TinyML.Var)
     (self : ValRel) (vin vout : Srt.value.denote) : Env :=
-  let ρ1 := ρ.updateBinaryRel .value .value fn self
+  let ρ1 := ρ.updateBinaryRel .value .value fn.relName self
   let ρ2 := ρ1.updateConst .value x vin
   ρ2.updateConst .value res vout
 
@@ -81,7 +65,7 @@ def Rel.call (fn : SpecFn) (arg : Term .value) (k : Term .value → Rel) : Rel :
     let s' := s.reserve r
     do
       let φ ← k (.var .value r) s'
-      .ok (.exists_ r .value (.and (Formula.funcall fn arg (.var .value r)) φ))
+      .ok (.exists_ r .value (.and (fn.rel arg (.var .value r)) φ))
 
 def Rel.ite (cond : Term .bool) (thenEnc elseEnc : Rel) : Rel :=
   fun s => do
@@ -104,7 +88,7 @@ theorem Rel.error_wfIn {Δ : Signature} {msg : String} :
   simp [Rel.error] at hrun
 
 theorem Rel.call_wfIn {Δ : Signature} {fn : SpecFn} {arg : Term .value}
-    (hrel : (⟨fn, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
+    (hrel : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
     (harg : arg.wfIn Δ)
     {k : Term .value → Rel}
     (hk : ∀ {Δ'}, Δ.Subset Δ' → Δ'.wf →
@@ -126,7 +110,7 @@ theorem Rel.call_wfIn {Δ : Signature} {fn : SpecFn} {arg : Term .value}
     Term.wfIn_mono _ harg hsubt hΔ''wf
   have hrvar : (Term.var .value r).wfIn Δ'' :=
     var_value_wfIn hΔ''wf (by simpa [hΔ''] using Signature.var_mem_declVar Δ' ⟨r, .value⟩)
-  have hrel'' : (⟨fn, .value, .value⟩ : FOL.BinaryRel) ∈ Δ''.binaryRel :=
+  have hrel'' : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ''.binaryRel :=
     hsub''.binaryRel _ (hsub.binaryRel _ hrel)
   have hcov' : s'.Covers Δ'' := by
     simpa [hΔ'', hs'] using NameSupply.Covers.declVar hcov r .value
@@ -139,7 +123,7 @@ theorem Rel.call_wfIn {Δ : Signature} {fn : SpecFn} {arg : Term .value}
       hk hsubt hΔ''wf _ hrvar
     have hinnerWf : inner.wfIn Δ'' :=
       hkWf Δ'' s' inner (Signature.Subset.refl _) hΔ''wf hcov' hinner
-    exact ⟨Formula.funcall_wfIn hrel'' hΔ''wf harg'' hrvar, hinnerWf⟩
+    exact ⟨SpecFn.rel_wfIn hrel'' hΔ''wf harg'' hrvar, hinnerWf⟩
 
 theorem Rel.ite_wfIn {Δ : Signature} {cond : Term .bool}
     {thenEnc elseEnc : Rel}
@@ -196,7 +180,7 @@ theorem Rel.call_mono {fn : SpecFn} {arg : Term .value}
     simp only [Formula.eval] at hφ ⊢
     rcases hφ with ⟨w, hcall_ev, hbody⟩
     refine ⟨w, ?_, ?_⟩
-    · simp only [Formula.funcall, Formula.eval, BinPred.eval] at hcall_ev ⊢
+    · simp only [SpecFn.rel, Formula.eval, BinPred.eval] at hcall_ev ⊢
       have hleU : Fix.Env.le (ρ.updateConst .value r w) (ρ'.updateConst .value r w) :=
         Fix.Env.le.updateConst hle .value r w
       rw [← Fix.Term.eval_le hleU, ← Fix.Term.eval_le hleU]
@@ -280,8 +264,8 @@ def semrel
 def BinaryRelDet (Γ : FunCtx) (ρ₁ ρ₂ : Env) : Prop :=
   ∀ f fn, (f, fn) ∈ Γ →
     ∀ vin y₁ y₂,
-      ρ₁.binaryRel .value .value fn vin y₁ →
-      ρ₂.binaryRel .value .value fn vin y₂ →
+      ρ₁.binaryRel .value .value fn.relName vin y₁ →
+      ρ₂.binaryRel .value .value fn.relName vin y₂ →
       y₁ = y₂
 
 /-- A relational carrier is deterministic in `res` at any extension of its
@@ -356,7 +340,7 @@ theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
         arg.eval (ρ₁.updateConst .value r w₁) =
           arg.eval (ρ₂.updateConst .value r w₁) :=
       Term.eval_termAgree hargΔ' hagree'
-    simp only [Formula.funcall, Formula.eval, BinPred.eval, Term.eval] at hcall₁ hcall₂
+    simp only [SpecFn.rel, Formula.eval, BinPred.eval, Term.eval] at hcall₁ hcall₂
     have hargEq₂ :
         arg.eval (ρ₂.updateConst .value r w₁) =
           arg.eval (ρ₂.updateConst .value r w₂) := by
@@ -369,11 +353,11 @@ theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
       exact Term.eval_termAgree hargΔ hag
     have hw : w₁ = w₂ := by
       have hcall₁base :
-          ρ₁.binaryRel .value .value fn
+          ρ₁.binaryRel .value .value fn.relName
             (arg.eval (ρ₁.updateConst .value r w₁)) w₁ := by
         simpa [Env.updateConst_binaryRel, Env.lookupConst_updateConst_same] using hcall₁
       have hcall₂base :
-          ρ₂.binaryRel .value .value fn
+          ρ₂.binaryRel .value .value fn.relName
             (arg.eval (ρ₂.updateConst .value r w₂)) w₂ := by
         simpa [Env.updateConst_binaryRel, Env.lookupConst_updateConst_same] using hcall₂
       apply hrel f fn hmem (arg.eval (ρ₁.updateConst .value r w₁))
@@ -453,7 +437,7 @@ theorem semrel_functional
     {body : Formula}
     (henc : relEncodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.relWfIn Δ)
-    (hrelFresh : fn ∉ Δ.allNames)
+    (hrelFresh : fn.relName ∉ Δ.allNames)
     (hΔbody : (bodySig Δ fn x).wf)
     (hresFresh : res ∉ (bodySig Δ fn x).allNames)
     (hρdet : BinaryRelDet Γ ρ ρ)
@@ -492,7 +476,7 @@ theorem semrel_functional
     intro n hn
     by_contra hnAvoid
     have hnΔ : n ∉ Δ.allNames := fun h => hnAvoid (by simp [relBodySupply, h])
-    have hnRel : n ≠ fn := fun h => hnAvoid (by simp [relBodySupply, h])
+    have hnRel : n ≠ fn.relName := fun h => hnAvoid (by simp [relBodySupply, h])
     have hnX : n ≠ x := fun h => hnAvoid (by simp [relBodySupply, h])
     exact (Signature.not_mem_allNames_declVar
       (Signature.not_mem_allNames_addBinaryRel hnΔ hnRel) hnX)
@@ -523,9 +507,9 @@ theorem semrel_functional
             simp [relEnv, Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
             exact hz₁.2 z₂ hz₂
         | tail _ htail =>
-            have hrel'_mem : (⟨fn', .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel :=
+            have hrel'_mem : (⟨fn'.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel :=
               hΓ f' fn' htail
-            have hne : fn' ≠ fn := fun h =>
+            have hne : fn'.relName ≠ fn.relName := fun h =>
               hrelFresh (h ▸ Signature.mem_allNames_of_binaryRel hrel'_mem)
             simp only [relEnv, Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
             simp [hne] at hz₁ hz₂
@@ -538,7 +522,7 @@ theorem semrel_functional
         refine ⟨?_, ?_, ?_, ?_⟩
         · intro v hv
           have hv' : v ∈ ⟨x, .value⟩ ::
-              ((Δ.addBinaryRel ⟨fn, .value, .value⟩).remove x).vars := by
+              ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).remove x).vars := by
             simpa [Signature.declVar, Signature.addVar] using hv
           cases hv' with
           | head =>
@@ -547,7 +531,7 @@ theorem semrel_functional
               have hneX : v.name ≠ x := by
                 intro hxv
                 have hmem : v.name ∈
-                    ((Δ.addBinaryRel ⟨fn, .value, .value⟩).remove x).allNames :=
+                    ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).remove x).allNames :=
                   Signature.mem_allNames_of_var htail
                 exact Signature.remove_allNames hmem hxv
               have hneRes : v.name ≠ res := by
@@ -560,7 +544,7 @@ theorem semrel_functional
           have hneX : c.name ≠ x := by
             intro hcx
             have hmem : c.name ∈
-                ((Δ.addBinaryRel ⟨fn, .value, .value⟩).remove x).allNames :=
+                ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).remove x).allNames :=
               Signature.mem_allNames_of_const (by
                 simpa [bodySig, Signature.declVar, Signature.addVar] using hc)
             exact Signature.remove_allNames hmem hcx

--- a/Mica/Verifier/RelationalEncoding/Relation.lean
+++ b/Mica/Verifier/RelationalEncoding/Relation.lean
@@ -65,7 +65,7 @@ def Rel.call (fn : SpecFn) (arg : Term .value) (k : Term .value → Rel) : Rel :
     let s' := s.reserve r
     do
       let φ ← k (.var .value r) s'
-      .ok (.exists_ r .value (.and (fn.rel arg (.var .value r)) φ))
+      .ok (.exists_ r .value (.and (fn.relates arg (.var .value r)) φ))
 
 def Rel.ite (cond : Term .bool) (thenEnc elseEnc : Rel) : Rel :=
   fun s => do

--- a/Mica/Verifier/RelationalEncoding/Relation.lean
+++ b/Mica/Verifier/RelationalEncoding/Relation.lean
@@ -38,29 +38,29 @@ namespace Relation
 
 abbrev ValRel : Type := Fix.Rel Srt.value.denote Srt.value.denote
 
-def relEnv (ρ : Env) (rel : String) (x r : TinyML.Var)
+def relEnv (ρ : Env) (fn : SpecFn) (x res : TinyML.Var)
     (self : ValRel) (vin vout : Srt.value.denote) : Env :=
-  let ρ1 := ρ.updateBinaryRel .value .value rel self
+  let ρ1 := ρ.updateBinaryRel .value .value fn self
   let ρ2 := ρ1.updateConst .value x vin
-  ρ2.updateConst .value r vout
+  ρ2.updateConst .value res vout
 
 def semanticBody {M : Type} (sem : SemPred M)
-    (ρ : Env) (rel : String) (x r : TinyML.Var) (m : M) : ValRel → ValRel :=
-  fun self vin vout => sem m (relEnv ρ rel x r self vin vout)
+    (ρ : Env) (fn : SpecFn) (x res : TinyML.Var) (m : M) : ValRel → ValRel :=
+  fun self vin vout => sem m (relEnv ρ fn x res self vin vout)
 
 def semanticFixpoint {M : Type} (encoded : Except String M) (sem : SemPred M)
-    (ρ : Env) (rel : String) (x r : TinyML.Var) : ValRel :=
+    (ρ : Env) (fn : SpecFn) (x res : TinyML.Var) : ValRel :=
   match encoded with
   | .error _ => fun _ _ => False
-  | .ok m    => Fix.lfp (semanticBody sem ρ rel x r m)
+  | .ok m    => Fix.lfp (semanticBody sem ρ fn x res m)
 
 theorem semanticBody_mono_of_semanticMono {M : Type} {sem : SemPred M}
-    {ρ : Env} {rel : String} {x r : TinyML.Var} {m : M}
+    {ρ : Env} {fn : SpecFn} {x res : TinyML.Var} {m : M}
     (hm : SemanticMono sem m) :
-    Fix.Mono (semanticBody sem ρ rel x r m) := by
+    Fix.Mono (semanticBody sem ρ fn x res m) := by
   intro S S' hSS' vin vout hF
-  have hle : Fix.Env.le (relEnv ρ rel x r S vin vout)
-                    (relEnv ρ rel x r S' vin vout) := by
+  have hle : Fix.Env.le (relEnv ρ fn x res S vin vout)
+                    (relEnv ρ fn x res S' vin vout) := by
     refine Fix.Env.le.updateConst (Fix.Env.le.updateConst ?_ _ _ _) _ _ _
     refine ⟨rfl, rfl, rfl, fun _ _ _ h => h, ?_⟩
     intro τ₁ τ₂ name a b
@@ -75,13 +75,13 @@ abbrev Rel : Type := NameSupply → Except String Formula
 
 def Rel.error (msg : String) : Rel := fun _ => .error msg
 
-def Rel.call (rel : String) (arg : Term .value) (k : Term .value → Rel) : Rel :=
+def Rel.call (fn : SpecFn) (arg : Term .value) (k : Term .value → Rel) : Rel :=
   fun s =>
     let r := s.fresh "r"
     let s' := s.reserve r
     do
       let φ ← k (.var .value r) s'
-      .ok (.exists_ r .value (.and (Formula.funcall rel arg (.var .value r)) φ))
+      .ok (.exists_ r .value (.and (Formula.funcall fn arg (.var .value r)) φ))
 
 def Rel.ite (cond : Term .bool) (thenEnc elseEnc : Rel) : Rel :=
   fun s => do
@@ -103,13 +103,13 @@ theorem Rel.error_wfIn {Δ : Signature} {msg : String} :
   intro Δ' s φ _ _ _ hrun
   simp [Rel.error] at hrun
 
-theorem Rel.call_wfIn {Δ : Signature} {rel : String} {arg : Term .value}
-    (hrel : (⟨rel, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
+theorem Rel.call_wfIn {Δ : Signature} {fn : SpecFn} {arg : Term .value}
+    (hrel : (⟨fn, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
     (harg : arg.wfIn Δ)
     {k : Term .value → Rel}
     (hk : ∀ {Δ'}, Δ.Subset Δ' → Δ'.wf →
       ∀ v, v.wfIn Δ' → Rel.wfIn Δ' (k v)) :
-    Rel.wfIn Δ (Rel.call rel arg k) := by
+    Rel.wfIn Δ (Rel.call fn arg k) := by
   intro Δ' s φ hsub hΔ' hcov hrun
   simp only [Rel.call] at hrun
   set r := s.fresh "r" with hr
@@ -126,7 +126,7 @@ theorem Rel.call_wfIn {Δ : Signature} {rel : String} {arg : Term .value}
     Term.wfIn_mono _ harg hsubt hΔ''wf
   have hrvar : (Term.var .value r).wfIn Δ'' :=
     var_value_wfIn hΔ''wf (by simpa [hΔ''] using Signature.var_mem_declVar Δ' ⟨r, .value⟩)
-  have hrel'' : (⟨rel, .value, .value⟩ : FOL.BinaryRel) ∈ Δ''.binaryRel :=
+  have hrel'' : (⟨fn, .value, .value⟩ : FOL.BinaryRel) ∈ Δ''.binaryRel :=
     hsub''.binaryRel _ (hsub.binaryRel _ hrel)
   have hcov' : s'.Covers Δ'' := by
     simpa [hΔ'', hs'] using NameSupply.Covers.declVar hcov r .value
@@ -159,11 +159,11 @@ theorem Rel.ite_wfIn {Δ : Signature} {cond : Term .bool}
       have hφe := he Δ' s φe hsub hΔ' hcov heRun
       exact Formula.iteBool_wfIn (Term.wfIn_mono _ hcond hsub hΔ') hφt hφe
 
-def encoderOps_wf : EncoderOpsSig encoderOps Rel.wfIn FunCtx.wfIn where
-  ctx_mono := fun hΓ hsub => FunCtx.wfIn_mono hΓ hsub
+def encoderOps_wf : EncoderOpsSig encoderOps Rel.wfIn FunCtx.relWfIn where
+  ctx_mono := fun hΓ hsub => FunCtx.relWfIn_mono hΓ hsub
   call_ind := by
-    intro Γ Δ f rel arg k hΔ hΓ hmem harg hk
-    exact Rel.call_wfIn (hΓ f rel hmem) harg hk
+    intro Γ Δ f fn arg k hΔ hΓ hmem harg hk
+    exact Rel.call_wfIn (hΓ f fn hmem) harg hk
   ite_ind := by
     intro Δ cond t e _ hcond ht he
     exact Rel.ite_wfIn hcond ht he
@@ -178,10 +178,10 @@ def Rel.Mono (m : Rel) : Prop :=
 theorem Rel.error_mono {msg : String} : Rel.Mono (Rel.error msg) := by
   intro _ _ hrun; simp [Rel.error] at hrun
 
-theorem Rel.call_mono {rel : String} {arg : Term .value}
+theorem Rel.call_mono {fn : SpecFn} {arg : Term .value}
     {k : Term .value → Rel}
     (hk : ∀ v, Rel.Mono (k v)) :
-    Rel.Mono (Rel.call rel arg k) := by
+    Rel.Mono (Rel.call fn arg k) := by
   intro s φ hrun ρ ρ' hle hφ
   simp only [Rel.call, Bind.bind, Except.bind] at hrun
   set r : String := s.fresh "r" with hr
@@ -234,21 +234,21 @@ def encoderOps_preservesMono :
   ite_ind  := Rel.ite_mono
   error_ind := Rel.error_mono
 
-def kEq (r : String) : Term .value → Rel :=
-  fun v _ => .ok (.eq .value v (.var .value r))
+def kEq (res : String) : Term .value → Rel :=
+  fun v _ => .ok (.eq .value v (.var .value res))
 
-theorem kEq_wfCont {Δ : Signature} {r : String}
-    (hr : (⟨r, .value⟩ : Var) ∈ Δ.vars) :
+theorem kEq_wfCont {Δ : Signature} {res : String}
+    (hres : (⟨res, .value⟩ : Var) ∈ Δ.vars) :
     ∀ {Δ'}, Δ.Subset Δ' → Δ'.wf →
-      ∀ v, v.wfIn Δ' → Rel.wfIn Δ' (kEq r v) := by
+      ∀ v, v.wfIn Δ' → Rel.wfIn Δ' (kEq res v) := by
   intro Δ' hsub hΔ' v hv Δ'' s φ hsub' hΔ'' _ hrun
   simp only [kEq, Except.ok.injEq] at hrun
   subst hrun
   exact ⟨Term.wfIn_mono _ hv hsub' hΔ'',
-    var_value_wfIn hΔ'' ((hsub.trans hsub').vars _ hr)⟩
+    var_value_wfIn hΔ'' ((hsub.trans hsub').vars _ hres)⟩
 
-theorem kEq_mono (r : String) :
-    ∀ v, Rel.Mono (kEq r v) := by
+theorem kEq_mono (res : String) :
+    ∀ v, Rel.Mono (kEq res v) := by
   intro v s φ hrun ρ ρ' hle
   simp only [kEq, Except.ok.injEq] at hrun
   subst hrun
@@ -257,31 +257,31 @@ theorem kEq_mono (r : String) :
   simp only [Formula.eval] at h ⊢
   rw [← Fix.Term.eval_le hle, ← Fix.Term.eval_le hle]; exact h
 
-/-- Extend the function context so recursive calls to `f` resolve to `rel`. -/
-def ctx (Γ : FunCtx) (f : TinyML.Var) (rel : String) : FunCtx :=
-  (f, rel) :: Γ
+/-- Extend the function context so recursive calls to `f` resolve to `fn`. -/
+def ctx (Γ : FunCtx) (f : TinyML.Var) (fn : SpecFn) : FunCtx :=
+  (f, fn) :: Γ
 
 /-- Relational body encoding: encodes `rec f x := e` into a closed FOL formula
 pinned at result variable `res`. -/
 def relEncodeBody (Γ : FunCtx) (Δ : Signature)
-    (f : TinyML.Var) (rel : String) (x res : TinyML.Var) (e : Typed.Expr) :
+    (f : TinyML.Var) (fn : SpecFn) (x res : TinyML.Var) (e : Typed.Expr) :
     Except String Formula :=
-  encodeWith encoderOps (ctx Γ f rel) (VarEnv.ofSignature (bodySig Δ rel x)) e (kEq res)
-    (relBodySupply Δ rel x res)
+  encodeWith encoderOps (ctx Γ f fn) (VarEnv.ofSignature (bodySig Δ fn x)) e (kEq res)
+    (relBodySupply Δ fn x res)
 
 /-- Least-fixpoint relational interpretation of `rec f x := e`. -/
 def semrel
     (Γ : FunCtx) (Δ : Signature) (ρ : Env)
-    (f : TinyML.Var) (rel : String) (x res : TinyML.Var) (e : Typed.Expr) :
+    (f : TinyML.Var) (fn : SpecFn) (x res : TinyML.Var) (e : Typed.Expr) :
     ValRel :=
-  semanticFixpoint (relEncodeBody Γ Δ f rel x res e) Formula.sem ρ rel x res
+  semanticFixpoint (relEncodeBody Γ Δ f fn x res e) Formula.sem ρ fn x res
 
 /-- Cross-environment determinism for the relation symbols registered in `Γ`. -/
 def BinaryRelDet (Γ : FunCtx) (ρ₁ ρ₂ : Env) : Prop :=
-  ∀ f rel, (f, rel) ∈ Γ →
+  ∀ f fn, (f, fn) ∈ Γ →
     ∀ vin y₁ y₂,
-      ρ₁.binaryRel .value .value rel vin y₁ →
-      ρ₂.binaryRel .value .value rel vin y₂ →
+      ρ₁.binaryRel .value .value fn vin y₁ →
+      ρ₂.binaryRel .value .value fn vin y₂ →
       y₁ = y₂
 
 /-- A relational carrier is deterministic in `res` at any extension of its
@@ -312,12 +312,12 @@ theorem kEq_det {Γ : FunCtx} {res : String} {Δview : Signature}
   rw [← hφ₁, ← hφ₂, hveq]
 
 theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
-    {f : TinyML.Var} {rel : String} {arg : Term .value}
-    (hmem : (f, rel) ∈ Γ) (harg : arg.wfIn Δview)
+    {f : TinyML.Var} {fn : SpecFn} {arg : Term .value}
+    (hmem : (f, fn) ∈ Γ) (harg : arg.wfIn Δview)
     {k : Term .value → Rel}
     (hk : ∀ {Δ : Signature} {v : Term .value},
             Δview.Subset Δ → Δ.wf → v.wfIn Δ → Rel.Det Γ res Δ (k v)) :
-    Rel.Det Γ res Δview (Rel.call rel arg k) := by
+    Rel.Det Γ res Δview (Rel.call fn arg k) := by
   intro Δ s φ ρ₁ ρ₂ hsubView hΔ hcov hresA hrun hrel hagree hφ₁ hφ₂
   simp only [Rel.call, Bind.bind, Except.bind] at hrun
   set r : String := s.fresh "r" with hr
@@ -369,14 +369,14 @@ theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
       exact Term.eval_termAgree hargΔ hag
     have hw : w₁ = w₂ := by
       have hcall₁base :
-          ρ₁.binaryRel .value .value rel
+          ρ₁.binaryRel .value .value fn
             (arg.eval (ρ₁.updateConst .value r w₁)) w₁ := by
         simpa [Env.updateConst_binaryRel, Env.lookupConst_updateConst_same] using hcall₁
       have hcall₂base :
-          ρ₂.binaryRel .value .value rel
+          ρ₂.binaryRel .value .value fn
             (arg.eval (ρ₂.updateConst .value r w₂)) w₂ := by
         simpa [Env.updateConst_binaryRel, Env.lookupConst_updateConst_same] using hcall₂
-      apply hrel f rel hmem (arg.eval (ρ₁.updateConst .value r w₁))
+      apply hrel f fn hmem (arg.eval (ρ₁.updateConst .value r w₁))
       · exact hcall₁base
       · rw [hargEval, hargEq₂]
         exact hcall₂base
@@ -384,9 +384,9 @@ theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
     have hrelUpd :
         BinaryRelDet Γ
           (ρ₁.updateConst .value r w₁) (ρ₂.updateConst .value r w₁) := by
-      intro f' rel' hmem' vin y₁ y₂ hy₁ hy₂
+      intro f' fn' hmem' vin y₁ y₂ hy₁ hy₂
       simp only [Env.updateConst_binaryRel] at hy₁ hy₂
-      exact hrel f' rel' hmem' vin y₁ y₂ hy₁ hy₂
+      exact hrel f' fn' hmem' vin y₁ y₂ hy₁ hy₂
     have hkDet : Rel.Det Γ res Δ' (k (.var .value r)) :=
       hk hsubView' hΔ'wf hrvar
     have hresEqUpd :=
@@ -449,38 +449,38 @@ theorem encodeWith_det {Γ : FunCtx} {Δenc : Signature} {res : String}
 /-- The relational semantics induced by an encoded pure body is functional. -/
 theorem semrel_functional
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {body : Formula}
-    (henc : relEncodeBody Γ Δ f rel x res e = .ok body)
-    (hΓ : Γ.wfIn Δ)
-    (hrelFresh : rel ∉ Δ.allNames)
-    (hΔbody : (bodySig Δ rel x).wf)
-    (hresFresh : res ∉ (bodySig Δ rel x).allNames)
+    (henc : relEncodeBody Γ Δ f fn x res e = .ok body)
+    (hΓ : Γ.relWfIn Δ)
+    (hrelFresh : fn ∉ Δ.allNames)
+    (hΔbody : (bodySig Δ fn x).wf)
+    (hresFresh : res ∉ (bodySig Δ fn x).allNames)
     (hρdet : BinaryRelDet Γ ρ ρ)
     (vin y₁ y₂ : Srt.value.denote) :
-    semrel Γ Δ ρ f rel x res e vin y₁ →
-      semrel Γ Δ ρ f rel x res e vin y₂ →
+    semrel Γ Δ ρ f fn x res e vin y₁ →
+      semrel Γ Δ ρ f fn x res e vin y₂ →
       y₁ = y₂ := by
-  let F : ValRel → ValRel := semanticBody Formula.sem ρ rel x res body
-  let R : ValRel := semrel Γ Δ ρ f rel x res e
-  set δ := VarEnv.ofSignature (bodySig Δ rel x) with hδ_def
-  set m := encodeWith encoderOps (ctx Γ f rel) δ e (kEq res) with hm_def
-  have hrun : m (relBodySupply Δ rel x res) = .ok body := by
+  let F : ValRel → ValRel := semanticBody Formula.sem ρ fn x res body
+  let R : ValRel := semrel Γ Δ ρ f fn x res e
+  set δ := VarEnv.ofSignature (bodySig Δ fn x) with hδ_def
+  set m := encodeWith encoderOps (ctx Γ f fn) δ e (kEq res) with hm_def
+  have hrun : m (relBodySupply Δ fn x res) = .ok body := by
     simpa [relEncodeBody, hm_def] using henc
   have hR : R = Fix.lfp F := by simp [R, F, semrel, semanticFixpoint, henc]
   have hmMono : Rel.Mono m :=
     encodeWith_ind encoderOps_preservesMono e (kEq_mono res)
   have hmonoBody : SemanticMono Formula.sem body :=
-    hmMono (relBodySupply Δ rel x res) body hrun
+    hmMono (relBodySupply Δ fn x res) body hrun
   have hmono : Fix.Mono F := by
     simpa [F] using
       (semanticBody_mono_of_semanticMono
-        (ρ := ρ) (rel := rel) (x := x) (r := res) hmonoBody)
-  have hdetM : Rel.Det (ctx Γ f rel) res (bodySig Δ rel x) m :=
+        (ρ := ρ) (fn := fn) (x := x) (res := res) hmonoBody)
+  have hdetM : Rel.Det (ctx Γ f fn) res (bodySig Δ fn x) m :=
     by
       simpa [hm_def] using
-        encodeWith_det (Γ := ctx Γ f rel) (Δenc := bodySig Δ rel x)
-          (res := res) (e := e) (Δview := bodySig Δ rel x) (δ := δ)
+        encodeWith_det (Γ := ctx Γ f fn) (Δenc := bodySig Δ fn x)
+          (res := res) (e := e) (Δview := bodySig Δ fn x) (δ := δ)
           (Signature.Subset.refl _) hΔbody
           (by simpa [hδ_def] using VarEnv.ofSignature_wfIn hΔbody)
           (fun _ _ hv => kEq_det hv)
@@ -488,16 +488,16 @@ theorem semrel_functional
     intro h
     exact hresFresh (by
       simp [bodySig, Signature.declVar, Signature.addVar, Signature.allNames, h])
-  have hcovBody : (relBodySupply Δ rel x res).Covers (bodySig Δ rel x) := by
+  have hcovBody : (relBodySupply Δ fn x res).Covers (bodySig Δ fn x) := by
     intro n hn
     by_contra hnAvoid
     have hnΔ : n ∉ Δ.allNames := fun h => hnAvoid (by simp [relBodySupply, h])
-    have hnRel : n ≠ rel := fun h => hnAvoid (by simp [relBodySupply, h])
+    have hnRel : n ≠ fn := fun h => hnAvoid (by simp [relBodySupply, h])
     have hnX : n ≠ x := fun h => hnAvoid (by simp [relBodySupply, h])
     exact (Signature.not_mem_allNames_declVar
       (Signature.not_mem_allNames_addBinaryRel hnΔ hnRel) hnX)
       (by simpa [bodySig] using hn)
-  have hresAvoid : res ∈ (relBodySupply Δ rel x res).avoid := by simp [relBodySupply]
+  have hresAvoid : res ∈ (relBodySupply Δ fn x res).avoid := by simp [relBodySupply]
   let S : ValRel := fun a b => R a b ∧ ∀ b', R a b' → b = b'
   have hSleR : Fix.le S R := fun _ _ h => h.1
   have hpre : Fix.le (F S) S := by
@@ -514,31 +514,31 @@ theorem semrel_functional
           exact (Fix.lfp_unfold hmono a b').mp hRb'
         simpa [hR] using hFRlfp
       have hrelDet :
-          BinaryRelDet (ctx Γ f rel)
-            (relEnv ρ rel x res S a b)
-            (relEnv ρ rel x res R a b') := by
-        intro f' rel' hmem' vin' z₁ z₂ hz₁ hz₂
+          BinaryRelDet (ctx Γ f fn)
+            (relEnv ρ fn x res S a b)
+            (relEnv ρ fn x res R a b') := by
+        intro f' fn' hmem' vin' z₁ z₂ hz₁ hz₂
         cases hmem' with
         | head =>
             simp [relEnv, Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
             exact hz₁.2 z₂ hz₂
         | tail _ htail =>
-            have hrel'_mem : (⟨rel', .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel :=
-              hΓ f' rel' htail
-            have hne : rel' ≠ rel := fun h =>
+            have hrel'_mem : (⟨fn', .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel :=
+              hΓ f' fn' htail
+            have hne : fn' ≠ fn := fun h =>
               hrelFresh (h ▸ Signature.mem_allNames_of_binaryRel hrel'_mem)
             simp only [relEnv, Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
             simp [hne] at hz₁ hz₂
-            exact hρdet f' rel' htail vin' z₁ z₂ hz₁ hz₂
+            exact hρdet f' fn' htail vin' z₁ z₂ hz₁ hz₂
       have htermAgree :
-          Env.termAgree (bodySig Δ rel x)
-            (relEnv ρ rel x res S a b)
-            (relEnv ρ rel x res R a b') := by
+          Env.termAgree (bodySig Δ fn x)
+            (relEnv ρ fn x res S a b)
+            (relEnv ρ fn x res R a b') := by
         unfold bodySig relEnv
         refine ⟨?_, ?_, ?_, ?_⟩
         · intro v hv
           have hv' : v ∈ ⟨x, .value⟩ ::
-              ((Δ.addBinaryRel ⟨rel, .value, .value⟩).remove x).vars := by
+              ((Δ.addBinaryRel ⟨fn, .value, .value⟩).remove x).vars := by
             simpa [Signature.declVar, Signature.addVar] using hv
           cases hv' with
           | head =>
@@ -547,12 +547,12 @@ theorem semrel_functional
               have hneX : v.name ≠ x := by
                 intro hxv
                 have hmem : v.name ∈
-                    ((Δ.addBinaryRel ⟨rel, .value, .value⟩).remove x).allNames :=
+                    ((Δ.addBinaryRel ⟨fn, .value, .value⟩).remove x).allNames :=
                   Signature.mem_allNames_of_var htail
                 exact Signature.remove_allNames hmem hxv
               have hneRes : v.name ≠ res := by
                 intro hres
-                have hmem : v.name ∈ (bodySig Δ rel x).allNames := by
+                have hmem : v.name ∈ (bodySig Δ fn x).allNames := by
                   exact Signature.mem_allNames_of_var hv
                 exact hresFresh (hres ▸ hmem)
               simp [Env.updateConst, Env.updateBinaryRel, hneX, hneRes]
@@ -560,13 +560,13 @@ theorem semrel_functional
           have hneX : c.name ≠ x := by
             intro hcx
             have hmem : c.name ∈
-                ((Δ.addBinaryRel ⟨rel, .value, .value⟩).remove x).allNames :=
+                ((Δ.addBinaryRel ⟨fn, .value, .value⟩).remove x).allNames :=
               Signature.mem_allNames_of_const (by
                 simpa [bodySig, Signature.declVar, Signature.addVar] using hc)
             exact Signature.remove_allNames hmem hcx
           have hneRes : c.name ≠ res := by
             intro hres
-            have hmem : c.name ∈ (bodySig Δ rel x).allNames :=
+            have hmem : c.name ∈ (bodySig Δ fn x).allNames :=
               Signature.mem_allNames_of_const hc
             exact hresFresh (hres ▸ hmem)
           simp [Env.updateConst, Env.updateBinaryRel, hneX, hneRes]
@@ -575,8 +575,8 @@ theorem semrel_functional
         · intro bin hbin
           simp [Env.updateConst_binary, Env.updateBinaryRel]
       have hresEq :=
-        hdetM (bodySig Δ rel x) (relBodySupply Δ rel x res) body
-        (relEnv ρ rel x res S a b) (relEnv ρ rel x res R a b')
+        hdetM (bodySig Δ fn x) (relBodySupply Δ fn x res) body
+        (relEnv ρ fn x res S a b) (relEnv ρ fn x res R a b')
         (Signature.Subset.refl _) hΔbody hcovBody hresAvoid hrun
         hrelDet htermAgree hFS hFR
       simpa [relEnv, Env.lookupConst_updateConst_same] using hresEq

--- a/Mica/Verifier/RelationalEncoding/Relation.lean
+++ b/Mica/Verifier/RelationalEncoding/Relation.lean
@@ -88,7 +88,7 @@ theorem Rel.error_wfIn {Δ : Signature} {msg : String} :
   simp [Rel.error] at hrun
 
 theorem Rel.call_wfIn {Δ : Signature} {fn : SpecFn} {arg : Term .value}
-    (hrel : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
+    (hrel : fn.rel ∈ Δ.binaryRel)
     (harg : arg.wfIn Δ)
     {k : Term .value → Rel}
     (hk : ∀ {Δ'}, Δ.Subset Δ' → Δ'.wf →
@@ -110,7 +110,7 @@ theorem Rel.call_wfIn {Δ : Signature} {fn : SpecFn} {arg : Term .value}
     Term.wfIn_mono _ harg hsubt hΔ''wf
   have hrvar : (Term.var .value r).wfIn Δ'' :=
     var_value_wfIn hΔ''wf (by simpa [hΔ''] using Signature.var_mem_declVar Δ' ⟨r, .value⟩)
-  have hrel'' : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ''.binaryRel :=
+  have hrel'' : fn.rel ∈ Δ''.binaryRel :=
     hsub''.binaryRel _ (hsub.binaryRel _ hrel)
   have hcov' : s'.Covers Δ'' := by
     simpa [hΔ'', hs'] using NameSupply.Covers.declVar hcov r .value
@@ -123,7 +123,7 @@ theorem Rel.call_wfIn {Δ : Signature} {fn : SpecFn} {arg : Term .value}
       hk hsubt hΔ''wf _ hrvar
     have hinnerWf : inner.wfIn Δ'' :=
       hkWf Δ'' s' inner (Signature.Subset.refl _) hΔ''wf hcov' hinner
-    exact ⟨SpecFn.rel_wfIn hrel'' hΔ''wf harg'' hrvar, hinnerWf⟩
+    exact ⟨SpecFn.relates_wfIn hrel'' hΔ''wf harg'' hrvar, hinnerWf⟩
 
 theorem Rel.ite_wfIn {Δ : Signature} {cond : Term .bool}
     {thenEnc elseEnc : Rel}
@@ -180,7 +180,7 @@ theorem Rel.call_mono {fn : SpecFn} {arg : Term .value}
     simp only [Formula.eval] at hφ ⊢
     rcases hφ with ⟨w, hcall_ev, hbody⟩
     refine ⟨w, ?_, ?_⟩
-    · simp only [SpecFn.rel, Formula.eval, BinPred.eval] at hcall_ev ⊢
+    · simp only [SpecFn.relates, Formula.eval, BinPred.eval] at hcall_ev ⊢
       have hleU : Fix.Env.le (ρ.updateConst .value r w) (ρ'.updateConst .value r w) :=
         Fix.Env.le.updateConst hle .value r w
       rw [← Fix.Term.eval_le hleU, ← Fix.Term.eval_le hleU]
@@ -264,8 +264,8 @@ def semrel
 def BinaryRelDet (Γ : FunCtx) (ρ₁ ρ₂ : Env) : Prop :=
   ∀ f fn, (f, fn) ∈ Γ →
     ∀ vin y₁ y₂,
-      ρ₁.binaryRel .value .value fn.relName vin y₁ →
-      ρ₂.binaryRel .value .value fn.relName vin y₂ →
+      fn.evalRelates ρ₁ vin y₁ →
+      fn.evalRelates ρ₂ vin y₂ →
       y₁ = y₂
 
 /-- A relational carrier is deterministic in `res` at any extension of its
@@ -340,7 +340,7 @@ theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
         arg.eval (ρ₁.updateConst .value r w₁) =
           arg.eval (ρ₂.updateConst .value r w₁) :=
       Term.eval_termAgree hargΔ' hagree'
-    simp only [SpecFn.rel, Formula.eval, BinPred.eval, Term.eval] at hcall₁ hcall₂
+    simp only [SpecFn.relates, Formula.eval, BinPred.eval, Term.eval] at hcall₁ hcall₂
     have hargEq₂ :
         arg.eval (ρ₂.updateConst .value r w₁) =
           arg.eval (ρ₂.updateConst .value r w₂) := by
@@ -353,13 +353,13 @@ theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
       exact Term.eval_termAgree hargΔ hag
     have hw : w₁ = w₂ := by
       have hcall₁base :
-          ρ₁.binaryRel .value .value fn.relName
-            (arg.eval (ρ₁.updateConst .value r w₁)) w₁ := by
-        simpa [Env.updateConst_binaryRel, Env.lookupConst_updateConst_same] using hcall₁
+          fn.evalRelates ρ₁ (arg.eval (ρ₁.updateConst .value r w₁)) w₁ := by
+        simpa [SpecFn.evalRelates, Env.updateConst_binaryRel,
+          Env.lookupConst_updateConst_same] using hcall₁
       have hcall₂base :
-          ρ₂.binaryRel .value .value fn.relName
-            (arg.eval (ρ₂.updateConst .value r w₂)) w₂ := by
-        simpa [Env.updateConst_binaryRel, Env.lookupConst_updateConst_same] using hcall₂
+          fn.evalRelates ρ₂ (arg.eval (ρ₂.updateConst .value r w₂)) w₂ := by
+        simpa [SpecFn.evalRelates, Env.updateConst_binaryRel,
+          Env.lookupConst_updateConst_same] using hcall₂
       apply hrel f fn hmem (arg.eval (ρ₁.updateConst .value r w₁))
       · exact hcall₁base
       · rw [hargEval, hargEq₂]
@@ -369,7 +369,7 @@ theorem Rel.call_det {Γ : FunCtx} {res : String} {Δview : Signature}
         BinaryRelDet Γ
           (ρ₁.updateConst .value r w₁) (ρ₂.updateConst .value r w₁) := by
       intro f' fn' hmem' vin y₁ y₂ hy₁ hy₂
-      simp only [Env.updateConst_binaryRel] at hy₁ hy₂
+      simp only [SpecFn.evalRelates_updateConst] at hy₁ hy₂
       exact hrel f' fn' hmem' vin y₁ y₂ hy₁ hy₂
     have hkDet : Rel.Det Γ res Δ' (k (.var .value r)) :=
       hk hsubView' hΔ'wf hrvar
@@ -504,14 +504,16 @@ theorem semrel_functional
         intro f' fn' hmem' vin' z₁ z₂ hz₁ hz₂
         cases hmem' with
         | head =>
-            simp [relEnv, Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
+            simp [SpecFn.evalRelates, SpecFn.rel, relEnv,
+              Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
             exact hz₁.2 z₂ hz₂
         | tail _ htail =>
-            have hrel'_mem : (⟨fn'.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel :=
+            have hrel'_mem : fn'.rel ∈ Δ.binaryRel :=
               hΓ f' fn' htail
             have hne : fn'.relName ≠ fn.relName := fun h =>
               hrelFresh (h ▸ Signature.mem_allNames_of_binaryRel hrel'_mem)
-            simp only [relEnv, Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
+            simp only [SpecFn.evalRelates, SpecFn.rel, relEnv,
+              Env.updateConst_binaryRel, Env.updateBinaryRel] at hz₁ hz₂
             simp [hne] at hz₁ hz₂
             exact hρdet f' fn' htail vin' z₁ z₂ hz₁ hz₂
       have htermAgree :
@@ -522,7 +524,7 @@ theorem semrel_functional
         refine ⟨?_, ?_, ?_, ?_⟩
         · intro v hv
           have hv' : v ∈ ⟨x, .value⟩ ::
-              ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).remove x).vars := by
+              ((Δ.addBinaryRel fn.rel).remove x).vars := by
             simpa [Signature.declVar, Signature.addVar] using hv
           cases hv' with
           | head =>
@@ -531,7 +533,7 @@ theorem semrel_functional
               have hneX : v.name ≠ x := by
                 intro hxv
                 have hmem : v.name ∈
-                    ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).remove x).allNames :=
+                    ((Δ.addBinaryRel fn.rel).remove x).allNames :=
                   Signature.mem_allNames_of_var htail
                 exact Signature.remove_allNames hmem hxv
               have hneRes : v.name ≠ res := by
@@ -544,7 +546,7 @@ theorem semrel_functional
           have hneX : c.name ≠ x := by
             intro hcx
             have hmem : c.name ∈
-                ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).remove x).allNames :=
+                ((Δ.addBinaryRel fn.rel).remove x).allNames :=
               Signature.mem_allNames_of_const (by
                 simpa [bodySig, Signature.declVar, Signature.addVar] using hc)
             exact Signature.remove_allNames hmem hcx

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
@@ -614,30 +614,21 @@ end Skolemize
 agree for every relation-marked function in the context. -/
 def FunCtx.splitCompatible (Γ : FunCtx) (ρ : Env) : Prop :=
   ∀ f fn, (f, fn) ∈ Γ →
-    ∀ x y,
-      ρ.binaryRel .value .value fn.relName x y ↔
-        ρ.unaryRel .value (fn.defName) x ∧
-          ρ.unary .value .value (fn.funcName) x = y
+    ∀ x y, fn.evalRelates ρ x y ↔ fn.evalDefined ρ x ∧ fn.evalCall ρ x = y
 
 /-- Completeness half of split compatibility: relational calls imply the
 defined/value presentation. This is the half used by relational-to-split
 directional proofs. -/
 def FunCtx.splitComplete (Γ : FunCtx) (ρ : Env) : Prop :=
   ∀ f fn, (f, fn) ∈ Γ →
-    ∀ x y,
-      ρ.binaryRel .value .value fn.relName x y →
-        ρ.unaryRel .value (fn.defName) x ∧
-          ρ.unary .value .value (fn.funcName) x = y
+    ∀ x y, fn.evalRelates ρ x y → fn.evalDefined ρ x ∧ fn.evalCall ρ x = y
 
 /-- Soundness half of split compatibility: the defined/value presentation
 implies the relational call. This is the half used by split-to-relational
 directional proofs. -/
 def FunCtx.splitSound (Γ : FunCtx) (ρ : Env) : Prop :=
   ∀ f fn, (f, fn) ∈ Γ →
-    ∀ x y,
-      ρ.unaryRel .value (fn.defName) x ∧
-        ρ.unary .value .value (fn.funcName) x = y →
-          ρ.binaryRel .value .value fn.relName x y
+    ∀ x y, fn.evalDefined ρ x ∧ fn.evalCall ρ x = y → fn.evalRelates ρ x y
 
 theorem FunCtx.splitComplete_updateConst {Γ : FunCtx} {ρ : Env}
     (hΓ : Γ.splitComplete ρ) (τ : Srt) (x : String) (v : τ.denote) :
@@ -662,7 +653,7 @@ theorem FunCtx.splitSound_of_compatible {Γ : FunCtx} {ρ : Env}
 relation names already present in the tail function context. -/
 def FunCtx.freshFn (Γ : FunCtx) (fn : SpecFn) : Prop :=
   ∀ g fn', (g, fn') ∈ Γ →
-    fn' ≠ fn ∧ (fn').funcName ≠ fn.funcName ∧ (fn').defName ≠ fn.defName
+    fn'.relName ≠ fn.relName ∧ fn'.funcName ≠ fn.funcName ∧ fn'.defName ≠ fn.defName
 
 namespace Skolemize
 
@@ -681,18 +672,20 @@ theorem splitSound_cons_relSplitEnv
   cases hmem with
   | head =>
       have hsplit' : D x ∧ F x = y := by
-        simpa [relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
+        simpa [SpecFn.evalDefined, SpecFn.evalCall, SpecFn.defined, SpecFn.func,
+          relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
           using hsplit
-      simpa [relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
+      simpa [SpecFn.evalRelates, SpecFn.rel, relSplitEnv,
+        Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
         using hRF x y hsplit'
   | tail _ htail =>
       have hnames := hfresh g fn' htail
-      have hsplit' :
-          ρ.unaryRel .value ((fn').defName) x ∧
-            ρ.unary .value .value ((fn').funcName) x = y := by
-        simpa [relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel,
+      have hsplit' : fn'.evalDefined ρ x ∧ fn'.evalCall ρ x = y := by
+        simpa [SpecFn.evalDefined, SpecFn.evalCall, SpecFn.defined, SpecFn.func,
+          relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel,
           hnames.1, hnames.2.1, hnames.2.2] using hsplit
-      simpa [relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel,
+      simpa [SpecFn.evalRelates, SpecFn.rel, relSplitEnv,
+        Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel,
         hnames.1, hnames.2.1, hnames.2.2] using hΓ g fn' htail x y hsplit'
 
 
@@ -717,28 +710,28 @@ theorem encodeBody_def_bodySig {Γ : FunCtx} {Δ : Signature}
 /-- Freshness assumptions for the common Skolemization signature, in the exact
 order in which `sig` introduces the head relation symbols and bound variables. -/
 structure HeadFresh (Δ : Signature) (fn : SpecFn) (x res : String) : Prop where
-  relFresh : fn ∉ Δ.allNames
+  relFresh : fn.relName ∉ Δ.allNames
   funFresh :
-    fn.funcName ∉ (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).allNames
+    fn.funcName ∉ (Δ.addBinaryRel fn.rel).allNames
   defFresh :
     fn.defName ∉
-    ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).allNames
+    ((Δ.addBinaryRel fn.rel).addUnary fn.func).allNames
   argFresh :
     x ∉
-    (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+    (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
       (fn.defined)).allNames
   resFresh :
     res ∉
-    ((((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+    ((((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
       (fn.defined)).declVar ⟨x, .value⟩).allNames
 
 /-! ### Subset lemmas -/
 
 theorem relBase_subset_bodyBase {Δ : Signature} {fn : SpecFn} :
-    (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).Subset
-      (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+    (Δ.addBinaryRel fn.rel).Subset
+      (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
         (fn.defined)) :=
-  (Signature.Subset.subset_addUnary _ (fn.func)).trans
+  (Signature.Subset.subset_addUnary _ fn.func).trans
     (Signature.Subset.subset_addUnaryRel _ (fn.defined))
 
 theorem subset_bodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
@@ -746,27 +739,27 @@ theorem subset_bodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : Stri
     Δ.Subset (bodySig Δ fn x) := by
   unfold bodySig
   exact
-    (((Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩).trans
-      (Signature.Subset.subset_addUnary _ (fn.func))).trans
+    (((Signature.Subset.subset_addBinaryRel Δ fn.rel).trans
+      (Signature.Subset.subset_addUnary _ fn.func)).trans
       (Signature.Subset.subset_addUnaryRel _ (fn.defined))).trans
       (Signature.subset_declVar_of_fresh (Δ :=
-        (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+        (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
           (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh)
 
 theorem subset_relBodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
     (hfresh : HeadFresh Δ fn x res) :
     Δ.Subset (Relation.bodySig Δ fn x) := by
   unfold Relation.bodySig
-  exact (Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩).trans
-    (Signature.subset_declVar_of_fresh (Δ := Δ.addBinaryRel ⟨fn.relName, .value, .value⟩)
+  exact (Signature.Subset.subset_addBinaryRel Δ fn.rel).trans
+    (Signature.subset_declVar_of_fresh (Δ := Δ.addBinaryRel fn.rel)
       (v := ⟨x, .value⟩) (by
         intro h
         exact hfresh.argFresh (Signature.allNames_subset
           (relBase_subset_bodyBase (Δ := Δ) (fn := fn)) _ h)))
 
 theorem splitBase_subset_bodyBase {Δ : Signature} {fn : SpecFn} :
-    ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)).Subset
-      (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+    ((Δ.addUnary fn.func).addUnaryRel (fn.defined)).Subset
+      (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
         (fn.defined)) := by
   refine ⟨?_, ?_, ?_, ?_, ?_, fun a ha => List.mem_cons_of_mem _ ha⟩ <;>
     intro a ha <;>
@@ -786,10 +779,10 @@ theorem subset_defvalBodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res 
     (hfresh : HeadFresh Δ fn x res) :
     Δ.Subset (defvalBodySig Δ fn x) := by
   unfold defvalBodySig
-  exact ((Signature.Subset.subset_addUnary Δ (fn.func)).trans
+  exact ((Signature.Subset.subset_addUnary Δ fn.func).trans
     (Signature.Subset.subset_addUnaryRel _ (fn.defined))).trans
     (Signature.subset_declVar_of_fresh (Δ :=
-      ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)))
+      ((Δ.addUnary fn.func).addUnaryRel (fn.defined)))
       (v := ⟨x, .value⟩) (by
         intro h
         exact hfresh.argFresh (Signature.allNames_subset
@@ -819,13 +812,13 @@ theorem bodySig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
     (bodySig Δ fn x).wf := by
   unfold bodySig
   have hrel :
-      (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).wf :=
+      (Δ.addBinaryRel fn.rel).wf :=
     Signature.wf_addBinaryRel hΔ hfresh.relFresh
   have hfun :
-      ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).wf :=
+      ((Δ.addBinaryRel fn.rel).addUnary fn.func).wf :=
     Signature.wf_addUnary hrel hfresh.funFresh
   have hdef :
-      (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+      (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
         (fn.defined)).wf :=
     Signature.wf_addUnaryRel hfun hfresh.defFresh
   exact Signature.wf_declVar hdef
@@ -839,7 +832,7 @@ theorem relBodySig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : Strin
 theorem var_fresh_splitBase_of_headFresh
     {Δ : Signature} {fn : SpecFn} {x res : String}
     (hfresh : HeadFresh Δ fn x res) :
-    x ∉ ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)).allNames := by
+    x ∉ ((Δ.addUnary fn.func).addUnaryRel (fn.defined)).allNames := by
   intro h
   exact hfresh.argFresh (Signature.allNames_subset
     (splitBase_subset_bodyBase (Δ := Δ) (fn := fn)) _ h)
@@ -857,7 +850,7 @@ theorem splitEnv_relSplitEnv_agreeOn_splitBase
     {R : ValRel} {D : Srt.value.denote → Prop}
     {F : Srt.value.denote → Srt.value.denote}
     (hfresh : HeadFresh Δ fn x res) :
-    Env.agreeOn ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined))
+    Env.agreeOn ((Δ.addUnary fn.func).addUnaryRel (fn.defined))
       (splitEnv ρ fn D F) (relSplitEnv ρ fn R D F) := by
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   iterate 5
@@ -866,7 +859,7 @@ theorem splitEnv_relSplitEnv_agreeOn_splitBase
   intro b hb
   have hbΔ : b ∈ Δ.binaryRel := by
     simpa [Signature.addUnary, Signature.addUnaryRel] using hb
-  have hne : b.name ≠ fn := fun h =>
+  have hne : b.name ≠ fn.relName := fun h =>
     hfresh.relFresh (h ▸ Signature.mem_allNames_of_binaryRel hbΔ)
   simp [splitEnv, relSplitEnv, Env.updateBinaryRel, Env.updateUnary,
     Env.updateUnaryRel, hne]
@@ -881,7 +874,7 @@ theorem defvalBodySig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : St
     (Signature.wf_addUnaryRel
       (Signature.wf_addUnary hΔ (fun h =>
         hfresh.funFresh (Signature.allNames_subset
-          (Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩) _ h)))
+          (Signature.Subset.subset_addBinaryRel Δ fn.rel) _ h)))
       (fun h =>
         hfresh.defFresh (Signature.allNames_subset
           (by
@@ -905,7 +898,7 @@ theorem freshFn_of_headFresh {Γ : FunCtx} {Δ : Signature} {fn : SpecFn} {x res
     (hΓ : Γ.wfIn Δ) (hfresh : HeadFresh Δ fn x res) :
     FunCtx.freshFn Γ fn := by
   intro g fn' hmem
-  have hrel'_mem : fn' ∈ Δ.allNames :=
+  have hrel'_mem : fn'.relName ∈ Δ.allNames :=
     Signature.mem_allNames_of_binaryRel (hΓ.rel g fn' hmem)
   have hfun_mem : (fn').funcName ∈ Δ.allNames :=
     Signature.mem_allNames_of_unary (hΓ.split g fn' hmem).1
@@ -916,11 +909,11 @@ theorem freshFn_of_headFresh {Γ : FunCtx} {Δ : Signature} {fn : SpecFn} {x res
     exact hfresh.relFresh (h ▸ hrel'_mem)
   · intro h
     exact hfresh.funFresh (h ▸ Signature.allNames_subset
-      (Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩) _ hfun_mem)
+      (Signature.Subset.subset_addBinaryRel Δ fn.rel) _ hfun_mem)
   · intro h
     exact hfresh.defFresh (h ▸ Signature.allNames_subset
-      ((Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩).trans
-        (Signature.Subset.subset_addUnary _ (fn.func))) _ hdef_mem)
+      ((Signature.Subset.subset_addBinaryRel Δ fn.rel).trans
+        (Signature.Subset.subset_addUnary _ fn.func)) _ hdef_mem)
 
 
 theorem ctx_relWfIn_relSig_of_headFresh
@@ -931,7 +924,7 @@ theorem ctx_relWfIn_relSig_of_headFresh
   cases hmem with
   | head =>
       have hxFresh :
-          x ∉ (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).allNames := by
+          x ∉ (Δ.addBinaryRel fn.rel).allNames := by
         intro h
         exact hfresh.argFresh (Signature.allNames_subset
           (relBase_subset_bodyBase (Δ := Δ) (fn := fn)) _ h)
@@ -939,7 +932,7 @@ theorem ctx_relWfIn_relSig_of_headFresh
         (by
           unfold Relation.bodySig
           exact (Signature.subset_declVar_of_fresh
-            (Δ := Δ.addBinaryRel ⟨fn.relName, .value, .value⟩)
+            (Δ := Δ.addBinaryRel fn.rel)
             (v := ⟨x, .value⟩) hxFresh).binaryRel _
             (List.Mem.head _))
   | tail _ htail =>
@@ -958,12 +951,12 @@ theorem ctx_splitWfIn_bodySig_of_headFresh
       · exact Signature.Subset.unary
           ((Signature.Subset.subset_addUnaryRel _ (fn.defined)).trans
             (Signature.subset_declVar_of_fresh (Δ :=
-              (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+              (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
                 (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh))
-          (fn.func) (List.Mem.head _)
+          fn.func (List.Mem.head _)
       · exact Signature.Subset.unaryRel
           (Signature.subset_declVar_of_fresh (Δ :=
-            (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+            (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
               (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh)
           (fn.defined) (List.Mem.head _)
   | tail _ htail =>
@@ -981,12 +974,12 @@ theorem ctx_splitWfIn_defvalBodySig_of_headFresh
       · exact Signature.Subset.unary
           ((Signature.Subset.subset_addUnaryRel _ (fn.defined)).trans
             (Signature.subset_declVar_of_fresh (Δ :=
-              ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)))
+              ((Δ.addUnary fn.func).addUnaryRel (fn.defined)))
               (v := ⟨x, .value⟩) (var_fresh_splitBase_of_headFresh hfresh)))
-          (fn.func) (List.Mem.head _)
+          fn.func (List.Mem.head _)
       · exact Signature.Subset.unaryRel
           (Signature.subset_declVar_of_fresh (Δ :=
-            ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)))
+            ((Δ.addUnary fn.func).addUnaryRel (fn.defined)))
             (v := ⟨x, .value⟩) (var_fresh_splitBase_of_headFresh hfresh))
           (fn.defined) (List.Mem.head _)
   | tail _ htail =>
@@ -1061,31 +1054,31 @@ theorem relEnv_relSplitEnv_agreeOn_relSig
   let ρbin := ρ.updateBinaryRel .value .value fn.relName R
   let ρfun := ρbin.updateUnary .value .value (fn.funcName) F
   have hbase :
-      Env.agreeOn (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) ρbin
+      Env.agreeOn (Δ.addBinaryRel fn.rel) ρbin
         (relSplitEnv ρ fn R D F) := by
-    have hfun : Env.agreeOn (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) ρbin ρfun := by
+    have hfun : Env.agreeOn (Δ.addBinaryRel fn.rel) ρbin ρfun := by
       simpa [ρbin, ρfun] using
         (Env.agreeOn_update_fresh_unary (ρ := ρbin) (u := fn.func)
-          (f := F) (Δ := Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) hfresh.funFresh)
+          (f := F) (Δ := Δ.addBinaryRel fn.rel) hfresh.funFresh)
     have hdef :
-        Env.agreeOn (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) ρfun
+        Env.agreeOn (Δ.addBinaryRel fn.rel) ρfun
           (relSplitEnv ρ fn R D F) := by
-      have hdefFresh : fn.defName ∉ (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).allNames := by
+      have hdefFresh : fn.defName ∉ (Δ.addBinaryRel fn.rel).allNames := by
         intro h
         exact hfresh.defFresh (Signature.allNames_subset
-          (Signature.Subset.subset_addUnary _ (fn.func)) _ h)
+          (Signature.Subset.subset_addUnary _ fn.func) _ h)
       simpa [relSplitEnv, ρbin, ρfun] using
         (Env.agreeOn_update_fresh_unaryRel (ρ := ρfun) (u := fn.defined)
-          (f := D) (Δ := Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) hdefFresh)
+          (f := D) (Δ := Δ.addBinaryRel fn.rel) hdefFresh)
     exact Env.agreeOn_trans hfun hdef
   simpa [Relation.relEnv, Relation.sig, Relation.bodySig] using
     (Env.agreeOn_declVar
       (Env.agreeOn_declVar hbase : Env.agreeOn
-        ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).declVar ⟨x, .value⟩)
+        ((Δ.addBinaryRel fn.rel).declVar ⟨x, .value⟩)
         ((ρ.updateBinaryRel .value .value fn.relName R).updateConst .value x vin)
         ((relSplitEnv ρ fn R D F).updateConst .value x vin)) :
       Env.agreeOn
-        (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).declVar ⟨x, .value⟩).declVar
+        (((Δ.addBinaryRel fn.rel).declVar ⟨x, .value⟩).declVar
           ⟨res, .value⟩)
         (((ρ.updateBinaryRel .value .value fn.relName R).updateConst .value x vin).updateConst
           .value res vout)

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
@@ -1,0 +1,1181 @@
+-- SUMMARY: Shared split encoding and semantic infrastructure for Skolemization.
+import Mica.Verifier.RelationalEncoding.Relation
+
+namespace Verifier.RelationalEncoding
+open Relation
+
+namespace Skolemize
+
+/-! ## `DefVal` Syntax -/
+
+/-- Solver-facing expression encoding: a value term plus the condition under
+which that value is defined. -/
+structure DefVal where
+  value : Term .value
+  defined : Formula
+  deriving DecidableEq
+
+namespace DefVal
+
+def pure (v : Term .value) : DefVal :=
+  { value := v, defined := .true_ }
+
+def bind (m : DefVal) (k : Term .value → Except String DefVal) : Except String DefVal := do
+  let n ← k m.value
+  Except.ok { value := n.value, defined := .and m.defined n.defined }
+
+def call (fn : SpecFn) (arg : Term .value) : DefVal :=
+  { value := fn.call arg, defined := fn.isDefined arg }
+
+def ite (cond : Term .bool) (thenVal elseVal : DefVal) : DefVal :=
+  { value := .ite cond thenVal.value elseVal.value
+    defined := Formula.iteBool cond thenVal.defined elseVal.defined }
+
+end DefVal
+
+/-- Defined/value instance of `EncoderOps`. The carrier is `Except String
+DefVal`, so error handling lives inside the carrier itself; `error` is
+`Except.error`. The CPS `call` allocates the solver-facing value/definedness
+symbols and threads the value through the continuation, conjoining the local
+definedness obligation via `DefVal.bind`. -/
+def encoderOps : EncoderOps (Except String DefVal) where
+  call fn arg k := DefVal.bind (DefVal.call fn arg) k
+  ite c t e     := do let dt ← t; let de ← e; .ok (DefVal.ite c dt de)
+  error msg     := .error msg
+
+/-- Defined/value encoding of a pure typed TinyML expression for SMT emission.
+Calls are encoded using total value functions and separate definedness
+predicates, so this encoding introduces no existential witnesses. Implemented
+as the shared traversal `encodeWith` instantiated at `encoderOps`. -/
+def encode (Γ : FunCtx) (Δ : Signature) (e : Typed.Expr) :
+    Except String DefVal :=
+  encodeWith encoderOps Γ (VarEnv.ofSignature Δ) e (fun v => .ok (DefVal.pure v))
+
+/-! ## Well-formedness of `encode` -/
+
+namespace DefVal
+
+/-- A defined/value encoding is well-formed when both its value term and its
+definedness formula are well-formed. -/
+def wfIn (m : DefVal) (Δ : Signature) : Prop :=
+  m.value.wfIn Δ ∧ m.defined.wfIn Δ
+
+theorem pure_wfIn {v : Term .value} {Δ : Signature} (hv : v.wfIn Δ) :
+    (pure v).wfIn Δ := ⟨hv, trivial⟩
+
+theorem bind_wfIn {m n : DefVal} {Δ : Signature}
+    (hm : m.wfIn Δ) (hn : n.wfIn Δ) :
+    ({ value := n.value, defined := .and m.defined n.defined } : DefVal).wfIn Δ :=
+  ⟨hn.1, hm.2, hn.2⟩
+
+/-- A successful `DefVal.bind` exposes the continuation result and the final
+definedness shape. -/
+theorem bind_ok {m out : DefVal}
+    {kc : Term .value → Except String DefVal}
+    (h : bind m kc = .ok out) :
+    ∃ n, kc m.value = .ok n ∧
+      out = { value := n.value, defined := .and m.defined n.defined } := by
+  unfold bind at h
+  cases hn : kc m.value with
+  | error msg =>
+      simp only [hn, Bind.bind, Except.bind] at h
+      cases h
+  | ok n =>
+      simp only [hn, Bind.bind, Except.bind, Except.ok.injEq] at h
+      cases h
+      exact ⟨n, rfl, rfl⟩
+
+theorem call_wfIn {fn : SpecFn} {arg : Term .value} {Δ : Signature}
+    (hfun : fn.func ∈ Δ.unary) (hrel : fn.defined ∈ Δ.unaryRel)
+    (hΔ : Δ.wf) (harg : arg.wfIn Δ) :
+    (call fn arg).wfIn Δ :=
+  ⟨SpecFn.call_wfIn hfun hΔ harg, SpecFn.isDefined_wfIn hrel hΔ harg⟩
+
+theorem ite_wfIn {cond : Term .bool} {thenVal elseVal : DefVal} {Δ : Signature}
+    (hc : cond.wfIn Δ) (ht : thenVal.wfIn Δ) (he : elseVal.wfIn Δ) :
+    (ite cond thenVal elseVal).wfIn Δ :=
+  ⟨⟨hc, ht.1, he.1⟩, Formula.iteBool_wfIn hc ht.2 he.2⟩
+
+/-- The then-branch of a well-formed defined/value conditional is well-formed. -/
+theorem wfIn_of_ite_then {cond : Term .bool} {thenVal elseVal : DefVal}
+    {Δ : Signature} (h : (ite cond thenVal elseVal).wfIn Δ) :
+    thenVal.wfIn Δ := by
+  obtain ⟨hval, hdef⟩ := h
+  simp only [ite, Term.wfIn] at hval
+  simp only [ite, Formula.iteBool, Formula.wfIn] at hdef
+  exact ⟨hval.2.1, hdef.1.2⟩
+
+/-- The else-branch of a well-formed defined/value conditional is well-formed. -/
+theorem wfIn_of_ite_else {cond : Term .bool} {thenVal elseVal : DefVal}
+    {Δ : Signature} (h : (ite cond thenVal elseVal).wfIn Δ) :
+    elseVal.wfIn Δ := by
+  obtain ⟨hval, hdef⟩ := h
+  simp only [ite, Term.wfIn] at hval
+  simp only [ite, Formula.iteBool, Formula.wfIn] at hdef
+  exact ⟨hval.2.2, hdef.2.2⟩
+
+end DefVal
+
+/-- Successful solver-facing conditional encoding means both branches
+succeeded and the output is exactly their `DefVal.ite`. -/
+theorem encoderOps_ite_ok {cond : Term .bool} {t e : Except String DefVal}
+    {body : DefVal} (h : encoderOps.ite cond t e = .ok body) :
+    ∃ dt de, t = .ok dt ∧ e = .ok de ∧ body = DefVal.ite cond dt de := by
+  simp only [encoderOps, Bind.bind, Except.bind] at h
+  cases ht : t with
+  | error msg => rw [ht] at h; simp at h
+  | ok dt =>
+    cases he : e with
+    | error msg => rw [ht, he] at h; simp at h
+    | ok de =>
+      rw [ht, he] at h
+      simp only [Except.ok.injEq] at h
+      exact ⟨dt, de, rfl, rfl, h.symm⟩
+
+/-- Successful relational conditional encoding means both relational branches
+succeeded and the output is exactly their `Formula.iteBool`. -/
+theorem relation_encoderOps_ite_ok {cond : Term .bool} {t e : Rel}
+    {s : NameSupply} {φ : Formula}
+    (h : Relation.encoderOps.ite cond t e s = .ok φ) :
+    ∃ φt φe, t s = .ok φt ∧ e s = .ok φe ∧ φ = Formula.iteBool cond φt φe := by
+  simp only [Relation.encoderOps, Rel.ite, Bind.bind, Except.bind] at h
+  cases ht : t s with
+  | error msg => rw [ht] at h; simp at h
+  | ok φt =>
+    cases he : e s with
+    | error msg => rw [ht, he] at h; simp at h
+    | ok φe =>
+      simp only [ht, he] at h
+      simp only [Except.ok.injEq] at h
+      exact ⟨φt, φe, rfl, rfl, h.symm⟩
+
+/-- Fresh variable data produced by a relation-call encoding at a name supply. -/
+structure FreshValueCtx (s : NameSupply) (Δ : Signature) where
+  r : String
+  s' : NameSupply
+  Δ' : Signature
+  hr : r = s.fresh "r"
+  hs' : s' = s.reserve r
+  hΔ' : Δ' = Δ.declVar ⟨r, .value⟩
+  fresh : r ∉ Δ.allNames
+  wf : Δ'.wf
+  subset : Δ.Subset Δ'
+  covers : s'.Covers Δ'
+  var_wf : (Term.var .value r).wfIn Δ'
+
+/-- Package the standard fresh result variable facts for a relation-call
+continuation. -/
+def freshValueCtx (s : NameSupply) {Δ : Signature}
+    (hΔ : Δ.wf) (hcov : s.Covers Δ) : FreshValueCtx s Δ := by
+  let r := s.fresh "r"
+  let s' := s.reserve r
+  let Δ' := Δ.declVar ⟨r, .value⟩
+  have hfresh_avoid : r ∉ s.avoid := by
+    simpa [r] using NameSupply.fresh_not_in_avoid s "r"
+  have hfresh : r ∉ Δ.allNames := fun hm => hfresh_avoid (hcov r hm)
+  have hΔ'wf : Δ'.wf := by simpa [Δ'] using Signature.wf_declVar hΔ
+  have hsub : Δ.Subset Δ' := by
+    simpa [Δ'] using Signature.subset_declVar_of_fresh (Δ := Δ)
+      (v := ⟨r, .value⟩) hfresh
+  refine
+    { r := r, s' := s', Δ' := Δ', hr := rfl, hs' := rfl, hΔ' := rfl,
+      fresh := hfresh, wf := hΔ'wf, subset := hsub, covers := ?_,
+      var_wf := ?_ }
+  · simpa [Δ', s'] using NameSupply.Covers.declVar hcov r .value
+  · exact var_value_wfIn hΔ'wf
+      (by simpa [Δ'] using Signature.var_mem_declVar Δ ⟨r, .value⟩)
+
+namespace FreshValueCtx
+
+theorem fresh_of_subset {s : NameSupply} {Δ Δ₀ : Signature}
+    (ctx : FreshValueCtx s Δ) (hsub : Δ₀.Subset Δ) :
+    ctx.r ∉ Δ₀.allNames := fun hm => ctx.fresh (Signature.allNames_subset hsub ctx.r hm)
+
+theorem ne_of_var_mem {s : NameSupply} {Δ : Signature}
+    (ctx : FreshValueCtx s Δ) {x : String}
+    (hx : (⟨x, .value⟩ : Var) ∈ Δ.vars) : ctx.r ≠ x := fun heq =>
+  ctx.fresh (heq ▸ Signature.mem_allNames_of_var hx)
+
+theorem eval_update_fresh {s : NameSupply} {Δ : Signature}
+    (ctx : FreshValueCtx s Δ) {ρ : Env} {τ : Srt} {w : τ.denote}
+    {arg : Term .value} (harg : arg.wfIn Δ) :
+    arg.eval (ρ.updateConst τ ctx.r w) = arg.eval ρ :=
+  Term.eval_update_fresh (ρ := ρ) (τ := τ) (x := ctx.r) (v := w)
+    (Δ := Δ) harg ctx.fresh
+
+end FreshValueCtx
+
+/-- A signature-derived variable environment agrees with itself in the same
+semantic environment. -/
+theorem varEnv_ofSignature_agree_self {Δ : Signature} {ρ : Env} (hΔ : Δ.wf) :
+    VarEnv.Agree Δ Δ ρ ρ (VarEnv.ofSignature Δ) (VarEnv.ofSignature Δ) where
+  sameDomain := by
+    intro x
+    rfl
+  agree := by
+    intro x v₁ v₂ h₁ h₂
+    have hv₁ := VarEnv.ofSignature_wfIn hΔ x v₁ h₁
+    rw [h₁] at h₂
+    injection h₂ with heq
+    subst v₂
+    exact ⟨hv₁, hv₁, rfl⟩
+
+/-- Carrier-level well-formedness predicate for the `Except String DefVal`
+encoder carrier: an `.ok` carrier is well-formed when its `DefVal` is, an
+error is vacuously well-formed. -/
+def wfInE (Δ : Signature) : Except String DefVal → Prop
+  | .ok d    => d.wfIn Δ
+  | .error _ => True
+
+/-- Well-formedness case for a solver-facing call in `encodeWith`. -/
+theorem encoderOps_call_wfInE {Γ : FunCtx} {Δ : Signature}
+    {f : TinyML.Var} {fn : SpecFn} {arg : Term .value}
+    {k : Term .value → Except String DefVal}
+    (hΔ : Δ.wf) (hΓ : Γ.defWfIn Δ) (hmem : (f, fn) ∈ Γ)
+    (harg : arg.wfIn Δ) (hk : SigCont wfInE Δ k) :
+    wfInE Δ (encoderOps.call fn arg k) := by
+  have hsyms := hΓ f fn hmem
+  show wfInE Δ (DefVal.bind (DefVal.call fn arg) k)
+  unfold DefVal.bind
+  cases hk_call : k (DefVal.call fn arg).value with
+  | error _ => exact True.intro
+  | ok n =>
+    have hcallWf : (DefVal.call fn arg).wfIn Δ :=
+      DefVal.call_wfIn hsyms.1 hsyms.2 hΔ harg
+    have hnWf : n.wfIn Δ := by
+      have := hk (Signature.Subset.refl _) hΔ _ hcallWf.1
+      rw [hk_call] at this
+      exact this
+    exact DefVal.bind_wfIn hcallWf hnWf
+
+/-- Well-formedness case for a solver-facing conditional in `encodeWith`. -/
+theorem encoderOps_ite_wfInE {Δ : Signature} {cond : Term .bool}
+    {t e : Except String DefVal}
+    (_hΔ : Δ.wf) (hcond : cond.wfIn Δ) (ht : wfInE Δ t) (he : wfInE Δ e) :
+    wfInE Δ (encoderOps.ite cond t e) := by
+  show wfInE Δ (do let dt ← t; let de ← e; .ok (DefVal.ite cond dt de))
+  cases ht_eq : t with
+  | error _ => exact True.intro
+  | ok dt =>
+    cases he_eq : e with
+    | error _ => exact True.intro
+    | ok de =>
+      rw [ht_eq] at ht
+      rw [he_eq] at he
+      exact DefVal.ite_wfIn hcond ht he
+
+/-- `EncoderOpsSig` instance for the solver-facing defined/value encoder. The
+generic `encodeWith_indWithSig` then yields the well-formedness of `encode`. -/
+def encoderOps_wf : EncoderOpsSig encoderOps wfInE FunCtx.defWfIn where
+  ctx_mono := fun hΓ hsub => FunCtx.defWfIn_mono hΓ hsub
+  call_ind := encoderOps_call_wfInE
+  ite_ind := encoderOps_ite_wfInE
+  error_ind := True.intro
+
+/-- Well-formedness of the solver-facing defined/value encoding. -/
+theorem encode_wfIn {Γ : FunCtx} {Δ : Signature} (e : Typed.Expr)
+    {m : DefVal} (hΔ : Δ.wf) (hΓ : Γ.defWfIn Δ)
+    (henc : encode Γ Δ e = .ok m) : m.wfIn Δ := by
+  have hcarrier : wfInE Δ
+      (encodeWith encoderOps Γ (VarEnv.ofSignature Δ) e (fun v => .ok (DefVal.pure v))) := by
+    refine encodeWith_indWithSig encoderOps_wf e (Signature.Subset.refl Δ) hΔ hΓ
+      (VarEnv.ofSignature_wfIn hΔ) ?_
+    intro Δ' _ _ v hv
+    exact DefVal.pure_wfIn hv
+  unfold encode at henc
+  rw [henc] at hcarrier
+  exact hcarrier
+
+/-! ## Monotonicity of `encode` definedness -/
+
+namespace DefVal
+
+/-- The definedness component of a `DefVal` encoding is monotone in the
+environment's uninterpreted predicates. -/
+def Mono (m : DefVal) : Prop :=
+  SemanticMono (fun m ρ => m.defined.eval ρ) m
+
+theorem call_mono (fn : SpecFn) (arg : Term .value) : Mono (call fn arg) := by
+  intro ρ ρ' hle hdef
+  simp only [call, SpecFn.isDefined, SpecFn.isDefined, Formula.eval, UnPred.eval] at hdef ⊢
+  rw [← Fix.Term.eval_le hle arg]
+  exact hle.2.2.2.1 .value (fn.defName) (arg.eval ρ) hdef
+
+theorem ite_mono {cond : Term .bool} {thenVal elseVal : DefVal}
+    (ht : Mono thenVal) (he : Mono elseVal) : Mono (ite cond thenVal elseVal) := by
+  intro ρ ρ' hle hdef
+  simp only [ite, Formula.iteBool, Formula.eval] at hdef ⊢
+  constructor
+  · intro hcond
+    have hcond' : cond.eval ρ = true := by
+      rw [Fix.Term.eval_le hle]; exact hcond
+    exact ht hle (hdef.1 hcond')
+  · intro hcond
+    have hcond' : cond.eval ρ = false := by
+      rw [Fix.Term.eval_le hle]; exact hcond
+    exact he hle (hdef.2 hcond')
+
+end DefVal
+
+/-- Carrier-level monotonicity predicate for the `Except String DefVal`
+encoder carrier: `.ok` carriers must satisfy `DefVal.Mono`, errors are
+vacuous. -/
+def MonoE : Except String DefVal → Prop
+  | .ok d    => d.Mono
+  | .error _ => True
+
+/-- Monotonicity case for a solver-facing call in `encodeWith`. -/
+theorem encoderOps_call_monoE {fn : SpecFn} {arg : Term .value}
+    {k : Term .value → Except String DefVal}
+    (hk : ∀ v, MonoE (k v)) :
+    MonoE (encoderOps.call fn arg k) := by
+  show MonoE (DefVal.bind (DefVal.call fn arg) k)
+  unfold DefVal.bind
+  cases hk_call : k (DefVal.call fn arg).value with
+  | error _ => exact True.intro
+  | ok n =>
+    have hnMono : n.Mono := by
+      intro ρ ρ' hle hdef
+      have h : MonoE (k (DefVal.call fn arg).value) := hk _
+      rw [hk_call] at h
+      exact h hle hdef
+    intro ρ ρ' hle hdef
+    simp only [Formula.eval] at hdef ⊢
+    refine ⟨DefVal.call_mono fn arg hle hdef.1, ?_⟩
+    exact hnMono hle hdef.2
+
+/-- Monotonicity case for a solver-facing conditional in `encodeWith`. -/
+theorem encoderOps_ite_monoE {cond : Term .bool} {t e : Except String DefVal}
+    (ht : MonoE t) (he : MonoE e) :
+    MonoE (encoderOps.ite cond t e) := by
+  show MonoE (do let dt ← t; let de ← e; .ok (DefVal.ite cond dt de))
+  cases ht_eq : t with
+  | error _ => exact True.intro
+  | ok dt =>
+    cases he_eq : e with
+    | error _ => exact True.intro
+    | ok de =>
+      rw [ht_eq] at ht
+      rw [he_eq] at he
+      exact DefVal.ite_mono ht he
+
+/-- `encoderOps` preserves monotonicity of the definedness component. -/
+def encoderOps_preservesMono :
+    EncoderOpsInd encoderOps MonoE where
+  call_ind := encoderOps_call_monoE
+  ite_ind := encoderOps_ite_monoE
+  error_ind := True.intro
+
+/-! ## Body Encoding -/
+
+/-- Encode a function body using the solver-facing defined/value presentation. -/
+def encodeBody (Γ : FunCtx) (Δ : Signature)
+    (f : TinyML.Var) (fn : SpecFn) (x _res : TinyML.Var) (e : Typed.Expr) :
+    Except String DefVal :=
+  let Γ' := Relation.ctx Γ f fn
+  let Δ' := defvalBodySig Δ fn x
+  encode Γ' Δ' e
+
+/-- Proof-only binary relation: whenever the split `DefVal` carrier succeeds,
+the paired relational carrier succeeds under any name supply covering the
+relational signature. -/
+def RelSucceedsWhenDef (Γ : FunCtx) :
+    Signature → Signature → Env → Env → Rel → Except String DefVal → Prop :=
+  fun Δrel Δdef _ _ m d =>
+    Δrel.wf → Δdef.wf → Γ.defWfIn Δdef →
+      ∀ s, s.Covers Δrel → ∀ body, d = .ok body → ∃ φ, m s = .ok φ
+
+/-- Call case for `RelSucceedsWhenDef`: split success of the continuation
+provides success of the relational continuation under the freshly reserved
+witness name. -/
+theorem relSucceedsWhenDef_call {Γ : FunCtx}
+    {Δrel Δdef : Signature} {ρrel ρdef : Env}
+    {f : TinyML.Var} {fn : SpecFn} {argRel argDef : Term .value}
+    {kRel : Term .value → Rel} {kDef : Term .value → Except String DefVal}
+    (hmem : (f, fn) ∈ Γ)
+    (_hargRel : argRel.wfIn Δrel) (hargDef : argDef.wfIn Δdef)
+    (_hargEval : Term.eval ρrel argRel = Term.eval ρdef argDef)
+    (hk : EncoderContSpec (RelSucceedsWhenDef Γ) Δrel Δdef ρrel ρdef kRel kDef) :
+  RelSucceedsWhenDef Γ Δrel Δdef ρrel ρdef
+      (Relation.encoderOps.call fn argRel kRel) (encoderOps.call fn argDef kDef) := by
+  intro hΔrel hΔdef hΓdef s hcov body hd
+  simp only [encoderOps] at hd
+  obtain ⟨n, hkn, _hbody⟩ := DefVal.bind_ok hd
+  let ctx := freshValueCtx s hΔrel hcov
+  have hcallWf : (SpecFn.call fn argDef).wfIn Δdef :=
+    SpecFn.call_wfIn (hΓdef f fn hmem).1 hΔdef hargDef
+  let w := (SpecFn.call fn argDef).eval ρdef
+  have hagRel : Env.agreeOn Δrel ρrel (ρrel.updateConst .value ctx.r w) :=
+    Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) ctx.fresh
+  have heval :
+      Term.eval (ρrel.updateConst .value ctx.r w) (Term.var .value ctx.r) =
+        Term.eval ρdef (SpecFn.call fn argDef) := by
+    simp [Term.eval, Env.lookupConst_updateConst_same, w]
+  have hcont :=
+    hk ctx.subset (Signature.Subset.refl Δdef) ctx.wf hΔdef
+      hagRel Env.agreeOn_refl
+      (Term.var .value ctx.r) (SpecFn.call fn argDef) ctx.var_wf hcallWf heval
+  obtain ⟨φ, hφ⟩ := hcont ctx.wf hΔdef hΓdef ctx.s' ctx.covers n hkn
+  exact ⟨.exists_ ctx.r .value (.and (Formula.funcall fn argRel (.var .value ctx.r)) φ), by
+    change (Rel.call fn argRel kRel) s =
+      .ok (.exists_ ctx.r .value (.and (Formula.funcall fn argRel (.var .value ctx.r)) φ))
+    simp only [Rel.call]
+    rw [← ctx.hr, ← ctx.hs', hφ]
+    rfl⟩
+
+/-- Conditional case for `RelSucceedsWhenDef`: if the split conditional
+succeeds, both split branches succeeded, so both relational branches can be
+run at the same supply. -/
+theorem relSucceedsWhenDef_ite {Γ : FunCtx}
+    {Δrel Δdef : Signature} {ρrel ρdef : Env}
+    {condRel condDef : Term .bool} {thenRel elseRel : Rel}
+    {thenDef elseDef : Except String DefVal}
+    (_hcondEval : Term.eval ρrel condRel = Term.eval ρdef condDef)
+    (ht : RelSucceedsWhenDef Γ Δrel Δdef ρrel ρdef thenRel thenDef)
+    (he : RelSucceedsWhenDef Γ Δrel Δdef ρrel ρdef elseRel elseDef) :
+  RelSucceedsWhenDef Γ Δrel Δdef ρrel ρdef
+      (Relation.encoderOps.ite condRel thenRel elseRel)
+      (encoderOps.ite condDef thenDef elseDef) := by
+  intro hΔrel hΔdef hΓdef s hcov body hd
+  obtain ⟨dt, de, htDef, heDef, _⟩ := encoderOps_ite_ok hd
+  obtain ⟨φt, hφt⟩ := ht hΔrel hΔdef hΓdef s hcov dt htDef
+  obtain ⟨φe, hφe⟩ := he hΔrel hΔdef hΓdef s hcov de heDef
+  exact ⟨Formula.iteBool condRel φt φe, by
+    simp [Relation.encoderOps, Rel.ite, hφt, hφe, bind, Except.bind]⟩
+
+/-- Operation-level data used by `encodeWith_bind_binary` to recover
+relational body success from split body success. -/
+def relSucceedsWhenDef_ops (Γ : FunCtx) :
+    EncoderOpsBinary Γ Relation.encoderOps encoderOps (RelSucceedsWhenDef Γ) where
+  call_binary := relSucceedsWhenDef_call
+  ite_binary := relSucceedsWhenDef_ite
+  error_binary := by
+    intro Δrel Δdef ρrel ρdef msg _ _ _ s _ body h
+    simp [encoderOps] at h
+
+/-! ## Semantic Infrastructure -/
+def semDefined (R : ValRel) (x : Srt.value.denote) : Prop :=
+  ∃ y, R x y
+
+/-- The value function induced by a relation: choose an arbitrary related
+output when one exists, and Lean's default epsilon value otherwise. -/
+noncomputable def semFunc (R : ValRel) (x : Srt.value.denote) : Srt.value.denote :=
+  Classical.epsilon (R x)
+
+/-- If the relation is defined at `x`, `semFunc` chooses a related output. -/
+theorem semFunc_spec {R : ValRel} {x : Srt.value.denote}
+    (h : semDefined R x) : R x (semFunc R x) := by
+  unfold semDefined semFunc at *
+  exact Classical.epsilon_spec h
+
+/-- Interpret the solver-facing split symbols for a relation name using a
+chosen value function `F` and a candidate definedness predicate `D`. -/
+def splitEnv (ρ : Env) (fn : SpecFn)
+    (D : Srt.value.denote → Prop)
+    (F : Srt.value.denote → Srt.value.denote) : Env :=
+  (ρ.updateUnary .value .value (fn.funcName) F).updateUnaryRel .value (fn.defName) D
+
+/-- Combined environment used when comparing one recursive relation with its
+split presentation. It interprets the binary relation, value function, and
+definedness predicate for `fn` at once. -/
+def relSplitEnv (ρ : Env) (fn : SpecFn)
+    (R : ValRel) (D : Srt.value.denote → Prop)
+    (F : Srt.value.denote → Srt.value.denote) : Env :=
+  ((ρ.updateBinaryRel .value .value fn R).updateUnary .value .value (fn.funcName) F)
+    |>.updateUnaryRel .value (fn.defName) D
+
+/-- Environment for evaluating a split encoded body at input `vin`, with
+recursive calls interpreted by `D` and `F`. -/
+def defEnv (ρ : Env) (fn : SpecFn) (x : String)
+    (D : Srt.value.denote → Prop)
+    (F : Srt.value.denote → Srt.value.denote)
+    (vin : Srt.value.denote) : Env :=
+  (splitEnv ρ fn D F).updateConst .value x vin
+
+/-- The unary body operator induced by the definedness component of a
+`DefVal` body under a fixed recursive value function. -/
+def defBody (ρ : Env) (fn : SpecFn) (x : String) (body : DefVal)
+    (F : Srt.value.denote → Srt.value.denote) :
+    (Srt.value.denote → Prop) → Srt.value.denote → Prop :=
+  fun D vin => body.defined.eval (defEnv ρ fn x D F vin)
+
+/-- Increasing the candidate definedness predicate increases the corresponding
+split environments. -/
+theorem splitEnv_le {ρ : Env} {fn : SpecFn}
+    {D D' : Srt.value.denote → Prop}
+    {F : Srt.value.denote → Srt.value.denote}
+    (hDD' : UnaryFix.le D D') :
+    Fix.Env.le (splitEnv ρ fn D F) (splitEnv ρ fn D' F) := by
+  refine ⟨rfl, rfl, rfl, ?_, ?_⟩
+  · intro τ name a h
+    simp only [splitEnv, Env.updateUnaryRel] at h ⊢
+    split at h
+    · rename_i heq
+      rcases heq with ⟨rfl, rfl⟩
+      simpa only [Env.updateUnaryRel, dif_pos (And.intro rfl rfl)] using hDD' a h
+    · rename_i hne
+      simp only [dif_neg hne]
+      exact h
+  · intro τ₁ τ₂ name a b h
+    exact h
+
+/-- The definedness body operator is monotone whenever the encoded body has
+monotone definedness. -/
+theorem defBody_mono {ρ : Env} {fn : SpecFn} {x : String} {body : DefVal}
+    {F : Srt.value.denote → Srt.value.denote}
+    (hbody : DefVal.Mono body) :
+    UnaryFix.Mono (defBody ρ fn x body F) := by
+  intro D D' hDD' vin hdef
+  exact hbody (Fix.Env.le.updateConst (splitEnv_le (ρ := ρ) (fn := fn)
+    (D := D) (D' := D') (F := F) hDD') .value x vin) hdef
+
+/-- Semantic definedness for the split presentation: the least fixpoint of the
+encoded definedness condition, interpreted with the value function chosen from
+the ground-truth relation. -/
+noncomputable def semdef
+    (Γ : FunCtx) (Δ : Signature) (ρ : Env)
+    (f : TinyML.Var) (fn : SpecFn) (x res : TinyML.Var) (e : Typed.Expr)
+    (body : DefVal) : Srt.value.denote → Prop :=
+  UnaryFix.lfp (defBody ρ fn x body
+    (semFunc (semrel Γ Δ ρ f fn x res e)))
+
+/-- Canonical environment for the split presentation extracted from the
+ground-truth relation. -/
+noncomputable def defInterpEnv
+    (Γ : FunCtx) (Δ : Signature) (ρ : Env)
+    (f : TinyML.Var) (fn : SpecFn) (x res : TinyML.Var) (e : Typed.Expr)
+    (body : DefVal) : Env :=
+  let R := semrel Γ Δ ρ f fn x res e
+  splitEnv ρ fn (semdef Γ Δ ρ f fn x res e body) (semFunc R)
+
+/-- Unfolding principle specialized to a successfully encoded `DefVal` body. -/
+theorem semdef_unfold_of_encode
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
+    (vin : Srt.value.denote) :
+    semdef Γ Δ ρ f fn x res e body vin ↔
+      defBody ρ fn x body
+        (semFunc (semrel Γ Δ ρ f fn x res e))
+        (semdef Γ Δ ρ f fn x res e body) vin := by
+  unfold semdef
+  have hcarrier : MonoE
+      (encodeWith encoderOps (Relation.ctx Γ f fn) (VarEnv.ofSignature (defvalBodySig Δ fn x)) e
+        (fun v => .ok (DefVal.pure v))) :=
+    encodeWith_ind encoderOps_preservesMono e
+      (by
+        intro v
+        show MonoE (.ok (DefVal.pure v))
+        intro ρ ρ' _ _
+        simp [DefVal.pure, Formula.eval])
+  have hdef : encode (Relation.ctx Γ f fn) (defvalBodySig Δ fn x) e = .ok body := henc
+  unfold encode at hdef
+  rw [hdef] at hcarrier
+  have hbodyMono : DefVal.Mono body := hcarrier
+  exact UnaryFix.lfp_unfold (defBody_mono (ρ := ρ) (fn := fn) (x := x)
+    (body := body) hbodyMono) vin
+
+/-- Under the canonical split interpretation, the definedness symbol denotes
+`semdef`. -/
+theorem definedCall_eval_defInterpEnv
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (vin : Srt.value.denote) :
+    (fn.isDefined (.var .value x)).eval
+      ((defInterpEnv Γ Δ ρ f fn x res e body).updateConst .value x vin)
+      ↔ semdef Γ Δ ρ f fn x res e body vin := by
+  simp [SpecFn.isDefined, SpecFn.isDefined, Formula.eval, UnPred.eval, Term.eval,
+    Env.lookupConst_updateConst_same]
+  unfold defInterpEnv splitEnv
+  simp [Env.updateConst_unaryRel, Env.updateUnaryRel]
+
+/-- Under the canonical split interpretation, the value symbol denotes the
+chosen witness function of `semrel`. -/
+theorem valueCall_eval_defInterpEnv
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (vin : Srt.value.denote) :
+    (fn.call (.var .value x)).eval
+      ((defInterpEnv Γ Δ ρ f fn x res e body).updateConst .value x vin)
+      =
+    semFunc (semrel Γ Δ ρ f fn x res e) vin := by
+  simp only [SpecFn.call, SpecFn.call, Term.eval, UnOp.eval, Env.lookupConst_updateConst_same]
+  rw [Env.updateConst_unary]
+  change ((ρ.updateUnary .value .value (fn.funcName)
+    (semFunc (semrel Γ Δ ρ f fn x res e))).unary .value .value (fn.funcName) vin =
+      semFunc (semrel Γ Δ ρ f fn x res e) vin)
+  simp [Env.updateUnary]
+
+
+end Skolemize
+
+/-! ## Split Compatibility -/
+/-- A binary relational interpretation and the split defined/value symbols
+agree for every relation-marked function in the context. -/
+def FunCtx.splitCompatible (Γ : FunCtx) (ρ : Env) : Prop :=
+  ∀ f fn, (f, fn) ∈ Γ →
+    ∀ x y,
+      ρ.binaryRel .value .value fn x y ↔
+        ρ.unaryRel .value (fn.defName) x ∧
+          ρ.unary .value .value (fn.funcName) x = y
+
+/-- Completeness half of split compatibility: relational calls imply the
+defined/value presentation. This is the half used by relational-to-split
+directional proofs. -/
+def FunCtx.splitComplete (Γ : FunCtx) (ρ : Env) : Prop :=
+  ∀ f fn, (f, fn) ∈ Γ →
+    ∀ x y,
+      ρ.binaryRel .value .value fn x y →
+        ρ.unaryRel .value (fn.defName) x ∧
+          ρ.unary .value .value (fn.funcName) x = y
+
+/-- Soundness half of split compatibility: the defined/value presentation
+implies the relational call. This is the half used by split-to-relational
+directional proofs. -/
+def FunCtx.splitSound (Γ : FunCtx) (ρ : Env) : Prop :=
+  ∀ f fn, (f, fn) ∈ Γ →
+    ∀ x y,
+      ρ.unaryRel .value (fn.defName) x ∧
+        ρ.unary .value .value (fn.funcName) x = y →
+          ρ.binaryRel .value .value fn x y
+
+theorem FunCtx.splitComplete_updateConst {Γ : FunCtx} {ρ : Env}
+    (hΓ : Γ.splitComplete ρ) (τ : Srt) (x : String) (v : τ.denote) :
+    Γ.splitComplete (ρ.updateConst τ x v) := by
+  intro f fn hmem a b hcall
+  simpa [Env.updateConst_unary, Env.updateConst_unaryRel, Env.updateConst_binaryRel]
+    using hΓ f fn hmem a b hcall
+
+theorem FunCtx.splitSound_updateConst {Γ : FunCtx} {ρ : Env}
+    (hΓ : Γ.splitSound ρ) (τ : Srt) (x : String) (v : τ.denote) :
+    Γ.splitSound (ρ.updateConst τ x v) := by
+  intro f fn hmem a b hsplit
+  apply hΓ f fn hmem a b
+  simpa [Env.updateConst_unary, Env.updateConst_unaryRel] using hsplit
+
+theorem FunCtx.splitSound_of_compatible {Γ : FunCtx} {ρ : Env}
+    (hΓ : Γ.splitCompatible ρ) : Γ.splitSound ρ := by
+  intro f fn hmem x y hsplit
+  exact (hΓ f fn hmem x y).mpr hsplit
+
+/-- The newly introduced relation and split symbols do not collide with the
+relation names already present in the tail function context. -/
+def FunCtx.freshFn (Γ : FunCtx) (fn : SpecFn) : Prop :=
+  ∀ g fn', (g, fn') ∈ Γ →
+    fn' ≠ fn ∧ (fn').funcName ≠ fn.funcName ∧ (fn').defName ≠ fn.defName
+
+namespace Skolemize
+
+/-- Extending a split-sound context with a fresh head function preserves split
+soundness when the head relation is sound for the chosen split predicate and
+value function. -/
+theorem splitSound_cons_relSplitEnv
+    {Γ : FunCtx} {ρ : Env} {f : TinyML.Var} {fn : SpecFn}
+    {R : ValRel} {D : Srt.value.denote → Prop}
+    {F : Srt.value.denote → Srt.value.denote}
+    (hΓ : FunCtx.splitSound Γ ρ)
+    (hfresh : FunCtx.freshFn Γ fn)
+    (hRF : ∀ x y, D x ∧ F x = y → R x y) :
+    FunCtx.splitSound ((f, fn) :: Γ) (relSplitEnv ρ fn R D F) := by
+  intro g fn' hmem x y hsplit
+  cases hmem with
+  | head =>
+      have hsplit' : D x ∧ F x = y := by
+        simpa [relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
+          using hsplit
+      simpa [relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
+        using hRF x y hsplit'
+  | tail _ htail =>
+      have hnames := hfresh g fn' htail
+      have hsplit' :
+          ρ.unaryRel .value ((fn').defName) x ∧
+            ρ.unary .value .value ((fn').funcName) x = y := by
+        simpa [relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel,
+          hnames.1, hnames.2.1, hnames.2.2] using hsplit
+      simpa [relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel,
+        hnames.1, hnames.2.1, hnames.2.2] using hΓ g fn' htail x y hsplit'
+
+
+/-! ### Body-signature transport helpers -/
+
+theorem encodeBody_def_bodySig {Γ : FunCtx} {Δ : Signature}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body) :
+    encode (Relation.ctx Γ f fn) (bodySig Δ fn x) e = .ok body := by
+  unfold encode
+  have hvars :
+      VarEnv.ofSignature (bodySig Δ fn x) =
+        VarEnv.ofSignature (defvalBodySig Δ fn x) := by
+    simp [VarEnv.ofSignature, bodySig, defvalBodySig, Signature.declVar,
+      Signature.addBinaryRel, Signature.addUnary, Signature.addUnaryRel,
+      Signature.remove, Signature.addVar]
+  rw [hvars]
+  exact henc
+
+/-! ### Freshness and signature infrastructure -/
+
+/-- Freshness assumptions for the common Skolemization signature, in the exact
+order in which `sig` introduces the head relation symbols and bound variables. -/
+structure HeadFresh (Δ : Signature) (fn : SpecFn) (x res : String) : Prop where
+  relFresh : fn ∉ Δ.allNames
+  funFresh :
+    fn.funcName ∉ (Δ.addBinaryRel ⟨fn, .value, .value⟩).allNames
+  defFresh :
+    fn.defName ∉
+    ((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).allNames
+  argFresh :
+    x ∉
+    (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+      (fn.defined)).allNames
+  resFresh :
+    res ∉
+    ((((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+      (fn.defined)).declVar ⟨x, .value⟩).allNames
+
+/-! ### Subset lemmas -/
+
+theorem relBase_subset_bodyBase {Δ : Signature} {fn : SpecFn} :
+    (Δ.addBinaryRel ⟨fn, .value, .value⟩).Subset
+      (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+        (fn.defined)) :=
+  (Signature.Subset.subset_addUnary _ (fn.func)).trans
+    (Signature.Subset.subset_addUnaryRel _ (fn.defined))
+
+theorem subset_bodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hfresh : HeadFresh Δ fn x res) :
+    Δ.Subset (bodySig Δ fn x) := by
+  unfold bodySig
+  exact
+    (((Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩).trans
+      (Signature.Subset.subset_addUnary _ (fn.func))).trans
+      (Signature.Subset.subset_addUnaryRel _ (fn.defined))).trans
+      (Signature.subset_declVar_of_fresh (Δ :=
+        (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+          (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh)
+
+theorem subset_relBodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hfresh : HeadFresh Δ fn x res) :
+    Δ.Subset (Relation.bodySig Δ fn x) := by
+  unfold Relation.bodySig
+  exact (Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩).trans
+    (Signature.subset_declVar_of_fresh (Δ := Δ.addBinaryRel ⟨fn, .value, .value⟩)
+      (v := ⟨x, .value⟩) (by
+        intro h
+        exact hfresh.argFresh (Signature.allNames_subset
+          (relBase_subset_bodyBase (Δ := Δ) (fn := fn)) _ h)))
+
+theorem splitBase_subset_bodyBase {Δ : Signature} {fn : SpecFn} :
+    ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)).Subset
+      (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+        (fn.defined)) := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, fun a ha => List.mem_cons_of_mem _ ha⟩ <;>
+    intro a ha <;>
+    simpa [Signature.addUnary, Signature.addUnaryRel, Signature.addBinaryRel] using ha
+
+theorem relBodySig_subset_bodySig {Δ : Signature} {fn : SpecFn} {x : String} :
+    (Relation.bodySig Δ fn x).Subset (bodySig Δ fn x) := by
+  unfold Relation.bodySig bodySig
+  exact Signature.Subset.declVar relBase_subset_bodyBase ⟨x, .value⟩
+
+theorem defvalBodySig_subset_bodySig {Δ : Signature} {fn : SpecFn} {x : String} :
+    (defvalBodySig Δ fn x).Subset (bodySig Δ fn x) := by
+  unfold defvalBodySig bodySig
+  exact Signature.Subset.declVar splitBase_subset_bodyBase ⟨x, .value⟩
+
+theorem subset_defvalBodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hfresh : HeadFresh Δ fn x res) :
+    Δ.Subset (defvalBodySig Δ fn x) := by
+  unfold defvalBodySig
+  exact ((Signature.Subset.subset_addUnary Δ (fn.func)).trans
+    (Signature.Subset.subset_addUnaryRel _ (fn.defined))).trans
+    (Signature.subset_declVar_of_fresh (Δ :=
+      ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)))
+      (v := ⟨x, .value⟩) (by
+        intro h
+        exact hfresh.argFresh (Signature.allNames_subset
+          (splitBase_subset_bodyBase (Δ := Δ) (fn := fn)) _ h)))
+
+theorem bodySig_subset_sig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hfresh : HeadFresh Δ fn x res) :
+    (bodySig Δ fn x).Subset (sig Δ fn x res) := by
+  unfold sig
+  exact Signature.subset_declVar_of_fresh (Δ := bodySig Δ fn x) (v := ⟨res, .value⟩)
+    (by simpa [bodySig] using hfresh.resFresh)
+
+theorem relBodySig_subset_relSig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hfresh : HeadFresh Δ fn x res) :
+    (Relation.bodySig Δ fn x).Subset (Relation.sig Δ fn x res) := by
+  unfold Relation.sig
+  exact Signature.subset_declVar_of_fresh (Δ := Relation.bodySig Δ fn x) (v := ⟨res, .value⟩)
+    (by
+      intro h
+      exact hfresh.resFresh (Signature.allNames_subset
+        (relBodySig_subset_bodySig (Δ := Δ) (fn := fn) (x := x)) _ h))
+
+/-! ### Well-formedness lemmas -/
+
+theorem bodySig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hΔ : Δ.wf) (hfresh : HeadFresh Δ fn x res) :
+    (bodySig Δ fn x).wf := by
+  unfold bodySig
+  have hrel :
+      (Δ.addBinaryRel ⟨fn, .value, .value⟩).wf :=
+    Signature.wf_addBinaryRel hΔ hfresh.relFresh
+  have hfun :
+      ((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).wf :=
+    Signature.wf_addUnary hrel hfresh.funFresh
+  have hdef :
+      (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+        (fn.defined)).wf :=
+    Signature.wf_addUnaryRel hfun hfresh.defFresh
+  exact Signature.wf_declVar hdef
+
+theorem relBodySig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hΔ : Δ.wf) (hfresh : HeadFresh Δ fn x res) :
+    (Relation.bodySig Δ fn x).wf := by
+  unfold Relation.bodySig
+  exact Signature.wf_declVar (Signature.wf_addBinaryRel hΔ hfresh.relFresh)
+
+theorem var_fresh_splitBase_of_headFresh
+    {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hfresh : HeadFresh Δ fn x res) :
+    x ∉ ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)).allNames := by
+  intro h
+  exact hfresh.argFresh (Signature.allNames_subset
+    (splitBase_subset_bodyBase (Δ := Δ) (fn := fn)) _ h)
+
+theorem res_fresh_defvalBodySig_of_headFresh
+    {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hfresh : HeadFresh Δ fn x res) :
+    res ∉ (defvalBodySig Δ fn x).allNames := by
+  intro h
+  exact hfresh.resFresh (Signature.allNames_subset
+    (defvalBodySig_subset_bodySig (Δ := Δ) (fn := fn) (x := x)) _ h)
+
+theorem splitEnv_relSplitEnv_agreeOn_splitBase
+    {Δ : Signature} {ρ : Env} {fn : SpecFn} {x res : String}
+    {R : ValRel} {D : Srt.value.denote → Prop}
+    {F : Srt.value.denote → Srt.value.denote}
+    (hfresh : HeadFresh Δ fn x res) :
+    Env.agreeOn ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined))
+      (splitEnv ρ fn D F) (relSplitEnv ρ fn R D F) := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
+  iterate 5
+    intro _ _
+    simp [splitEnv, relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
+  intro b hb
+  have hbΔ : b ∈ Δ.binaryRel := by
+    simpa [Signature.addUnary, Signature.addUnaryRel] using hb
+  have hne : b.name ≠ fn := fun h =>
+    hfresh.relFresh (h ▸ Signature.mem_allNames_of_binaryRel hbΔ)
+  simp [splitEnv, relSplitEnv, Env.updateBinaryRel, Env.updateUnary,
+    Env.updateUnaryRel, hne]
+
+/-- The split-only body signature is well-formed under the existing head
+freshness assumptions. -/
+theorem defvalBodySig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hΔ : Δ.wf) (hfresh : HeadFresh Δ fn x res) :
+    (defvalBodySig Δ fn x).wf := by
+  unfold defvalBodySig
+  exact Signature.wf_declVar
+    (Signature.wf_addUnaryRel
+      (Signature.wf_addUnary hΔ (fun h =>
+        hfresh.funFresh (Signature.allNames_subset
+          (Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩) _ h)))
+      (fun h =>
+        hfresh.defFresh (Signature.allNames_subset
+          (by
+            constructor <;> intro a ha
+            · simpa [Signature.addUnary, Signature.addBinaryRel] using ha
+            · simpa [Signature.addUnary, Signature.addBinaryRel] using ha
+            · simpa [Signature.addUnary, Signature.addBinaryRel] using ha
+            · simpa [Signature.addUnary, Signature.addBinaryRel] using ha
+            · simpa [Signature.addUnary, Signature.addBinaryRel] using ha
+            · exact List.mem_cons_of_mem _ ha) _ h)))
+
+theorem sig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hΔ : Δ.wf) (hfresh : HeadFresh Δ fn x res) :
+    (sig Δ fn x res).wf := by
+  unfold sig
+  exact Signature.wf_declVar (bodySig_wf_of_headFresh hΔ hfresh)
+
+/-! ### Freshness derivations -/
+
+theorem freshFn_of_headFresh {Γ : FunCtx} {Δ : Signature} {fn : SpecFn} {x res : String}
+    (hΓfn : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hfresh : HeadFresh Δ fn x res) :
+    FunCtx.freshFn Γ fn := by
+  intro g fn' hmem
+  have hrel'_mem : fn' ∈ Δ.allNames :=
+    Signature.mem_allNames_of_binaryRel (hΓfn g fn' hmem)
+  have hfun_mem : (fn').funcName ∈ Δ.allNames :=
+    Signature.mem_allNames_of_unary (hΓdef g fn' hmem).1
+  have hdef_mem : (fn').defName ∈ Δ.allNames :=
+    Signature.mem_allNames_of_unaryRel (hΓdef g fn' hmem).2
+  refine ⟨?_, ?_, ?_⟩
+  · intro h
+    exact hfresh.relFresh (h ▸ hrel'_mem)
+  · intro h
+    exact hfresh.funFresh (h ▸ Signature.allNames_subset
+      (Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩) _ hfun_mem)
+  · intro h
+    exact hfresh.defFresh (h ▸ Signature.allNames_subset
+      ((Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩).trans
+        (Signature.Subset.subset_addUnary _ (fn.func))) _ hdef_mem)
+
+
+theorem ctx_wfIn_relSig_of_headFresh
+    {Γ : FunCtx} {Δ : Signature} {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var}
+    (hΓfn : Γ.wfIn Δ) (hfresh : HeadFresh Δ fn x res) :
+    (Relation.ctx Γ f fn).wfIn (Relation.sig Δ fn x res) := by
+  intro g fn' hmem
+  cases hmem with
+  | head =>
+      have hxFresh :
+          x ∉ (Δ.addBinaryRel ⟨fn, .value, .value⟩).allNames := by
+        intro h
+        exact hfresh.argFresh (Signature.allNames_subset
+          (relBase_subset_bodyBase (Δ := Δ) (fn := fn)) _ h)
+      exact (relBodySig_subset_relSig_of_headFresh hfresh).binaryRel _
+        (by
+          unfold Relation.bodySig
+          exact (Signature.subset_declVar_of_fresh
+            (Δ := Δ.addBinaryRel ⟨fn, .value, .value⟩)
+            (v := ⟨x, .value⟩) hxFresh).binaryRel _
+            (List.Mem.head _))
+  | tail _ htail =>
+      exact ((subset_relBodySig_of_headFresh hfresh).trans
+        (relBodySig_subset_relSig_of_headFresh hfresh)).binaryRel _ (hΓfn g fn' htail)
+
+theorem ctx_defWfIn_bodySig_of_headFresh
+    {Γ : FunCtx} {Δ : Signature} {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var}
+    (hΓdef : Γ.defWfIn Δ) (hfresh : HeadFresh Δ fn x res) :
+    (Relation.ctx Γ f fn).defWfIn (bodySig Δ fn x) := by
+  intro g fn' hmem
+  cases hmem with
+  | head =>
+      unfold bodySig
+      refine ⟨?_, ?_⟩
+      · exact Signature.Subset.unary
+          ((Signature.Subset.subset_addUnaryRel _ (fn.defined)).trans
+            (Signature.subset_declVar_of_fresh (Δ :=
+              (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+                (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh))
+          (fn.func) (List.Mem.head _)
+      · exact Signature.Subset.unaryRel
+          (Signature.subset_declVar_of_fresh (Δ :=
+            (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+              (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh)
+          (fn.defined) (List.Mem.head _)
+  | tail _ htail =>
+      exact FunCtx.defWfIn_mono hΓdef (subset_bodySig_of_headFresh hfresh) g fn' htail
+
+theorem ctx_defWfIn_defvalBodySig_of_headFresh
+    {Γ : FunCtx} {Δ : Signature} {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var}
+    (hΓdef : Γ.defWfIn Δ) (hfresh : HeadFresh Δ fn x res) :
+    (Relation.ctx Γ f fn).defWfIn (defvalBodySig Δ fn x) := by
+  intro g fn' hmem
+  cases hmem with
+  | head =>
+      unfold defvalBodySig
+      refine ⟨?_, ?_⟩
+      · exact Signature.Subset.unary
+          ((Signature.Subset.subset_addUnaryRel _ (fn.defined)).trans
+            (Signature.subset_declVar_of_fresh (Δ :=
+              ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)))
+              (v := ⟨x, .value⟩) (var_fresh_splitBase_of_headFresh hfresh)))
+          (fn.func) (List.Mem.head _)
+      · exact Signature.Subset.unaryRel
+          (Signature.subset_declVar_of_fresh (Δ :=
+            ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)))
+            (v := ⟨x, .value⟩) (var_fresh_splitBase_of_headFresh hfresh))
+          (fn.defined) (List.Mem.head _)
+  | tail _ htail =>
+      exact FunCtx.defWfIn_mono hΓdef (subset_defvalBodySig_of_headFresh hfresh)
+        g fn' htail
+
+/-- If the split defined/value body encoder succeeds, the relational body
+encoder succeeds too. This keeps `encodeBody` focused on the solver-facing
+split encoding while preserving the relational witness needed by semantic
+proofs. -/
+theorem encodeBody_relEncodeBody {Γ : FunCtx} {Δ : Signature}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal}
+    (hΔ : Δ.wf) (hΓdef : Γ.defWfIn Δ) (hheadFresh : HeadFresh Δ fn x res)
+    (henc : encodeBody Γ Δ f fn x res e = .ok body) :
+    ∃ φ, relEncodeBody Γ Δ f fn x res e = .ok φ := by
+  have hΔbody : (bodySig Δ fn x).wf := bodySig_wf_of_headFresh hΔ hheadFresh
+  have hΓbody : (Relation.ctx Γ f fn).defWfIn (bodySig Δ fn x) :=
+    ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh
+  have hbinary :
+      RelSucceedsWhenDef (Relation.ctx Γ f fn) (bodySig Δ fn x) (bodySig Δ fn x)
+        default default
+        (encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
+          (VarEnv.ofSignature (bodySig Δ fn x)) e (Relation.kEq res))
+        (encode (Relation.ctx Γ f fn) (bodySig Δ fn x) e) := by
+    refine encodeWith_bind_binary (δ₁ := VarEnv.ofSignature (bodySig Δ fn x))
+      (δ₂ := VarEnv.ofSignature (bodySig Δ fn x))
+      (relSucceedsWhenDef_ops (Relation.ctx Γ f fn)) e
+      (Signature.Subset.refl _) (Signature.Subset.refl _) hΔbody hΔbody ?_ ?_
+    · exact varEnv_ofSignature_agree_self hΔbody
+    · intro Δrel' Δdef' ρrel' ρdef' _ _ _ _ _ _ vrel vdef _ _ _ _ _ _ s _ body' hbody'
+      exact ⟨.eq .value vrel (.var .value res), by simp [Relation.kEq]⟩
+  have hdefBody : encode (Relation.ctx Γ f fn) (bodySig Δ fn x) e = .ok body :=
+    encodeBody_def_bodySig henc
+  have hcov : (relBodySupply Δ fn x res).Covers (bodySig Δ fn x) := by
+    intro n hn
+    exact relBodySupply_covers_sig Δ fn x res n
+      (Signature.allNames_subset (bodySig_subset_sig_of_headFresh hheadFresh) n hn)
+  obtain ⟨φ, hφ⟩ := hbinary hΔbody hΔbody hΓbody
+    (relBodySupply Δ fn x res) hcov body hdefBody
+  have hvars :
+      VarEnv.ofSignature (bodySig Δ fn x) =
+        VarEnv.ofSignature (Relation.bodySig Δ fn x) := by
+    simp [VarEnv.ofSignature, bodySig, Relation.bodySig, Signature.declVar,
+      Signature.addBinaryRel, Signature.addUnary, Signature.addUnaryRel,
+      Signature.remove, Signature.addVar]
+  exact ⟨φ, by simpa [Relation.relEncodeBody, hvars] using hφ⟩
+
+/-- Successful split body encodings are well-formed in the split-only body
+signature; the proof-only binary relation is not needed for the `DefVal`
+output. -/
+theorem encodeBody_wfIn_defvalBodySig
+    {Γ : FunCtx} {Δ : Signature}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal}
+    (hΔ : Δ.wf) (hΓdef : Γ.defWfIn Δ)
+    (hheadFresh : HeadFresh Δ fn x res)
+    (henc : encodeBody Γ Δ f fn x res e = .ok body) :
+    body.wfIn (defvalBodySig Δ fn x) :=
+  encode_wfIn e (defvalBodySig_wf_of_headFresh hΔ hheadFresh)
+    (ctx_defWfIn_defvalBodySig_of_headFresh hΓdef hheadFresh)
+    henc
+
+theorem relEnv_relSplitEnv_agreeOn_relSig
+    {Δ : Signature} {ρ : Env} {fn : SpecFn} {x res : String}
+    {R : ValRel} {D : Srt.value.denote → Prop}
+    {F : Srt.value.denote → Srt.value.denote}
+    (hfresh : HeadFresh Δ fn x res) (vin vout : Srt.value.denote) :
+    Env.agreeOn (Relation.sig Δ fn x res)
+      (Relation.relEnv ρ fn x res R vin vout)
+      (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst .value res vout) := by
+  let ρbin := ρ.updateBinaryRel .value .value fn R
+  let ρfun := ρbin.updateUnary .value .value (fn.funcName) F
+  have hbase :
+      Env.agreeOn (Δ.addBinaryRel ⟨fn, .value, .value⟩) ρbin
+        (relSplitEnv ρ fn R D F) := by
+    have hfun : Env.agreeOn (Δ.addBinaryRel ⟨fn, .value, .value⟩) ρbin ρfun := by
+      simpa [ρbin, ρfun] using
+        (Env.agreeOn_update_fresh_unary (ρ := ρbin) (u := fn.func)
+          (f := F) (Δ := Δ.addBinaryRel ⟨fn, .value, .value⟩) hfresh.funFresh)
+    have hdef :
+        Env.agreeOn (Δ.addBinaryRel ⟨fn, .value, .value⟩) ρfun
+          (relSplitEnv ρ fn R D F) := by
+      have hdefFresh : fn.defName ∉ (Δ.addBinaryRel ⟨fn, .value, .value⟩).allNames := by
+        intro h
+        exact hfresh.defFresh (Signature.allNames_subset
+          (Signature.Subset.subset_addUnary _ (fn.func)) _ h)
+      simpa [relSplitEnv, ρbin, ρfun] using
+        (Env.agreeOn_update_fresh_unaryRel (ρ := ρfun) (u := fn.defined)
+          (f := D) (Δ := Δ.addBinaryRel ⟨fn, .value, .value⟩) hdefFresh)
+    exact Env.agreeOn_trans hfun hdef
+  simpa [Relation.relEnv, Relation.sig, Relation.bodySig] using
+    (Env.agreeOn_declVar
+      (Env.agreeOn_declVar hbase : Env.agreeOn
+        ((Δ.addBinaryRel ⟨fn, .value, .value⟩).declVar ⟨x, .value⟩)
+        ((ρ.updateBinaryRel .value .value fn R).updateConst .value x vin)
+        ((relSplitEnv ρ fn R D F).updateConst .value x vin)) :
+      Env.agreeOn
+        (((Δ.addBinaryRel ⟨fn, .value, .value⟩).declVar ⟨x, .value⟩).declVar
+          ⟨res, .value⟩)
+        (((ρ.updateBinaryRel .value .value fn R).updateConst .value x vin).updateConst
+          .value res vout)
+        (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst .value res vout))
+
+theorem relEncodeBody_wfIn_relSig
+    {Γ : FunCtx} {Δ : Signature}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {φ : Formula}
+    (hΓfn : Γ.wfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
+    (hrelEnc : relEncodeBody Γ Δ f fn x res e = .ok φ) :
+    φ.wfIn (Relation.sig Δ fn x res) := by
+  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
+      (VarEnv.ofSignature (Relation.bodySig Δ fn x)) e (Relation.kEq res) with hm_def
+  have hrun : m (relBodySupply Δ fn x res) = .ok φ := by
+    simpa [Relation.relEncodeBody, hm_def] using hrelEnc
+  have hsigWf : (Relation.sig Δ fn x res).wf := by
+    unfold Relation.sig
+    exact Signature.wf_declVar (relBodySig_wf_of_headFresh hΔ hheadFresh)
+  have hres_mem : (⟨res, .value⟩ : Var) ∈ (Relation.sig Δ fn x res).vars := by
+    unfold Relation.sig
+    exact Signature.var_mem_declVar (Relation.bodySig Δ fn x) ⟨res, .value⟩
+  have hmWf : Relation.Rel.wfIn (Relation.sig Δ fn x res) m :=
+    encodeWith_indWithSig Relation.encoderOps_wf e
+      (relBodySig_subset_relSig_of_headFresh hheadFresh)
+      hsigWf
+      (ctx_wfIn_relSig_of_headFresh hΓfn hheadFresh)
+      (fun y v hlookup =>
+        Term.wfIn_mono v ((VarEnv.ofSignature_wfIn
+          (relBodySig_wf_of_headFresh hΔ hheadFresh)) y v hlookup)
+          (relBodySig_subset_relSig_of_headFresh hheadFresh) hsigWf)
+      (Relation.kEq_wfCont hres_mem)
+  have hcov : (relBodySupply Δ fn x res).Covers (Relation.sig Δ fn x res) := by
+    intro n hn
+    exact relBodySupply_covers_sig Δ fn x res n
+      (Signature.allNames_subset
+        (by
+          unfold Relation.sig sig
+          exact Signature.Subset.declVar relBodySig_subset_bodySig ⟨res, .value⟩)
+        n hn)
+  exact hmWf (Relation.sig Δ fn x res) (relBodySupply Δ fn x res) φ
+    (Signature.Subset.refl _) hsigWf hcov hrun
+
+/-- `splitEnv` (extended with `x ↦ vin`) and `relSplitEnv` (extended with
+`x ↦ vin, res ↦ vout`) agree on the split-only body signature. The body's
+value and definedness depend only on this signature, so both transport
+proofs reduce to this fact. -/
+theorem splitEnv_relSplitEnv_agreeOn_defvalBodySig
+    {Δ : Signature} {ρ : Env} {fn : SpecFn} {x res : String}
+    {R : ValRel} {D : Srt.value.denote → Prop}
+    {F : Srt.value.denote → Srt.value.denote}
+    (hfresh : HeadFresh Δ fn x res)
+    (vin vout : Srt.value.denote) :
+    Env.agreeOn (defvalBodySig Δ fn x)
+      ((splitEnv ρ fn D F).updateConst .value x vin)
+      (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst .value res vout) := by
+  have hagX :
+      Env.agreeOn (defvalBodySig Δ fn x)
+        ((splitEnv ρ fn D F).updateConst .value x vin)
+        ((relSplitEnv ρ fn R D F).updateConst .value x vin) :=
+    Env.agreeOn_declVar (splitEnv_relSplitEnv_agreeOn_splitBase hfresh)
+  have hagRes :
+      Env.agreeOn (defvalBodySig Δ fn x)
+        ((relSplitEnv ρ fn R D F).updateConst .value x vin)
+        (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst .value res vout) :=
+    Env.agreeOn_update_fresh_const (c := ⟨res, .value⟩)
+      (res_fresh_defvalBodySig_of_headFresh hfresh)
+  exact Env.agreeOn_trans hagX hagRes
+
+/-- Evaluating the relational body formula in the combined `relSplitEnv` is
+equivalent to the abstract semantic body operator. -/
+theorem rel_body_eval_iff
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {φ : Formula} {R : ValRel}
+    {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
+    (hΓrel : Γ.wfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hrelEnc : relEncodeBody Γ Δ f rel x res e = .ok φ)
+    (vin vout : Srt.value.denote) :
+    φ.eval (((relSplitEnv ρ rel R D F).updateConst .value x vin).updateConst
+        .value res vout) ↔
+      Relation.semanticBody Formula.sem ρ rel x res φ R vin vout := by
+  have hφwf : φ.wfIn (Relation.sig Δ rel x res) :=
+    relEncodeBody_wfIn_relSig hΓrel hΔ hheadFresh hrelEnc
+  have hag :=
+    relEnv_relSplitEnv_agreeOn_relSig (Δ := Δ) (ρ := ρ) (fn := rel)
+      (x := x) (res := res) (R := R) (D := D) (F := F) hheadFresh vin vout
+  unfold Relation.semanticBody Formula.sem
+  exact (Formula.eval_env_agree hφwf hag).symm
+
+end Skolemize
+end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
@@ -231,7 +231,7 @@ def wfInE (Δ : Signature) : Except String DefVal → Prop
 theorem encoderOps_call_wfInE {Γ : FunCtx} {Δ : Signature}
     {f : TinyML.Var} {fn : SpecFn} {arg : Term .value}
     {k : Term .value → Except String DefVal}
-    (hΔ : Δ.wf) (hΓ : Γ.defWfIn Δ) (hmem : (f, fn) ∈ Γ)
+    (hΔ : Δ.wf) (hΓ : Γ.splitWfIn Δ) (hmem : (f, fn) ∈ Γ)
     (harg : arg.wfIn Δ) (hk : SigCont wfInE Δ k) :
     wfInE Δ (encoderOps.call fn arg k) := by
   have hsyms := hΓ f fn hmem
@@ -266,15 +266,15 @@ theorem encoderOps_ite_wfInE {Δ : Signature} {cond : Term .bool}
 
 /-- `EncoderOpsSig` instance for the solver-facing defined/value encoder. The
 generic `encodeWith_indWithSig` then yields the well-formedness of `encode`. -/
-def encoderOps_wf : EncoderOpsSig encoderOps wfInE FunCtx.defWfIn where
-  ctx_mono := fun hΓ hsub => FunCtx.defWfIn_mono hΓ hsub
+def encoderOps_wf : EncoderOpsSig encoderOps wfInE FunCtx.splitWfIn where
+  ctx_mono := fun hΓ hsub => FunCtx.splitWfIn_mono hΓ hsub
   call_ind := encoderOps_call_wfInE
   ite_ind := encoderOps_ite_wfInE
   error_ind := True.intro
 
 /-- Well-formedness of the solver-facing defined/value encoding. -/
 theorem encode_wfIn {Γ : FunCtx} {Δ : Signature} (e : Typed.Expr)
-    {m : DefVal} (hΔ : Δ.wf) (hΓ : Γ.defWfIn Δ)
+    {m : DefVal} (hΔ : Δ.wf) (hΓ : Γ.splitWfIn Δ)
     (henc : encode Γ Δ e = .ok m) : m.wfIn Δ := by
   have hcarrier : wfInE Δ
       (encodeWith encoderOps Γ (VarEnv.ofSignature Δ) e (fun v => .ok (DefVal.pure v))) := by
@@ -382,7 +382,7 @@ relational signature. -/
 def RelSucceedsWhenDef (Γ : FunCtx) :
     Signature → Signature → Env → Env → Rel → Except String DefVal → Prop :=
   fun Δrel Δdef _ _ m d =>
-    Δrel.wf → Δdef.wf → Γ.defWfIn Δdef →
+    Δrel.wf → Δdef.wf → Γ.splitWfIn Δdef →
       ∀ s, s.Covers Δrel → ∀ body, d = .ok body → ∃ φ, m s = .ok φ
 
 /-- Call case for `RelSucceedsWhenDef`: split success of the continuation
@@ -902,16 +902,15 @@ theorem sig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
 /-! ### Freshness derivations -/
 
 theorem freshFn_of_headFresh {Γ : FunCtx} {Δ : Signature} {fn : SpecFn} {x res : String}
-    (hΓfn : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hfresh : HeadFresh Δ fn x res) :
+    (hΓ : Γ.wfIn Δ) (hfresh : HeadFresh Δ fn x res) :
     FunCtx.freshFn Γ fn := by
   intro g fn' hmem
   have hrel'_mem : fn' ∈ Δ.allNames :=
-    Signature.mem_allNames_of_binaryRel (hΓfn g fn' hmem)
+    Signature.mem_allNames_of_binaryRel (hΓ.rel g fn' hmem)
   have hfun_mem : (fn').funcName ∈ Δ.allNames :=
-    Signature.mem_allNames_of_unary (hΓdef g fn' hmem).1
+    Signature.mem_allNames_of_unary (hΓ.split g fn' hmem).1
   have hdef_mem : (fn').defName ∈ Δ.allNames :=
-    Signature.mem_allNames_of_unaryRel (hΓdef g fn' hmem).2
+    Signature.mem_allNames_of_unaryRel (hΓ.split g fn' hmem).2
   refine ⟨?_, ?_, ?_⟩
   · intro h
     exact hfresh.relFresh (h ▸ hrel'_mem)
@@ -924,10 +923,10 @@ theorem freshFn_of_headFresh {Γ : FunCtx} {Δ : Signature} {fn : SpecFn} {x res
         (Signature.Subset.subset_addUnary _ (fn.func))) _ hdef_mem)
 
 
-theorem ctx_wfIn_relSig_of_headFresh
+theorem ctx_relWfIn_relSig_of_headFresh
     {Γ : FunCtx} {Δ : Signature} {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var}
-    (hΓfn : Γ.wfIn Δ) (hfresh : HeadFresh Δ fn x res) :
-    (Relation.ctx Γ f fn).wfIn (Relation.sig Δ fn x res) := by
+    (hΓfn : Γ.relWfIn Δ) (hfresh : HeadFresh Δ fn x res) :
+    (Relation.ctx Γ f fn).relWfIn (Relation.sig Δ fn x res) := by
   intro g fn' hmem
   cases hmem with
   | head =>
@@ -947,10 +946,10 @@ theorem ctx_wfIn_relSig_of_headFresh
       exact ((subset_relBodySig_of_headFresh hfresh).trans
         (relBodySig_subset_relSig_of_headFresh hfresh)).binaryRel _ (hΓfn g fn' htail)
 
-theorem ctx_defWfIn_bodySig_of_headFresh
+theorem ctx_splitWfIn_bodySig_of_headFresh
     {Γ : FunCtx} {Δ : Signature} {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var}
-    (hΓdef : Γ.defWfIn Δ) (hfresh : HeadFresh Δ fn x res) :
-    (Relation.ctx Γ f fn).defWfIn (bodySig Δ fn x) := by
+    (hΓdef : Γ.splitWfIn Δ) (hfresh : HeadFresh Δ fn x res) :
+    (Relation.ctx Γ f fn).splitWfIn (bodySig Δ fn x) := by
   intro g fn' hmem
   cases hmem with
   | head =>
@@ -968,12 +967,12 @@ theorem ctx_defWfIn_bodySig_of_headFresh
               (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh)
           (fn.defined) (List.Mem.head _)
   | tail _ htail =>
-      exact FunCtx.defWfIn_mono hΓdef (subset_bodySig_of_headFresh hfresh) g fn' htail
+      exact FunCtx.splitWfIn_mono hΓdef (subset_bodySig_of_headFresh hfresh) g fn' htail
 
-theorem ctx_defWfIn_defvalBodySig_of_headFresh
+theorem ctx_splitWfIn_defvalBodySig_of_headFresh
     {Γ : FunCtx} {Δ : Signature} {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var}
-    (hΓdef : Γ.defWfIn Δ) (hfresh : HeadFresh Δ fn x res) :
-    (Relation.ctx Γ f fn).defWfIn (defvalBodySig Δ fn x) := by
+    (hΓdef : Γ.splitWfIn Δ) (hfresh : HeadFresh Δ fn x res) :
+    (Relation.ctx Γ f fn).splitWfIn (defvalBodySig Δ fn x) := by
   intro g fn' hmem
   cases hmem with
   | head =>
@@ -991,7 +990,7 @@ theorem ctx_defWfIn_defvalBodySig_of_headFresh
             (v := ⟨x, .value⟩) (var_fresh_splitBase_of_headFresh hfresh))
           (fn.defined) (List.Mem.head _)
   | tail _ htail =>
-      exact FunCtx.defWfIn_mono hΓdef (subset_defvalBodySig_of_headFresh hfresh)
+      exact FunCtx.splitWfIn_mono hΓdef (subset_defvalBodySig_of_headFresh hfresh)
         g fn' htail
 
 /-- If the split defined/value body encoder succeeds, the relational body
@@ -1001,12 +1000,12 @@ proofs. -/
 theorem encodeBody_relEncodeBody {Γ : FunCtx} {Δ : Signature}
     {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {body : DefVal}
-    (hΔ : Δ.wf) (hΓdef : Γ.defWfIn Δ) (hheadFresh : HeadFresh Δ fn x res)
+    (hΔ : Δ.wf) (hΓdef : Γ.splitWfIn Δ) (hheadFresh : HeadFresh Δ fn x res)
     (henc : encodeBody Γ Δ f fn x res e = .ok body) :
     ∃ φ, relEncodeBody Γ Δ f fn x res e = .ok φ := by
   have hΔbody : (bodySig Δ fn x).wf := bodySig_wf_of_headFresh hΔ hheadFresh
-  have hΓbody : (Relation.ctx Γ f fn).defWfIn (bodySig Δ fn x) :=
-    ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh
+  have hΓbody : (Relation.ctx Γ f fn).splitWfIn (bodySig Δ fn x) :=
+    ctx_splitWfIn_bodySig_of_headFresh hΓdef hheadFresh
   have hbinary :
       RelSucceedsWhenDef (Relation.ctx Γ f fn) (bodySig Δ fn x) (bodySig Δ fn x)
         default default
@@ -1043,12 +1042,12 @@ theorem encodeBody_wfIn_defvalBodySig
     {Γ : FunCtx} {Δ : Signature}
     {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {body : DefVal}
-    (hΔ : Δ.wf) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hΓdef : Γ.splitWfIn Δ)
     (hheadFresh : HeadFresh Δ fn x res)
     (henc : encodeBody Γ Δ f fn x res e = .ok body) :
     body.wfIn (defvalBodySig Δ fn x) :=
   encode_wfIn e (defvalBodySig_wf_of_headFresh hΔ hheadFresh)
-    (ctx_defWfIn_defvalBodySig_of_headFresh hΓdef hheadFresh)
+    (ctx_splitWfIn_defvalBodySig_of_headFresh hΓdef hheadFresh)
     henc
 
 theorem relEnv_relSplitEnv_agreeOn_relSig
@@ -1096,7 +1095,7 @@ theorem relEncodeBody_wfIn_relSig
     {Γ : FunCtx} {Δ : Signature}
     {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {φ : Formula}
-    (hΓfn : Γ.wfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
+    (hΓfn : Γ.relWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hrelEnc : relEncodeBody Γ Δ f fn x res e = .ok φ) :
     φ.wfIn (Relation.sig Δ fn x res) := by
   set m := encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
@@ -1113,7 +1112,7 @@ theorem relEncodeBody_wfIn_relSig
     encodeWith_indWithSig Relation.encoderOps_wf e
       (relBodySig_subset_relSig_of_headFresh hheadFresh)
       hsigWf
-      (ctx_wfIn_relSig_of_headFresh hΓfn hheadFresh)
+      (ctx_relWfIn_relSig_of_headFresh hΓfn hheadFresh)
       (fun y v hlookup =>
         Term.wfIn_mono v ((VarEnv.ofSignature_wfIn
           (relBodySig_wf_of_headFresh hΔ hheadFresh)) y v hlookup)
@@ -1160,19 +1159,19 @@ theorem splitEnv_relSplitEnv_agreeOn_defvalBodySig
 equivalent to the abstract semantic body operator. -/
 theorem rel_body_eval_iff
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {φ : Formula} {R : ValRel}
     {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
-    (hΓrel : Γ.wfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
-    (hrelEnc : relEncodeBody Γ Δ f rel x res e = .ok φ)
+    (hΓrel : Γ.relWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
+    (hrelEnc : relEncodeBody Γ Δ f fn x res e = .ok φ)
     (vin vout : Srt.value.denote) :
-    φ.eval (((relSplitEnv ρ rel R D F).updateConst .value x vin).updateConst
+    φ.eval (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst
         .value res vout) ↔
-      Relation.semanticBody Formula.sem ρ rel x res φ R vin vout := by
-  have hφwf : φ.wfIn (Relation.sig Δ rel x res) :=
+      Relation.semanticBody Formula.sem ρ fn x res φ R vin vout := by
+  have hφwf : φ.wfIn (Relation.sig Δ fn x res) :=
     relEncodeBody_wfIn_relSig hΓrel hΔ hheadFresh hrelEnc
   have hag :=
-    relEnv_relSplitEnv_agreeOn_relSig (Δ := Δ) (ρ := ρ) (fn := rel)
+    relEnv_relSplitEnv_agreeOn_relSig (Δ := Δ) (ρ := ρ) (fn := fn)
       (x := x) (res := res) (R := R) (D := D) (F := F) hheadFresh vin vout
   unfold Relation.semanticBody Formula.sem
   exact (Formula.eval_env_agree hφwf hag).symm

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
@@ -416,9 +416,9 @@ theorem relSucceedsWhenDef_call {Γ : FunCtx}
       hagRel Env.agreeOn_refl
       (Term.var .value ctx.r) (fn.call argDef) ctx.var_wf hcallWf heval
   obtain ⟨φ, hφ⟩ := hcont ctx.wf hΔdef hΓdef ctx.s' ctx.covers n hkn
-  exact ⟨.exists_ ctx.r .value (.and (fn.rel argRel (.var .value ctx.r)) φ), by
+  exact ⟨.exists_ ctx.r .value (.and (fn.relates argRel (.var .value ctx.r)) φ), by
     change (Rel.call fn argRel kRel) s =
-      .ok (.exists_ ctx.r .value (.and (fn.rel argRel (.var .value ctx.r)) φ))
+      .ok (.exists_ ctx.r .value (.and (fn.relates argRel (.var .value ctx.r)) φ))
     simp only [Rel.call]
     rw [← ctx.hr, ← ctx.hs', hφ]
     rfl⟩

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
@@ -402,23 +402,23 @@ theorem relSucceedsWhenDef_call {Γ : FunCtx}
   simp only [encoderOps] at hd
   obtain ⟨n, hkn, _hbody⟩ := DefVal.bind_ok hd
   let ctx := freshValueCtx s hΔrel hcov
-  have hcallWf : (SpecFn.call fn argDef).wfIn Δdef :=
+  have hcallWf : (fn.call argDef).wfIn Δdef :=
     SpecFn.call_wfIn (hΓdef f fn hmem).1 hΔdef hargDef
-  let w := (SpecFn.call fn argDef).eval ρdef
+  let w := (fn.call argDef).eval ρdef
   have hagRel : Env.agreeOn Δrel ρrel (ρrel.updateConst .value ctx.r w) :=
     Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) ctx.fresh
   have heval :
       Term.eval (ρrel.updateConst .value ctx.r w) (Term.var .value ctx.r) =
-        Term.eval ρdef (SpecFn.call fn argDef) := by
+        Term.eval ρdef (fn.call argDef) := by
     simp [Term.eval, Env.lookupConst_updateConst_same, w]
   have hcont :=
     hk ctx.subset (Signature.Subset.refl Δdef) ctx.wf hΔdef
       hagRel Env.agreeOn_refl
-      (Term.var .value ctx.r) (SpecFn.call fn argDef) ctx.var_wf hcallWf heval
+      (Term.var .value ctx.r) (fn.call argDef) ctx.var_wf hcallWf heval
   obtain ⟨φ, hφ⟩ := hcont ctx.wf hΔdef hΓdef ctx.s' ctx.covers n hkn
-  exact ⟨.exists_ ctx.r .value (.and (Formula.funcall fn argRel (.var .value ctx.r)) φ), by
+  exact ⟨.exists_ ctx.r .value (.and (fn.rel argRel (.var .value ctx.r)) φ), by
     change (Rel.call fn argRel kRel) s =
-      .ok (.exists_ ctx.r .value (.and (Formula.funcall fn argRel (.var .value ctx.r)) φ))
+      .ok (.exists_ ctx.r .value (.and (fn.rel argRel (.var .value ctx.r)) φ))
     simp only [Rel.call]
     rw [← ctx.hr, ← ctx.hs', hφ]
     rfl⟩
@@ -481,7 +481,7 @@ definedness predicate for `fn` at once. -/
 def relSplitEnv (ρ : Env) (fn : SpecFn)
     (R : ValRel) (D : Srt.value.denote → Prop)
     (F : Srt.value.denote → Srt.value.denote) : Env :=
-  ((ρ.updateBinaryRel .value .value fn R).updateUnary .value .value (fn.funcName) F)
+  ((ρ.updateBinaryRel .value .value fn.relName R).updateUnary .value .value (fn.funcName) F)
     |>.updateUnaryRel .value (fn.defName) D
 
 /-- Environment for evaluating a split encoded body at input `vin`, with
@@ -615,7 +615,7 @@ agree for every relation-marked function in the context. -/
 def FunCtx.splitCompatible (Γ : FunCtx) (ρ : Env) : Prop :=
   ∀ f fn, (f, fn) ∈ Γ →
     ∀ x y,
-      ρ.binaryRel .value .value fn x y ↔
+      ρ.binaryRel .value .value fn.relName x y ↔
         ρ.unaryRel .value (fn.defName) x ∧
           ρ.unary .value .value (fn.funcName) x = y
 
@@ -625,7 +625,7 @@ directional proofs. -/
 def FunCtx.splitComplete (Γ : FunCtx) (ρ : Env) : Prop :=
   ∀ f fn, (f, fn) ∈ Γ →
     ∀ x y,
-      ρ.binaryRel .value .value fn x y →
+      ρ.binaryRel .value .value fn.relName x y →
         ρ.unaryRel .value (fn.defName) x ∧
           ρ.unary .value .value (fn.funcName) x = y
 
@@ -637,7 +637,7 @@ def FunCtx.splitSound (Γ : FunCtx) (ρ : Env) : Prop :=
     ∀ x y,
       ρ.unaryRel .value (fn.defName) x ∧
         ρ.unary .value .value (fn.funcName) x = y →
-          ρ.binaryRel .value .value fn x y
+          ρ.binaryRel .value .value fn.relName x y
 
 theorem FunCtx.splitComplete_updateConst {Γ : FunCtx} {ρ : Env}
     (hΓ : Γ.splitComplete ρ) (τ : Srt) (x : String) (v : τ.denote) :
@@ -719,24 +719,24 @@ order in which `sig` introduces the head relation symbols and bound variables. -
 structure HeadFresh (Δ : Signature) (fn : SpecFn) (x res : String) : Prop where
   relFresh : fn ∉ Δ.allNames
   funFresh :
-    fn.funcName ∉ (Δ.addBinaryRel ⟨fn, .value, .value⟩).allNames
+    fn.funcName ∉ (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).allNames
   defFresh :
     fn.defName ∉
-    ((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).allNames
+    ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).allNames
   argFresh :
     x ∉
-    (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+    (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
       (fn.defined)).allNames
   resFresh :
     res ∉
-    ((((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+    ((((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
       (fn.defined)).declVar ⟨x, .value⟩).allNames
 
 /-! ### Subset lemmas -/
 
 theorem relBase_subset_bodyBase {Δ : Signature} {fn : SpecFn} :
-    (Δ.addBinaryRel ⟨fn, .value, .value⟩).Subset
-      (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+    (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).Subset
+      (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
         (fn.defined)) :=
   (Signature.Subset.subset_addUnary _ (fn.func)).trans
     (Signature.Subset.subset_addUnaryRel _ (fn.defined))
@@ -746,19 +746,19 @@ theorem subset_bodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : Stri
     Δ.Subset (bodySig Δ fn x) := by
   unfold bodySig
   exact
-    (((Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩).trans
+    (((Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩).trans
       (Signature.Subset.subset_addUnary _ (fn.func))).trans
       (Signature.Subset.subset_addUnaryRel _ (fn.defined))).trans
       (Signature.subset_declVar_of_fresh (Δ :=
-        (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+        (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
           (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh)
 
 theorem subset_relBodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
     (hfresh : HeadFresh Δ fn x res) :
     Δ.Subset (Relation.bodySig Δ fn x) := by
   unfold Relation.bodySig
-  exact (Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩).trans
-    (Signature.subset_declVar_of_fresh (Δ := Δ.addBinaryRel ⟨fn, .value, .value⟩)
+  exact (Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩).trans
+    (Signature.subset_declVar_of_fresh (Δ := Δ.addBinaryRel ⟨fn.relName, .value, .value⟩)
       (v := ⟨x, .value⟩) (by
         intro h
         exact hfresh.argFresh (Signature.allNames_subset
@@ -766,7 +766,7 @@ theorem subset_relBodySig_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : S
 
 theorem splitBase_subset_bodyBase {Δ : Signature} {fn : SpecFn} :
     ((Δ.addUnary (fn.func)).addUnaryRel (fn.defined)).Subset
-      (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+      (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
         (fn.defined)) := by
   refine ⟨?_, ?_, ?_, ?_, ?_, fun a ha => List.mem_cons_of_mem _ ha⟩ <;>
     intro a ha <;>
@@ -819,13 +819,13 @@ theorem bodySig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : String}
     (bodySig Δ fn x).wf := by
   unfold bodySig
   have hrel :
-      (Δ.addBinaryRel ⟨fn, .value, .value⟩).wf :=
+      (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).wf :=
     Signature.wf_addBinaryRel hΔ hfresh.relFresh
   have hfun :
-      ((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).wf :=
+      ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).wf :=
     Signature.wf_addUnary hrel hfresh.funFresh
   have hdef :
-      (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+      (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
         (fn.defined)).wf :=
     Signature.wf_addUnaryRel hfun hfresh.defFresh
   exact Signature.wf_declVar hdef
@@ -881,7 +881,7 @@ theorem defvalBodySig_wf_of_headFresh {Δ : Signature} {fn : SpecFn} {x res : St
     (Signature.wf_addUnaryRel
       (Signature.wf_addUnary hΔ (fun h =>
         hfresh.funFresh (Signature.allNames_subset
-          (Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩) _ h)))
+          (Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩) _ h)))
       (fun h =>
         hfresh.defFresh (Signature.allNames_subset
           (by
@@ -916,10 +916,10 @@ theorem freshFn_of_headFresh {Γ : FunCtx} {Δ : Signature} {fn : SpecFn} {x res
     exact hfresh.relFresh (h ▸ hrel'_mem)
   · intro h
     exact hfresh.funFresh (h ▸ Signature.allNames_subset
-      (Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩) _ hfun_mem)
+      (Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩) _ hfun_mem)
   · intro h
     exact hfresh.defFresh (h ▸ Signature.allNames_subset
-      ((Signature.Subset.subset_addBinaryRel Δ ⟨fn, .value, .value⟩).trans
+      ((Signature.Subset.subset_addBinaryRel Δ ⟨fn.relName, .value, .value⟩).trans
         (Signature.Subset.subset_addUnary _ (fn.func))) _ hdef_mem)
 
 
@@ -931,7 +931,7 @@ theorem ctx_relWfIn_relSig_of_headFresh
   cases hmem with
   | head =>
       have hxFresh :
-          x ∉ (Δ.addBinaryRel ⟨fn, .value, .value⟩).allNames := by
+          x ∉ (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).allNames := by
         intro h
         exact hfresh.argFresh (Signature.allNames_subset
           (relBase_subset_bodyBase (Δ := Δ) (fn := fn)) _ h)
@@ -939,7 +939,7 @@ theorem ctx_relWfIn_relSig_of_headFresh
         (by
           unfold Relation.bodySig
           exact (Signature.subset_declVar_of_fresh
-            (Δ := Δ.addBinaryRel ⟨fn, .value, .value⟩)
+            (Δ := Δ.addBinaryRel ⟨fn.relName, .value, .value⟩)
             (v := ⟨x, .value⟩) hxFresh).binaryRel _
             (List.Mem.head _))
   | tail _ htail =>
@@ -958,12 +958,12 @@ theorem ctx_splitWfIn_bodySig_of_headFresh
       · exact Signature.Subset.unary
           ((Signature.Subset.subset_addUnaryRel _ (fn.defined)).trans
             (Signature.subset_declVar_of_fresh (Δ :=
-              (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+              (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
                 (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh))
           (fn.func) (List.Mem.head _)
       · exact Signature.Subset.unaryRel
           (Signature.subset_declVar_of_fresh (Δ :=
-            (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary (fn.func)).addUnaryRel
+            (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary (fn.func)).addUnaryRel
               (fn.defined))) (v := ⟨x, .value⟩) hfresh.argFresh)
           (fn.defined) (List.Mem.head _)
   | tail _ htail =>
@@ -1058,36 +1058,36 @@ theorem relEnv_relSplitEnv_agreeOn_relSig
     Env.agreeOn (Relation.sig Δ fn x res)
       (Relation.relEnv ρ fn x res R vin vout)
       (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst .value res vout) := by
-  let ρbin := ρ.updateBinaryRel .value .value fn R
+  let ρbin := ρ.updateBinaryRel .value .value fn.relName R
   let ρfun := ρbin.updateUnary .value .value (fn.funcName) F
   have hbase :
-      Env.agreeOn (Δ.addBinaryRel ⟨fn, .value, .value⟩) ρbin
+      Env.agreeOn (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) ρbin
         (relSplitEnv ρ fn R D F) := by
-    have hfun : Env.agreeOn (Δ.addBinaryRel ⟨fn, .value, .value⟩) ρbin ρfun := by
+    have hfun : Env.agreeOn (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) ρbin ρfun := by
       simpa [ρbin, ρfun] using
         (Env.agreeOn_update_fresh_unary (ρ := ρbin) (u := fn.func)
-          (f := F) (Δ := Δ.addBinaryRel ⟨fn, .value, .value⟩) hfresh.funFresh)
+          (f := F) (Δ := Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) hfresh.funFresh)
     have hdef :
-        Env.agreeOn (Δ.addBinaryRel ⟨fn, .value, .value⟩) ρfun
+        Env.agreeOn (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) ρfun
           (relSplitEnv ρ fn R D F) := by
-      have hdefFresh : fn.defName ∉ (Δ.addBinaryRel ⟨fn, .value, .value⟩).allNames := by
+      have hdefFresh : fn.defName ∉ (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).allNames := by
         intro h
         exact hfresh.defFresh (Signature.allNames_subset
           (Signature.Subset.subset_addUnary _ (fn.func)) _ h)
       simpa [relSplitEnv, ρbin, ρfun] using
         (Env.agreeOn_update_fresh_unaryRel (ρ := ρfun) (u := fn.defined)
-          (f := D) (Δ := Δ.addBinaryRel ⟨fn, .value, .value⟩) hdefFresh)
+          (f := D) (Δ := Δ.addBinaryRel ⟨fn.relName, .value, .value⟩) hdefFresh)
     exact Env.agreeOn_trans hfun hdef
   simpa [Relation.relEnv, Relation.sig, Relation.bodySig] using
     (Env.agreeOn_declVar
       (Env.agreeOn_declVar hbase : Env.agreeOn
-        ((Δ.addBinaryRel ⟨fn, .value, .value⟩).declVar ⟨x, .value⟩)
-        ((ρ.updateBinaryRel .value .value fn R).updateConst .value x vin)
+        ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).declVar ⟨x, .value⟩)
+        ((ρ.updateBinaryRel .value .value fn.relName R).updateConst .value x vin)
         ((relSplitEnv ρ fn R D F).updateConst .value x vin)) :
       Env.agreeOn
-        (((Δ.addBinaryRel ⟨fn, .value, .value⟩).declVar ⟨x, .value⟩).declVar
+        (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).declVar ⟨x, .value⟩).declVar
           ⟨res, .value⟩)
-        (((ρ.updateBinaryRel .value .value fn R).updateConst .value x vin).updateConst
+        (((ρ.updateBinaryRel .value .value fn.relName R).updateConst .value x vin).updateConst
           .value res vout)
         (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst .value res vout))
 

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
@@ -106,8 +106,9 @@ theorem CompleteBinary.call
     have hargΔ : arg₁.wfIn Δ := Term.wfIn_mono _ harg₁ hsub1 hΔ
     have hargeval' : arg₁.eval (ρ₁.updateConst .value ctx.r w) = arg₁.eval ρ₁ :=
       ctx.eval_update_fresh hargΔ
-    have hcall' : ρ₁.binaryRel .value .value fn.relName (arg₁.eval ρ₁) w := by
-      simpa [SpecFn.rel, Formula.eval, BinPred.eval, Term.eval,
+    have hcall' : fn.evalRelates ρ₁ (arg₁.eval ρ₁) w := by
+      simpa [SpecFn.relates, SpecFn.evalRelates, SpecFn.rel,
+        Formula.eval, BinPred.eval, Term.eval,
         Env.updateConst_binaryRel, Env.lookupConst_updateConst_same, hargeval']
         using hcall
     have hsplit := hΓc f fn hmem (arg₁.eval ρ₁) w hcall'
@@ -117,12 +118,14 @@ theorem CompleteBinary.call
     have hunaryRel_eq : ρ₁.unaryRel .value (fn.defName) =
         ρ₂.unaryRel .value (fn.defName) :=
       hag.2.2.2.2.1 (fn.defined) hdef_mem
-    have hw_eq : w = ρ₂.unary .value .value (fn.funcName) (arg₂.eval ρ₂) := by
-      rw [← hsplit.2, congrFun hunary_eq (arg₁.eval ρ₁), hargeval]
+    have hevalCall_eq : fn.evalCall ρ₁ = fn.evalCall ρ₂ := hunary_eq
+    have hevalDef_eq : fn.evalDefined ρ₁ = fn.evalDefined ρ₂ := hunaryRel_eq
+    have hw_eq : w = fn.evalCall ρ₂ (arg₂.eval ρ₂) := by
+      rw [← hsplit.2, congrFun hevalCall_eq (arg₁.eval ρ₁), hargeval]
     have hisdef_ev : (fn.isDefined arg₂).eval ρ₂ := by
       have hu := hsplit.1
-      rw [congrFun hunaryRel_eq (arg₁.eval ρ₁), hargeval] at hu
-      simpa [SpecFn.isDefined, Formula.eval, UnPred.eval] using hu
+      rw [congrFun hevalDef_eq (arg₁.eval ρ₁), hargeval] at hu
+      simpa using hu
     -- recurse through the continuation
     have hsplit_upd : Γ.splitComplete (ρ₁.updateConst .value ctx.r w) :=
       FunCtx.splitComplete_updateConst hΓc .value ctx.r w
@@ -138,7 +141,8 @@ theorem CompleteBinary.call
     have heval_eq :
         Term.eval (ρ₁.updateConst .value ctx.r w) (Term.var .value ctx.r) =
           Term.eval ρ₂ (fn.call arg₂) := by
-      simp [Term.eval, SpecFn.call, UnOp.eval, Env.lookupConst_updateConst_same, hw_eq]
+      simp [Term.eval, SpecFn.call, SpecFn.evalCall, SpecFn.func, UnOp.eval,
+        Env.lookupConst_updateConst_same, hw_eq]
     have hcont :=
       hk (hsub1.trans ctx.subset) (Signature.Subset.refl Δ₂) ctx.wf hΔ₂
         hagree₁ Env.agreeOn_refl
@@ -281,19 +285,21 @@ theorem semrel_complete
       cases hmem with
       | head =>
           have hhead :
-              ρS.binaryRel .value .value fn.relName a b →
-                ρS.unaryRel .value (fn.defName) a ∧
-                  ρS.unary .value .value (fn.funcName) a = b := by
-            simp [ρS, relSplitEnv, S, Env.updateBinaryRel, Env.updateUnary,
+              fn.evalRelates ρS a b →
+                fn.evalDefined ρS a ∧ fn.evalCall ρS a = b := by
+            simp [SpecFn.evalRelates, SpecFn.evalDefined, SpecFn.evalCall,
+              SpecFn.rel, SpecFn.defined, SpecFn.func,
+              ρS, relSplitEnv, S, Env.updateBinaryRel, Env.updateUnary,
               Env.updateUnaryRel]
           exact hhead hcall
       | tail _ htail =>
           have hnames := freshFn_of_headFresh hΓwf hheadFresh g fn' htail
           have htailComplete :
-              ρS.binaryRel .value .value fn'.relName a b →
-                ρS.unaryRel .value (fn'.defName) a ∧
-                  ρS.unary .value .value (fn'.funcName) a = b := by
-            simpa [ρS, relSplitEnv, Env.updateBinaryRel, Env.updateUnary,
+              fn'.evalRelates ρS a b →
+                fn'.evalDefined ρS a ∧ fn'.evalCall ρS a = b := by
+            simpa [SpecFn.evalRelates, SpecFn.evalDefined, SpecFn.evalCall,
+              SpecFn.rel, SpecFn.defined, SpecFn.func,
+              ρS, relSplitEnv, Env.updateBinaryRel, Env.updateUnary,
               Env.updateUnaryRel, hnames.1, hnames.2.1, hnames.2.2]
               using (hΓ g fn' htail a b).mp
           exact htailComplete hcall

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
@@ -1,0 +1,356 @@
+-- SUMMARY: Completeness of Skolemization: relational encoding implies split definedness/value.
+import Mica.Verifier.RelationalEncoding.SkolemizeSoundness
+
+namespace Verifier.RelationalEncoding
+open Relation
+
+namespace Skolemize
+
+/-! ## The completeness binary relation
+
+`CompleteBinary Γ P res` is the relation fed to the generic
+`encodeWith_bind_binary` to transfer information *from* the relational
+encoding *to* the split defined/value encoding — the opposite direction of
+`SoundBinary`. As with soundness, `ρ₁` interprets the relational carrier and
+`ρ₂` the `DefVal` carrier, and the continuation contract is handled
+generically by `EncoderContSpec`. -/
+def CompleteBinary (Γ : FunCtx) (P : Env → Srt.value.denote → Prop) (res : String) :
+    Signature → Signature → Env → Env → Rel → Except String DefVal → Prop :=
+  fun Δ₁ Δ₂ ρ₁ ρ₂ m d =>
+    ∀ (Δ : Signature) (s : NameSupply) (φ : Formula) (body : DefVal),
+      Δ₂.Subset Δ₁ → Δ₂.wf → Γ.defWfIn Δ₂ →
+      Δ₁.Subset Δ → Δ.wf → s.Covers Δ →
+      (⟨res, .value⟩ : Var) ∈ Δ.vars →
+      m s = .ok φ →
+      d = .ok body →
+      body.wfIn Δ₂ →
+      Γ.splitComplete ρ₁ →
+      Env.agreeOn Δ₂ ρ₁ ρ₂ →
+      ρ₁.lookupConst .value res = ρ₂.lookupConst .value res →
+      φ.eval ρ₁ →
+      body.defined.eval ρ₂ ∧ P ρ₂ (body.value.eval ρ₂)
+
+/-- Completeness binary case for conditionals. The relational formula selects
+a branch, and the corresponding branch binary reconstructs the split
+definedness/value facts. -/
+theorem CompleteBinary.ite
+    {Γ : FunCtx} {P : Env → Srt.value.denote → Prop} {res : String}
+    {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
+    {c₁ c₂ : Term .bool} {t₁ e₁ : Rel} {t₂ e₂ : Except String DefVal}
+    (hceval : Term.eval ρ₁ c₁ = Term.eval ρ₂ c₂)
+    (ht : CompleteBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂ t₁ t₂)
+    (he : CompleteBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂ e₁ e₂) :
+  CompleteBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂
+      (Relation.encoderOps.ite c₁ t₁ e₁) (encoderOps.ite c₂ t₂ e₂) := by
+  intro Δ s φ body hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres hrun hd hbody hΓc hag hres_eq hφ
+  obtain ⟨dt, de, ht₂, he₂, rfl⟩ := encoderOps_ite_ok hd
+  obtain ⟨φt, φe, ht₁, he₁, rfl⟩ := relation_encoderOps_ite_ok hrun
+  have hdtwf : dt.wfIn Δ₂ := DefVal.wfIn_of_ite_then hbody
+  have hdewf : de.wfIn Δ₂ := DefVal.wfIn_of_ite_else hbody
+  simp only [Formula.iteBool, Formula.eval, Term.eval, Const.denote] at hφ
+  by_cases hc1 : c₁.eval ρ₁ = true
+  · have hc2 : c₂.eval ρ₂ = true := by rw [← hceval]; exact hc1
+    have hres' := ht Δ s φt dt hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres ht₁ ht₂
+      hdtwf hΓc hag hres_eq (hφ.1 hc1)
+    simp [DefVal.ite, Formula.iteBool, Formula.eval, Term.eval, Const.denote,
+      hc2, hres'.1, hres'.2]
+  · have hc1' : c₁.eval ρ₁ = false := by
+      cases h : c₁.eval ρ₁ <;> simp_all
+    have hc2 : c₂.eval ρ₂ = false := by rw [← hceval]; exact hc1'
+    have hres' := he Δ s φe de hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres he₁ he₂
+      hdewf hΓc hag hres_eq (hφ.2 hc1')
+    simp [DefVal.ite, Formula.iteBool, Formula.eval, Term.eval, Const.denote,
+      hc2, hres'.1, hres'.2]
+
+/-- Completeness binary case for calls. A relational call edge is converted
+back into split definedness/value facts using `Γ.splitComplete`, then the
+continuation binary handles the fresh result variable. -/
+theorem CompleteBinary.call
+    {Γ : FunCtx} {P : Env → Srt.value.denote → Prop} {res : String}
+    {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
+    {f rel : String} {arg₁ arg₂ : Term .value}
+    {k₁ : Term .value → Rel} {k₂ : Term .value → Except String DefVal}
+    (hmem : (f, rel) ∈ Γ)
+    (harg₁ : arg₁.wfIn Δ₁) (harg₂ : arg₂.wfIn Δ₂)
+    (hargeval : Term.eval ρ₁ arg₁ = Term.eval ρ₂ arg₂)
+    (hk : EncoderContSpec (CompleteBinary Γ P res) Δ₁ Δ₂ ρ₁ ρ₂ k₁ k₂) :
+    CompleteBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂
+      (Relation.encoderOps.call rel arg₁ k₁) (encoderOps.call rel arg₂ k₂) := by
+  intro Δ s φ body hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres hrun hd hbody hΓc hag hres_eq hφ
+  -- DefVal side: d = encoderOps.call rel arg₂ k₂ = DefVal.bind (DefVal.call rel arg₂) k₂
+  simp only [encoderOps] at hd
+  obtain ⟨n, hkn, hbodyeq⟩ := DefVal.bind_ok hd
+  simp only [DefVal.call] at hkn
+  subst hbodyeq
+  obtain ⟨hnval_wf, hisdef_wf, hndef_wf⟩ := hbody
+  have hnwf : n.wfIn Δ₂ := ⟨hnval_wf, hndef_wf⟩
+  have hfun_mem : SpecFn.func rel ∈ Δ₂.unary := (hΓdef f rel hmem).1
+  have hdef_mem : SpecFn.defined rel ∈ Δ₂.unaryRel := (hΓdef f rel hmem).2
+  -- Rel side: m = Rel.call rel arg₁ k₁
+  simp only [Relation.encoderOps, Rel.call] at hrun
+  let ctx := freshValueCtx s hΔ hcov
+  have hfreshΔ₁ : ctx.r ∉ Δ₁.allNames := ctx.fresh_of_subset hsub1
+  have hfreshΔ₂ : ctx.r ∉ Δ₂.allNames := ctx.fresh_of_subset (hsub21.trans hsub1)
+  have hr_ne_res : ctx.r ≠ res := ctx.ne_of_var_mem hres
+  cases hk₁run : k₁ (.var .value ctx.r) ctx.s' with
+  | error msg =>
+    rw [← ctx.hr, ← ctx.hs', hk₁run] at hrun
+    simp [Bind.bind, Except.bind] at hrun
+  | ok φ' =>
+    rw [← ctx.hr, ← ctx.hs', hk₁run] at hrun
+    simp only [Bind.bind, Except.bind, Except.ok.injEq] at hrun
+    subst hrun
+    -- the relational call edge supplies the witness
+    simp only [Formula.eval] at hφ
+    obtain ⟨w, hcall, hbody'⟩ := hφ
+    have hargΔ : arg₁.wfIn Δ := Term.wfIn_mono _ harg₁ hsub1 hΔ
+    have hargeval' : arg₁.eval (ρ₁.updateConst .value ctx.r w) = arg₁.eval ρ₁ :=
+      ctx.eval_update_fresh hargΔ
+    have hcall' : ρ₁.binaryRel .value .value rel (arg₁.eval ρ₁) w := by
+      simpa [Formula.funcall, Formula.eval, BinPred.eval, Term.eval,
+        Env.updateConst_binaryRel, Env.lookupConst_updateConst_same, hargeval']
+        using hcall
+    have hsplit := hΓc f rel hmem (arg₁.eval ρ₁) w hcall'
+    have hunary_eq : ρ₁.unary .value .value (SpecFn.funcName rel) =
+        ρ₂.unary .value .value (SpecFn.funcName rel) :=
+      hag.2.2.1 (SpecFn.func rel) hfun_mem
+    have hunaryRel_eq : ρ₁.unaryRel .value (SpecFn.defName rel) =
+        ρ₂.unaryRel .value (SpecFn.defName rel) :=
+      hag.2.2.2.2.1 (SpecFn.defined rel) hdef_mem
+    have hw_eq : w = ρ₂.unary .value .value (SpecFn.funcName rel) (arg₂.eval ρ₂) := by
+      rw [← hsplit.2, congrFun hunary_eq (arg₁.eval ρ₁), hargeval]
+    have hisdef_ev : (SpecFn.isDefined rel arg₂).eval ρ₂ := by
+      have hu := hsplit.1
+      rw [congrFun hunaryRel_eq (arg₁.eval ρ₁), hargeval] at hu
+      simpa [SpecFn.isDefined, Formula.eval, UnPred.eval] using hu
+    -- recurse through the continuation
+    have hsplit_upd : Γ.splitComplete (ρ₁.updateConst .value ctx.r w) :=
+      FunCtx.splitComplete_updateConst hΓc .value ctx.r w
+    have hag_upd : Env.agreeOn Δ₂ (ρ₁.updateConst .value ctx.r w) ρ₂ :=
+      Env.agreeOn_trans
+        (Env.agreeOn_symm
+          (Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₂))
+        hag
+    have hcallwf : (SpecFn.call rel arg₂).wfIn Δ₂ :=
+      SpecFn.call_wfIn hfun_mem hΔ₂ harg₂
+    have hagree₁ : Env.agreeOn Δ₁ ρ₁ (ρ₁.updateConst .value ctx.r w) :=
+      Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₁
+    have heval_eq :
+        Term.eval (ρ₁.updateConst .value ctx.r w) (Term.var .value ctx.r) =
+          Term.eval ρ₂ (SpecFn.call rel arg₂) := by
+      simp [Term.eval, SpecFn.call, UnOp.eval, Env.lookupConst_updateConst_same, hw_eq]
+    have hcont :=
+      hk (hsub1.trans ctx.subset) (Signature.Subset.refl Δ₂) ctx.wf hΔ₂
+        hagree₁ Env.agreeOn_refl
+        (Term.var .value ctx.r) (SpecFn.call rel arg₂) ctx.var_wf hcallwf heval_eq
+    have hrec := hcont ctx.Δ' ctx.s' φ' n
+      (hsub21.trans (hsub1.trans ctx.subset)) hΔ₂ hΓdef
+      (Signature.Subset.refl ctx.Δ') ctx.wf ctx.covers
+      (ctx.subset.vars _ hres) hk₁run hkn hnwf hsplit_upd hag_upd
+      (by rw [Env.lookupConst_updateConst_ne hr_ne_res.symm]; exact hres_eq)
+      hbody'
+    refine ⟨?_, hrec.2⟩
+    simp only [DefVal.call, Formula.eval]
+    exact ⟨hisdef_ev, hrec.1⟩
+
+/-- Operation-level binary data: the completeness relation is preserved by the
+encoder operations. As for soundness, `unop`/`binop` are handled generically
+by `encodeWith_bind_binary`, so only `call`, `ite` and `error` appear here. -/
+def completeBinary_ops (Γ : FunCtx) (P : Env → Srt.value.denote → Prop) (res : String) :
+    EncoderOpsBinary Γ Relation.encoderOps encoderOps (CompleteBinary Γ P res) where
+  error_binary := by
+    intro _Δ₁ _Δ₂ _ρ₁ _ρ₂ msg Δ s φ body _ _ _ _ _ _ _ _ hd _ _ _ _ _
+    simp [encoderOps] at hd
+  ite_binary := CompleteBinary.ite
+  call_binary := CompleteBinary.call
+
+/-- Pinned-result completeness, obtained directly from a successful paired
+encoding of the same expression: the relational formula implies the split
+body's definedness and value. -/
+theorem encodeWith_kEq_complete {Γ : FunCtx} {Δenc Δrun : Signature}
+    {srun : NameSupply} {ρ : Env}
+    {e : Typed.Expr} {body : DefVal}
+    {res : String} {φ : Formula}
+    (hrun : encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res) srun = .ok φ)
+    (hdef : encode Γ Δenc e = .ok body)
+    (hΓ : Γ.splitComplete ρ) (hΓdef : Γ.defWfIn Δenc)
+    (hΔenc : Δenc.wf) (hΔrun : Δrun.wf) (hcov : srun.Covers Δrun)
+    (hsub : Δenc.Subset Δrun)
+    (hbody : body.wfIn Δenc)
+    (hres : (⟨res, .value⟩ : Var) ∈ Δrun.vars) :
+    φ.eval ρ →
+      body.defined.eval ρ ∧ body.value.eval ρ = (Term.var .value res).eval ρ := by
+  intro hφ
+  have hbinary :
+      CompleteBinary Γ (fun ρ v => v = (Term.var .value res).eval ρ) res Δenc Δenc ρ ρ
+        (encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res))
+        (encodeWith encoderOps Γ (VarEnv.ofSignature Δenc) e (fun v => .ok (DefVal.pure v))) := by
+    refine encodeWith_bind_binary (δ₁ := VarEnv.ofSignature Δenc)
+      (δ₂ := VarEnv.ofSignature Δenc) (completeBinary_ops Γ _ res) e
+      (Signature.Subset.refl _) (Signature.Subset.refl _) hΔenc hΔenc
+      ?_ ?_
+    · exact varEnv_ofSignature_agree_self hΔenc
+    -- EncoderContSpec for the `(kEq res, pure)` continuation pair
+    intro Δ₁' Δ₂' ρ₁' ρ₂' _hs₁ _hs₂ _hw₁ _hw₂ _ha₁ _ha₂ v₁ v₂ _hv₁ _hv₂ heval Δ s φ' body'
+      _ _ _ _ _ _ _ hrun' hd' _ _ _ hres_eq' hφ'
+    simp only [Relation.kEq, Except.ok.injEq] at hrun'
+    simp only [Except.ok.injEq] at hd'
+    subst hd'
+    subst hrun'
+    simp only [DefVal.pure, Formula.eval, Term.eval] at hφ' ⊢
+    refine ⟨trivial, ?_⟩
+    rw [← heval, hφ', hres_eq']
+  exact hbinary Δrun srun φ body (Signature.Subset.refl _) hΔenc hΓdef hsub hΔrun hcov
+    hres hrun hdef hbody hΓ Env.agreeOn_refl rfl hφ
+
+/-! ## Transport between split and combined environments -/
+
+theorem defval_eval_transport_from_relSplit_final
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} {R : ValRel}
+    {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
+    (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓdef : Γ.defWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (vin vout : Srt.value.denote) :
+    body.defined.eval (((relSplitEnv ρ rel R D F).updateConst .value x vin).updateConst .value res vout) ∧
+        body.value.eval (((relSplitEnv ρ rel R D F).updateConst .value x vin).updateConst .value res vout) =
+          vout →
+      body.defined.eval ((splitEnv ρ rel D F).updateConst .value x vin) ∧
+        body.value.eval ((splitEnv ρ rel D F).updateConst .value x vin) =
+          vout := by
+  intro hsplit
+  have hbody : body.wfIn (defvalBodySig Δ rel x) :=
+    encodeBody_wfIn_defvalBodySig hΔ hΓdef hheadFresh henc
+  have hag := splitEnv_relSplitEnv_agreeOn_defvalBodySig
+    (ρ := ρ) (R := R) (D := D) (F := F) hheadFresh vin vout
+  exact ⟨(Formula.eval_env_agree hbody.2 hag).mpr hsplit.1,
+    (Term.eval_env_agree hbody.1 hag).trans hsplit.2⟩
+
+/-- A relational edge through the semantic body determines the split
+definedness predicate and the value computed by the split body. This is one
+half of the relation/split fixpoint equivalence. -/
+theorem semrel_complete
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ)
+    (vin vout : Srt.value.denote) :
+    semrel Γ Δ ρ f rel x res e vin vout →
+      semdef Γ Δ ρ f rel x res e body vin ∧
+      body.value.eval
+        ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin) =
+      vout := by
+  intro hrel
+  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓdef hheadFresh henc
+  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f rel)
+      (VarEnv.ofSignature (bodySig Δ rel x)) e (Relation.kEq res) with hm_def
+  have hrun : m (relBodySupply Δ rel x res) = .ok φ := by
+    have hvars :
+        VarEnv.ofSignature (bodySig Δ rel x) =
+          VarEnv.ofSignature (Relation.bodySig Δ rel x) := by
+      simp [VarEnv.ofSignature, bodySig, Relation.bodySig, Signature.declVar,
+        Signature.addBinaryRel, Signature.addUnary, Signature.addUnaryRel,
+        Signature.remove, Signature.addVar]
+    rw [hm_def, hvars]
+    simpa [Relation.relEncodeBody] using hrelEnc
+  have hbodyWf_body : body.wfIn (bodySig Δ rel x) :=
+    encode_wfIn e (bodySig_wf_of_headFresh hΔ hheadFresh)
+      (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh) (encodeBody_def_bodySig henc)
+  have hres_mem : (⟨res, .value⟩ : Var) ∈ (sig Δ rel x res).vars := by
+    unfold sig
+    exact Signature.var_mem_declVar _ ⟨res, .value⟩
+  let R : ValRel := semrel Γ Δ ρ f rel x res e
+  let D : Srt.value.denote → Prop := semdef Γ Δ ρ f rel x res e body
+  let F : Srt.value.denote → Srt.value.denote := semFunc R
+  let S : ValRel := fun x y => D x ∧ F x = y
+  have hrelEncR : Relation.relEncodeBody Γ Δ f rel x res e = .ok φ := by
+    exact hrelEnc
+  have hrel_eq :
+      R = Fix.lfp (Relation.semanticBody Formula.sem ρ rel x res φ) := by
+    simp [R, Relation.semrel, Relation.semanticFixpoint, hrelEncR]
+  have hpre :
+      Fix.le (Relation.semanticBody Formula.sem ρ rel x res φ S) S := by
+    intro vin vout hbody
+    let ρS := relSplitEnv ρ rel S D F
+    have hΓS : (Relation.ctx Γ f rel).splitComplete ρS := by
+      intro g rel' hmem a b hcall
+      cases hmem with
+      | head =>
+          have hhead :
+              ρS.binaryRel .value .value rel a b →
+                ρS.unaryRel .value (SpecFn.defName rel) a ∧
+                  ρS.unary .value .value (SpecFn.funcName rel) a = b := by
+            simp [ρS, relSplitEnv, S, Env.updateBinaryRel, Env.updateUnary,
+              Env.updateUnaryRel]
+          exact hhead hcall
+      | tail _ htail =>
+          have hnames := freshFn_of_headFresh hΓrel hΓdef hheadFresh g rel' htail
+          have htailComplete :
+              ρS.binaryRel .value .value rel' a b →
+                ρS.unaryRel .value (SpecFn.defName rel') a ∧
+                  ρS.unary .value .value (SpecFn.funcName rel') a = b := by
+            simpa [ρS, relSplitEnv, Env.updateBinaryRel, Env.updateUnary,
+              Env.updateUnaryRel, hnames.1, hnames.2.1, hnames.2.2]
+              using (hΓ g rel' htail a b).mp
+          exact htailComplete hcall
+    have hbodyρS :
+        φ.eval ((ρS.updateConst .value x vin).updateConst .value res vout) := by
+      simpa [ρS] using
+        (rel_body_eval_iff (D := D) (F := F) hΓrel hΔ hheadFresh hrelEnc vin vout).mpr hbody
+    have hproof :=
+      encodeWith_kEq_complete (Γ := Relation.ctx Γ f rel)
+        (Δenc := bodySig Δ rel x) (Δrun := sig Δ rel x res)
+        (srun := relBodySupply Δ rel x res)
+        (ρ := (ρS.updateConst .value x vin).updateConst .value res vout)
+        (e := e) (body := body) (res := res) (φ := φ)
+        hrun (encodeBody_def_bodySig henc)
+        (FunCtx.splitComplete_updateConst
+          (FunCtx.splitComplete_updateConst hΓS .value x vin) .value res vout)
+        (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh)
+        (bodySig_wf_of_headFresh hΔ hheadFresh)
+        (sig_wf_of_headFresh hΔ hheadFresh)
+        (relBodySupply_covers_sig Δ rel x res)
+        (bodySig_subset_sig_of_headFresh hheadFresh)
+        hbodyWf_body hres_mem
+    have hsplitρS :
+        body.defined.eval ((ρS.updateConst .value x vin).updateConst .value res vout) ∧
+          body.value.eval ((ρS.updateConst .value x vin).updateConst .value res vout) =
+            vout := by
+      simpa [Term.eval, Env.lookupConst_updateConst_same] using hproof hbodyρS
+    have hsplit :
+        body.defined.eval ((splitEnv ρ rel D F).updateConst .value x vin) ∧
+          body.value.eval ((splitEnv ρ rel D F).updateConst .value x vin) =
+            vout := by
+      exact defval_eval_transport_from_relSplit_final henc hΓdef hΔ hheadFresh
+        vin vout hsplitρS
+    have hdefined : D vin := by
+      exact (semdef_unfold_of_encode (ρ := ρ) (x := x) (res := res) henc vin).mpr
+        (by simpa [D, F, defBody, defEnv] using hsplit.1)
+    have hfun : F vin = vout := by
+      simpa [D, F, R, defInterpEnv] using
+        semFunc_eq_of_semdef_value henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+          vin vout (by simpa [D] using hdefined)
+          (by simpa [D, F, R, defInterpEnv] using hsplit.2)
+    exact ⟨hdefined, hfun⟩
+  have hlfp :
+      Fix.lfp (Relation.semanticBody Formula.sem ρ rel x res φ) vin vout := by
+    simpa [R, hrel_eq] using hrel
+  have hS : S vin vout := Fix.lfp_le_of_prefixed hpre vin vout hlfp
+  have hdefined : D vin := hS.1
+  let vbody :=
+    body.value.eval
+      ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin)
+  have hbody_eq_fun : vbody = F vin := by
+    have hfun : F vin = vbody := by
+      simpa [D, F, R, defInterpEnv, vbody] using
+        semFunc_eq_of_semdef_value henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+          vin vbody (by simpa [D] using hdefined) rfl
+    exact hfun.symm
+  exact ⟨by simpa [D] using hdefined, by simpa [vbody] using hbody_eq_fun.trans hS.2⟩
+
+end Skolemize
+end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
@@ -18,7 +18,7 @@ def CompleteBinary (Γ : FunCtx) (P : Env → Srt.value.denote → Prop) (res : 
     Signature → Signature → Env → Env → Rel → Except String DefVal → Prop :=
   fun Δ₁ Δ₂ ρ₁ ρ₂ m d =>
     ∀ (Δ : Signature) (s : NameSupply) (φ : Formula) (body : DefVal),
-      Δ₂.Subset Δ₁ → Δ₂.wf → Γ.defWfIn Δ₂ →
+      Δ₂.Subset Δ₁ → Δ₂.wf → Γ.splitWfIn Δ₂ →
       Δ₁.Subset Δ → Δ.wf → s.Covers Δ →
       (⟨res, .value⟩ : Var) ∈ Δ.vars →
       m s = .ok φ →
@@ -68,25 +68,25 @@ continuation binary handles the fresh result variable. -/
 theorem CompleteBinary.call
     {Γ : FunCtx} {P : Env → Srt.value.denote → Prop} {res : String}
     {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
-    {f rel : String} {arg₁ arg₂ : Term .value}
+    {f : TinyML.Var} {fn : SpecFn} {arg₁ arg₂ : Term .value}
     {k₁ : Term .value → Rel} {k₂ : Term .value → Except String DefVal}
-    (hmem : (f, rel) ∈ Γ)
+    (hmem : (f, fn) ∈ Γ)
     (harg₁ : arg₁.wfIn Δ₁) (harg₂ : arg₂.wfIn Δ₂)
     (hargeval : Term.eval ρ₁ arg₁ = Term.eval ρ₂ arg₂)
     (hk : EncoderContSpec (CompleteBinary Γ P res) Δ₁ Δ₂ ρ₁ ρ₂ k₁ k₂) :
     CompleteBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂
-      (Relation.encoderOps.call rel arg₁ k₁) (encoderOps.call rel arg₂ k₂) := by
+      (Relation.encoderOps.call fn arg₁ k₁) (encoderOps.call fn arg₂ k₂) := by
   intro Δ s φ body hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres hrun hd hbody hΓc hag hres_eq hφ
-  -- DefVal side: d = encoderOps.call rel arg₂ k₂ = DefVal.bind (DefVal.call rel arg₂) k₂
+  -- DefVal side: d = encoderOps.call fn arg₂ k₂ = DefVal.bind (DefVal.call fn arg₂) k₂
   simp only [encoderOps] at hd
   obtain ⟨n, hkn, hbodyeq⟩ := DefVal.bind_ok hd
   simp only [DefVal.call] at hkn
   subst hbodyeq
   obtain ⟨hnval_wf, hisdef_wf, hndef_wf⟩ := hbody
   have hnwf : n.wfIn Δ₂ := ⟨hnval_wf, hndef_wf⟩
-  have hfun_mem : SpecFn.func rel ∈ Δ₂.unary := (hΓdef f rel hmem).1
-  have hdef_mem : SpecFn.defined rel ∈ Δ₂.unaryRel := (hΓdef f rel hmem).2
-  -- Rel side: m = Rel.call rel arg₁ k₁
+  have hfun_mem : SpecFn.func fn ∈ Δ₂.unary := (hΓdef f fn hmem).1
+  have hdef_mem : SpecFn.defined fn ∈ Δ₂.unaryRel := (hΓdef f fn hmem).2
+  -- Rel side: m = Rel.call fn arg₁ k₁
   simp only [Relation.encoderOps, Rel.call] at hrun
   let ctx := freshValueCtx s hΔ hcov
   have hfreshΔ₁ : ctx.r ∉ Δ₁.allNames := ctx.fresh_of_subset hsub1
@@ -106,20 +106,20 @@ theorem CompleteBinary.call
     have hargΔ : arg₁.wfIn Δ := Term.wfIn_mono _ harg₁ hsub1 hΔ
     have hargeval' : arg₁.eval (ρ₁.updateConst .value ctx.r w) = arg₁.eval ρ₁ :=
       ctx.eval_update_fresh hargΔ
-    have hcall' : ρ₁.binaryRel .value .value rel (arg₁.eval ρ₁) w := by
+    have hcall' : ρ₁.binaryRel .value .value fn (arg₁.eval ρ₁) w := by
       simpa [Formula.funcall, Formula.eval, BinPred.eval, Term.eval,
         Env.updateConst_binaryRel, Env.lookupConst_updateConst_same, hargeval']
         using hcall
-    have hsplit := hΓc f rel hmem (arg₁.eval ρ₁) w hcall'
-    have hunary_eq : ρ₁.unary .value .value (SpecFn.funcName rel) =
-        ρ₂.unary .value .value (SpecFn.funcName rel) :=
-      hag.2.2.1 (SpecFn.func rel) hfun_mem
-    have hunaryRel_eq : ρ₁.unaryRel .value (SpecFn.defName rel) =
-        ρ₂.unaryRel .value (SpecFn.defName rel) :=
-      hag.2.2.2.2.1 (SpecFn.defined rel) hdef_mem
-    have hw_eq : w = ρ₂.unary .value .value (SpecFn.funcName rel) (arg₂.eval ρ₂) := by
+    have hsplit := hΓc f fn hmem (arg₁.eval ρ₁) w hcall'
+    have hunary_eq : ρ₁.unary .value .value (SpecFn.funcName fn) =
+        ρ₂.unary .value .value (SpecFn.funcName fn) :=
+      hag.2.2.1 (SpecFn.func fn) hfun_mem
+    have hunaryRel_eq : ρ₁.unaryRel .value (SpecFn.defName fn) =
+        ρ₂.unaryRel .value (SpecFn.defName fn) :=
+      hag.2.2.2.2.1 (SpecFn.defined fn) hdef_mem
+    have hw_eq : w = ρ₂.unary .value .value (SpecFn.funcName fn) (arg₂.eval ρ₂) := by
       rw [← hsplit.2, congrFun hunary_eq (arg₁.eval ρ₁), hargeval]
-    have hisdef_ev : (SpecFn.isDefined rel arg₂).eval ρ₂ := by
+    have hisdef_ev : (SpecFn.isDefined fn arg₂).eval ρ₂ := by
       have hu := hsplit.1
       rw [congrFun hunaryRel_eq (arg₁.eval ρ₁), hargeval] at hu
       simpa [SpecFn.isDefined, Formula.eval, UnPred.eval] using hu
@@ -131,18 +131,18 @@ theorem CompleteBinary.call
         (Env.agreeOn_symm
           (Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₂))
         hag
-    have hcallwf : (SpecFn.call rel arg₂).wfIn Δ₂ :=
+    have hcallwf : (SpecFn.call fn arg₂).wfIn Δ₂ :=
       SpecFn.call_wfIn hfun_mem hΔ₂ harg₂
     have hagree₁ : Env.agreeOn Δ₁ ρ₁ (ρ₁.updateConst .value ctx.r w) :=
       Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₁
     have heval_eq :
         Term.eval (ρ₁.updateConst .value ctx.r w) (Term.var .value ctx.r) =
-          Term.eval ρ₂ (SpecFn.call rel arg₂) := by
+          Term.eval ρ₂ (SpecFn.call fn arg₂) := by
       simp [Term.eval, SpecFn.call, UnOp.eval, Env.lookupConst_updateConst_same, hw_eq]
     have hcont :=
       hk (hsub1.trans ctx.subset) (Signature.Subset.refl Δ₂) ctx.wf hΔ₂
         hagree₁ Env.agreeOn_refl
-        (Term.var .value ctx.r) (SpecFn.call rel arg₂) ctx.var_wf hcallwf heval_eq
+        (Term.var .value ctx.r) (SpecFn.call fn arg₂) ctx.var_wf hcallwf heval_eq
     have hrec := hcont ctx.Δ' ctx.s' φ' n
       (hsub21.trans (hsub1.trans ctx.subset)) hΔ₂ hΓdef
       (Signature.Subset.refl ctx.Δ') ctx.wf ctx.covers
@@ -173,7 +173,7 @@ theorem encodeWith_kEq_complete {Γ : FunCtx} {Δenc Δrun : Signature}
     {res : String} {φ : Formula}
     (hrun : encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res) srun = .ok φ)
     (hdef : encode Γ Δenc e = .ok body)
-    (hΓ : Γ.splitComplete ρ) (hΓdef : Γ.defWfIn Δenc)
+    (hΓ : Γ.splitComplete ρ) (hΓdef : Γ.splitWfIn Δenc)
     (hΔenc : Δenc.wf) (hΔrun : Δrun.wf) (hcov : srun.Covers Δrun)
     (hsub : Δenc.Subset Δrun)
     (hbody : body.wfIn Δenc)
@@ -207,20 +207,20 @@ theorem encodeWith_kEq_complete {Γ : FunCtx} {Δenc Δrun : Signature}
 
 theorem defval_eval_transport_from_relSplit_final
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {body : DefVal} {R : ValRel}
     {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
-    (henc : encodeBody Γ Δ f rel x res e = .ok body)
-    (hΓdef : Γ.defWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (henc : encodeBody Γ Δ f fn x res e = .ok body)
+    (hΓdef : Γ.splitWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (vin vout : Srt.value.denote) :
-    body.defined.eval (((relSplitEnv ρ rel R D F).updateConst .value x vin).updateConst .value res vout) ∧
-        body.value.eval (((relSplitEnv ρ rel R D F).updateConst .value x vin).updateConst .value res vout) =
+    body.defined.eval (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst .value res vout) ∧
+        body.value.eval (((relSplitEnv ρ fn R D F).updateConst .value x vin).updateConst .value res vout) =
           vout →
-      body.defined.eval ((splitEnv ρ rel D F).updateConst .value x vin) ∧
-        body.value.eval ((splitEnv ρ rel D F).updateConst .value x vin) =
+      body.defined.eval ((splitEnv ρ fn D F).updateConst .value x vin) ∧
+        body.value.eval ((splitEnv ρ fn D F).updateConst .value x vin) =
           vout := by
   intro hsplit
-  have hbody : body.wfIn (defvalBodySig Δ rel x) :=
+  have hbody : body.wfIn (defvalBodySig Δ fn x) :=
     encodeBody_wfIn_defvalBodySig hΔ hΓdef hheadFresh henc
   have hag := splitEnv_relSplitEnv_agreeOn_defvalBodySig
     (ρ := ρ) (R := R) (D := D) (F := F) hheadFresh vin vout
@@ -232,88 +232,88 @@ definedness predicate and the value computed by the split body. This is one
 half of the relation/split fixpoint equivalence. -/
 theorem semrel_complete
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (vin vout : Srt.value.denote) :
-    semrel Γ Δ ρ f rel x res e vin vout →
-      semdef Γ Δ ρ f rel x res e body vin ∧
+    semrel Γ Δ ρ f fn x res e vin vout →
+      semdef Γ Δ ρ f fn x res e body vin ∧
       body.value.eval
-        ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin) =
+        ((defInterpEnv Γ Δ ρ f fn x res e body).updateConst .value x vin) =
       vout := by
   intro hrel
-  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓdef hheadFresh henc
-  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f rel)
-      (VarEnv.ofSignature (bodySig Δ rel x)) e (Relation.kEq res) with hm_def
-  have hrun : m (relBodySupply Δ rel x res) = .ok φ := by
+  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓwf.split hheadFresh henc
+  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
+      (VarEnv.ofSignature (bodySig Δ fn x)) e (Relation.kEq res) with hm_def
+  have hrun : m (relBodySupply Δ fn x res) = .ok φ := by
     have hvars :
-        VarEnv.ofSignature (bodySig Δ rel x) =
-          VarEnv.ofSignature (Relation.bodySig Δ rel x) := by
+        VarEnv.ofSignature (bodySig Δ fn x) =
+          VarEnv.ofSignature (Relation.bodySig Δ fn x) := by
       simp [VarEnv.ofSignature, bodySig, Relation.bodySig, Signature.declVar,
         Signature.addBinaryRel, Signature.addUnary, Signature.addUnaryRel,
         Signature.remove, Signature.addVar]
     rw [hm_def, hvars]
     simpa [Relation.relEncodeBody] using hrelEnc
-  have hbodyWf_body : body.wfIn (bodySig Δ rel x) :=
+  have hbodyWf_body : body.wfIn (bodySig Δ fn x) :=
     encode_wfIn e (bodySig_wf_of_headFresh hΔ hheadFresh)
-      (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh) (encodeBody_def_bodySig henc)
-  have hres_mem : (⟨res, .value⟩ : Var) ∈ (sig Δ rel x res).vars := by
+      (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh) (encodeBody_def_bodySig henc)
+  have hres_mem : (⟨res, .value⟩ : Var) ∈ (sig Δ fn x res).vars := by
     unfold sig
     exact Signature.var_mem_declVar _ ⟨res, .value⟩
-  let R : ValRel := semrel Γ Δ ρ f rel x res e
-  let D : Srt.value.denote → Prop := semdef Γ Δ ρ f rel x res e body
+  let R : ValRel := semrel Γ Δ ρ f fn x res e
+  let D : Srt.value.denote → Prop := semdef Γ Δ ρ f fn x res e body
   let F : Srt.value.denote → Srt.value.denote := semFunc R
   let S : ValRel := fun x y => D x ∧ F x = y
-  have hrelEncR : Relation.relEncodeBody Γ Δ f rel x res e = .ok φ := by
+  have hrelEncR : Relation.relEncodeBody Γ Δ f fn x res e = .ok φ := by
     exact hrelEnc
   have hrel_eq :
-      R = Fix.lfp (Relation.semanticBody Formula.sem ρ rel x res φ) := by
+      R = Fix.lfp (Relation.semanticBody Formula.sem ρ fn x res φ) := by
     simp [R, Relation.semrel, Relation.semanticFixpoint, hrelEncR]
   have hpre :
-      Fix.le (Relation.semanticBody Formula.sem ρ rel x res φ S) S := by
+      Fix.le (Relation.semanticBody Formula.sem ρ fn x res φ S) S := by
     intro vin vout hbody
-    let ρS := relSplitEnv ρ rel S D F
-    have hΓS : (Relation.ctx Γ f rel).splitComplete ρS := by
-      intro g rel' hmem a b hcall
+    let ρS := relSplitEnv ρ fn S D F
+    have hΓS : (Relation.ctx Γ f fn).splitComplete ρS := by
+      intro g fn' hmem a b hcall
       cases hmem with
       | head =>
           have hhead :
-              ρS.binaryRel .value .value rel a b →
-                ρS.unaryRel .value (SpecFn.defName rel) a ∧
-                  ρS.unary .value .value (SpecFn.funcName rel) a = b := by
+              ρS.binaryRel .value .value fn a b →
+                ρS.unaryRel .value (SpecFn.defName fn) a ∧
+                  ρS.unary .value .value (SpecFn.funcName fn) a = b := by
             simp [ρS, relSplitEnv, S, Env.updateBinaryRel, Env.updateUnary,
               Env.updateUnaryRel]
           exact hhead hcall
       | tail _ htail =>
-          have hnames := freshFn_of_headFresh hΓrel hΓdef hheadFresh g rel' htail
+          have hnames := freshFn_of_headFresh hΓwf hheadFresh g fn' htail
           have htailComplete :
-              ρS.binaryRel .value .value rel' a b →
-                ρS.unaryRel .value (SpecFn.defName rel') a ∧
-                  ρS.unary .value .value (SpecFn.funcName rel') a = b := by
+              ρS.binaryRel .value .value fn' a b →
+                ρS.unaryRel .value (SpecFn.defName fn') a ∧
+                  ρS.unary .value .value (SpecFn.funcName fn') a = b := by
             simpa [ρS, relSplitEnv, Env.updateBinaryRel, Env.updateUnary,
               Env.updateUnaryRel, hnames.1, hnames.2.1, hnames.2.2]
-              using (hΓ g rel' htail a b).mp
+              using (hΓ g fn' htail a b).mp
           exact htailComplete hcall
     have hbodyρS :
         φ.eval ((ρS.updateConst .value x vin).updateConst .value res vout) := by
       simpa [ρS] using
-        (rel_body_eval_iff (D := D) (F := F) hΓrel hΔ hheadFresh hrelEnc vin vout).mpr hbody
+        (rel_body_eval_iff (D := D) (F := F) hΓwf.rel hΔ hheadFresh hrelEnc vin vout).mpr hbody
     have hproof :=
-      encodeWith_kEq_complete (Γ := Relation.ctx Γ f rel)
-        (Δenc := bodySig Δ rel x) (Δrun := sig Δ rel x res)
-        (srun := relBodySupply Δ rel x res)
+      encodeWith_kEq_complete (Γ := Relation.ctx Γ f fn)
+        (Δenc := bodySig Δ fn x) (Δrun := sig Δ fn x res)
+        (srun := relBodySupply Δ fn x res)
         (ρ := (ρS.updateConst .value x vin).updateConst .value res vout)
         (e := e) (body := body) (res := res) (φ := φ)
         hrun (encodeBody_def_bodySig henc)
         (FunCtx.splitComplete_updateConst
           (FunCtx.splitComplete_updateConst hΓS .value x vin) .value res vout)
-        (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh)
+        (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
         (bodySig_wf_of_headFresh hΔ hheadFresh)
         (sig_wf_of_headFresh hΔ hheadFresh)
-        (relBodySupply_covers_sig Δ rel x res)
+        (relBodySupply_covers_sig Δ fn x res)
         (bodySig_subset_sig_of_headFresh hheadFresh)
         hbodyWf_body hres_mem
     have hsplitρS :
@@ -322,32 +322,32 @@ theorem semrel_complete
             vout := by
       simpa [Term.eval, Env.lookupConst_updateConst_same] using hproof hbodyρS
     have hsplit :
-        body.defined.eval ((splitEnv ρ rel D F).updateConst .value x vin) ∧
-          body.value.eval ((splitEnv ρ rel D F).updateConst .value x vin) =
+        body.defined.eval ((splitEnv ρ fn D F).updateConst .value x vin) ∧
+          body.value.eval ((splitEnv ρ fn D F).updateConst .value x vin) =
             vout := by
-      exact defval_eval_transport_from_relSplit_final henc hΓdef hΔ hheadFresh
+      exact defval_eval_transport_from_relSplit_final henc hΓwf.split hΔ hheadFresh
         vin vout hsplitρS
     have hdefined : D vin := by
       exact (semdef_unfold_of_encode (ρ := ρ) (x := x) (res := res) henc vin).mpr
         (by simpa [D, F, defBody, defEnv] using hsplit.1)
     have hfun : F vin = vout := by
       simpa [D, F, R, defInterpEnv] using
-        semFunc_eq_of_semdef_value henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+        semFunc_eq_of_semdef_value henc hΓ hΓwf hΔ hheadFresh hρdet
           vin vout (by simpa [D] using hdefined)
           (by simpa [D, F, R, defInterpEnv] using hsplit.2)
     exact ⟨hdefined, hfun⟩
   have hlfp :
-      Fix.lfp (Relation.semanticBody Formula.sem ρ rel x res φ) vin vout := by
+      Fix.lfp (Relation.semanticBody Formula.sem ρ fn x res φ) vin vout := by
     simpa [R, hrel_eq] using hrel
   have hS : S vin vout := Fix.lfp_le_of_prefixed hpre vin vout hlfp
   have hdefined : D vin := hS.1
   let vbody :=
     body.value.eval
-      ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin)
+      ((defInterpEnv Γ Δ ρ f fn x res e body).updateConst .value x vin)
   have hbody_eq_fun : vbody = F vin := by
     have hfun : F vin = vbody := by
       simpa [D, F, R, defInterpEnv, vbody] using
-        semFunc_eq_of_semdef_value henc hΓ hΓrel hΓdef hΔ hheadFresh hρdet
+        semFunc_eq_of_semdef_value henc hΓ hΓwf hΔ hheadFresh hρdet
           vin vbody (by simpa [D] using hdefined) rfl
     exact hfun.symm
   exact ⟨by simpa [D] using hdefined, by simpa [vbody] using hbody_eq_fun.trans hS.2⟩

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
@@ -84,8 +84,8 @@ theorem CompleteBinary.call
   subst hbodyeq
   obtain ⟨hnval_wf, hisdef_wf, hndef_wf⟩ := hbody
   have hnwf : n.wfIn Δ₂ := ⟨hnval_wf, hndef_wf⟩
-  have hfun_mem : SpecFn.func fn ∈ Δ₂.unary := (hΓdef f fn hmem).1
-  have hdef_mem : SpecFn.defined fn ∈ Δ₂.unaryRel := (hΓdef f fn hmem).2
+  have hfun_mem : fn.func ∈ Δ₂.unary := (hΓdef f fn hmem).1
+  have hdef_mem : fn.defined ∈ Δ₂.unaryRel := (hΓdef f fn hmem).2
   -- Rel side: m = Rel.call fn arg₁ k₁
   simp only [Relation.encoderOps, Rel.call] at hrun
   let ctx := freshValueCtx s hΔ hcov
@@ -106,20 +106,20 @@ theorem CompleteBinary.call
     have hargΔ : arg₁.wfIn Δ := Term.wfIn_mono _ harg₁ hsub1 hΔ
     have hargeval' : arg₁.eval (ρ₁.updateConst .value ctx.r w) = arg₁.eval ρ₁ :=
       ctx.eval_update_fresh hargΔ
-    have hcall' : ρ₁.binaryRel .value .value fn (arg₁.eval ρ₁) w := by
-      simpa [Formula.funcall, Formula.eval, BinPred.eval, Term.eval,
+    have hcall' : ρ₁.binaryRel .value .value fn.relName (arg₁.eval ρ₁) w := by
+      simpa [SpecFn.rel, Formula.eval, BinPred.eval, Term.eval,
         Env.updateConst_binaryRel, Env.lookupConst_updateConst_same, hargeval']
         using hcall
     have hsplit := hΓc f fn hmem (arg₁.eval ρ₁) w hcall'
-    have hunary_eq : ρ₁.unary .value .value (SpecFn.funcName fn) =
-        ρ₂.unary .value .value (SpecFn.funcName fn) :=
-      hag.2.2.1 (SpecFn.func fn) hfun_mem
-    have hunaryRel_eq : ρ₁.unaryRel .value (SpecFn.defName fn) =
-        ρ₂.unaryRel .value (SpecFn.defName fn) :=
-      hag.2.2.2.2.1 (SpecFn.defined fn) hdef_mem
-    have hw_eq : w = ρ₂.unary .value .value (SpecFn.funcName fn) (arg₂.eval ρ₂) := by
+    have hunary_eq : ρ₁.unary .value .value (fn.funcName) =
+        ρ₂.unary .value .value (fn.funcName) :=
+      hag.2.2.1 (fn.func) hfun_mem
+    have hunaryRel_eq : ρ₁.unaryRel .value (fn.defName) =
+        ρ₂.unaryRel .value (fn.defName) :=
+      hag.2.2.2.2.1 (fn.defined) hdef_mem
+    have hw_eq : w = ρ₂.unary .value .value (fn.funcName) (arg₂.eval ρ₂) := by
       rw [← hsplit.2, congrFun hunary_eq (arg₁.eval ρ₁), hargeval]
-    have hisdef_ev : (SpecFn.isDefined fn arg₂).eval ρ₂ := by
+    have hisdef_ev : (fn.isDefined arg₂).eval ρ₂ := by
       have hu := hsplit.1
       rw [congrFun hunaryRel_eq (arg₁.eval ρ₁), hargeval] at hu
       simpa [SpecFn.isDefined, Formula.eval, UnPred.eval] using hu
@@ -131,18 +131,18 @@ theorem CompleteBinary.call
         (Env.agreeOn_symm
           (Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₂))
         hag
-    have hcallwf : (SpecFn.call fn arg₂).wfIn Δ₂ :=
+    have hcallwf : (fn.call arg₂).wfIn Δ₂ :=
       SpecFn.call_wfIn hfun_mem hΔ₂ harg₂
     have hagree₁ : Env.agreeOn Δ₁ ρ₁ (ρ₁.updateConst .value ctx.r w) :=
       Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₁
     have heval_eq :
         Term.eval (ρ₁.updateConst .value ctx.r w) (Term.var .value ctx.r) =
-          Term.eval ρ₂ (SpecFn.call fn arg₂) := by
+          Term.eval ρ₂ (fn.call arg₂) := by
       simp [Term.eval, SpecFn.call, UnOp.eval, Env.lookupConst_updateConst_same, hw_eq]
     have hcont :=
       hk (hsub1.trans ctx.subset) (Signature.Subset.refl Δ₂) ctx.wf hΔ₂
         hagree₁ Env.agreeOn_refl
-        (Term.var .value ctx.r) (SpecFn.call fn arg₂) ctx.var_wf hcallwf heval_eq
+        (Term.var .value ctx.r) (fn.call arg₂) ctx.var_wf hcallwf heval_eq
     have hrec := hcont ctx.Δ' ctx.s' φ' n
       (hsub21.trans (hsub1.trans ctx.subset)) hΔ₂ hΓdef
       (Signature.Subset.refl ctx.Δ') ctx.wf ctx.covers
@@ -281,18 +281,18 @@ theorem semrel_complete
       cases hmem with
       | head =>
           have hhead :
-              ρS.binaryRel .value .value fn a b →
-                ρS.unaryRel .value (SpecFn.defName fn) a ∧
-                  ρS.unary .value .value (SpecFn.funcName fn) a = b := by
+              ρS.binaryRel .value .value fn.relName a b →
+                ρS.unaryRel .value (fn.defName) a ∧
+                  ρS.unary .value .value (fn.funcName) a = b := by
             simp [ρS, relSplitEnv, S, Env.updateBinaryRel, Env.updateUnary,
               Env.updateUnaryRel]
           exact hhead hcall
       | tail _ htail =>
           have hnames := freshFn_of_headFresh hΓwf hheadFresh g fn' htail
           have htailComplete :
-              ρS.binaryRel .value .value fn' a b →
-                ρS.unaryRel .value (SpecFn.defName fn') a ∧
-                  ρS.unary .value .value (SpecFn.funcName fn') a = b := by
+              ρS.binaryRel .value .value fn'.relName a b →
+                ρS.unaryRel .value (fn'.defName) a ∧
+                  ρS.unary .value .value (fn'.funcName) a = b := by
             simpa [ρS, relSplitEnv, Env.updateBinaryRel, Env.updateUnary,
               Env.updateUnaryRel, hnames.1, hnames.2.1, hnames.2.2]
               using (hΓ g fn' htail a b).mp

--- a/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
@@ -1,0 +1,419 @@
+-- SUMMARY: Soundness of Skolemization: split definedness/value implies the relational encoding.
+import Mica.Verifier.RelationalEncoding.SkolemizeCommon
+
+namespace Verifier.RelationalEncoding
+open Relation
+
+namespace Skolemize
+
+/-! ## The soundness binary relation
+
+`SoundBinary Γ P res` is the relation fed to the generic
+`encodeWith_bind_binary` to transfer information *from* the split
+defined/value encoding *to* the relational encoding. It is the soundness
+analogue of the old `Soundness` predicate, with the two interpreting
+environments threaded explicitly: `ρ₁` interprets the relational carrier and
+`ρ₂` the `DefVal` carrier. The continuation contract that used to be packaged
+as `RelContSemSoundness`/`BindSpec` is now handled generically by
+`EncoderContSpec`.
+
+`P` is an abstract value postcondition; `res` is the pinned result variable
+used by the top-level `kEq` continuation. -/
+def SoundBinary (Γ : FunCtx) (P : Env → Srt.value.denote → Prop) (res : String) :
+    Signature → Signature → Env → Env → Rel → Except String DefVal → Prop :=
+  fun Δ₁ Δ₂ ρ₁ ρ₂ m d =>
+    ∀ (Δ : Signature) (s : NameSupply) (φ : Formula) (body : DefVal),
+      Δ₂.Subset Δ₁ → Δ₂.wf → Γ.defWfIn Δ₂ →
+      Δ₁.Subset Δ → Δ.wf → s.Covers Δ →
+      (⟨res, .value⟩ : Var) ∈ Δ.vars →
+      m s = .ok φ →
+      d = .ok body →
+      body.wfIn Δ₂ →
+      Γ.splitSound ρ₁ →
+      Env.agreeOn Δ₂ ρ₁ ρ₂ →
+      ρ₁.lookupConst .value res = ρ₂.lookupConst .value res →
+      body.defined.eval ρ₂ →
+      P ρ₂ (body.value.eval ρ₂) →
+      φ.eval ρ₁
+
+/-- Soundness binary case for conditionals. The generic paired-encoding
+induction supplies binary hypotheses for both branches; this lemma unpacks the
+two successful carriers and dispatches to the branch selected by the condition. -/
+theorem SoundBinary.ite
+    {Γ : FunCtx} {P : Env → Srt.value.denote → Prop} {res : String}
+    {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
+    {c₁ c₂ : Term .bool} {t₁ e₁ : Rel} {t₂ e₂ : Except String DefVal}
+    (hceval : Term.eval ρ₁ c₁ = Term.eval ρ₂ c₂)
+    (ht : SoundBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂ t₁ t₂)
+    (he : SoundBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂ e₁ e₂) :
+  SoundBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂
+      (Relation.encoderOps.ite c₁ t₁ e₁) (encoderOps.ite c₂ t₂ e₂) := by
+  intro Δ s φ body hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres hrun hd hbody hΓs hag
+    hres_eq hdefd hP
+  obtain ⟨dt, de, ht₂, he₂, rfl⟩ :=
+    Skolemize.encoderOps_ite_ok hd
+  obtain ⟨φt, φe, ht₁, he₁, rfl⟩ :=
+    Skolemize.relation_encoderOps_ite_ok hrun
+  have hdtwf : dt.wfIn Δ₂ := DefVal.wfIn_of_ite_then hbody
+  have hdewf : de.wfIn Δ₂ := DefVal.wfIn_of_ite_else hbody
+  simp only [DefVal.ite, Formula.iteBool, Formula.eval, Term.eval, Const.denote]
+    at hdefd hP ⊢
+  constructor
+  · intro hc1
+    have hc2 : c₂.eval ρ₂ = true := by rw [← hceval]; exact hc1
+    refine ht Δ s φt dt hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres ht₁ ht₂
+      hdtwf hΓs hag hres_eq (hdefd.1 hc2) ?_
+    simpa [hc2] using hP
+  · intro hc1
+    have hc2 : c₂.eval ρ₂ = false := by rw [← hceval]; exact hc1
+    refine he Δ s φe de hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres he₁ he₂
+      hdewf hΓs hag hres_eq (hdefd.2 hc2) ?_
+    simpa [hc2] using hP
+
+/-- Soundness binary case for calls. A split call contributes the definedness
+and value-function facts; `Γ.splitSound` turns those facts into a relational
+edge, and the continuation runs under a fresh pinned result variable. -/
+theorem SoundBinary.call
+    {Γ : FunCtx} {P : Env → Srt.value.denote → Prop} {res : String}
+    {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
+    {f rel : String} {arg₁ arg₂ : Term .value}
+    {k₁ : Term .value → Rel} {k₂ : Term .value → Except String DefVal}
+    (hmem : (f, rel) ∈ Γ)
+    (harg₁ : arg₁.wfIn Δ₁) (harg₂ : arg₂.wfIn Δ₂)
+    (hargeval : Term.eval ρ₁ arg₁ = Term.eval ρ₂ arg₂)
+    (hk : EncoderContSpec (SoundBinary Γ P res) Δ₁ Δ₂ ρ₁ ρ₂ k₁ k₂) :
+    SoundBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂
+      (Relation.encoderOps.call rel arg₁ k₁) (encoderOps.call rel arg₂ k₂) := by
+  intro Δ s φ body hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres hrun hd hbody hΓs hag
+    hres_eq hdefd hP
+  -- DefVal side: d = encoderOps.call rel arg₂ k₂ = DefVal.bind (DefVal.call rel arg₂) k₂
+  simp only [encoderOps] at hd
+  obtain ⟨n, hkn, hbodyeq⟩ := DefVal.bind_ok hd
+  simp only [DefVal.call] at hkn
+  subst hbodyeq
+  -- decompose well-formedness, definedness, value postcondition
+  obtain ⟨hnval_wf, hisdef_wf, hndef_wf⟩ := hbody
+  simp only [Formula.eval] at hdefd
+  obtain ⟨hisdef_ev, hndef_ev⟩ := hdefd
+  have hnwf : n.wfIn Δ₂ := ⟨hnval_wf, hndef_wf⟩
+  have hfun_mem : SpecFn.func rel ∈ Δ₂.unary := (hΓdef f rel hmem).1
+  have hdef_mem : SpecFn.defined rel ∈ Δ₂.unaryRel := (hΓdef f rel hmem).2
+  -- Rel side: m = Rel.call rel arg₁ k₁
+  simp only [Relation.encoderOps, Rel.call] at hrun
+  let ctx := freshValueCtx s hΔ hcov
+  have hfreshΔ₁ : ctx.r ∉ Δ₁.allNames := ctx.fresh_of_subset hsub1
+  have hfreshΔ₂ : ctx.r ∉ Δ₂.allNames := ctx.fresh_of_subset (hsub21.trans hsub1)
+  have hr_ne_res : ctx.r ≠ res := ctx.ne_of_var_mem hres
+  cases hk₁run : k₁ (.var .value ctx.r) ctx.s' with
+  | error msg =>
+    rw [← ctx.hr, ← ctx.hs', hk₁run] at hrun
+    simp [Bind.bind, Except.bind] at hrun
+  | ok φ' =>
+    rw [← ctx.hr, ← ctx.hs', hk₁run] at hrun
+    simp only [Bind.bind, Except.bind, Except.ok.injEq] at hrun
+    subst hrun
+    -- existential witness
+    set w := ρ₂.unary .value .value (SpecFn.funcName rel) (arg₂.eval ρ₂) with hw
+    simp only [Formula.eval]
+    refine ⟨w, ?_, ?_⟩
+    · -- the relational call edge holds
+      have hunary_eq : ρ₁.unary .value .value (SpecFn.funcName rel) =
+          ρ₂.unary .value .value (SpecFn.funcName rel) :=
+        hag.2.2.1 (SpecFn.func rel) hfun_mem
+      have hunaryRel_eq : ρ₁.unaryRel .value (SpecFn.defName rel) =
+          ρ₂.unaryRel .value (SpecFn.defName rel) :=
+        hag.2.2.2.2.1 (SpecFn.defined rel) hdef_mem
+      have hisdef_ev' : ρ₂.unaryRel .value (SpecFn.defName rel) (arg₂.eval ρ₂) := by
+        simpa [SpecFn.isDefined, Formula.eval, UnPred.eval] using hisdef_ev
+      have hargΔ : arg₁.wfIn Δ := Term.wfIn_mono _ harg₁ hsub1 hΔ
+      have hargeval' : arg₁.eval (ρ₁.updateConst .value ctx.r w) = arg₁.eval ρ₁ :=
+        ctx.eval_update_fresh hargΔ
+      have hedge : ρ₁.binaryRel .value .value rel (arg₁.eval ρ₁) w := by
+        refine hΓs f rel hmem (arg₁.eval ρ₁) w ⟨?_, ?_⟩
+        · rw [congrFun hunaryRel_eq (arg₁.eval ρ₁), hargeval]
+          exact hisdef_ev'
+        · rw [congrFun hunary_eq (arg₁.eval ρ₁), hargeval, hw]
+      simpa [Formula.funcall, Formula.eval, BinPred.eval, Term.eval,
+        Env.updateConst_binaryRel, Env.lookupConst_updateConst_same, hargeval']
+        using hedge
+    · -- the continuation is sound
+      have hsplit_upd : Γ.splitSound (ρ₁.updateConst .value ctx.r w) :=
+        FunCtx.splitSound_updateConst hΓs .value ctx.r w
+      have hag_upd : Env.agreeOn Δ₂ (ρ₁.updateConst .value ctx.r w) ρ₂ :=
+        Env.agreeOn_trans
+          (Env.agreeOn_symm
+            (Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₂))
+          hag
+      have hcallwf : (SpecFn.call rel arg₂).wfIn Δ₂ :=
+        SpecFn.call_wfIn hfun_mem hΔ₂ harg₂
+      have hagree₁ : Env.agreeOn Δ₁ ρ₁ (ρ₁.updateConst .value ctx.r w) :=
+        Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₁
+      have heval_eq :
+          Term.eval (ρ₁.updateConst .value ctx.r w) (Term.var .value ctx.r) =
+            Term.eval ρ₂ (SpecFn.call rel arg₂) := by
+        simp [Term.eval, SpecFn.call, UnOp.eval, Env.lookupConst_updateConst_same, hw]
+      have hcont :=
+        hk (hsub1.trans ctx.subset) (Signature.Subset.refl Δ₂) ctx.wf hΔ₂
+          hagree₁ Env.agreeOn_refl
+          (Term.var .value ctx.r) (SpecFn.call rel arg₂) ctx.var_wf hcallwf heval_eq
+      exact hcont ctx.Δ' ctx.s' φ' n
+        (hsub21.trans (hsub1.trans ctx.subset)) hΔ₂ hΓdef
+        (Signature.Subset.refl ctx.Δ') ctx.wf ctx.covers
+        (ctx.subset.vars _ hres) hk₁run hkn hnwf hsplit_upd hag_upd
+        (by rw [Env.lookupConst_updateConst_ne hr_ne_res.symm]; exact hres_eq)
+        hndef_ev hP
+
+/-- Operation-level binary data: the soundness relation is preserved by the
+encoder operations. `unop`/`binop` are handled generically by
+`encodeWith_bind_binary`, so only `call`, `ite` and `error` appear here. -/
+def soundBinary_ops (Γ : FunCtx) (P : Env → Srt.value.denote → Prop) (res : String) :
+    EncoderOpsBinary Γ Relation.encoderOps encoderOps (SoundBinary Γ P res) where
+  error_binary := by
+    intro _Δ₁ _Δ₂ _ρ₁ _ρ₂ msg Δ s φ body _ _ _ _ _ _ _ _ hd _ _ _ _ _
+    simp [encoderOps] at hd
+  ite_binary := SoundBinary.ite
+  call_binary := SoundBinary.call
+
+/-- Pinned-result soundness, obtained directly from a successful paired
+encoding of the same expression: the split body's definedness and value
+imply the relational formula. -/
+theorem encodeWith_kEq_sound {Γ : FunCtx} {Δenc Δrun : Signature}
+    {srun : NameSupply} {ρ : Env}
+    {e : Typed.Expr} {body : DefVal}
+    {res : String} {φ : Formula}
+    (hrun : encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res) srun = .ok φ)
+    (hdef : encode Γ Δenc e = .ok body)
+    (hΓ : Γ.splitSound ρ) (hΓdef : Γ.defWfIn Δenc)
+    (hΔenc : Δenc.wf) (hΔrun : Δrun.wf) (hcov : srun.Covers Δrun)
+    (hsub : Δenc.Subset Δrun)
+    (hbody : body.wfIn Δenc)
+    (hres : (⟨res, .value⟩ : Var) ∈ Δrun.vars) :
+    body.defined.eval ρ ∧ body.value.eval ρ = (Term.var .value res).eval ρ →
+      φ.eval ρ := by
+  intro hsplit
+  have hbinary :
+      SoundBinary Γ (fun ρ v => v = (Term.var .value res).eval ρ) res Δenc Δenc ρ ρ
+        (encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res))
+        (encodeWith encoderOps Γ (VarEnv.ofSignature Δenc) e (fun v => .ok (DefVal.pure v))) := by
+    refine encodeWith_bind_binary (δ₁ := VarEnv.ofSignature Δenc)
+      (δ₂ := VarEnv.ofSignature Δenc) (soundBinary_ops Γ _ res) e
+      (Signature.Subset.refl _) (Signature.Subset.refl _) hΔenc hΔenc
+      ?_ ?_
+    · exact varEnv_ofSignature_agree_self hΔenc
+    -- EncoderContSpec for the `(kEq res, pure)` continuation pair
+    intro Δ₁' Δ₂' ρ₁' ρ₂' _hs₁ _hs₂ _hw₁ _hw₂ _ha₁ _ha₂ v₁ v₂ _hv₁ _hv₂ heval Δ s φ' body'
+      _ _ _ _ _ _ _ hrun' hd' _ _ _ hres_eq' _ hP'
+    simp only [Relation.kEq, Except.ok.injEq] at hrun'
+    simp only [Except.ok.injEq] at hd'
+    subst hd'
+    subst hrun'
+    simp only [DefVal.pure, Formula.eval, Term.eval] at hP' ⊢
+    rw [heval, hP', hres_eq']
+  exact hbinary Δrun srun φ body (Signature.Subset.refl _) hΔenc hΓdef hsub hΔrun hcov
+    hres hrun hdef hbody hΓ Env.agreeOn_refl rfl hsplit.1 hsplit.2
+
+/-! ## Transport between split and combined environments -/
+
+theorem defval_eval_transport_to_relSplit_domain
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} {R : ValRel}
+    {P : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
+    (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓdef : Γ.defWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (vin : Srt.value.denote)
+    (hdefBody : defBody ρ rel x body F P vin) :
+    let vbody := body.value.eval (defEnv ρ rel x P F vin)
+    body.defined.eval (((relSplitEnv ρ rel R P F).updateConst .value x vin).updateConst .value res vbody) ∧
+      body.value.eval (((relSplitEnv ρ rel R P F).updateConst .value x vin).updateConst .value res vbody) =
+        vbody := by
+  let vbody := body.value.eval (defEnv ρ rel x P F vin)
+  have hbody : body.wfIn (defvalBodySig Δ rel x) :=
+    encodeBody_wfIn_defvalBodySig hΔ hΓdef hheadFresh henc
+  have hag : Env.agreeOn (defvalBodySig Δ rel x)
+      (defEnv ρ rel x P F vin)
+      (((relSplitEnv ρ rel R P F).updateConst .value x vin).updateConst .value res vbody) :=
+    splitEnv_relSplitEnv_agreeOn_defvalBodySig (R := R) (D := P) (F := F)
+      hheadFresh vin vbody
+  exact ⟨(Formula.eval_env_agree hbody.2 hag).mp hdefBody,
+    (Term.eval_env_agree hbody.1 hag).symm⟩
+
+/-- Split definedness plus the split body value gives a relational edge. This
+is the converse half of the relation/split fixpoint equivalence. -/
+theorem semrel_sound
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (vin vout : Srt.value.denote) :
+    semdef Γ Δ ρ f rel x res e body vin →
+      body.value.eval
+        ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin) =
+      vout →
+      semrel Γ Δ ρ f rel x res e vin vout := by
+  intro hsem hval
+  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓdef hheadFresh henc
+  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f rel)
+      (VarEnv.ofSignature (bodySig Δ rel x)) e (Relation.kEq res) with hm_def
+  have hrun : m (relBodySupply Δ rel x res) = .ok φ := by
+    have hvars :
+        VarEnv.ofSignature (bodySig Δ rel x) =
+          VarEnv.ofSignature (Relation.bodySig Δ rel x) := by
+      simp [VarEnv.ofSignature, bodySig, Relation.bodySig, Signature.declVar,
+        Signature.addBinaryRel, Signature.addUnary, Signature.addUnaryRel,
+        Signature.remove, Signature.addVar]
+    rw [hm_def, hvars]
+    simpa [Relation.relEncodeBody] using hrelEnc
+  let R : ValRel := semrel Γ Δ ρ f rel x res e
+  let F : Srt.value.denote → Srt.value.denote := semFunc R
+  let D : Srt.value.denote → Prop := semdef Γ Δ ρ f rel x res e body
+  have hrelEncR : Relation.relEncodeBody Γ Δ f rel x res e = .ok φ := by
+    exact hrelEnc
+  have hrel_eq :
+      R = Fix.lfp (Relation.semanticBody Formula.sem ρ rel x res φ) := by
+    simp [R, Relation.semrel, Relation.semanticFixpoint, hrelEncR]
+  have hmMono : Rel.Mono m :=
+    encodeWith_ind Relation.encoderOps_preservesMono e (Relation.kEq_mono res)
+  have hmonoφ : SemanticMono Formula.sem φ :=
+    hmMono (relBodySupply Δ rel x res) φ hrun
+  have hpreR :
+      Fix.le (Relation.semanticBody Formula.sem ρ rel x res φ R) R := by
+    rw [hrel_eq]
+    exact Fix.lfp_prefixed (Relation.semanticBody_mono_of_semanticMono hmonoφ)
+  have hbodyWf_body : body.wfIn (bodySig Δ rel x) :=
+    encode_wfIn e (bodySig_wf_of_headFresh hΔ hheadFresh)
+      (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh) (encodeBody_def_bodySig henc)
+  have hres_mem : (⟨res, .value⟩ : Var) ∈ (sig Δ rel x res).vars := by
+    unfold sig
+    exact Signature.var_mem_declVar _ ⟨res, .value⟩
+  have hφ_of_split
+      {ρsplit : Env} {vin' vout' : Srt.value.denote}
+      (hΓsplit : (Relation.ctx Γ f rel).splitSound ρsplit)
+      (hsplit :
+        body.defined.eval ((ρsplit.updateConst .value x vin').updateConst .value res vout') ∧
+          body.value.eval ((ρsplit.updateConst .value x vin').updateConst .value res vout') =
+            vout') :
+      φ.eval ((ρsplit.updateConst .value x vin').updateConst .value res vout') :=
+    encodeWith_kEq_sound (Γ := Relation.ctx Γ f rel)
+      (Δenc := bodySig Δ rel x) (Δrun := sig Δ rel x res)
+      (srun := relBodySupply Δ rel x res)
+      (ρ := (ρsplit.updateConst .value x vin').updateConst .value res vout')
+      (e := e) (body := body) (res := res) (φ := φ)
+      hrun (encodeBody_def_bodySig henc)
+      (FunCtx.splitSound_updateConst
+        (FunCtx.splitSound_updateConst hΓsplit .value x vin') .value res vout')
+      (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh)
+      (bodySig_wf_of_headFresh hΔ hheadFresh)
+      (sig_wf_of_headFresh hΔ hheadFresh) (relBodySupply_covers_sig Δ rel x res)
+      (bodySig_subset_sig_of_headFresh hheadFresh)
+      hbodyWf_body hres_mem
+      (by simpa [Term.eval, Env.lookupConst_updateConst_same] using hsplit)
+  have hdomain :
+      UnaryFix.le D (semDefined R) := by
+    unfold D semdef
+    apply UnaryFix.lfp_le_of_prefixed
+    intro vin hdefBody
+    let P : Srt.value.denote → Prop := semDefined R
+    let vbody := body.value.eval (defEnv ρ rel x P F vin)
+    let ρP := relSplitEnv ρ rel R P F
+    have hΓP : (Relation.ctx Γ f rel).splitSound ρP := by
+      exact splitSound_cons_relSplitEnv
+        (FunCtx.splitSound_of_compatible hΓ)
+        (freshFn_of_headFresh hΓrel hΓdef hheadFresh)
+        (by
+          intro a b hsplit
+          have hcall : R a (F a) := semFunc_spec hsplit.1
+          simpa [hsplit.2] using hcall)
+    have hsplitP :
+        body.defined.eval ((ρP.updateConst .value x vin).updateConst .value res vbody) ∧
+          body.value.eval ((ρP.updateConst .value x vin).updateConst .value res vbody) =
+            vbody :=
+      defval_eval_transport_to_relSplit_domain (R := R) (P := P)
+        henc hΓdef hΔ hheadFresh vin hdefBody
+    have hφP :
+        φ.eval ((ρP.updateConst .value x vin).updateConst .value res vbody) :=
+      hφ_of_split hΓP hsplitP
+    have hbodyR : Relation.semanticBody Formula.sem ρ rel x res φ R vin vbody :=
+      (rel_body_eval_iff (D := P) (F := F) hΓrel hΔ hheadFresh hrelEnc vin vbody).mp hφP
+    exact ⟨vbody, hpreR vin vbody hbodyR⟩
+  have hdefBody :
+      defBody ρ rel x body F D vin := by
+    simpa [D, F] using
+      (semdef_unfold_of_encode (ρ := ρ) (x := x) (res := res) henc vin).mp hsem
+  let ρD := relSplitEnv ρ rel R D F
+  have hΓD : (Relation.ctx Γ f rel).splitSound ρD := by
+    exact splitSound_cons_relSplitEnv
+      (FunCtx.splitSound_of_compatible hΓ)
+      (freshFn_of_headFresh hΓrel hΓdef hheadFresh)
+      (by
+        intro a b hsplit
+        have hcall : R a (F a) := semFunc_spec (hdomain a hsplit.1)
+        simpa [hsplit.2] using hcall)
+  have hsplitD :
+      body.defined.eval ((ρD.updateConst .value x vin).updateConst .value res vout) ∧
+        body.value.eval ((ρD.updateConst .value x vin).updateConst .value res vout) =
+          vout := by
+    have hvalEq : body.value.eval (defEnv ρ rel x D F vin) = vout := by
+      simpa [D, F, R, defInterpEnv, defEnv] using hval
+    rw [← hvalEq]
+    exact defval_eval_transport_to_relSplit_domain (R := R) (P := D)
+      henc hΓdef hΔ hheadFresh vin hdefBody
+  have hφD :
+      φ.eval ((ρD.updateConst .value x vin).updateConst .value res vout) :=
+    hφ_of_split hΓD hsplitD
+  have hbodyR : Relation.semanticBody Formula.sem ρ rel x res φ R vin vout :=
+    (rel_body_eval_iff (D := D) (F := F) hΓrel hΔ hheadFresh hrelEnc vin vout).mp hφD
+  exact hpreR vin vout hbodyR
+
+theorem relation_semrel_functional_of_encodeBody
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
+    (hΔ : Δ.wf) (hΓfn : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hheadFresh : HeadFresh Δ fn x res)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ)
+    (vin y₁ y₂ : Srt.value.denote) :
+    semrel Γ Δ ρ f fn x res e vin y₁ →
+      semrel Γ Δ ρ f fn x res e vin y₂ →
+      y₁ = y₂ := by
+  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓdef hheadFresh henc
+  have hresFreshR : res ∉ (Relation.bodySig Δ fn x).allNames := by
+    intro hres
+    exact hheadFresh.resFresh (Signature.allNames_subset
+      (relBodySig_subset_bodySig (Δ := Δ) (fn := fn) (x := x)) _ hres)
+  exact Relation.semrel_functional hrelEnc hΓfn hheadFresh.relFresh
+    (relBodySig_wf_of_headFresh hΔ hheadFresh)
+    hresFreshR hρdet vin y₁ y₂
+
+/-- If the split body is defined at an input, then the body value is the
+canonical value chosen from the relational semantics. This is the exact
+soundness fact needed by the completeness direction when it builds the graph
+of the split interpretation inside the relational fixpoint. -/
+theorem semFunc_eq_of_semdef_value
+    {Γ : FunCtx} {Δ : Signature} {ρ : Env}
+    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    (hΓ : Γ.splitCompatible ρ)
+    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hρdet : Relation.BinaryRelDet Γ ρ ρ)
+    (vin vout : Srt.value.denote) :
+    semdef Γ Δ ρ f rel x res e body vin →
+      body.value.eval
+        ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin) =
+      vout →
+      semFunc (semrel Γ Δ ρ f rel x res e) vin = vout := by
+  intro hdefined hval
+  let R : ValRel := semrel Γ Δ ρ f rel x res e
+  have hrelBody : R vin vout := by
+    simpa [R] using
+      semrel_sound henc hΓ hΓrel hΓdef hΔ hheadFresh vin vout hdefined hval
+  have hdefinedR : semDefined R vin := ⟨vout, hrelBody⟩
+  have hchosen : R vin (semFunc R vin) := semFunc_spec hdefinedR
+  exact relation_semrel_functional_of_encodeBody henc hΔ hΓrel hΓdef hheadFresh hρdet vin
+      (semFunc R vin) vout (by simpa [R] using hchosen) (by simpa [R] using hrelBody)
+
+end Skolemize
+end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
@@ -96,8 +96,8 @@ theorem SoundBinary.call
   simp only [Formula.eval] at hdefd
   obtain ⟨hisdef_ev, hndef_ev⟩ := hdefd
   have hnwf : n.wfIn Δ₂ := ⟨hnval_wf, hndef_wf⟩
-  have hfun_mem : SpecFn.func fn ∈ Δ₂.unary := (hΓdef f fn hmem).1
-  have hdef_mem : SpecFn.defined fn ∈ Δ₂.unaryRel := (hΓdef f fn hmem).2
+  have hfun_mem : fn.func ∈ Δ₂.unary := (hΓdef f fn hmem).1
+  have hdef_mem : fn.defined ∈ Δ₂.unaryRel := (hΓdef f fn hmem).2
   -- Rel side: m = Rel.call fn arg₁ k₁
   simp only [Relation.encoderOps, Rel.call] at hrun
   let ctx := freshValueCtx s hΔ hcov
@@ -113,27 +113,27 @@ theorem SoundBinary.call
     simp only [Bind.bind, Except.bind, Except.ok.injEq] at hrun
     subst hrun
     -- existential witness
-    set w := ρ₂.unary .value .value (SpecFn.funcName fn) (arg₂.eval ρ₂) with hw
+    set w := ρ₂.unary .value .value (fn.funcName) (arg₂.eval ρ₂) with hw
     simp only [Formula.eval]
     refine ⟨w, ?_, ?_⟩
     · -- the relational call edge holds
-      have hunary_eq : ρ₁.unary .value .value (SpecFn.funcName fn) =
-          ρ₂.unary .value .value (SpecFn.funcName fn) :=
-        hag.2.2.1 (SpecFn.func fn) hfun_mem
-      have hunaryRel_eq : ρ₁.unaryRel .value (SpecFn.defName fn) =
-          ρ₂.unaryRel .value (SpecFn.defName fn) :=
-        hag.2.2.2.2.1 (SpecFn.defined fn) hdef_mem
-      have hisdef_ev' : ρ₂.unaryRel .value (SpecFn.defName fn) (arg₂.eval ρ₂) := by
+      have hunary_eq : ρ₁.unary .value .value (fn.funcName) =
+          ρ₂.unary .value .value (fn.funcName) :=
+        hag.2.2.1 (fn.func) hfun_mem
+      have hunaryRel_eq : ρ₁.unaryRel .value (fn.defName) =
+          ρ₂.unaryRel .value (fn.defName) :=
+        hag.2.2.2.2.1 (fn.defined) hdef_mem
+      have hisdef_ev' : ρ₂.unaryRel .value (fn.defName) (arg₂.eval ρ₂) := by
         simpa [SpecFn.isDefined, Formula.eval, UnPred.eval] using hisdef_ev
       have hargΔ : arg₁.wfIn Δ := Term.wfIn_mono _ harg₁ hsub1 hΔ
       have hargeval' : arg₁.eval (ρ₁.updateConst .value ctx.r w) = arg₁.eval ρ₁ :=
         ctx.eval_update_fresh hargΔ
-      have hedge : ρ₁.binaryRel .value .value fn (arg₁.eval ρ₁) w := by
+      have hedge : ρ₁.binaryRel .value .value fn.relName (arg₁.eval ρ₁) w := by
         refine hΓs f fn hmem (arg₁.eval ρ₁) w ⟨?_, ?_⟩
         · rw [congrFun hunaryRel_eq (arg₁.eval ρ₁), hargeval]
           exact hisdef_ev'
         · rw [congrFun hunary_eq (arg₁.eval ρ₁), hargeval, hw]
-      simpa [Formula.funcall, Formula.eval, BinPred.eval, Term.eval,
+      simpa [SpecFn.rel, Formula.eval, BinPred.eval, Term.eval,
         Env.updateConst_binaryRel, Env.lookupConst_updateConst_same, hargeval']
         using hedge
     · -- the continuation is sound
@@ -144,18 +144,18 @@ theorem SoundBinary.call
           (Env.agreeOn_symm
             (Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₂))
           hag
-      have hcallwf : (SpecFn.call fn arg₂).wfIn Δ₂ :=
+      have hcallwf : (fn.call arg₂).wfIn Δ₂ :=
         SpecFn.call_wfIn hfun_mem hΔ₂ harg₂
       have hagree₁ : Env.agreeOn Δ₁ ρ₁ (ρ₁.updateConst .value ctx.r w) :=
         Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₁
       have heval_eq :
           Term.eval (ρ₁.updateConst .value ctx.r w) (Term.var .value ctx.r) =
-            Term.eval ρ₂ (SpecFn.call fn arg₂) := by
+            Term.eval ρ₂ (fn.call arg₂) := by
         simp [Term.eval, SpecFn.call, UnOp.eval, Env.lookupConst_updateConst_same, hw]
       have hcont :=
         hk (hsub1.trans ctx.subset) (Signature.Subset.refl Δ₂) ctx.wf hΔ₂
           hagree₁ Env.agreeOn_refl
-          (Term.var .value ctx.r) (SpecFn.call fn arg₂) ctx.var_wf hcallwf heval_eq
+          (Term.var .value ctx.r) (fn.call arg₂) ctx.var_wf hcallwf heval_eq
       exact hcont ctx.Δ' ctx.s' φ' n
         (hsub21.trans (hsub1.trans ctx.subset)) hΔ₂ hΓdef
         (Signature.Subset.refl ctx.Δ') ctx.wf ctx.covers

--- a/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
@@ -113,7 +113,7 @@ theorem SoundBinary.call
     simp only [Bind.bind, Except.bind, Except.ok.injEq] at hrun
     subst hrun
     -- existential witness
-    set w := ρ₂.unary .value .value (fn.funcName) (arg₂.eval ρ₂) with hw
+    set w := fn.evalCall ρ₂ (arg₂.eval ρ₂) with hw
     simp only [Formula.eval]
     refine ⟨w, ?_, ?_⟩
     · -- the relational call edge holds
@@ -123,17 +123,23 @@ theorem SoundBinary.call
       have hunaryRel_eq : ρ₁.unaryRel .value (fn.defName) =
           ρ₂.unaryRel .value (fn.defName) :=
         hag.2.2.2.2.1 (fn.defined) hdef_mem
-      have hisdef_ev' : ρ₂.unaryRel .value (fn.defName) (arg₂.eval ρ₂) := by
-        simpa [SpecFn.isDefined, Formula.eval, UnPred.eval] using hisdef_ev
+      have hisdef_ev' : fn.evalDefined ρ₂ (arg₂.eval ρ₂) := by
+        simpa using hisdef_ev
       have hargΔ : arg₁.wfIn Δ := Term.wfIn_mono _ harg₁ hsub1 hΔ
       have hargeval' : arg₁.eval (ρ₁.updateConst .value ctx.r w) = arg₁.eval ρ₁ :=
         ctx.eval_update_fresh hargΔ
-      have hedge : ρ₁.binaryRel .value .value fn.relName (arg₁.eval ρ₁) w := by
+      have hevalDef_eq : fn.evalDefined ρ₁ = fn.evalDefined ρ₂ := hunaryRel_eq
+      have hevalCall_eq : fn.evalCall ρ₁ = fn.evalCall ρ₂ := hunary_eq
+      have hedge : fn.evalRelates ρ₁ (arg₁.eval ρ₁) w := by
         refine hΓs f fn hmem (arg₁.eval ρ₁) w ⟨?_, ?_⟩
-        · rw [congrFun hunaryRel_eq (arg₁.eval ρ₁), hargeval]
+        · rw [show fn.evalDefined ρ₁ (arg₁.eval ρ₁) =
+                fn.evalDefined ρ₂ (arg₁.eval ρ₁) from congrFun hevalDef_eq _,
+              hargeval]
           exact hisdef_ev'
-        · rw [congrFun hunary_eq (arg₁.eval ρ₁), hargeval, hw]
-      simpa [SpecFn.rel, Formula.eval, BinPred.eval, Term.eval,
+        · rw [show fn.evalCall ρ₁ (arg₁.eval ρ₁) =
+                fn.evalCall ρ₂ (arg₁.eval ρ₁) from congrFun hevalCall_eq _,
+              hargeval, hw]
+      simpa [SpecFn.relates, Formula.eval, BinPred.eval, Term.eval,
         Env.updateConst_binaryRel, Env.lookupConst_updateConst_same, hargeval']
         using hedge
     · -- the continuation is sound
@@ -151,7 +157,8 @@ theorem SoundBinary.call
       have heval_eq :
           Term.eval (ρ₁.updateConst .value ctx.r w) (Term.var .value ctx.r) =
             Term.eval ρ₂ (fn.call arg₂) := by
-        simp [Term.eval, SpecFn.call, UnOp.eval, Env.lookupConst_updateConst_same, hw]
+        simp [Term.eval, SpecFn.call, SpecFn.evalCall, SpecFn.func, UnOp.eval,
+          Env.lookupConst_updateConst_same, hw]
       have hcont :=
         hk (hsub1.trans ctx.subset) (Signature.Subset.refl Δ₂) ctx.wf hΔ₂
           hagree₁ Env.agreeOn_refl

--- a/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
@@ -23,7 +23,7 @@ def SoundBinary (Γ : FunCtx) (P : Env → Srt.value.denote → Prop) (res : Str
     Signature → Signature → Env → Env → Rel → Except String DefVal → Prop :=
   fun Δ₁ Δ₂ ρ₁ ρ₂ m d =>
     ∀ (Δ : Signature) (s : NameSupply) (φ : Formula) (body : DefVal),
-      Δ₂.Subset Δ₁ → Δ₂.wf → Γ.defWfIn Δ₂ →
+      Δ₂.Subset Δ₁ → Δ₂.wf → Γ.splitWfIn Δ₂ →
       Δ₁.Subset Δ → Δ.wf → s.Covers Δ →
       (⟨res, .value⟩ : Var) ∈ Δ.vars →
       m s = .ok φ →
@@ -76,17 +76,17 @@ edge, and the continuation runs under a fresh pinned result variable. -/
 theorem SoundBinary.call
     {Γ : FunCtx} {P : Env → Srt.value.denote → Prop} {res : String}
     {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
-    {f rel : String} {arg₁ arg₂ : Term .value}
+    {f : TinyML.Var} {fn : SpecFn} {arg₁ arg₂ : Term .value}
     {k₁ : Term .value → Rel} {k₂ : Term .value → Except String DefVal}
-    (hmem : (f, rel) ∈ Γ)
+    (hmem : (f, fn) ∈ Γ)
     (harg₁ : arg₁.wfIn Δ₁) (harg₂ : arg₂.wfIn Δ₂)
     (hargeval : Term.eval ρ₁ arg₁ = Term.eval ρ₂ arg₂)
     (hk : EncoderContSpec (SoundBinary Γ P res) Δ₁ Δ₂ ρ₁ ρ₂ k₁ k₂) :
     SoundBinary Γ P res Δ₁ Δ₂ ρ₁ ρ₂
-      (Relation.encoderOps.call rel arg₁ k₁) (encoderOps.call rel arg₂ k₂) := by
+      (Relation.encoderOps.call fn arg₁ k₁) (encoderOps.call fn arg₂ k₂) := by
   intro Δ s φ body hsub21 hΔ₂ hΓdef hsub1 hΔ hcov hres hrun hd hbody hΓs hag
     hres_eq hdefd hP
-  -- DefVal side: d = encoderOps.call rel arg₂ k₂ = DefVal.bind (DefVal.call rel arg₂) k₂
+  -- DefVal side: d = encoderOps.call fn arg₂ k₂ = DefVal.bind (DefVal.call fn arg₂) k₂
   simp only [encoderOps] at hd
   obtain ⟨n, hkn, hbodyeq⟩ := DefVal.bind_ok hd
   simp only [DefVal.call] at hkn
@@ -96,9 +96,9 @@ theorem SoundBinary.call
   simp only [Formula.eval] at hdefd
   obtain ⟨hisdef_ev, hndef_ev⟩ := hdefd
   have hnwf : n.wfIn Δ₂ := ⟨hnval_wf, hndef_wf⟩
-  have hfun_mem : SpecFn.func rel ∈ Δ₂.unary := (hΓdef f rel hmem).1
-  have hdef_mem : SpecFn.defined rel ∈ Δ₂.unaryRel := (hΓdef f rel hmem).2
-  -- Rel side: m = Rel.call rel arg₁ k₁
+  have hfun_mem : SpecFn.func fn ∈ Δ₂.unary := (hΓdef f fn hmem).1
+  have hdef_mem : SpecFn.defined fn ∈ Δ₂.unaryRel := (hΓdef f fn hmem).2
+  -- Rel side: m = Rel.call fn arg₁ k₁
   simp only [Relation.encoderOps, Rel.call] at hrun
   let ctx := freshValueCtx s hΔ hcov
   have hfreshΔ₁ : ctx.r ∉ Δ₁.allNames := ctx.fresh_of_subset hsub1
@@ -113,23 +113,23 @@ theorem SoundBinary.call
     simp only [Bind.bind, Except.bind, Except.ok.injEq] at hrun
     subst hrun
     -- existential witness
-    set w := ρ₂.unary .value .value (SpecFn.funcName rel) (arg₂.eval ρ₂) with hw
+    set w := ρ₂.unary .value .value (SpecFn.funcName fn) (arg₂.eval ρ₂) with hw
     simp only [Formula.eval]
     refine ⟨w, ?_, ?_⟩
     · -- the relational call edge holds
-      have hunary_eq : ρ₁.unary .value .value (SpecFn.funcName rel) =
-          ρ₂.unary .value .value (SpecFn.funcName rel) :=
-        hag.2.2.1 (SpecFn.func rel) hfun_mem
-      have hunaryRel_eq : ρ₁.unaryRel .value (SpecFn.defName rel) =
-          ρ₂.unaryRel .value (SpecFn.defName rel) :=
-        hag.2.2.2.2.1 (SpecFn.defined rel) hdef_mem
-      have hisdef_ev' : ρ₂.unaryRel .value (SpecFn.defName rel) (arg₂.eval ρ₂) := by
+      have hunary_eq : ρ₁.unary .value .value (SpecFn.funcName fn) =
+          ρ₂.unary .value .value (SpecFn.funcName fn) :=
+        hag.2.2.1 (SpecFn.func fn) hfun_mem
+      have hunaryRel_eq : ρ₁.unaryRel .value (SpecFn.defName fn) =
+          ρ₂.unaryRel .value (SpecFn.defName fn) :=
+        hag.2.2.2.2.1 (SpecFn.defined fn) hdef_mem
+      have hisdef_ev' : ρ₂.unaryRel .value (SpecFn.defName fn) (arg₂.eval ρ₂) := by
         simpa [SpecFn.isDefined, Formula.eval, UnPred.eval] using hisdef_ev
       have hargΔ : arg₁.wfIn Δ := Term.wfIn_mono _ harg₁ hsub1 hΔ
       have hargeval' : arg₁.eval (ρ₁.updateConst .value ctx.r w) = arg₁.eval ρ₁ :=
         ctx.eval_update_fresh hargΔ
-      have hedge : ρ₁.binaryRel .value .value rel (arg₁.eval ρ₁) w := by
-        refine hΓs f rel hmem (arg₁.eval ρ₁) w ⟨?_, ?_⟩
+      have hedge : ρ₁.binaryRel .value .value fn (arg₁.eval ρ₁) w := by
+        refine hΓs f fn hmem (arg₁.eval ρ₁) w ⟨?_, ?_⟩
         · rw [congrFun hunaryRel_eq (arg₁.eval ρ₁), hargeval]
           exact hisdef_ev'
         · rw [congrFun hunary_eq (arg₁.eval ρ₁), hargeval, hw]
@@ -144,18 +144,18 @@ theorem SoundBinary.call
           (Env.agreeOn_symm
             (Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₂))
           hag
-      have hcallwf : (SpecFn.call rel arg₂).wfIn Δ₂ :=
+      have hcallwf : (SpecFn.call fn arg₂).wfIn Δ₂ :=
         SpecFn.call_wfIn hfun_mem hΔ₂ harg₂
       have hagree₁ : Env.agreeOn Δ₁ ρ₁ (ρ₁.updateConst .value ctx.r w) :=
         Env.agreeOn_update_fresh_const (c := ⟨ctx.r, .value⟩) hfreshΔ₁
       have heval_eq :
           Term.eval (ρ₁.updateConst .value ctx.r w) (Term.var .value ctx.r) =
-            Term.eval ρ₂ (SpecFn.call rel arg₂) := by
+            Term.eval ρ₂ (SpecFn.call fn arg₂) := by
         simp [Term.eval, SpecFn.call, UnOp.eval, Env.lookupConst_updateConst_same, hw]
       have hcont :=
         hk (hsub1.trans ctx.subset) (Signature.Subset.refl Δ₂) ctx.wf hΔ₂
           hagree₁ Env.agreeOn_refl
-          (Term.var .value ctx.r) (SpecFn.call rel arg₂) ctx.var_wf hcallwf heval_eq
+          (Term.var .value ctx.r) (SpecFn.call fn arg₂) ctx.var_wf hcallwf heval_eq
       exact hcont ctx.Δ' ctx.s' φ' n
         (hsub21.trans (hsub1.trans ctx.subset)) hΔ₂ hΓdef
         (Signature.Subset.refl ctx.Δ') ctx.wf ctx.covers
@@ -183,7 +183,7 @@ theorem encodeWith_kEq_sound {Γ : FunCtx} {Δenc Δrun : Signature}
     {res : String} {φ : Formula}
     (hrun : encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res) srun = .ok φ)
     (hdef : encode Γ Δenc e = .ok body)
-    (hΓ : Γ.splitSound ρ) (hΓdef : Γ.defWfIn Δenc)
+    (hΓ : Γ.splitSound ρ) (hΓdef : Γ.splitWfIn Δenc)
     (hΔenc : Δenc.wf) (hΔrun : Δrun.wf) (hcov : srun.Covers Δrun)
     (hsub : Δenc.Subset Δrun)
     (hbody : body.wfIn Δenc)
@@ -216,23 +216,23 @@ theorem encodeWith_kEq_sound {Γ : FunCtx} {Δenc Δrun : Signature}
 
 theorem defval_eval_transport_to_relSplit_domain
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {body : DefVal} {R : ValRel}
     {P : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
-    (henc : encodeBody Γ Δ f rel x res e = .ok body)
-    (hΓdef : Γ.defWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (henc : encodeBody Γ Δ f fn x res e = .ok body)
+    (hΓdef : Γ.splitWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (vin : Srt.value.denote)
-    (hdefBody : defBody ρ rel x body F P vin) :
-    let vbody := body.value.eval (defEnv ρ rel x P F vin)
-    body.defined.eval (((relSplitEnv ρ rel R P F).updateConst .value x vin).updateConst .value res vbody) ∧
-      body.value.eval (((relSplitEnv ρ rel R P F).updateConst .value x vin).updateConst .value res vbody) =
+    (hdefBody : defBody ρ fn x body F P vin) :
+    let vbody := body.value.eval (defEnv ρ fn x P F vin)
+    body.defined.eval (((relSplitEnv ρ fn R P F).updateConst .value x vin).updateConst .value res vbody) ∧
+      body.value.eval (((relSplitEnv ρ fn R P F).updateConst .value x vin).updateConst .value res vbody) =
         vbody := by
-  let vbody := body.value.eval (defEnv ρ rel x P F vin)
-  have hbody : body.wfIn (defvalBodySig Δ rel x) :=
+  let vbody := body.value.eval (defEnv ρ fn x P F vin)
+  have hbody : body.wfIn (defvalBodySig Δ fn x) :=
     encodeBody_wfIn_defvalBodySig hΔ hΓdef hheadFresh henc
-  have hag : Env.agreeOn (defvalBodySig Δ rel x)
-      (defEnv ρ rel x P F vin)
-      (((relSplitEnv ρ rel R P F).updateConst .value x vin).updateConst .value res vbody) :=
+  have hag : Env.agreeOn (defvalBodySig Δ fn x)
+      (defEnv ρ fn x P F vin)
+      (((relSplitEnv ρ fn R P F).updateConst .value x vin).updateConst .value res vbody) :=
     splitEnv_relSplitEnv_agreeOn_defvalBodySig (R := R) (D := P) (F := F)
       hheadFresh vin vbody
   exact ⟨(Formula.eval_env_agree hbody.2 hag).mp hdefBody,
@@ -242,71 +242,71 @@ theorem defval_eval_transport_to_relSplit_domain
 is the converse half of the relation/split fixpoint equivalence. -/
 theorem semrel_sound
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (vin vout : Srt.value.denote) :
-    semdef Γ Δ ρ f rel x res e body vin →
+    semdef Γ Δ ρ f fn x res e body vin →
       body.value.eval
-        ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin) =
+        ((defInterpEnv Γ Δ ρ f fn x res e body).updateConst .value x vin) =
       vout →
-      semrel Γ Δ ρ f rel x res e vin vout := by
+      semrel Γ Δ ρ f fn x res e vin vout := by
   intro hsem hval
-  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓdef hheadFresh henc
-  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f rel)
-      (VarEnv.ofSignature (bodySig Δ rel x)) e (Relation.kEq res) with hm_def
-  have hrun : m (relBodySupply Δ rel x res) = .ok φ := by
+  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓwf.split hheadFresh henc
+  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
+      (VarEnv.ofSignature (bodySig Δ fn x)) e (Relation.kEq res) with hm_def
+  have hrun : m (relBodySupply Δ fn x res) = .ok φ := by
     have hvars :
-        VarEnv.ofSignature (bodySig Δ rel x) =
-          VarEnv.ofSignature (Relation.bodySig Δ rel x) := by
+        VarEnv.ofSignature (bodySig Δ fn x) =
+          VarEnv.ofSignature (Relation.bodySig Δ fn x) := by
       simp [VarEnv.ofSignature, bodySig, Relation.bodySig, Signature.declVar,
         Signature.addBinaryRel, Signature.addUnary, Signature.addUnaryRel,
         Signature.remove, Signature.addVar]
     rw [hm_def, hvars]
     simpa [Relation.relEncodeBody] using hrelEnc
-  let R : ValRel := semrel Γ Δ ρ f rel x res e
+  let R : ValRel := semrel Γ Δ ρ f fn x res e
   let F : Srt.value.denote → Srt.value.denote := semFunc R
-  let D : Srt.value.denote → Prop := semdef Γ Δ ρ f rel x res e body
-  have hrelEncR : Relation.relEncodeBody Γ Δ f rel x res e = .ok φ := by
+  let D : Srt.value.denote → Prop := semdef Γ Δ ρ f fn x res e body
+  have hrelEncR : Relation.relEncodeBody Γ Δ f fn x res e = .ok φ := by
     exact hrelEnc
   have hrel_eq :
-      R = Fix.lfp (Relation.semanticBody Formula.sem ρ rel x res φ) := by
+      R = Fix.lfp (Relation.semanticBody Formula.sem ρ fn x res φ) := by
     simp [R, Relation.semrel, Relation.semanticFixpoint, hrelEncR]
   have hmMono : Rel.Mono m :=
     encodeWith_ind Relation.encoderOps_preservesMono e (Relation.kEq_mono res)
   have hmonoφ : SemanticMono Formula.sem φ :=
-    hmMono (relBodySupply Δ rel x res) φ hrun
+    hmMono (relBodySupply Δ fn x res) φ hrun
   have hpreR :
-      Fix.le (Relation.semanticBody Formula.sem ρ rel x res φ R) R := by
+      Fix.le (Relation.semanticBody Formula.sem ρ fn x res φ R) R := by
     rw [hrel_eq]
     exact Fix.lfp_prefixed (Relation.semanticBody_mono_of_semanticMono hmonoφ)
-  have hbodyWf_body : body.wfIn (bodySig Δ rel x) :=
+  have hbodyWf_body : body.wfIn (bodySig Δ fn x) :=
     encode_wfIn e (bodySig_wf_of_headFresh hΔ hheadFresh)
-      (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh) (encodeBody_def_bodySig henc)
-  have hres_mem : (⟨res, .value⟩ : Var) ∈ (sig Δ rel x res).vars := by
+      (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh) (encodeBody_def_bodySig henc)
+  have hres_mem : (⟨res, .value⟩ : Var) ∈ (sig Δ fn x res).vars := by
     unfold sig
     exact Signature.var_mem_declVar _ ⟨res, .value⟩
   have hφ_of_split
       {ρsplit : Env} {vin' vout' : Srt.value.denote}
-      (hΓsplit : (Relation.ctx Γ f rel).splitSound ρsplit)
+      (hΓsplit : (Relation.ctx Γ f fn).splitSound ρsplit)
       (hsplit :
         body.defined.eval ((ρsplit.updateConst .value x vin').updateConst .value res vout') ∧
           body.value.eval ((ρsplit.updateConst .value x vin').updateConst .value res vout') =
             vout') :
       φ.eval ((ρsplit.updateConst .value x vin').updateConst .value res vout') :=
-    encodeWith_kEq_sound (Γ := Relation.ctx Γ f rel)
-      (Δenc := bodySig Δ rel x) (Δrun := sig Δ rel x res)
-      (srun := relBodySupply Δ rel x res)
+    encodeWith_kEq_sound (Γ := Relation.ctx Γ f fn)
+      (Δenc := bodySig Δ fn x) (Δrun := sig Δ fn x res)
+      (srun := relBodySupply Δ fn x res)
       (ρ := (ρsplit.updateConst .value x vin').updateConst .value res vout')
       (e := e) (body := body) (res := res) (φ := φ)
       hrun (encodeBody_def_bodySig henc)
       (FunCtx.splitSound_updateConst
         (FunCtx.splitSound_updateConst hΓsplit .value x vin') .value res vout')
-      (ctx_defWfIn_bodySig_of_headFresh hΓdef hheadFresh)
+      (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
       (bodySig_wf_of_headFresh hΔ hheadFresh)
-      (sig_wf_of_headFresh hΔ hheadFresh) (relBodySupply_covers_sig Δ rel x res)
+      (sig_wf_of_headFresh hΔ hheadFresh) (relBodySupply_covers_sig Δ fn x res)
       (bodySig_subset_sig_of_headFresh hheadFresh)
       hbodyWf_body hres_mem
       (by simpa [Term.eval, Env.lookupConst_updateConst_same] using hsplit)
@@ -316,12 +316,12 @@ theorem semrel_sound
     apply UnaryFix.lfp_le_of_prefixed
     intro vin hdefBody
     let P : Srt.value.denote → Prop := semDefined R
-    let vbody := body.value.eval (defEnv ρ rel x P F vin)
-    let ρP := relSplitEnv ρ rel R P F
-    have hΓP : (Relation.ctx Γ f rel).splitSound ρP := by
+    let vbody := body.value.eval (defEnv ρ fn x P F vin)
+    let ρP := relSplitEnv ρ fn R P F
+    have hΓP : (Relation.ctx Γ f fn).splitSound ρP := by
       exact splitSound_cons_relSplitEnv
         (FunCtx.splitSound_of_compatible hΓ)
-        (freshFn_of_headFresh hΓrel hΓdef hheadFresh)
+        (freshFn_of_headFresh hΓwf hheadFresh)
         (by
           intro a b hsplit
           have hcall : R a (F a) := semFunc_spec hsplit.1
@@ -331,22 +331,22 @@ theorem semrel_sound
           body.value.eval ((ρP.updateConst .value x vin).updateConst .value res vbody) =
             vbody :=
       defval_eval_transport_to_relSplit_domain (R := R) (P := P)
-        henc hΓdef hΔ hheadFresh vin hdefBody
+        henc hΓwf.split hΔ hheadFresh vin hdefBody
     have hφP :
         φ.eval ((ρP.updateConst .value x vin).updateConst .value res vbody) :=
       hφ_of_split hΓP hsplitP
-    have hbodyR : Relation.semanticBody Formula.sem ρ rel x res φ R vin vbody :=
-      (rel_body_eval_iff (D := P) (F := F) hΓrel hΔ hheadFresh hrelEnc vin vbody).mp hφP
+    have hbodyR : Relation.semanticBody Formula.sem ρ fn x res φ R vin vbody :=
+      (rel_body_eval_iff (D := P) (F := F) hΓwf.rel hΔ hheadFresh hrelEnc vin vbody).mp hφP
     exact ⟨vbody, hpreR vin vbody hbodyR⟩
   have hdefBody :
-      defBody ρ rel x body F D vin := by
+      defBody ρ fn x body F D vin := by
     simpa [D, F] using
       (semdef_unfold_of_encode (ρ := ρ) (x := x) (res := res) henc vin).mp hsem
-  let ρD := relSplitEnv ρ rel R D F
-  have hΓD : (Relation.ctx Γ f rel).splitSound ρD := by
+  let ρD := relSplitEnv ρ fn R D F
+  have hΓD : (Relation.ctx Γ f fn).splitSound ρD := by
     exact splitSound_cons_relSplitEnv
       (FunCtx.splitSound_of_compatible hΓ)
-      (freshFn_of_headFresh hΓrel hΓdef hheadFresh)
+      (freshFn_of_headFresh hΓwf hheadFresh)
       (by
         intro a b hsplit
         have hcall : R a (F a) := semFunc_spec (hdomain a hsplit.1)
@@ -355,35 +355,35 @@ theorem semrel_sound
       body.defined.eval ((ρD.updateConst .value x vin).updateConst .value res vout) ∧
         body.value.eval ((ρD.updateConst .value x vin).updateConst .value res vout) =
           vout := by
-    have hvalEq : body.value.eval (defEnv ρ rel x D F vin) = vout := by
+    have hvalEq : body.value.eval (defEnv ρ fn x D F vin) = vout := by
       simpa [D, F, R, defInterpEnv, defEnv] using hval
     rw [← hvalEq]
     exact defval_eval_transport_to_relSplit_domain (R := R) (P := D)
-      henc hΓdef hΔ hheadFresh vin hdefBody
+      henc hΓwf.split hΔ hheadFresh vin hdefBody
   have hφD :
       φ.eval ((ρD.updateConst .value x vin).updateConst .value res vout) :=
     hφ_of_split hΓD hsplitD
-  have hbodyR : Relation.semanticBody Formula.sem ρ rel x res φ R vin vout :=
-    (rel_body_eval_iff (D := D) (F := F) hΓrel hΔ hheadFresh hrelEnc vin vout).mp hφD
+  have hbodyR : Relation.semanticBody Formula.sem ρ fn x res φ R vin vout :=
+    (rel_body_eval_iff (D := D) (F := F) hΓwf.rel hΔ hheadFresh hrelEnc vin vout).mp hφD
   exact hpreR vin vout hbodyR
 
 theorem relation_semrel_functional_of_encodeBody
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
     {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
-    (hΔ : Δ.wf) (hΓfn : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
+    (hΔ : Δ.wf) (hΓwf : Γ.wfIn Δ)
     (hheadFresh : HeadFresh Δ fn x res)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (vin y₁ y₂ : Srt.value.denote) :
     semrel Γ Δ ρ f fn x res e vin y₁ →
       semrel Γ Δ ρ f fn x res e vin y₂ →
       y₁ = y₂ := by
-  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓdef hheadFresh henc
+  obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓwf.split hheadFresh henc
   have hresFreshR : res ∉ (Relation.bodySig Δ fn x).allNames := by
     intro hres
     exact hheadFresh.resFresh (Signature.allNames_subset
       (relBodySig_subset_bodySig (Δ := Δ) (fn := fn) (x := x)) _ hres)
-  exact Relation.semrel_functional hrelEnc hΓfn hheadFresh.relFresh
+  exact Relation.semrel_functional hrelEnc hΓwf.rel hheadFresh.relFresh
     (relBodySig_wf_of_headFresh hΔ hheadFresh)
     hresFreshR hρdet vin y₁ y₂
 
@@ -393,26 +393,26 @@ soundness fact needed by the completeness direction when it builds the graph
 of the split interpretation inside the relational fixpoint. -/
 theorem semFunc_eq_of_semdef_value
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
-    {f : TinyML.Var} {rel : String} {x res : TinyML.Var} {e : Typed.Expr}
-    {body : DefVal} (henc : encodeBody Γ Δ f rel x res e = .ok body)
+    {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
+    {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.splitCompatible ρ)
-    (hΓrel : Γ.wfIn Δ) (hΓdef : Γ.defWfIn Δ)
-    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ rel x res)
+    (hΓwf : Γ.wfIn Δ)
+    (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (vin vout : Srt.value.denote) :
-    semdef Γ Δ ρ f rel x res e body vin →
+    semdef Γ Δ ρ f fn x res e body vin →
       body.value.eval
-        ((defInterpEnv Γ Δ ρ f rel x res e body).updateConst .value x vin) =
+        ((defInterpEnv Γ Δ ρ f fn x res e body).updateConst .value x vin) =
       vout →
-      semFunc (semrel Γ Δ ρ f rel x res e) vin = vout := by
+      semFunc (semrel Γ Δ ρ f fn x res e) vin = vout := by
   intro hdefined hval
-  let R : ValRel := semrel Γ Δ ρ f rel x res e
+  let R : ValRel := semrel Γ Δ ρ f fn x res e
   have hrelBody : R vin vout := by
     simpa [R] using
-      semrel_sound henc hΓ hΓrel hΓdef hΔ hheadFresh vin vout hdefined hval
+      semrel_sound henc hΓ hΓwf hΔ hheadFresh vin vout hdefined hval
   have hdefinedR : semDefined R vin := ⟨vout, hrelBody⟩
   have hchosen : R vin (semFunc R vin) := semFunc_spec hdefinedR
-  exact relation_semrel_functional_of_encodeBody henc hΔ hΓrel hΓdef hheadFresh hρdet vin
+  exact relation_semrel_functional_of_encodeBody henc hΔ hΓwf hheadFresh hρdet vin
       (semFunc R vin) vout (by simpa [R] using hchosen) (by simpa [R] using hrelBody)
 
 end Skolemize

--- a/Mica/Verifier/RelationalEncoding/Variables.lean
+++ b/Mica/Verifier/RelationalEncoding/Variables.lean
@@ -151,23 +151,34 @@ theorem FunCtx.mem_of_lookup {Γ : FunCtx} {x : TinyML.Var} {fn : SpecFn}
 
 /-- Every relation in `Γ` is registered in `Δ` as a binary uninterpreted predicate
 on `value × value`. -/
-def FunCtx.wfIn (Γ : FunCtx) (Δ : Signature) : Prop :=
+def FunCtx.relWfIn (Γ : FunCtx) (Δ : Signature) : Prop :=
   ∀ x (fn : SpecFn), (x, fn) ∈ Γ → (⟨fn, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel
 
-theorem FunCtx.wfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
-    (h : Γ.wfIn Δ) (hsub : Δ.Subset Δ') : Γ.wfIn Δ' :=
+theorem FunCtx.relWfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
+    (h : Γ.relWfIn Δ) (hsub : Δ.Subset Δ') : Γ.relWfIn Δ' :=
   fun x fn hxr => hsub.binaryRel _ (h x fn hxr)
 
 /-- Every relation in `Γ` has its solver-facing value function and definedness
 predicate registered in `Δ`. -/
-def FunCtx.defWfIn (Γ : FunCtx) (Δ : Signature) : Prop :=
+def FunCtx.splitWfIn (Γ : FunCtx) (Δ : Signature) : Prop :=
   ∀ x (fn : SpecFn), (x, fn) ∈ Γ →
     fn.func ∈ Δ.unary ∧ fn.defined ∈ Δ.unaryRel
 
-theorem FunCtx.defWfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
-    (h : Γ.defWfIn Δ) (hsub : Δ.Subset Δ') : Γ.defWfIn Δ' := by
+theorem FunCtx.splitWfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
+    (h : Γ.splitWfIn Δ) (hsub : Δ.Subset Δ') : Γ.splitWfIn Δ' := by
   intro x fn hxr
   exact ⟨hsub.unary _ (h x fn hxr).1, hsub.unaryRel _ (h x fn hxr).2⟩
+
+/-- Bundled well-formedness: every relation in `Γ` has all three solver-facing
+symbols (the binary relation, the value function, and the definedness predicate)
+registered in `Δ`. -/
+structure FunCtx.wfIn (Γ : FunCtx) (Δ : Signature) : Prop where
+  rel : Γ.relWfIn Δ
+  split : Γ.splitWfIn Δ
+
+theorem FunCtx.wfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
+    (h : Γ.wfIn Δ) (hsub : Δ.Subset Δ') : Γ.wfIn Δ' :=
+  ⟨FunCtx.relWfIn_mono h.rel hsub, FunCtx.splitWfIn_mono h.split hsub⟩
 
 /-! ## Value-variable well-formedness -/
 

--- a/Mica/Verifier/RelationalEncoding/Variables.lean
+++ b/Mica/Verifier/RelationalEncoding/Variables.lean
@@ -79,6 +79,13 @@ theorem defName_ne_fn (f : SpecFn) : defName f ≠ f := by
     show ("-def" : String).length = 4 from rfl] at hlen
   omega
 
+theorem relName_ne_fn (f : SpecFn) : relName f ≠ f := by
+  intro h
+  have hlen := congrArg String.length h
+  simp only [relName, String.length_append,
+    show ("-rel" : String).length = 4 from rfl] at hlen
+  omega
+
 theorem defName_ne_funcName (f : SpecFn) :
     defName f ≠ funcName f := by
   intro h
@@ -87,6 +94,29 @@ theorem defName_ne_funcName (f : SpecFn) :
     show ("-func" : String).length = 5 from rfl,
     show ("-def" : String).length = 4 from rfl] at hlen
   omega
+
+theorem relName_ne_funcName (f : SpecFn) :
+    relName f ≠ funcName f := by
+  intro h
+  have hlen := congrArg String.length h
+  simp only [relName, funcName, String.length_append,
+    show ("-rel" : String).length = 4 from rfl,
+    show ("-func" : String).length = 5 from rfl] at hlen
+  omega
+
+theorem relName_ne_defName (f : SpecFn) :
+    relName f ≠ defName f := by
+  intro h
+  have hd := congrArg String.toList h
+  simp [relName, defName, String.toList_append,
+    show ("-rel" : String).toList = ['-','r','e','l'] from rfl,
+    show ("-def" : String).toList = ['-','d','e','f'] from rfl] at hd
+
+theorem funcName_ne_relName (f : SpecFn) : funcName f ≠ relName f :=
+  fun h => relName_ne_funcName f h.symm
+
+theorem defName_ne_relName (f : SpecFn) : defName f ≠ relName f :=
+  fun h => relName_ne_defName f h.symm
 
 /-- Solver-facing definedness predicate symbol for a spec-level function name. -/
 def defined (f : SpecFn) : FOL.UnaryRel :=
@@ -103,6 +133,10 @@ def call (f : SpecFn) (arg : Term .value) : Term .value :=
 /-- Apply the solver-facing definedness predicate for frontend function name `f`. -/
 def isDefined (f : SpecFn) (arg : Term .value) : Formula :=
   .unpred (.uninterpreted (defName f) .value) arg
+
+/-- Apply the solver-facing binary relation for frontend function name `f`. -/
+def rel (f : SpecFn) (arg res : Term .value) : Formula :=
+  .binpred (.uninterpreted (relName f) .value .value) arg res
 
 /-- A registered solver-facing value-function application is well-formed when
 its argument is well-formed. -/
@@ -128,6 +162,19 @@ theorem isDefined_wfIn {fn : SpecFn} {arg : Term .value} {Δ : Signature}
   · intro τ hrel'
     exact Signature.wf_unique_unaryRel hΔ hrel hrel'
 
+/-- A registered solver-facing relation application is well-formed when its
+arguments are well-formed. -/
+theorem rel_wfIn {fn : SpecFn} {arg res : Term .value} {Δ : Signature}
+    (hrel : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
+    (hΔ : Δ.wf) (harg : arg.wfIn Δ) (hres : res.wfIn Δ) :
+    (fn.rel arg res).wfIn Δ := by
+  refine ⟨?_, harg, hres⟩
+  refine ⟨hrel, ?_, ?_⟩
+  · intro τ₁ τ₂ τ₃ hb
+    exact Signature.wf_no_binaryRel_of_binary hΔ hb hrel
+  · intro τ₁ τ₂ hb
+    exact Signature.wf_unique_binaryRel hΔ hrel hb
+
 end SpecFn
 
 /-! ## Function context -/
@@ -152,7 +199,7 @@ theorem FunCtx.mem_of_lookup {Γ : FunCtx} {x : TinyML.Var} {fn : SpecFn}
 /-- Every relation in `Γ` is registered in `Δ` as a binary uninterpreted predicate
 on `value × value`. -/
 def FunCtx.relWfIn (Γ : FunCtx) (Δ : Signature) : Prop :=
-  ∀ x (fn : SpecFn), (x, fn) ∈ Γ → (⟨fn, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel
+  ∀ x (fn : SpecFn), (x, fn) ∈ Γ → (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel
 
 theorem FunCtx.relWfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
     (h : Γ.relWfIn Δ) (hsub : Δ.Subset Δ') : Γ.relWfIn Δ' :=
@@ -347,19 +394,19 @@ end VarEnv
 namespace Relation
 
 /-- Signature extended for encoding the body of `rec f x := e`: adds the input
-variable `x : value` and the binary predicate `rel ⊆ value × value`, but not
-the result variable. -/
-def bodySig (Δ : Signature) (rel : String) (x : TinyML.Var) : Signature :=
-  (Δ.addBinaryRel ⟨rel, .value, .value⟩).declVar ⟨x, .value⟩
+variable `x : value` and the binary predicate `fn.relName ⊆ value × value`, but
+not the result variable. -/
+def bodySig (Δ : Signature) (fn : SpecFn) (x : TinyML.Var) : Signature :=
+  (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).declVar ⟨x, .value⟩
 
-/-- Run signature: `bodySig Δ rel x` extended with the pinned result variable `r`. -/
-def sig (Δ : Signature) (rel : String) (x r : TinyML.Var) : Signature :=
-  (bodySig Δ rel x).declVar ⟨r, .value⟩
+/-- Run signature: `bodySig Δ fn x` extended with the pinned result variable `r`. -/
+def sig (Δ : Signature) (fn : SpecFn) (x r : TinyML.Var) : Signature :=
+  (bodySig Δ fn x).declVar ⟨r, .value⟩
 
 /-- Body supply: reserves base-signature names plus the relation symbol, the
 stage-2 split names, and the input and result variables. -/
 def relBodySupply (Δ : Signature) (fn : SpecFn) (x res : TinyML.Var) : NameSupply :=
-  { avoid := Δ.allNames ++ [fn, fn.funcName, fn.defName, x, res] }
+  { avoid := Δ.allNames ++ [fn.relName, fn.funcName, fn.defName, x, res] }
 
 end Relation
 
@@ -369,7 +416,7 @@ namespace Skolemize
 contains the binary relation, the split value/definedness symbols, and the
 input variable. -/
 def bodySig (Δ : Signature) (fn : SpecFn) (x : TinyML.Var) : Signature :=
-  ((((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary fn.func).addUnaryRel
+  ((((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary fn.func).addUnaryRel
     fn.defined).declVar ⟨x, .value⟩)
 
 /-- Common run signature used for the relational pinned-result continuation. -/
@@ -391,17 +438,17 @@ theorem relBodySupply_covers_sig (Δ : Signature) (fn : SpecFn) (x res : String)
     (relBodySupply Δ fn x res).Covers (sig Δ fn x res) := by
   intro n hn
   by_contra hcontra
-  have hnΔ   : n ∉ Δ.allNames  := fun h => hcontra (by simp [relBodySupply, h])
-  have hnRel : n ≠ fn          := fun h => hcontra (by simp [relBodySupply, h])
-  have hnFun : n ≠ fn.funcName := fun h => hcontra (by simp [relBodySupply, h])
-  have hnDef : n ≠ fn.defName  := fun h => hcontra (by simp [relBodySupply, h])
-  have hnX   : n ≠ x           := fun h => hcontra (by simp [relBodySupply, h])
-  have hnRes : n ≠ res         := fun h => hcontra (by simp [relBodySupply, h])
-  have h1 : n ∉ (Δ.addBinaryRel ⟨fn, .value, .value⟩).allNames :=
+  have hnΔ   : n ∉ Δ.allNames     := fun h => hcontra (by simp [relBodySupply, h])
+  have hnRel : n ≠ fn.relName     := fun h => hcontra (by simp [relBodySupply, h])
+  have hnFun : n ≠ fn.funcName    := fun h => hcontra (by simp [relBodySupply, h])
+  have hnDef : n ≠ fn.defName     := fun h => hcontra (by simp [relBodySupply, h])
+  have hnX   : n ≠ x              := fun h => hcontra (by simp [relBodySupply, h])
+  have hnRes : n ≠ res            := fun h => hcontra (by simp [relBodySupply, h])
+  have h1 : n ∉ (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).allNames :=
     Signature.not_mem_allNames_addBinaryRel hnΔ hnRel
-  have h2 : n ∉ ((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary fn.func).allNames :=
+  have h2 : n ∉ ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary fn.func).allNames :=
     Signature.not_mem_allNames_addUnary h1 (by simpa [SpecFn.func] using hnFun)
-  have h3 : n ∉ (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary fn.func).addUnaryRel
+  have h3 : n ∉ (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary fn.func).addUnaryRel
       fn.defined).allNames :=
     Signature.not_mem_allNames_addUnaryRel h2 (by simpa [SpecFn.defined] using hnDef)
   have h4 := Signature.not_mem_allNames_declVar h3 (show n ≠ (⟨x, .value⟩ : Var).name from hnX)

--- a/Mica/Verifier/RelationalEncoding/Variables.lean
+++ b/Mica/Verifier/RelationalEncoding/Variables.lean
@@ -135,7 +135,7 @@ def isDefined (f : SpecFn) (arg : Term .value) : Formula :=
   .unpred (.uninterpreted (defName f) .value) arg
 
 /-- Apply the solver-facing binary relation for frontend function name `f`. -/
-def rel (f : SpecFn) (arg res : Term .value) : Formula :=
+def relates (f : SpecFn) (arg res : Term .value) : Formula :=
   .binpred (.uninterpreted (relName f) .value .value) arg res
 
 /-- A registered solver-facing value-function application is well-formed when
@@ -164,10 +164,10 @@ theorem isDefined_wfIn {fn : SpecFn} {arg : Term .value} {Δ : Signature}
 
 /-- A registered solver-facing relation application is well-formed when its
 arguments are well-formed. -/
-theorem rel_wfIn {fn : SpecFn} {arg res : Term .value} {Δ : Signature}
+theorem relates_wfIn {fn : SpecFn} {arg res : Term .value} {Δ : Signature}
     (hrel : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
     (hΔ : Δ.wf) (harg : arg.wfIn Δ) (hres : res.wfIn Δ) :
-    (fn.rel arg res).wfIn Δ := by
+    (fn.relates arg res).wfIn Δ := by
   refine ⟨?_, harg, hres⟩
   refine ⟨hrel, ?_, ?_⟩
   · intro τ₁ τ₂ τ₃ hb

--- a/Mica/Verifier/RelationalEncoding/Variables.lean
+++ b/Mica/Verifier/RelationalEncoding/Variables.lean
@@ -1,0 +1,401 @@
+-- SUMMARY: Shared names, signatures, and freshness helpers for relational encoding.
+import Mica.FOL.Formulas
+import Mica.FOL.Fixpoint
+import Mica.TinyML.Typed
+import Mica.Base.Fresh
+
+namespace Verifier.RelationalEncoding
+
+/-! ## Name supply for fresh-name allocation -/
+
+/-- Avoid list used to generate fresh names. -/
+structure NameSupply where
+  avoid : List String
+
+/-- Allocate a name not in the avoid list, derived from `base`. -/
+def NameSupply.fresh (s : NameSupply) (base : String) : String :=
+  Fresh.freshName s.avoid base
+
+/-- Reserve a name in the supply so it is never returned by `fresh` again. -/
+def NameSupply.reserve (s : NameSupply) (name : String) : NameSupply :=
+  { avoid := name :: s.avoid }
+
+theorem NameSupply.fresh_not_in_avoid (s : NameSupply) (base : String) :
+    s.fresh base ∉ s.avoid :=
+  Fresh.freshName_not_in_avoid s.avoid base
+
+/-- A supply *covers* a signature when every name declared in the signature is
+already reserved. Reservation extends across `reserve`. -/
+def NameSupply.Covers (s : NameSupply) (Δ : Signature) : Prop :=
+  ∀ n, n ∈ Δ.allNames → n ∈ s.avoid
+
+theorem NameSupply.Covers.reserve {s : NameSupply} {Δ : Signature}
+    (h : s.Covers Δ) (name : String) : (s.reserve name).Covers Δ := by
+  intro n hn
+  exact List.mem_cons_of_mem _ (h n hn)
+
+/-- Reserving a name not currently in the signature covers the corresponding
+`declVar` extension. -/
+theorem NameSupply.Covers.declVar {s : NameSupply} {Δ : Signature}
+    (h : s.Covers Δ) (name : String) (τ : Srt) :
+    (s.reserve name).Covers (Δ.declVar ⟨name, τ⟩) := by
+  intro n hn
+  have hn' : n ∈ name :: (Δ.remove name).allNames := by
+    simpa [Signature.declVar, Signature.addVar, Signature.allNames] using hn
+  cases hn' with
+  | head => simp [NameSupply.reserve]
+  | tail _ ht =>
+    have hΔn : n ∈ Δ.allNames := Signature.remove_allNames_subset ht
+    exact List.mem_cons_of_mem _ (h n hΔn)
+
+/-- Frontend name of a specification-level function symbol. -/
+abbrev SpecFn := String
+
+namespace SpecFn
+
+/-- Solver-facing binary relation name derived from a spec function name. -/
+def relName (f : SpecFn) : String :=
+  f ++ "-rel"
+
+/-- Solver-facing value function name derived from a spec function name. -/
+def funcName (f : SpecFn) : String :=
+  f ++ "-func"
+
+/-- Solver-facing definedness predicate name derived from a spec function name. -/
+def defName (f : SpecFn) : String :=
+  f ++ "-def"
+
+theorem funcName_ne_fn (f : SpecFn) : funcName f ≠ f := by
+  intro h
+  have hlen := congrArg String.length h
+  simp only [funcName, String.length_append,
+    show ("-func" : String).length = 5 from rfl] at hlen
+  omega
+
+theorem defName_ne_fn (f : SpecFn) : defName f ≠ f := by
+  intro h
+  have hlen := congrArg String.length h
+  simp only [defName, String.length_append,
+    show ("-def" : String).length = 4 from rfl] at hlen
+  omega
+
+theorem defName_ne_funcName (f : SpecFn) :
+    defName f ≠ funcName f := by
+  intro h
+  have hlen := congrArg String.length h
+  simp only [defName, funcName, String.length_append,
+    show ("-func" : String).length = 5 from rfl,
+    show ("-def" : String).length = 4 from rfl] at hlen
+  omega
+
+/-- Solver-facing definedness predicate symbol for a spec-level function name. -/
+def defined (f : SpecFn) : FOL.UnaryRel :=
+  ⟨defName f, .value⟩
+
+/-- Solver-facing value function symbol for a spec-level function name. -/
+def func (f : SpecFn) : FOL.Unary :=
+  ⟨funcName f, .value, .value⟩
+
+/-- Apply the solver-facing value function for frontend function name `f`. -/
+def call (f : SpecFn) (arg : Term .value) : Term .value :=
+  .unop (.uninterpreted (funcName f) .value .value) arg
+
+/-- Apply the solver-facing definedness predicate for frontend function name `f`. -/
+def isDefined (f : SpecFn) (arg : Term .value) : Formula :=
+  .unpred (.uninterpreted (defName f) .value) arg
+
+/-- A registered solver-facing value-function application is well-formed when
+its argument is well-formed. -/
+theorem call_wfIn {fn : SpecFn} {arg : Term .value} {Δ : Signature}
+    (hfun : fn.func ∈ Δ.unary) (hΔ : Δ.wf) (harg : arg.wfIn Δ) :
+    (fn.call arg).wfIn Δ := by
+  refine ⟨?_, harg⟩
+  refine ⟨hfun, ?_, ?_⟩
+  · intro τ hrel
+    exact Signature.wf_no_unaryRel_of_unary hΔ hfun hrel
+  · intro τ₁ τ₂ hfun'
+    exact Signature.wf_unique_unary hΔ hfun hfun'
+
+/-- A registered solver-facing definedness-predicate application is
+well-formed when its argument is well-formed. -/
+theorem isDefined_wfIn {fn : SpecFn} {arg : Term .value} {Δ : Signature}
+    (hrel : fn.defined ∈ Δ.unaryRel) (hΔ : Δ.wf) (harg : arg.wfIn Δ) :
+    (fn.isDefined arg).wfIn Δ := by
+  refine ⟨?_, harg⟩
+  refine ⟨hrel, ?_, ?_⟩
+  · intro τ₁ τ₂ hfun
+    exact Signature.wf_no_unaryRel_of_unary hΔ hfun hrel
+  · intro τ hrel'
+    exact Signature.wf_unique_unaryRel hΔ hrel hrel'
+
+end SpecFn
+
+/-! ## Function context -/
+
+/-- Maps TinyML function names to spec-level function symbols. -/
+abbrev FunCtx := List (TinyML.Var × SpecFn)
+
+def FunCtx.lookup (Γ : FunCtx) (x : TinyML.Var) : Option SpecFn :=
+  (Γ.find? (·.1 == x)).map (·.2)
+
+theorem FunCtx.mem_of_lookup {Γ : FunCtx} {x : TinyML.Var} {fn : SpecFn}
+    (h : Γ.lookup x = some fn) : (x, fn) ∈ Γ := by
+  simp only [FunCtx.lookup, Option.map_eq_some_iff] at h
+  obtain ⟨⟨x', fn'⟩, hfind, hsnd⟩ := h
+  simp at hsnd
+  subst hsnd
+  have hp := List.find?_some hfind
+  simp at hp
+  subst hp
+  exact List.mem_of_find?_eq_some hfind
+
+/-- Every relation in `Γ` is registered in `Δ` as a binary uninterpreted predicate
+on `value × value`. -/
+def FunCtx.wfIn (Γ : FunCtx) (Δ : Signature) : Prop :=
+  ∀ x (fn : SpecFn), (x, fn) ∈ Γ → (⟨fn, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel
+
+theorem FunCtx.wfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
+    (h : Γ.wfIn Δ) (hsub : Δ.Subset Δ') : Γ.wfIn Δ' :=
+  fun x fn hxr => hsub.binaryRel _ (h x fn hxr)
+
+/-- Every relation in `Γ` has its solver-facing value function and definedness
+predicate registered in `Δ`. -/
+def FunCtx.defWfIn (Γ : FunCtx) (Δ : Signature) : Prop :=
+  ∀ x (fn : SpecFn), (x, fn) ∈ Γ →
+    fn.func ∈ Δ.unary ∧ fn.defined ∈ Δ.unaryRel
+
+theorem FunCtx.defWfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
+    (h : Γ.defWfIn Δ) (hsub : Δ.Subset Δ') : Γ.defWfIn Δ' := by
+  intro x fn hxr
+  exact ⟨hsub.unary _ (h x fn hxr).1, hsub.unaryRel _ (h x fn hxr).2⟩
+
+/-! ## Value-variable well-formedness -/
+
+/-- A bare value variable declared in a well-formed signature is a well-formed
+value term. -/
+theorem var_value_wfIn {x : String} {Δ : Signature}
+    (hΔ : Δ.wf) (hmem : (⟨x, .value⟩ : Var) ∈ Δ.vars) :
+    (Term.var .value x).wfIn Δ := by
+  refine ⟨hmem, ?_, ?_⟩
+  · intro τ' hc; exact Signature.wf_no_const_of_var hΔ hmem hc
+  · intro τ' hv; exact Signature.wf_unique_var hΔ hmem hv
+
+/-! ## Local variable environments -/
+
+/-- Local TinyML variables available to the relational encoder.  Bindings are
+searched from the front, so extending the environment implements shadowing. -/
+abbrev VarEnv := List (String × Term .value)
+
+namespace VarEnv
+
+/-- Look up a TinyML variable in the local encoder environment. -/
+def lookup (ρ : VarEnv) (x : String) : Option (Term .value) :=
+  List.lookup x ρ
+
+/-- Extend a local encoder environment with a TinyML variable binding. -/
+def bind (ρ : VarEnv) (x : String) (v : Term .value) : VarEnv :=
+  (x, v) :: ρ
+
+/-- Extend a local encoder environment when a TinyML binder is named; anonymous
+binders leave the environment unchanged. -/
+def bindBinder (ρ : VarEnv) (b : Typed.Binder) (v : Term .value) : VarEnv :=
+  match b.name with
+  | none => ρ
+  | some x => ρ.bind x v
+
+/-- Initial local environment induced by value variables declared in a FOL
+signature. -/
+def ofSignature (Δ : Signature) : VarEnv :=
+  Δ.vars.filterMap fun v =>
+    match v.sort with
+    | .value => some (v.name, .var .value v.name)
+    | _ => none
+
+/-- Every term stored in a local environment is well-formed in `Δ`. -/
+def wfIn (δ : VarEnv) (Δ : Signature) : Prop :=
+  ∀ x v, δ.lookup x = some v → v.wfIn Δ
+
+@[simp] theorem lookup_bind (δ : VarEnv) (x : String) (v : Term .value) :
+    (δ.bind x v).lookup x = some v := by
+  simp [lookup, bind]
+
+theorem lookup_bind_of_ne {δ : VarEnv} {x y : String} {v : Term .value}
+    (hxy : y ≠ x) : (δ.bind x v).lookup y = δ.lookup y := by
+  have hbeq : (y == x) = false := by
+    simp [hxy]
+  simp [lookup, bind, List.lookup, hbeq]
+
+theorem wfIn.bind {Δ : Signature} {δ : VarEnv} {x : String} {v : Term .value}
+    (henv : δ.wfIn Δ) (hv : v.wfIn Δ) :
+    (δ.bind x v).wfIn Δ := by
+  intro y w hlookup
+  by_cases hxy : y = x
+  · subst y
+    simp only [lookup_bind, Option.some.injEq] at hlookup
+    subst w
+    exact hv
+  · have htail : δ.lookup y = some w := by
+      simpa [lookup_bind_of_ne (δ := δ) (x := x) (v := v) hxy] using hlookup
+    exact henv y w htail
+
+theorem wfIn.bindBinder {Δ : Signature} {δ : VarEnv} {b : Typed.Binder}
+    {v : Term .value} (henv : δ.wfIn Δ) (hv : v.wfIn Δ) :
+    (δ.bindBinder b v).wfIn Δ := by
+  cases b with
+  | mk name ty =>
+      cases name with
+      | none => simpa [bindBinder] using henv
+      | some x => simpa [bindBinder] using henv.bind hv
+
+theorem ofSignature_wfIn {Δ : Signature} (hΔ : Δ.wf) :
+    (ofSignature Δ).wfIn Δ := by
+  intro x v hlookup
+  obtain ⟨l₁, l₂, heq, _⟩ := List.lookup_eq_some_iff.mp hlookup
+  have hmem : (x, v) ∈ ofSignature Δ := by
+    rw [heq]
+    simp
+  unfold ofSignature at hmem
+  simp only [List.mem_filterMap] at hmem
+  rcases hmem with ⟨a, haΔ, ha⟩
+  cases a with
+  | mk name sort =>
+    cases sort <;> simp at ha
+    rcases ha with ⟨rfl, rfl⟩
+    exact var_value_wfIn hΔ haΔ
+
+/-- Paired local environments agree semantically in two FOL environments:
+they share a lookup domain, and corresponding terms are well-formed in the
+respective signatures and evaluate equally. -/
+structure Agree (Δ₁ Δ₂ : Signature) (ρ₁ ρ₂ : Env) (δ₁ δ₂ : VarEnv) : Prop where
+  /-- Both environments bind the same set of TinyML variables. -/
+  sameDomain : ∀ x, (∃ v₁, δ₁.lookup x = some v₁) ↔ (∃ v₂, δ₂.lookup x = some v₂)
+  /-- Corresponding bound terms are well-formed and evaluate equally. -/
+  agree : ∀ x v₁ v₂,
+    δ₁.lookup x = some v₁ →
+    δ₂.lookup x = some v₂ →
+    v₁.wfIn Δ₁ ∧ v₂.wfIn Δ₂ ∧
+      Term.eval ρ₁ v₁ = Term.eval ρ₂ v₂
+
+theorem Agree.bind {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
+    {δ₁ δ₂ : VarEnv} {x : String} {v₁ v₂ : Term .value}
+    (henv : Agree Δ₁ Δ₂ ρ₁ ρ₂ δ₁ δ₂)
+    (hv₁ : v₁.wfIn Δ₁) (hv₂ : v₂.wfIn Δ₂)
+    (heval : Term.eval ρ₁ v₁ = Term.eval ρ₂ v₂) :
+    Agree Δ₁ Δ₂ ρ₁ ρ₂ (δ₁.bind x v₁) (δ₂.bind x v₂) where
+  sameDomain := by
+    intro y
+    by_cases hyx : y = x
+    · subst y
+      simp [lookup_bind]
+    · rw [lookup_bind_of_ne (δ := δ₁) (x := x) (v := v₁) hyx,
+        lookup_bind_of_ne (δ := δ₂) (x := x) (v := v₂) hyx]
+      exact henv.sameDomain y
+  agree := by
+    intro y w₁ w₂ h₁ h₂
+    by_cases hyx : y = x
+    · subst y
+      simp only [lookup_bind, Option.some.injEq] at h₁ h₂
+      subst w₁; subst w₂
+      exact ⟨hv₁, hv₂, heval⟩
+    · have h₁' : δ₁.lookup y = some w₁ := by
+        simpa [lookup_bind_of_ne (δ := δ₁) (x := x) (v := v₁) hyx] using h₁
+      have h₂' : δ₂.lookup y = some w₂ := by
+        simpa [lookup_bind_of_ne (δ := δ₂) (x := x) (v := v₂) hyx] using h₂
+      exact henv.agree y w₁ w₂ h₁' h₂'
+
+theorem Agree.bindBinder {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
+    {δ₁ δ₂ : VarEnv} {b : Typed.Binder} {v₁ v₂ : Term .value}
+    (henv : Agree Δ₁ Δ₂ ρ₁ ρ₂ δ₁ δ₂)
+    (hv₁ : v₁.wfIn Δ₁) (hv₂ : v₂.wfIn Δ₂)
+    (heval : Term.eval ρ₁ v₁ = Term.eval ρ₂ v₂) :
+    Agree Δ₁ Δ₂ ρ₁ ρ₂ (δ₁.bindBinder b v₁) (δ₂.bindBinder b v₂) := by
+  cases b with
+  | mk name ty =>
+      cases name with
+      | none => simpa [bindBinder] using henv
+      | some x => simpa [bindBinder] using henv.bind hv₁ hv₂ heval
+
+theorem Agree.mono {Δ₁ Δ₂ Δ₁' Δ₂' : Signature} {ρ₁ ρ₂ ρ₁' ρ₂' : Env}
+    {δ₁ δ₂ : VarEnv}
+    (hsub₁ : Δ₁.Subset Δ₁') (hsub₂ : Δ₂.Subset Δ₂')
+    (hwf₁ : Δ₁'.wf) (hwf₂ : Δ₂'.wf)
+    (ha₁ : Env.agreeOn Δ₁ ρ₁ ρ₁') (ha₂ : Env.agreeOn Δ₂ ρ₂ ρ₂')
+    (henv : Agree Δ₁ Δ₂ ρ₁ ρ₂ δ₁ δ₂) :
+    Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂ where
+  sameDomain := henv.sameDomain
+  agree := by
+    intro x v₁ v₂ h₁ h₂
+    rcases henv.agree x v₁ v₂ h₁ h₂ with ⟨hv₁, hv₂, heval⟩
+    have hv₁' := Term.wfIn_mono v₁ hv₁ hsub₁ hwf₁
+    have hv₂' := Term.wfIn_mono v₂ hv₂ hsub₂ hwf₂
+    refine ⟨hv₁', hv₂', ?_⟩
+    rw [← Term.eval_env_agree hv₁ ha₁, heval, Term.eval_env_agree hv₂ ha₂]
+
+end VarEnv
+
+namespace Relation
+
+/-- Signature extended for encoding the body of `rec f x := e`: adds the input
+variable `x : value` and the binary predicate `rel ⊆ value × value`, but not
+the result variable. -/
+def bodySig (Δ : Signature) (rel : String) (x : TinyML.Var) : Signature :=
+  (Δ.addBinaryRel ⟨rel, .value, .value⟩).declVar ⟨x, .value⟩
+
+/-- Run signature: `bodySig Δ rel x` extended with the pinned result variable `r`. -/
+def sig (Δ : Signature) (rel : String) (x r : TinyML.Var) : Signature :=
+  (bodySig Δ rel x).declVar ⟨r, .value⟩
+
+/-- Body supply: reserves base-signature names plus the relation symbol, the
+stage-2 split names, and the input and result variables. -/
+def relBodySupply (Δ : Signature) (fn : SpecFn) (x res : TinyML.Var) : NameSupply :=
+  { avoid := Δ.allNames ++ [fn, fn.funcName, fn.defName, x, res] }
+
+end Relation
+
+namespace Skolemize
+
+/-- Signature used to encode the body expression of `rec f x := e`. It
+contains the binary relation, the split value/definedness symbols, and the
+input variable. -/
+def bodySig (Δ : Signature) (fn : SpecFn) (x : TinyML.Var) : Signature :=
+  ((((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary fn.func).addUnaryRel
+    fn.defined).declVar ⟨x, .value⟩)
+
+/-- Common run signature used for the relational pinned-result continuation. -/
+def sig (Δ : Signature) (fn : SpecFn) (x res : TinyML.Var) : Signature :=
+  (bodySig Δ fn x).declVar ⟨res, .value⟩
+
+/-- Signature containing only the solver-facing split symbols and input
+variable used by the defined/value body. -/
+def defvalBodySig (Δ : Signature) (fn : SpecFn) (x : TinyML.Var) : Signature :=
+  (((Δ.addUnary fn.func).addUnaryRel fn.defined).declVar ⟨x, .value⟩)
+
+end Skolemize
+
+namespace Skolemize
+open Relation
+
+/-- The shared body supply covers the combined Skolemization run signature. -/
+theorem relBodySupply_covers_sig (Δ : Signature) (fn : SpecFn) (x res : String) :
+    (relBodySupply Δ fn x res).Covers (sig Δ fn x res) := by
+  intro n hn
+  by_contra hcontra
+  have hnΔ   : n ∉ Δ.allNames  := fun h => hcontra (by simp [relBodySupply, h])
+  have hnRel : n ≠ fn          := fun h => hcontra (by simp [relBodySupply, h])
+  have hnFun : n ≠ fn.funcName := fun h => hcontra (by simp [relBodySupply, h])
+  have hnDef : n ≠ fn.defName  := fun h => hcontra (by simp [relBodySupply, h])
+  have hnX   : n ≠ x           := fun h => hcontra (by simp [relBodySupply, h])
+  have hnRes : n ≠ res         := fun h => hcontra (by simp [relBodySupply, h])
+  have h1 : n ∉ (Δ.addBinaryRel ⟨fn, .value, .value⟩).allNames :=
+    Signature.not_mem_allNames_addBinaryRel hnΔ hnRel
+  have h2 : n ∉ ((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary fn.func).allNames :=
+    Signature.not_mem_allNames_addUnary h1 (by simpa [SpecFn.func] using hnFun)
+  have h3 : n ∉ (((Δ.addBinaryRel ⟨fn, .value, .value⟩).addUnary fn.func).addUnaryRel
+      fn.defined).allNames :=
+    Signature.not_mem_allNames_addUnaryRel h2 (by simpa [SpecFn.defined] using hnDef)
+  have h4 := Signature.not_mem_allNames_declVar h3 (show n ≠ (⟨x, .value⟩ : Var).name from hnX)
+  have h5 := Signature.not_mem_allNames_declVar h4 (show n ≠ (⟨res, .value⟩ : Var).name from hnRes)
+  exact h5 (by simpa [sig, bodySig] using hn)
+
+end Skolemize
+end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/Variables.lean
+++ b/Mica/Verifier/RelationalEncoding/Variables.lean
@@ -126,6 +126,10 @@ def defined (f : SpecFn) : FOL.UnaryRel :=
 def func (f : SpecFn) : FOL.Unary :=
   ⟨funcName f, .value, .value⟩
 
+/-- Solver-facing binary relation symbol for a spec-level function name. -/
+def rel (f : SpecFn) : FOL.BinaryRel :=
+  ⟨relName f, .value, .value⟩
+
 /-- Apply the solver-facing value function for frontend function name `f`. -/
 def call (f : SpecFn) (arg : Term .value) : Term .value :=
   .unop (.uninterpreted (funcName f) .value .value) arg
@@ -137,6 +141,48 @@ def isDefined (f : SpecFn) (arg : Term .value) : Formula :=
 /-- Apply the solver-facing binary relation for frontend function name `f`. -/
 def relates (f : SpecFn) (arg res : Term .value) : Formula :=
   .binpred (.uninterpreted (relName f) .value .value) arg res
+
+/-- Semantic value of the solver-facing value function on argument `arg`
+under environment `ρ`. -/
+def evalCall (f : SpecFn) (ρ : Env) (arg : Srt.value.denote) : Srt.value.denote :=
+  ρ.unary .value .value f.func.name arg
+
+/-- Semantic value of the solver-facing definedness predicate on argument `arg`
+under environment `ρ`. -/
+def evalDefined (f : SpecFn) (ρ : Env) (arg : Srt.value.denote) : Prop :=
+  ρ.unaryRel .value f.defined.name arg
+
+/-- Semantic value of the solver-facing binary relation on `(arg, res)`
+under environment `ρ`. -/
+def evalRelates (f : SpecFn) (ρ : Env) (arg res : Srt.value.denote) : Prop :=
+  ρ.binaryRel .value .value f.rel.name arg res
+
+/-- The value-function evaluation is preserved by `Env.updateConst`. -/
+@[simp] theorem evalCall_updateConst (f : SpecFn) (ρ : Env) (τ : Srt) (x : String)
+    (v : τ.denote) (a : Srt.value.denote) :
+    f.evalCall (ρ.updateConst τ x v) a = f.evalCall ρ a := rfl
+
+/-- The definedness predicate is preserved by `Env.updateConst`. -/
+@[simp] theorem evalDefined_updateConst (f : SpecFn) (ρ : Env) (τ : Srt) (x : String)
+    (v : τ.denote) (a : Srt.value.denote) :
+    f.evalDefined (ρ.updateConst τ x v) a = f.evalDefined ρ a := rfl
+
+/-- The binary relation is preserved by `Env.updateConst`. -/
+@[simp] theorem evalRelates_updateConst (f : SpecFn) (ρ : Env) (τ : Srt) (x : String)
+    (v : τ.denote) (a b : Srt.value.denote) :
+    f.evalRelates (ρ.updateConst τ x v) a b = f.evalRelates ρ a b := rfl
+
+/-- Evaluating `relates` reduces to the binary relation in the environment. -/
+@[simp] theorem relates_eval (f : SpecFn) (ρ : Env) (arg res : Term .value) :
+    (f.relates arg res).eval ρ = f.evalRelates ρ (arg.eval ρ) (res.eval ρ) := rfl
+
+/-- Evaluating `isDefined` reduces to the definedness predicate in the environment. -/
+@[simp] theorem isDefined_eval (f : SpecFn) (ρ : Env) (arg : Term .value) :
+    (f.isDefined arg).eval ρ = f.evalDefined ρ (arg.eval ρ) := rfl
+
+/-- Evaluating `call` reduces to the value function in the environment. -/
+@[simp] theorem call_eval (f : SpecFn) (ρ : Env) (arg : Term .value) :
+    (f.call arg).eval ρ = f.evalCall ρ (arg.eval ρ) := rfl
 
 /-- A registered solver-facing value-function application is well-formed when
 its argument is well-formed. -/
@@ -165,7 +211,7 @@ theorem isDefined_wfIn {fn : SpecFn} {arg : Term .value} {Δ : Signature}
 /-- A registered solver-facing relation application is well-formed when its
 arguments are well-formed. -/
 theorem relates_wfIn {fn : SpecFn} {arg res : Term .value} {Δ : Signature}
-    (hrel : (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel)
+    (hrel : fn.rel ∈ Δ.binaryRel)
     (hΔ : Δ.wf) (harg : arg.wfIn Δ) (hres : res.wfIn Δ) :
     (fn.relates arg res).wfIn Δ := by
   refine ⟨?_, harg, hres⟩
@@ -199,7 +245,7 @@ theorem FunCtx.mem_of_lookup {Γ : FunCtx} {x : TinyML.Var} {fn : SpecFn}
 /-- Every relation in `Γ` is registered in `Δ` as a binary uninterpreted predicate
 on `value × value`. -/
 def FunCtx.relWfIn (Γ : FunCtx) (Δ : Signature) : Prop :=
-  ∀ x (fn : SpecFn), (x, fn) ∈ Γ → (⟨fn.relName, .value, .value⟩ : FOL.BinaryRel) ∈ Δ.binaryRel
+  ∀ x (fn : SpecFn), (x, fn) ∈ Γ → fn.rel ∈ Δ.binaryRel
 
 theorem FunCtx.relWfIn_mono {Γ : FunCtx} {Δ Δ' : Signature}
     (h : Γ.relWfIn Δ) (hsub : Δ.Subset Δ') : Γ.relWfIn Δ' :=
@@ -397,7 +443,7 @@ namespace Relation
 variable `x : value` and the binary predicate `fn.relName ⊆ value × value`, but
 not the result variable. -/
 def bodySig (Δ : Signature) (fn : SpecFn) (x : TinyML.Var) : Signature :=
-  (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).declVar ⟨x, .value⟩
+  (Δ.addBinaryRel fn.rel).declVar ⟨x, .value⟩
 
 /-- Run signature: `bodySig Δ fn x` extended with the pinned result variable `r`. -/
 def sig (Δ : Signature) (fn : SpecFn) (x r : TinyML.Var) : Signature :=
@@ -416,7 +462,7 @@ namespace Skolemize
 contains the binary relation, the split value/definedness symbols, and the
 input variable. -/
 def bodySig (Δ : Signature) (fn : SpecFn) (x : TinyML.Var) : Signature :=
-  ((((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary fn.func).addUnaryRel
+  ((((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
     fn.defined).declVar ⟨x, .value⟩)
 
 /-- Common run signature used for the relational pinned-result continuation. -/
@@ -444,11 +490,11 @@ theorem relBodySupply_covers_sig (Δ : Signature) (fn : SpecFn) (x res : String)
   have hnDef : n ≠ fn.defName     := fun h => hcontra (by simp [relBodySupply, h])
   have hnX   : n ≠ x              := fun h => hcontra (by simp [relBodySupply, h])
   have hnRes : n ≠ res            := fun h => hcontra (by simp [relBodySupply, h])
-  have h1 : n ∉ (Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).allNames :=
+  have h1 : n ∉ (Δ.addBinaryRel fn.rel).allNames :=
     Signature.not_mem_allNames_addBinaryRel hnΔ hnRel
-  have h2 : n ∉ ((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary fn.func).allNames :=
+  have h2 : n ∉ ((Δ.addBinaryRel fn.rel).addUnary fn.func).allNames :=
     Signature.not_mem_allNames_addUnary h1 (by simpa [SpecFn.func] using hnFun)
-  have h3 : n ∉ (((Δ.addBinaryRel ⟨fn.relName, .value, .value⟩).addUnary fn.func).addUnaryRel
+  have h3 : n ∉ (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel
       fn.defined).allNames :=
     Signature.not_mem_allNames_addUnaryRel h2 (by simpa [SpecFn.defined] using hnDef)
   have h4 := Signature.not_mem_allNames_declVar h3 (show n ≠ (⟨x, .value⟩ : Var).name from hnX)


### PR DESCRIPTION
This PR adds an encoding of spec-level functions to SMT terms. Specifically, it adds two encodings for  exposing spec-level functions to the verifier:
- A relational encoding that exposes each function as a graph (to get around termination restrictions).
- A functional version with a definedness predicate to use during verification. 