### PR TITLE
Remove the unused name in @@fn

### DIFF
--- a/Examples/avl.ml
+++ b/Examples/avl.ml
@@ -31,17 +31,17 @@ let max_int (x: int) (y: int) : int =
     assert (x <= result);
     assert (y <= result))];;
 
-let rec height_spec (tr: tree) : int =
+let rec height (tr: tree) : int =
   match tr with
   | Leaf -> 0
   | Node n -> n.1
-[@@fn height];;
+[@@fn];;
 
 (* [valid_raw (tree, lo, hi)] means:
    - values are in the inclusive BST interval [lo, hi],
    - cached heights are exact and non-negative,
    - every node satisfies the AVL balance bound. *)
-let rec valid_raw_spec (args: tree * int * int) : bool =
+let rec valid_raw (args: tree * int * int) : bool =
   let tr = args.0 in
   let lo = args.1 in
   let hi = args.2 in
@@ -52,40 +52,40 @@ let rec valid_raw_spec (args: tree * int * int) : bool =
     let h = n.1 in
     let l = n.2 in
     let r = n.3 in
-    let right_ok = valid_raw_spec (r, v, hi) in
-    let left_ok = valid_raw_spec (l, lo, v) in
-    let rh = height_spec r in
-    let lh = height_spec l in
+    let right_ok = valid_raw (r, v, hi) in
+    let left_ok = valid_raw (l, lo, v) in
+    let rh = height r in
+    let lh = height l in
     let mh = if lh < rh then rh else lh in
     right_ok && left_ok && lo <= v && v <= hi &&
     h = mh + 1 && lh <= rh + 1 && rh <= lh + 1
-[@@fn valid_raw];;
+[@@fn];;
 
-let valid_spec (h: t) : bool =
+let valid (h: t) : bool =
   match h with
   | Avl p ->
     let lo = p.0 in
     let tr = p.1 in
     let hi = p.2 in
-    let ok = valid_raw_spec (tr, lo, hi) in
+    let ok = valid_raw (tr, lo, hi) in
     lo <= hi && ok
-[@@fn valid];;
+[@@fn];;
 
-let height (tr: tree) : int =
+let height_impl (tr: tree) : int =
   match tr with
   | Leaf -> 0
   | Node n -> n.1;;
 
 let make_node (v: int) (l: tree) (r: tree) : tree =
-  let lh = height l in
-  let rh = height r in
+  let lh = height_impl l in
+  let rh = height_impl r in
   let h = max_int lh rh + 1 in
   Node (v, h, l, r)
 ;;
 
 let balance (v: int) (l: tree) (r: tree) : tree =
-  let lh = height l in
-  let rh = height r in
+  let lh = height_impl l in
+  let rh = height_impl r in
   if lh > rh + 1 then
     match l with
     | Leaf -> make_node v l r
@@ -93,7 +93,7 @@ let balance (v: int) (l: tree) (r: tree) : tree =
       let lv = ln.0 in
       let ll = ln.2 in
       let lr = ln.3 in
-      if height ll >= height lr then
+      if height_impl ll >= height_impl lr then
         make_node lv ll (make_node v lr r)
       else
         match lr with
@@ -110,7 +110,7 @@ let balance (v: int) (l: tree) (r: tree) : tree =
       let rv = rn.0 in
       let rl = rn.2 in
       let rr = rn.3 in
-      if height rr >= height rl then
+      if height_impl rr >= height_impl rl then
         make_node rv (make_node v l rl) rr
       else
         match rl with

--- a/Examples/bst.ml
+++ b/Examples/bst.ml
@@ -34,7 +34,7 @@ let max_int (x: int) (y: int) : int =
    inclusive interval [lo, hi].  Each recursive call tightens the
    interval with the parent value, so descendants are checked against
    every ancestor bound. *)
-let rec sorted_spec (args: tree * int * int) : bool =
+let rec sorted (args: tree * int * int) : bool =
   let tr = args.0 in
   let lo = args.1 in
   let hi = args.2 in
@@ -44,33 +44,33 @@ let rec sorted_spec (args: tree * int * int) : bool =
     let v = n.0 in
     let l = n.1 in
     let r = n.2 in
-    let right_sorted = sorted_spec (r, v, hi) in
-    let left_sorted = sorted_spec (l, lo, v) in
+    let right_sorted = sorted (r, v, hi) in
+    let left_sorted = sorted (l, lo, v) in
     right_sorted && left_sorted && lo <= v && v <= hi
-[@@fn sorted];;
+[@@fn];;
 
 (* The public invariant for handles. *)
-let valid_spec (h: t) : bool =
+let valid (h: t) : bool =
   match h with
   | Bst p ->
     let lo = p.0 in
     let tr = p.1 in
     let hi = p.2 in
-    let ok = sorted_spec (tr, lo, hi) in
+    let ok = sorted (tr, lo, hi) in
     lo <= hi && ok
-[@@fn valid];;
+[@@fn];;
 
 let make_node (v: int) (lo: int) (hi: int) (l: tree) (r: tree) : tree =
   Node (v, l, r)
 [@@spec fun v lo hi l r ->
   assert (lo <= v);
   assert (v <= hi);
-  let sr = sorted_spec (r, v, hi) in
+  let sr = sorted (r, v, hi) in
   assert (sr);
-  let sl = sorted_spec (l, lo, v) in
+  let sl = sorted (l, lo, v) in
   assert (sl);
   ret (fun result ->
-    let st = sorted_spec (result, lo, hi) in
+    let st = sorted (result, lo, hi) in
     assert (st))];;
 
 (* Lemma-like function: prove that [tr] is still sorted when its
@@ -90,10 +90,10 @@ let rec widen_tree (lo: int) (hi: int) (new_lo: int) (new_hi: int) (tr: tree) : 
 [@@spec fun lo hi new_lo new_hi tr ->
   assert (new_lo <= lo);
   assert (hi <= new_hi);
-  let st = sorted_spec (tr, lo, hi) in
+  let st = sorted (tr, lo, hi) in
   assert (st);
   ret (fun result ->
-    let sr = sorted_spec (tr, new_lo, new_hi) in
+    let sr = sorted (tr, new_lo, new_hi) in
     assert (sr))];;
 
 let rec insert_raw (x: int) (lo: int) (hi: int) (tr: tree) : tree =
@@ -109,17 +109,17 @@ let rec insert_raw (x: int) (lo: int) (hi: int) (tr: tree) : tree =
 [@@spec fun x lo hi tr ->
   assert (lo <= x);
   assert (x <= hi);
-  let st = sorted_spec (tr, lo, hi) in
+  let st = sorted (tr, lo, hi) in
   assert (st);
   ret (fun result ->
-    let sr = sorted_spec (result, lo, hi) in
+    let sr = sorted (result, lo, hi) in
     assert (sr))];;
 
 let singleton (x: int) : t =
   Bst (x, Node (x, Leaf, Leaf), x)
 [@@spec fun x ->
   ret (fun result ->
-    let vr = valid_spec result in
+    let vr = valid result in
     assert (vr))];;
 
 let insert (x: int) (h: t) : t =
@@ -133,17 +133,17 @@ let insert (x: int) (h: t) : t =
     widen_tree lo hi new_lo new_hi tr;
     Bst (new_lo, insert_raw x new_lo new_hi tr, new_hi)
 [@@spec fun x h ->
-  let vh = valid_spec h in
+  let vh = valid h in
   assert (vh);
   ret (fun result ->
-    let vr = valid_spec result in
+    let vr = valid result in
     assert (vr))];;
 
 let min (h: t) : int =
   match h with
   | Bst p -> p.0
 [@@spec fun h ->
-  let vh = valid_spec h in
+  let vh = valid h in
   assert (vh);
   bind (isinj 0 1 h) @@ fun (p : int * tree * int) ->
   ret (fun result ->
@@ -153,7 +153,7 @@ let max (h: t) : int =
   match h with
   | Bst p -> p.2
 [@@spec fun h ->
-  let vh = valid_spec h in
+  let vh = valid h in
   assert (vh);
   bind (isinj 0 1 h) @@ fun (p : int * tree * int) ->
   ret (fun result ->

--- a/Examples/fib.ml
+++ b/Examples/fib.ml
@@ -1,19 +1,19 @@
 (* Recursive specification function for Fibonacci. *)
-let rec fib_spec (n: int) : int =
-  if n < 1 then 0
-  else if n < 2 then 1
-  else fib_spec (n - 1) + fib_spec (n - 2)
-[@@fn fib];;
-
-(* Recursive implementation. *)
 let rec fib (n: int) : int =
   if n < 1 then 0
   else if n < 2 then 1
   else fib (n - 1) + fib (n - 2)
+[@@fn];;
+
+(* Recursive implementation. *)
+let rec fib_impl (n: int) : int =
+  if n < 1 then 0
+  else if n < 2 then 1
+  else fib_impl (n - 1) + fib_impl (n - 2)
 [@@spec fun x ->
   assert (x >= 0);
   ret (fun v ->
-    let expected = fib_spec x in
+    let expected = fib x in
     assert (v = expected))]
 ;;
 
@@ -31,12 +31,12 @@ let rec fib_loop (n: int) (i: int) (a: int) (b: int) : int =
   assert (n >= 0);
   assert (i >= 0);
   assert (i <= n);
-  let fi  = fib_spec i in
-  let fip = fib_spec (i + 1) in
+  let fi  = fib i in
+  let fip = fib (i + 1) in
   assert (a = fi);
   assert (b = fip);
   ret (fun v ->
-    let expected = fib_spec n in
+    let expected = fib n in
     assert (v = expected))]
 ;;
 
@@ -46,6 +46,6 @@ let fib_iter (n: int) : int = fib_loop n 0 0 1
 [@@spec fun x ->
   assert (x >= 0);
   ret (fun v ->
-    let expected = fib_spec x in
+    let expected = fib x in
     assert (v = expected))]
 ;;

--- a/Examples/spec_functions.ml
+++ b/Examples/spec_functions.ml
@@ -1,18 +1,18 @@
 (* Spec-level functions: fn-marked definitions introduce SMT functions
    that specifications can call as ordinary applications. *)
 
-let inc_spec (x: int) : int = x + 1
-[@@fn inc];;
+let inc (x: int) : int = x + 1
+[@@fn];;
 
 let incr_via_spec (x: int) : int = x + 1
 [@@spec fun x ->
-  let y = inc_spec x in
+  let y = inc x in
   ret (fun v ->
     assert (v = y))];;
 
 let double_incr_via_spec (x: int) : int = incr_via_spec (incr_via_spec x)
 [@@spec fun x ->
-  let y = inc_spec x in
+  let y = inc x in
   ret (fun v ->
     assert (y = x + 1);
     assert (v = x + 2))];;

--- a/Examples/spec_recursion_tuples.ml
+++ b/Examples/spec_recursion_tuples.ml
@@ -6,7 +6,7 @@
 
    The relational encoder requires unary calls, so a recursion that
    takes several arguments is paired into a single tuple value. The
-   spec function is declared once with `[@@fn name]`; a runtime
+   spec function is declared once with `[@@fn]`; a runtime
    implementation of the same shape is then verified against it by
    calling the spec function as an ordinary application in the spec.
 
@@ -19,36 +19,35 @@
 
 (* --- Sum of [1..n] via tail recursion on an `(acc, i)` pair. --- *)
 
-(* Spec-level recursive definition. The `[@@fn sum_acc]` annotation
-   registers it as an SMT function; specs invoke it by its OCaml name
-   `sum_acc_rec`. *)
-let rec sum_acc_rec (s: int * int) : int =
-  let acc = s.0 in
-  let i   = s.1 in
-  if i < 1 then acc
-  else sum_acc_rec (acc + i, i - 1)
-[@@fn sum_acc];;
-
-(* Runtime version with the same shape, verified against the spec
-   function exactly. Each recursive runtime call discharges
-   `sum_acc_rec (acc+i, i-1) = result`; the postcondition's
-   `sum_acc_rec s` is then equal to that, by one body unfolding. *)
+(* Spec-level recursive definition. The `[@@fn]` annotation registers
+   it as an SMT function; specs invoke it by its OCaml name `sum_acc`. *)
 let rec sum_acc (s: int * int) : int =
   let acc = s.0 in
   let i   = s.1 in
   if i < 1 then acc
   else sum_acc (acc + i, i - 1)
+[@@fn];;
+
+(* Runtime version with the same shape, verified against the spec
+   function exactly. Each recursive runtime call discharges
+   `sum_acc (acc+i, i-1) = result`; the postcondition's
+   `sum_acc s` is then equal to that, by one body unfolding. *)
+let rec sum_acc_impl (s: int * int) : int =
+  let acc = s.0 in
+  let i   = s.1 in
+  if i < 1 then acc
+  else sum_acc_impl (acc + i, i - 1)
 [@@spec fun s ->
   ret (fun v ->
-    let expected = sum_acc_rec s in
+    let expected = sum_acc s in
     assert (v = expected))];;
 
 (* Closed entry point.  This function does not carry recursion itself,
-   so its spec can only restate what `sum_acc` already promised on the
-   initial `(0, n)` pair.  The verifier accepts this without inspecting
-   the body of `sum_acc` any further. *)
-let sum_to_n (n: int) : int = sum_acc (0, n)
+   so its spec can only restate what `sum_acc_impl` already promised on
+   the initial `(0, n)` pair.  The verifier accepts this without
+   inspecting the body of `sum_acc_impl` any further. *)
+let sum_to_n (n: int) : int = sum_acc_impl (0, n)
 [@@spec fun n ->
   ret (fun v ->
-    let expected = sum_acc_rec (0, n) in
+    let expected = sum_acc (0, n) in
     assert (v = expected))];;

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -117,7 +117,7 @@ structure TypeDecl where
 
 structure Attribute where
   name    : String
-  payload : Expr
+  payload : Option Expr
 
 inductive DeclKind where
   | type_ (decl : TypeDecl)

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -492,29 +492,26 @@ private def elaborateAttrSpec (env : ElabEnv) (attrs : List Attribute)
     : ElabM (Option (Spec.Body Untyped.Expr)) :=
   match attrs.find? (·.name == "spec") with
   | none => .ok none
-  | some attr => do
-    let e ← Expr.elaborate env attr.payload
-    match Spec.parse e with
-    | .ok spec => .ok (some spec)
-    | .error msg => err attr.payload.loc (.unsupportedFeature s!"invalid [@@spec]: {msg}")
+  | some attr =>
+    match attr.payload with
+    | none => err default (.unsupportedFeature "[@@spec] expects a specification payload")
+    | some payload => do
+      let e ← Expr.elaborate env payload
+      match Spec.parse e with
+      | .ok spec => .ok (some spec)
+      | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@@spec]: {msg}")
 
-private def elaborateAttrRelationPayload (env : ElabEnv) (attr : Attribute) : ElabM String := do
-  let e ← Expr.elaborate env attr.payload
-  match e with
-  | .var name => .ok name
-  | _ => err attr.payload.loc (.unsupportedFeature "[@@fn] expects a bare identifier payload")
-
-private def elaborateAttrRelation (env : ElabEnv) (attrs : List Attribute)
-    : ElabM (Option String) :=
+/-- Whether the declaration is marked `[@@fn]`, registering it as a spec-level
+    function. The attribute carries no payload; the function's own name is used
+    for the derived relation. -/
+private def hasAttrRelation (attrs : List Attribute) : ElabM Bool :=
   match attrs.find? (·.name == "fn") with
-  | none => .ok none
-  | some attr => elaborateAttrRelationPayload env attr
-
-private def elaborateDeclMeta (env : ElabEnv) (attrs : List Attribute)
-    : ElabM (TinyML.DeclMeta (Spec.Body Untyped.Expr)) := do
-  let spec ← elaborateAttrSpec env attrs
-  let relation ← elaborateAttrRelation env attrs
-  .ok { spec, relation }
+  | none => .ok false
+  | some attr =>
+    match attr.payload with
+    | none => .ok true
+    | some payload => err payload.loc (.unsupportedFeature
+        "[@@fn] takes no payload; the function's own name is used for the relation")
 
 def Decl.elaborate (env : ElabEnv) (decl : Decl)
     : ElabM (ElabEnv × Option (Untyped.Decl (Spec.Body Untyped.Expr))) := do
@@ -523,9 +520,12 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
     let (env', tdecl') ← TypeDecl.elaborate env decl.loc tdecl
     .ok (env', tdecl'.map Untyped.Decl.type_)
   | .val_ isRec binders retTy body => do
-    let md ← elaborateDeclMeta env decl.attrs
-    let d ← ValDecl.elaborate env decl.loc isRec binders retTy body md
-    .ok (env, some (.val_ d))
+    let spec ← elaborateAttrSpec env decl.attrs
+    let fn ← hasAttrRelation decl.attrs
+    let d ← ValDecl.elaborate env decl.loc isRec binders retTy body { spec }
+    -- A `[@@fn]` declaration uses its own name for the derived relation.
+    let relation := if fn then (match d.name with | .named x _ => some x | .none => none) else none
+    .ok (env, some (.val_ { d with declMeta := { d.declMeta with relation } }))
 
 private def elaborateDecls (env : ElabEnv) :
     List Decl → ElabM (List (Untyped.Decl (Spec.Body Untyped.Expr)))

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -524,7 +524,11 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
     let fn ← hasAttrRelation decl.attrs
     let d ← ValDecl.elaborate env decl.loc isRec binders retTy body { spec }
     -- A `[@@fn]` declaration uses its own name for the derived relation.
-    let relation := if fn then (match d.name with | .named x _ => some x | .none => none) else none
+    let relation ← if fn then
+      match d.name with
+      | .named x _ => .ok (some x)
+      | .none => err decl.loc (.unsupportedFeature "[@@fn] requires a named declaration")
+    else .ok none
     .ok (env, some (.val_ { d with declMeta := { d.declMeta with relation } }))
 
 private def elaborateDecls (env : ElabEnv) :

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -770,7 +770,13 @@ where
       | .atat => do
         let st' := advance (advance st)  -- skip `[` and `@@`
         let (name, st') ← expectIdent st'
-        let (payload, st') ← parseExpr st'
+        -- An attribute may carry an expression payload (`[@@spec ...]`) or
+        -- stand alone with none (`[@@fn]`).
+        let (payload, st') ← match peekTok st' with
+          | .rbracket => .ok (none, st')
+          | _ => do
+            let (e, st') ← parseExpr st'
+            .ok (some e, st')
         let st' ← expect .rbracket st'
         let (rest, st') ← parseAttrs st'
         .ok ({ name, payload } :: rest, st')

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -192,7 +192,9 @@ partial def Expr.print (e : Expr) : String := Expr.printPrec e 0
 
 partial def Decl.print (d : Decl) : String :=
   let attrsStr := d.attrs.map fun attr =>
-    "\n[@@" ++ attr.name ++ " " ++ Expr.print attr.payload ++ "]"
+    match attr.payload with
+    | none => "\n[@@" ++ attr.name ++ "]"
+    | some payload => "\n[@@" ++ attr.name ++ " " ++ Expr.print payload ++ "]"
   let attrsSuffix := joinWith "" attrsStr
   match d.kind with
   | .type_ td => printTypeDecl td ++ attrsSuffix

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -195,7 +195,7 @@ def ValDecl.print {S : Type} [SpecPayloadPrinter S] (d : Untyped.ValDecl S) : St
     | .some e => s!"{decl} [@@spec {SpecPayloadPrinter.print e}]"
   match d.declMeta.relation with
   | .none => withSpec
-  | .some fn => s!"{withSpec} [@@fn {fn}]"
+  | .some _ => s!"{withSpec} [@@fn]"
 
 def TypeDecl.print (d : Untyped.TypeDecl) : String :=
   let payloads := (List.range d.body.payloads.length).zip d.body.payloads |>.map

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -47,7 +47,7 @@ def Program.prepare (prog : Untyped.Program (Spec.Body Untyped.Expr)) :
   | .ok prepared => .ret prepared
   | .error err => .fatal (toString err)
 
-/-- Globally assembled metadata for declarations marked with `[@@fn fn]`. -/
+/-- Globally assembled metadata for declarations marked with `[@@fn]`. -/
 structure RelationSpec where
   symbols : List FOL.BinaryRel
   axioms : List Formula
@@ -71,44 +71,44 @@ private structure RelationDecl where
   body : Typed.Expr
   bv : Skolemize.DefVal
 
-private def validateDecl (d : Typed.ValDecl (Spec.Body Typed.Expr)) (rel : String) :
+private def validateDecl (d : Typed.ValDecl (Spec.Body Typed.Expr)) :
     Except String (TinyML.Var × TinyML.Var × Typed.Expr) := do
   if d.declMeta.spec.isSome then
-    .error s!"declaration cannot have both [@@spec] and [@@fn {rel}]"
+    .error s!"declaration cannot have both [@@spec] and [@@fn]"
   let f ← match d.name.name with
     | some f => .ok f
-    | none => .error s!"[@@fn {rel}] requires a named declaration"
+    | none => .error s!"[@@fn] requires a named declaration"
   match d.body with
   | .fix _ [arg] _ body =>
     match arg.name with
     | some x => .ok (f, x, body)
-    | none => .error s!"[@@fn {rel}] requires a named unary argument"
-  | .fix _ _ _ _ => .error s!"[@@fn {rel}] requires a unary function"
-  | _ => .error s!"[@@fn {rel}] requires a function body"
+    | none => .error s!"[@@fn] requires a named unary argument"
+  | .fix _ _ _ _ => .error s!"[@@fn] requires a unary function"
+  | _ => .error s!"[@@fn] requires a function body"
 
 private def extend (acc : RelationSpec) (d : Typed.ValDecl (Spec.Body Typed.Expr)) :
     Except String RelationDecl := do
   match d.declMeta.relation with
   | none => .error "internal error: expected relation declaration"
   | some rel => do
-      let (f, arg, body) ← validateDecl d rel
+      let (f, arg, body) ← validateDecl d
       let relName := SpecFn.relName rel
       let funName := SpecFn.funcName rel
       let defName := SpecFn.defName rel
       if relName ∈ acc.delta.allNames then
-        .error s!"derived relation name '{relName}' for [@@fn {rel}] conflicts with an existing symbol"
+        .error s!"derived relation name '{relName}' for [@@fn] conflicts with an existing symbol"
       else if funName ∈ acc.delta.allNames then
-        .error s!"derived value-function name '{funName}' for [@@fn {rel}] conflicts with an existing symbol"
+        .error s!"derived value-function name '{funName}' for [@@fn] conflicts with an existing symbol"
       else if defName ∈ acc.delta.allNames then
-        .error s!"derived definedness name '{defName}' for [@@fn {rel}] conflicts with an existing symbol"
+        .error s!"derived definedness name '{defName}' for [@@fn] conflicts with an existing symbol"
       else if arg ∈ acc.delta.allNames then
-        .error s!"[@@fn {rel}] argument name '{arg}' conflicts with a global symbol"
+        .error s!"[@@fn] argument name '{arg}' conflicts with a global symbol"
       else if arg = relName then
-        .error s!"[@@fn {rel}] argument name '{arg}' clashes with derived relation name"
+        .error s!"[@@fn] argument name '{arg}' clashes with derived relation name"
       else if arg = funName then
-        .error s!"[@@fn {rel}] argument name '{arg}' clashes with derived value-function name"
+        .error s!"[@@fn] argument name '{arg}' clashes with derived value-function name"
       else if arg = defName then
-        .error s!"[@@fn {rel}] argument name '{arg}' clashes with derived definedness name"
+        .error s!"[@@fn] argument name '{arg}' clashes with derived definedness name"
       else
         let (res, bv, axs) ← Skolemize.bundle acc.functionMap acc.delta f rel arg body
         let spec := { symbols := acc.symbols ++ [SpecFn.rel rel],


### PR DESCRIPTION
This PR removes the now unused name from the `[@@fn func]` attribute. 