### PR TITLE
Typing environment threading

### DIFF
--- a/Mica/SeparationLogic/Interpretations.lean
+++ b/Mica/SeparationLogic/Interpretations.lean
@@ -1,6 +1,7 @@
 -- SUMMARY: Iris interpretations of spatial atoms and contexts, with lemmas relating syntax to separation-logic assertions.
 import Mica.SeparationLogic.Axioms
 import Mica.SeparationLogic.SpatialAtom
+import Mica.TinyML.Types
 
 open Iris Iris.BI
 
@@ -15,9 +16,9 @@ namespace SpatialAtom
 
 /-- Interpreting a well-formed atom only depends on the environment values of
     symbols in the ambient signature. -/
-theorem interp_env_agree {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
+theorem interp_env_agree (Θ : TinyML.TypeEnv) {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
     (hwf : a.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    interp ρ a ⊣⊢ interp ρ' a := by
+    interp Θ ρ a ⊣⊢ interp Θ ρ' a := by
   cases a with
   | pointsTo l v =>
     simp only [interp, Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
@@ -25,9 +26,9 @@ theorem interp_env_agree {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
 
 /-- If a points-to atom's location term evaluates to `loc`, its interpretation
     is equivalent to the raw points-to assertion for `loc`. -/
-theorem interp_pointsTo {ρ : Env} {lt vt : Term .value} {loc : Runtime.Location}
+theorem interp_pointsTo (Θ : TinyML.TypeEnv) {ρ : Env} {lt vt : Term .value} {loc : Runtime.Location}
     (hloc : Term.eval ρ lt = .loc loc) :
-    interp ρ (.pointsTo lt vt) ⊣⊢ loc ↦ Term.eval ρ vt := by
+    interp Θ ρ (.pointsTo lt vt) ⊣⊢ loc ↦ Term.eval ρ vt := by
   constructor
   · simp only [interp]
     istart
@@ -49,41 +50,41 @@ end SpatialAtom
 namespace SpatialContext
 
 /-- Iris interpretation of a spatial context: the separating conjunction of all items. -/
-def interp (ρ : Env) : SpatialContext → iProp
+def interp (Θ : TinyML.TypeEnv) (ρ : Env) : SpatialContext → iProp
   | []     => emp
-  | a :: Γ => a.interp ρ ∗ interp ρ Γ
+  | a :: Γ => a.interp Θ ρ ∗ interp Θ ρ Γ
 
 /-- Interpreting a well-formed context only depends on the environment values of
     symbols in the ambient signature. -/
-theorem interp_env_agree {ctx : SpatialContext} {Δ : Signature} {ρ ρ' : Env}
+theorem interp_env_agree (Θ : TinyML.TypeEnv) {ctx : SpatialContext} {Δ : Signature} {ρ ρ' : Env}
     (hwf : wfIn ctx Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    interp ρ ctx ⊣⊢ interp ρ' ctx := by
+    interp Θ ρ ctx ⊣⊢ interp Θ ρ' ctx := by
   induction ctx with
   | nil => simp [interp]
   | cons a ctx ih =>
-    have ha : SpatialAtom.interp ρ a ⊣⊢ SpatialAtom.interp ρ' a :=
-      SpatialAtom.interp_env_agree (hwf a (by simp)) hagree
+    have ha : SpatialAtom.interp Θ ρ a ⊣⊢ SpatialAtom.interp Θ ρ' a :=
+      SpatialAtom.interp_env_agree Θ (hwf a (by simp)) hagree
     have htail : wfIn ctx Δ := (wfIn_cons a ctx Δ).1 hwf |>.2
-    have hctx : interp ρ ctx ⊣⊢ interp ρ' ctx := ih htail
+    have hctx : interp Θ ρ ctx ⊣⊢ interp Θ ρ' ctx := ih htail
     simp only [interp]
     exact ⟨sep_mono ha.1 hctx.1, sep_mono ha.2 hctx.2⟩
 
-@[simp] theorem interp_nil (ρ : Env) : interp ρ [] = emp := rfl
-@[simp] theorem interp_cons (ρ : Env) (a : SpatialAtom) (Γ : SpatialContext) :
-    interp ρ (a :: Γ) = (a.interp ρ ∗ interp ρ Γ) := rfl
+@[simp] theorem interp_nil (Θ : TinyML.TypeEnv) (ρ : Env) : interp Θ ρ [] = emp := rfl
+@[simp] theorem interp_cons (Θ : TinyML.TypeEnv) (ρ : Env) (a : SpatialAtom) (Γ : SpatialContext) :
+    interp Θ ρ (a :: Γ) = (a.interp Θ ρ ∗ interp Θ ρ Γ) := rfl
 
-@[simp] theorem interp_insert (ρ : Env) (a : SpatialAtom) (ctx : SpatialContext) :
-    interp ρ (insert a ctx) = (a.interp ρ ∗ interp ρ ctx) := rfl
+@[simp] theorem interp_insert (Θ : TinyML.TypeEnv) (ρ : Env) (a : SpatialAtom) (ctx : SpatialContext) :
+    interp Θ ρ (insert a ctx) = (a.interp Θ ρ ∗ interp Θ ρ ctx) := rfl
 
 private theorem sep_comm3 {A B C : iProp} : A ∗ (B ∗ C) ⊣⊢ B ∗ (A ∗ C) :=
   ⟨sep_assoc.2 |>.trans (sep_mono_l sep_comm.1) |>.trans sep_assoc.1,
    sep_assoc.2 |>.trans (sep_mono_l sep_comm.2) |>.trans sep_assoc.1⟩
 
 /-- The interpretation of a context is equivalent to splitting off the atom at index `n`. -/
-theorem interp_remove (ρ : Env) (ctx : SpatialContext) (n : Nat)
+theorem interp_remove (Θ : TinyML.TypeEnv) (ρ : Env) (ctx : SpatialContext) (n : Nat)
     (a : SpatialAtom) (rest : SpatialContext)
     (h : remove ctx n = some (a, rest)) :
-    interp ρ ctx ⊣⊢ a.interp ρ ∗ interp ρ rest := by
+    interp Θ ρ ctx ⊣⊢ a.interp Θ ρ ∗ interp Θ ρ rest := by
   induction ctx generalizing n a rest with
   | nil => simp at h
   | cons x xs ih =>

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -119,7 +119,7 @@ theorem wp_bind_ref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
 
 /-- Reference allocation at values. The continuation receives fresh ownership in
     the updated environment for a caller-chosen fresh value constant. -/
-theorem wp_ref {v : Runtime.Val} {Q : Runtime.Val → iProp}
+theorem wp_ref (Θ : TinyML.TypeEnv) {v : Runtime.Val} {Q : Runtime.Val → iProp}
     {ctx : SpatialContext} {ρ : Env} {R : iProp} {Δ : Signature}
     {vt : Term .value} {name : String} {newctx : SpatialContext}
     (hctx : wfIn ctx Δ)
@@ -128,10 +128,10 @@ theorem wp_ref {v : Runtime.Val} {Q : Runtime.Val → iProp}
     (hfresh : name ∉ Δ.allNames)
     (hnewctx : insert (.pointsTo (.const (.uninterpreted name .value)) vt) ctx = newctx)
     (h : ∀ loc,
-      newctx.interp (ρ.updateConst .value name (.loc loc)) ∗ R ⊢
+      newctx.interp Θ (ρ.updateConst .value name (.loc loc)) ∗ R ⊢
       Q (.loc loc)) :
-    ctx.interp ρ ∗ R  ⊢ wp (.ref (.val v)) Q := by
-  have hforall : ctx.interp ρ ∗ R ⊢ BIBase.forall fun (loc : Runtime.Location) => loc ↦ v -∗ Q (.loc loc) := by
+    ctx.interp Θ ρ ∗ R  ⊢ wp (.ref (.val v)) Q := by
+  have hforall : ctx.interp Θ ρ ∗ R ⊢ BIBase.forall fun (loc : Runtime.Location) => loc ↦ v -∗ Q (.loc loc) := by
     apply forall_intro
     intro loc
     apply wand_intro
@@ -139,22 +139,22 @@ theorem wp_ref {v : Runtime.Val} {Q : Runtime.Val → iProp}
     let ρ' := ρ.updateConst .value name (.loc loc)
     let a : SpatialAtom := .pointsTo (.const (.uninterpreted name .value)) vt
     have hagree : Env.agreeOn Δ ρ ρ' := Env.agreeOn_update_fresh_const (c := ⟨name, .value⟩) hfresh
-    have hctxeq : ctx.interp ρ ⊢ ctx.interp ρ' := by
-      exact (SpatialContext.interp_env_agree hctx hagree).1
+    have hctxeq : ctx.interp Θ ρ ⊢ ctx.interp Θ ρ' := by
+      exact (SpatialContext.interp_env_agree Θ hctx hagree).1
     have hveq : Term.eval ρ' vt = v := by
       simpa [ρ'] using (Term.eval_update_fresh (t := vt) hvt hfresh).trans hv
     have hloc : Term.eval ρ' (.const (.uninterpreted name .value)) = .loc loc := by
       simp [ρ', Term.eval, Env.updateConst]
-    have hptIntro : loc ↦ v ⊢ a.interp ρ' := by
-      simpa [a, hveq] using (SpatialAtom.interp_pointsTo (ρ := ρ') (lt := .const (.uninterpreted name .value))
+    have hptIntro : loc ↦ v ⊢ a.interp Θ ρ' := by
+      simpa [a, hveq] using (SpatialAtom.interp_pointsTo Θ (ρ := ρ') (lt := .const (.uninterpreted name .value))
         (vt := vt) (loc := loc) hloc).2
-    have hinsert : ctx.interp ρ ∗ (loc ↦ v) ⊢ (insert a ctx).interp ρ' := by
+    have hinsert : ctx.interp Θ ρ ∗ (loc ↦ v) ⊢ (insert a ctx).interp Θ ρ' := by
       apply (sep_mono_l hctxeq).trans
       apply sep_comm.1.trans
       apply (sep_mono_l hptIntro).trans
       simp [a, SpatialContext.interp]
     -- rearrange (ctx.interp ρ ∗ R) ∗ (loc ↦ v) to (ctx.interp ρ ∗ (loc ↦ v)) ∗ R
-    have hrearrange : (ctx.interp ρ ∗ R) ∗ (loc ↦ v) ⊢ (ctx.interp ρ ∗ (loc ↦ v)) ∗ R :=
+    have hrearrange : (ctx.interp Θ ρ ∗ R) ∗ (loc ↦ v) ⊢ (ctx.interp Θ ρ ∗ (loc ↦ v)) ∗ R :=
       sep_assoc.1.trans (sep_mono_r sep_comm.1) |>.trans sep_assoc.2
     exact hrearrange.trans ((sep_mono_l hinsert).trans (by simpa [ρ', a, hnewctx] using h loc))
   exact hforall.trans wp.ref
@@ -175,20 +175,20 @@ theorem wp_bind_deref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     The pure premises identify the runtime value `v` with the location named
     by `lt`, and the continuation premise `h` works with the remaining
     context. -/
-theorem wp_deref {Q : Runtime.Val → iProp}
+theorem wp_deref (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     {ctx : SpatialContext} {ρ : Env} {R : iProp}
     {n : Nat} {lt vt : Term .value} {rest : SpatialContext}
     {v : Runtime.Val} {loc : Runtime.Location}
-    (h : ctx.interp ρ ∗ R ⊢ Q (Term.eval ρ vt)) :
+    (h : ctx.interp Θ ρ ∗ R ⊢ Q (Term.eval ρ vt)) :
     remove ctx n = some (.pointsTo lt vt, rest) →
     Term.eval ρ lt = v →
     v = .loc loc →
-    ctx.interp ρ ∗ R ⊢ wp (.deref (.val v)) Q := by
+    ctx.interp Θ ρ ∗ R ⊢ wp (.deref (.val v)) Q := by
   intro hrem hlt hv
   subst hv
   -- Split the context and rewrite the selected atom to a raw points-to fact.
-  have hsplit : ctx.interp ρ ⊢ (loc ↦ Term.eval ρ vt) ∗ rest.interp ρ :=
-    (interp_remove ρ ctx n _ _ hrem).1 |>.trans (sep_mono_l (SpatialAtom.interp_pointsTo hlt).1)
+  have hsplit : ctx.interp Θ ρ ⊢ (loc ↦ Term.eval ρ vt) ∗ rest.interp Θ ρ :=
+    (interp_remove Θ ρ ctx n _ _ hrem).1 |>.trans (sep_mono_l (SpatialAtom.interp_pointsTo Θ hlt).1)
   -- Rebuild the original context inside the wand, since reading preserves it.
   apply (sep_mono_l hsplit).trans
   istart
@@ -197,9 +197,9 @@ theorem wp_deref {Q : Runtime.Val → iProp}
   isplitl [Hpt]
   · iexact Hpt
   · iintro Hpt
-    have hctx : (loc ↦ Term.eval ρ vt) ∗ rest.interp ρ ⊢ ctx.interp ρ :=
-      (sep_mono_l (SpatialAtom.interp_pointsTo hlt).2).trans (interp_remove ρ ctx n _ _ hrem).2
-    have hq : (loc ↦ Term.eval ρ vt) ∗ rest.interp ρ ∗ R ⊢ Q (Term.eval ρ vt) :=
+    have hctx : (loc ↦ Term.eval ρ vt) ∗ rest.interp Θ ρ ⊢ ctx.interp Θ ρ :=
+      (sep_mono_l (SpatialAtom.interp_pointsTo Θ hlt).2).trans (interp_remove Θ ρ ctx n _ _ hrem).2
+    have hq : (loc ↦ Term.eval ρ vt) ∗ rest.interp Θ ρ ∗ R ⊢ Q (Term.eval ρ vt) :=
       sep_assoc.2.trans ((sep_mono_l hctx).trans h)
     iapply hq
     isplitl [Hpt]
@@ -224,20 +224,20 @@ theorem wp_bind_store {loc val : Runtime.Expr} {Q : Runtime.Val → iProp}
   exact h.trans (hloc.trans (wp.bind (k := TinyML.K.storeR loc .hole)))
 
 /-- Store at values: replace the selected points-to atom with the updated one. -/
-theorem wp_store {Q : Runtime.Val → iProp}
+theorem wp_store (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     {ctx : SpatialContext} {ρ : Env} {R : iProp}
     {n : Nat} {lt vt_old vt_new : Term .value} {rest : SpatialContext}
     {vloc vnew : Runtime.Val} {loc : Runtime.Location}
-    (h : (insert (.pointsTo lt vt_new) rest).interp ρ ∗ R ⊢ Q .unit) :
+    (h : (insert (.pointsTo lt vt_new) rest).interp Θ ρ ∗ R ⊢ Q .unit) :
     remove ctx n = some (.pointsTo lt vt_old, rest) →
     Term.eval ρ lt = vloc →
     vloc = .loc loc →
     Term.eval ρ vt_new = vnew →
-    ctx.interp ρ ∗ R ⊢ wp (.store (.val vloc) (.val vnew)) Q := by
+    ctx.interp Θ ρ ∗ R ⊢ wp (.store (.val vloc) (.val vnew)) Q := by
   intro hrem hlt hvloc hvnew
   subst hvloc
-  have hsplit : ctx.interp ρ ⊢ (loc ↦ Term.eval ρ vt_old) ∗ rest.interp ρ :=
-    (interp_remove ρ ctx n _ _ hrem).1 |>.trans (sep_mono_l (SpatialAtom.interp_pointsTo hlt).1)
+  have hsplit : ctx.interp Θ ρ ⊢ (loc ↦ Term.eval ρ vt_old) ∗ rest.interp Θ ρ :=
+    (interp_remove Θ ρ ctx n _ _ hrem).1 |>.trans (sep_mono_l (SpatialAtom.interp_pointsTo Θ hlt).1)
   apply (sep_mono_l hsplit).trans
   istart
   iintro ⟨⟨Hold, Hrest⟩, HR⟩
@@ -245,11 +245,11 @@ theorem wp_store {Q : Runtime.Val → iProp}
   isplitl [Hold]
   · iexact Hold
   · iintro Hnew
-    have hnew : loc ↦ vnew ⊢ SpatialAtom.interp ρ (.pointsTo lt vt_new) := by
-      simpa [← hvnew] using (SpatialAtom.interp_pointsTo hlt).2
-    have hctx : (loc ↦ vnew) ∗ rest.interp ρ ⊢ (insert (.pointsTo lt vt_new) rest).interp ρ := by
+    have hnew : loc ↦ vnew ⊢ SpatialAtom.interp Θ ρ (.pointsTo lt vt_new) := by
+      simpa [← hvnew] using (SpatialAtom.interp_pointsTo Θ hlt).2
+    have hctx : (loc ↦ vnew) ∗ rest.interp Θ ρ ⊢ (insert (.pointsTo lt vt_new) rest).interp Θ ρ := by
       simpa [insert, interp] using (sep_mono_l hnew)
-    have hq : (loc ↦ vnew) ∗ rest.interp ρ ∗ R ⊢ Q .unit :=
+    have hq : (loc ↦ vnew) ∗ rest.interp Θ ρ ∗ R ⊢ Q .unit :=
       sep_assoc.2.trans ((sep_mono_l hctx).trans h)
     iapply hq
     isplitl [Hnew]

--- a/Mica/SeparationLogic/SpatialAtom.lean
+++ b/Mica/SeparationLogic/SpatialAtom.lean
@@ -1,6 +1,7 @@
 -- SUMMARY: Syntactic spatial atoms and contexts for verifier state, together with their well-formedness conditions and basic operations.
 import Mica.FOL.Terms
 import Mica.SeparationLogic.Axioms
+import Mica.TinyML.Types
 
 open Iris Iris.BI
 
@@ -32,15 +33,15 @@ theorem wfIn_mono {a : SpatialAtom} {Δ Δ' : Signature}
   | pointsTo l v => exact ⟨Term.wfIn_mono l h.1 hsub hwf, Term.wfIn_mono v h.2 hsub hwf⟩
 
 /-- Iris interpretation of a single spatial atom. -/
-def interp (ρ : Env) : SpatialAtom → iProp
+def interp (_Θ : TinyML.TypeEnv) (ρ : Env) : SpatialAtom → iProp
   | .pointsTo l v => ∃ (loc : Runtime.Location),
       ⌜Term.eval ρ l = .loc loc⌝ ∗ loc ↦ Term.eval ρ v
 
 /-- Congruence for points-to interpretation under equal location and value evaluation. -/
-theorem pointsTo_congr {ρ : Env} {l l' v v' : Term .value}
+theorem pointsTo_congr (Θ : TinyML.TypeEnv) {ρ : Env} {l l' v v' : Term .value}
     (hl : Term.eval ρ l = Term.eval ρ l')
     (hv : Term.eval ρ v = Term.eval ρ v') :
-    interp ρ (.pointsTo l v) ⊣⊢ interp ρ (.pointsTo l' v') := by
+    interp Θ ρ (.pointsTo l v) ⊣⊢ interp Θ ρ (.pointsTo l' v') := by
   simp only [interp, hl, hv]
   exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -48,26 +48,26 @@ def Assertion.toStringHum {α : Type} (showA : α → String) : Assertion α →
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Assertion.pre (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
+def Assertion.pre (Θ : TinyML.TypeEnv) (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   (match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ.env⌝ ∗ Assertion.pre Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ.env; Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
-  | .pred x p k   => ∃ (v : x.sort.denote), p.eval ρ v ∗ Assertion.pre Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ.env⌝ ∗ Assertion.pre Θ Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ.env; Assertion.pre Θ Φ k (ρ.updateConst x.sort x.name v)
+  | .pred x p k   => ∃ (v : x.sort.denote), p.eval Θ ρ v ∗ Assertion.pre Θ Φ k (ρ.updateConst x.sort x.name v)
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.pre Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.pre Φ ke ρ)))
+      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.pre Θ Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.pre Θ Φ ke ρ)))
 
-def Assertion.post {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
+def Assertion.post (Θ : TinyML.TypeEnv) {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ.env⌝ -∗ Assertion.post Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ.env; Assertion.post Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ.env⌝ -∗ Assertion.post Θ Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ.env; Assertion.post Θ Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => iprop(∀ (v : x.sort.denote),
-      p.eval ρ v -∗ Assertion.post Φ k (ρ.updateConst x.sort x.name v))
+      p.eval Θ ρ v -∗ Assertion.post Θ Φ k (ρ.updateConst x.sort x.name v))
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.post Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.post Φ ke ρ))
+      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.post Θ Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.post Θ Φ ke ρ))
 
 
 -- ---------------------------------------------------------------------------
@@ -134,11 +134,11 @@ theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Pro
 -- Environment agreement
 -- ---------------------------------------------------------------------------
 
-theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature → Prop}
+theorem Assertion.pre_env_agree (Θ : TinyML.TypeEnv) {m : Assertion α} {retWf : α → Signature → Prop}
     {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
-    Assertion.pre Φ m ρ ⊢ Assertion.pre Φ m ρ' := by
+    Assertion.pre Θ Φ m ρ ⊢ Assertion.pre Θ Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
   | assert φ k ih =>
@@ -163,8 +163,8 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
     iintro ⟨%w, Hsep⟩
     iexists w
     iapply (sep_mono
-      (show p.eval ρ w ⊢ p.eval ρ' w by
-        simp [(Atom.eval_env_agree hpwf hagree)])
+      (show p.eval Θ ρ w ⊢ p.eval Θ ρ' w by
+        simp [(Atom.eval_env_agree Θ hpwf hagree)])
       (ih hkwf (VerifM.Env.agreeOn_declVar hagree)))
     iexact Hsep
   | ite φ kt ke iht ihe =>
@@ -194,11 +194,11 @@ theorem Assertion.pre_env_agree {m : Assertion α} {retWf : α → Signature →
       iapply hnφ
       iapply Hnφ
 
-theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature → Prop}
+theorem Assertion.post_env_agree (Θ : TinyML.TypeEnv) {m : Assertion α} {retWf : α → Signature → Prop}
     {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
-    Assertion.post Φ m ρ ⊢ Assertion.post Φ m ρ' := by
+    Assertion.post Θ Φ m ρ ⊢ Assertion.post Θ Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
   | assert φ k ih =>
@@ -223,7 +223,7 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
     iintro %w Hw
     iapply (ih hkwf (VerifM.Env.agreeOn_declVar hagree))
     iapply H
-    iapply (show p.eval ρ' w ⊢ p.eval ρ w by simp [(Atom.eval_env_agree hpwf hagree)])
+    iapply (show p.eval Θ ρ' w ⊢ p.eval Θ ρ w by simp [(Atom.eval_env_agree Θ hpwf hagree)])
     iexact Hw
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
@@ -247,13 +247,13 @@ theorem Assertion.post_env_agree {m : Assertion α} {retWf : α → Signature �
       exact hnφ'
 
 /-- Combining caller-side `pre` with verifier-side `post`. -/
-theorem Assertion.pre_post_combine {α : Type}
+theorem Assertion.pre_post_combine (Θ : TinyML.TypeEnv) {α : Type}
     {m : Assertion α}
     {Φ : α → VerifM.Env → iProp} {Ψ : α → VerifM.Env → iProp}
     {ρ : VerifM.Env}
     {R : iProp}
     (hR : ∀ (a : α) (ρ0 : VerifM.Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
-    : (Assertion.pre Φ m ρ ∗ Assertion.post Ψ m ρ) ⊢ R := by
+    : (Assertion.pre Θ Φ m ρ ∗ Assertion.post Θ Ψ m ρ) ⊢ R := by
   induction m generalizing ρ R with
   | ret a =>
     simpa [Assertion.pre, Assertion.post] using hR a ρ
@@ -369,7 +369,7 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
 -- Correctness theorems
 -- ---------------------------------------------------------------------------
 
-theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
+theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
@@ -379,8 +379,8 @@ theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : 
     VerifM.eval (Assertion.assume σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
       retWf a (Δ_base.declVars σ'.dom) →
-      st'.sl ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
-    st.sl ρ ∗ R ⊢ Assertion.post Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
+      st'.sl Θ ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
+    st.sl Θ ρ ∗ R ⊢ Assertion.post Θ Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
   intro hσwf hwf heval hpost
   induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
@@ -451,12 +451,12 @@ theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : 
         simpa [σ', FiniteSubst.rename_source_eq] using hkwf
       have hih := ih Δ_base σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
         (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
-      have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
-        SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+      have hinterp_bi : st.sl Θ ρ ⊣⊢ st.sl Θ (ρ.updateConst v.sort v'.name u) :=
+        SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
           (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
       exact (sep_mono hinterp_bi.1 (by
         iintro HR
-        iexact HR)).trans <| hih.trans <| Assertion.post_env_agree hkwf'
+        iexact HR)).trans <| hih.trans <| Assertion.post_env_agree Θ hkwf'
         (by
           simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
             (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -500,22 +500,22 @@ theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : 
         Atom.toItem_wfIn
           (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
             (TransState.freshConst.wf _ (VerifM.eval.wf heval)).namesDisjoint) hvar_wf
-      have hpu' : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-          (p.subst σ.subst).eval (ρ.updateConst v.sort v'.name u)
+      have hpu' : p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+          (p.subst σ.subst).eval Θ (ρ.updateConst v.sort v'.name u)
             ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
               (ρ.updateConst v.sort v'.name u).env) := by
         have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
             (ρ.updateConst v.sort v'.name u).env) = u := by
           simp [Term.eval, Const.denote, Env.updateConst]
         rw [hconst]
-        rw [Atom.eval_subst hpwf hsubst hrangewf]
+        rw [Atom.eval_subst Θ hpwf hsubst hrangewf]
         have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
           (τ := v.sort) (name' := v'.name) (u := u) hσwf hv'_fresh_range
         have heval_agree :
-            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) =
-              p.eval ((ρ.updateConst v.sort v'.name u).withEnv
+            p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) =
+              p.eval Θ ((ρ.updateConst v.sort v'.name u).withEnv
                 (σ.subst.eval (ρ.updateConst v.sort v'.name u).env)) :=
-          Atom.eval_env_agree (p := p)
+          Atom.eval_env_agree Θ (p := p)
             (ρ := ρ.withEnv (σ.subst.eval ρ.env))
             (ρ' := (ρ.updateConst v.sort v'.name u).withEnv
               (σ.subst.eval (ρ.updateConst v.sort v'.name u).env))
@@ -533,10 +533,10 @@ theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : 
         simpa [σ', FiniteSubst.rename_source_eq] using hkwf
       cases hitem : item with
       | pure φ =>
-        have hφ_entail : p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+        have hφ_entail : p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
             ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ := by
           simpa [item, hitem] using
-            (hpu'.trans (Atom.eval_purePart (p := p.subst σ.subst)
+            (hpu'.trans (Atom.eval_purePart Θ (p := p.subst σ.subst)
               (t := .const (.uninterpreted v'.name v.sort))
               (ρ := (ρ.updateConst v.sort v'.name u))))
         ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ $$ [Hpu]
@@ -553,17 +553,17 @@ theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : 
         have hih := ih Δ_base σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ))
           (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
         have hframe :
-            st.sl ρ ∗ R ⊢
+            st.sl Θ ρ ∗ R ⊢
               (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).sl
-                (ρ.updateConst v.sort v'.name u) ∗ R := by
+                Θ (ρ.updateConst v.sort v'.name u) ∗ R := by
           simp [TransState.addItem]
           exact sep_mono
-            (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+            (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
               (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
             (by
               iintro HR
               iexact HR)
-        iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree hkwf'
+        iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree Θ hkwf'
           (by
             simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -581,22 +581,22 @@ theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : 
         have hih := ih Δ_base σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.spatial a))
           (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
         have hitem_interp :
-            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-              CtxItem.interp (ρ.updateConst v.sort v'.name u) item := by
+            p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+              CtxItem.interp Θ (ρ.updateConst v.sort v'.name u) item := by
           simpa [item] using
-            (hpu'.trans (Atom.toItem_eval (p := p.subst σ.subst)
+            (hpu'.trans (Atom.toItem_eval Θ (p := p.subst σ.subst)
               (t := .const (.uninterpreted v'.name v.sort))
               (ρ := (ρ.updateConst v.sort v'.name u))).2)
         have hspatial_interp :
-            p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-              SpatialAtom.interp (ρ.updateConst v.sort v'.name u).env a := by
+            p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+              SpatialAtom.interp Θ (ρ.updateConst v.sort v'.name u).env a := by
           simpa [item, hitem, CtxItem.interp] using hitem_interp
         have howns_agree :
-            st.sl ρ ⊢
-              st.sl (ρ.updateConst v.sort v'.name u) :=
-          (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+            st.sl Θ ρ ⊢
+              st.sl Θ (ρ.updateConst v.sort v'.name u) :=
+          (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
             (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
-        iapply (hih.trans <| Assertion.post_env_agree hkwf'
+        iapply (hih.trans <| Assertion.post_env_agree Θ hkwf'
           (by
             simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -607,13 +607,13 @@ theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : 
         isplitr [HR]
         · isplitr [HS]
           · have hspatial_interp' :
-              p.eval (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-                SpatialAtom.interp (Env.updateConst ρ.env v.sort v'.name u) a := by
+              p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+                SpatialAtom.interp Θ (Env.updateConst ρ.env v.sort v'.name u) a := by
               simpa [VerifM.Env.updateConst] using hspatial_interp
             iapply hspatial_interp'
             simp [VerifM.Env.withEnv]
           · have howns_agree' :
-              st.sl ρ ⊢ SpatialContext.interp (Env.updateConst ρ.env v.sort v'.name u) st.owns := by
+              st.sl Θ ρ ⊢ SpatialContext.interp Θ (Env.updateConst ρ.env v.sort v'.name u) st.owns := by
               simpa [TransState.sl, VerifM.Env.updateConst] using howns_agree
             iapply howns_agree'
             simp [TransState.sl]
@@ -655,7 +655,7 @@ theorem Assertion.assume_correct (m : Assertion α) (Δ_base : Signature) (σ : 
         iapply (ihe Δ_base σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hkewf hassume hpost)
         simp [TransState.sl]
 
-theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
+theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
@@ -665,8 +665,8 @@ theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : F
     VerifM.eval (Assertion.prove σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
       retWf a (Δ_base.declVars σ'.dom) →
-      st'.sl ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
-    st.sl ρ ∗ R ⊢ Assertion.pre Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
+      st'.sl Θ ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
+    st.sl Θ ρ ∗ R ⊢ Assertion.pre Θ Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
   intro hσwf hwf heval hpost
   induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
@@ -684,8 +684,8 @@ theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : F
         Formula.wfIn_mono _ hsubst_wf_range huse hwfst
       have hassert := VerifM.eval_assert hb hsubst_wf
       have hφ_holds := (FiniteSubst.eval_subst_formula hσwf hφwf).mp hassert.1
-      show st.sl ρ ∗ R ⊢
-        (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
+      show st.sl Θ ρ ∗ R ⊢
+        (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre Θ Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
       istart
       iintro ⟨Howns, HR⟩
       isplitr [Howns HR]
@@ -744,12 +744,12 @@ theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : F
         simpa [σ', FiniteSubst.rename_source_eq] using hkwf
       have hih := ih Δ_base σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
         (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
-      have hinterp_bi : st.sl ρ ⊣⊢ st.sl (ρ.updateConst v.sort v'.name u) :=
-        SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf
+      have hinterp_bi : st.sl Θ ρ ⊣⊢ st.sl Θ (ρ.updateConst v.sort v'.name u) :=
+        SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
           (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
       exact (sep_mono hinterp_bi.1 (by
         iintro HR
-        iexact HR)).trans <| hih.trans <| Assertion.pre_env_agree hkwf'
+        iexact HR)).trans <| hih.trans <| Assertion.pre_env_agree Θ hkwf'
         (by
           simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
             (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -768,7 +768,7 @@ theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : F
         Atom.subst_wfIn hpwf hsubst (by intro x hx; exact hx) hsymbols hrangewf
       have hpwf_decls : (p.subst σ.subst).wfIn st.decls :=
         Atom.wfIn_mono hpwf_range huse hwfst
-      exact VerifM.eval_resolve hb hpwf_decls
+      exact VerifM.eval_resolve Θ hb hpwf_decls
         (fun st' ρ' hq hsub hagree => by
           exact (VerifM.eval_fatal hq).elim)
         (fun t st' ρ' hq hsub hagree htwf => by
@@ -783,12 +783,12 @@ theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : F
           iexists (t.eval ρ'.env)
           isplitr [Howns HR]
           · have hpred_subst :
-                (p.subst σ.subst).eval ρ' (t.eval ρ'.env) ⊢
-                  p.eval (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) := by
+                (p.subst σ.subst).eval Θ ρ' (t.eval ρ'.env) ⊢
+                  p.eval Θ (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) := by
               simpa [VerifM.Env.withEnv] using
-                (show (p.subst σ.subst).eval ρ' (t.eval ρ'.env) ⊢
-                    p.eval (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) by
-                  rw [Atom.eval_subst hpwf hsubst hrangewf]
+                (show (p.subst σ.subst).eval Θ ρ' (t.eval ρ'.env) ⊢
+                    p.eval Θ (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) by
+                  rw [Atom.eval_subst Θ hpwf hsubst hrangewf]
                   exact BIBase.Entails.rfl)
             have hagree_subst :
                 VerifM.Env.agreeOn (Δ_base.declVars σ.dom)
@@ -796,9 +796,9 @@ theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : F
                   (ρ'.withEnv (σ.subst.eval ρ'.env)) := by
               exact FiniteSubst.eval_agreeOn hσwf hagree
             have hpred_transport :
-                p.eval (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) ⊢
-                  p.eval (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ'.env) := by
-              rw [Atom.eval_env_agree hpwf (VerifM.Env.agreeOn_symm hagree_subst)]
+                p.eval Θ (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) ⊢
+                  p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ'.env) := by
+              rw [Atom.eval_env_agree Θ hpwf (VerifM.Env.agreeOn_symm hagree_subst)]
               exact BIBase.Entails.rfl
             iapply hpred_transport
             iapply hpred_subst
@@ -842,15 +842,15 @@ theorem Assertion.prove_correct (m : Assertion α) (Δ_base : Signature) (σ : F
               simpa [σ', FiniteSubst.rename_source_eq] using hkwf
             have hih := ih Δ_base σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
               (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) Ψ hσ'wf hkwf' hassume hpost
-            have hinterp_bi : st'.sl ρ' ⊣⊢ st'.sl (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) :=
-              SpatialContext.interp_env_agree (VerifM.eval.wf hq).ownsWf
+            have hinterp_bi : st'.sl Θ ρ' ⊣⊢ st'.sl Θ (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) :=
+              SpatialContext.interp_env_agree Θ (VerifM.eval.wf hq).ownsWf
                 (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-            have hframe : st'.sl ρ' ∗ R ⊢
-                st'.sl (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) ∗ R := by
+            have hframe : st'.sl Θ ρ' ∗ R ⊢
+                st'.sl Θ (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) ∗ R := by
               exact sep_mono hinterp_bi.1 (by
                 iintro HR
                 iexact HR)
-            iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree hkwf'
+            iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree Θ hkwf'
               (by
                 have hrename := (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st'.decls)
                     (v := v) (name' := v'.name) (ρ := ρ'.env) (u := t.eval ρ'.env)

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -64,7 +64,7 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Atom.eval {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
+def Atom.eval (_Θ : TinyML.TypeEnv) {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
   match p with
   | isint t  => λ v => ⌜.int v = t.eval ρ.env⌝
   | isbool t => λ v => ⌜.bool v = t.eval ρ.env⌝
@@ -134,9 +134,9 @@ theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
 def Atom.resolve (a : Atom τ) (C : List Formula) : Option (Term τ) :=
   C.findSome? (·.matchAtom a)
 
-theorem Atom.resolve_correct {a : Atom τ} {C : List Formula} {t : Term τ}
+theorem Atom.resolve_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {C : List Formula} {t : Term τ}
     (h : a.resolve C = some t) (ρ : VerifM.Env) (hC : ∀ φ ∈ C, φ.eval ρ.env) :
-    ⊢ (a.toItem t).interp ρ := by
+    ⊢ (a.toItem t).interp Θ ρ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
   rw [Formula.matchAtom_correct hφ_match]
   simpa [CtxItem.interp, hC _ hφ_mem] using (pure_intro (PROP := iProp) trivial)
@@ -201,8 +201,8 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | rel name t =>
     exact ⟨Formula.wfIn_mono _ h.1 hmono hwf, Term.wfIn_mono _ h.2 hmono hwf⟩
 
-theorem Atom.eval_env_agree {p : Atom τ} {ρ ρ' : VerifM.Env} {Δ : Signature}
-    (hwf : p.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') : p.eval ρ = p.eval ρ' := by
+theorem Atom.eval_env_agree (Θ : TinyML.TypeEnv) {p : Atom τ} {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : p.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') : p.eval Θ ρ = p.eval Θ ρ' := by
   cases p with
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
@@ -234,8 +234,8 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     simp only [Atom.toItem, CtxItem.wfIn, Formula.wfIn]
     exact ⟨hp.1, hp.2, ht⟩
 
-theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
-    CtxItem.interp ρ (p.toItem t) ⊣⊢ p.eval ρ (t.eval ρ.env) := by
+theorem Atom.toItem_eval (Θ : TinyML.TypeEnv) {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    CtxItem.interp Θ ρ (p.toItem t) ⊣⊢ p.eval Θ ρ (t.eval ρ.env) := by
   cases p with
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
@@ -246,8 +246,8 @@ theorem Atom.toItem_eval {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
   | rel name arg =>
     simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval]
 
-theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
-    p.eval ρ (t.eval ρ.env) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
+theorem Atom.eval_purePart (Θ : TinyML.TypeEnv) {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    p.eval Θ ρ (t.eval ρ.env) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
   cases p with
   | isint v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
@@ -267,9 +267,9 @@ theorem Atom.eval_purePart {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
 -- ---------------------------------------------------------------------------
 
 -- @agent: change eval_subst to a bi-entailment in the future.
-theorem Atom.eval_subst {p : Atom τ} {σ : Subst} {ρ : VerifM.Env} {Δ Δ' : Signature}
+theorem Atom.eval_subst (Θ : TinyML.TypeEnv) {p : Atom τ} {σ : Subst} {ρ : VerifM.Env} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hwfΔ' : Δ'.wf) :
-    (p.subst σ).eval ρ = p.eval (ρ.withEnv (σ.eval ρ.env)) := by
+    (p.subst σ).eval Θ ρ = p.eval Θ (ρ.withEnv (σ.eval ρ.env)) := by
   cases p with
   | isint t =>
     funext v
@@ -325,8 +325,8 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .own _ => []
   | .rel _ _ => []
 
-theorem Atom.candidates_correct {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : VerifM.Env}
-    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ.env) : ⊢ (a.toItem t).interp ρ := by
+theorem Atom.candidates_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : VerifM.Env}
+    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ.env) : ⊢ (a.toItem t).interp Θ ρ := by
   cases a with
   | isint v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
@@ -379,7 +379,7 @@ def VerifM.tryCandidates : List (Formula × Term τ) → VerifM (Option (Term τ
     if ← VerifM.check φ then pure (some t)
     else VerifM.tryCandidates rest
 
-private theorem VerifM.eval_tryCandidates
+private theorem VerifM.eval_tryCandidates (Θ : TinyML.TypeEnv)
     {candidates : List (Formula × Term τ)} {a : Atom τ}
     {st : TransState} {ρ : VerifM.Env} {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.tryCandidates candidates) st ρ Q)
@@ -387,7 +387,7 @@ private theorem VerifM.eval_tryCandidates
     (hpwf : a.wfIn st.decls) :
     ∃ result : Option (Term τ),
       Q result st ρ
-      ∧ (∀ t, result = some t → ⊢ (a.toItem t).interp ρ)
+      ∧ (∀ t, result = some t → ⊢ (a.toItem t).interp Θ ρ)
       ∧ (∀ t, result = some t → t.wfIn st.decls) := by
   induction candidates with
   | nil =>
@@ -405,7 +405,7 @@ private theorem VerifM.eval_tryCandidates
     | true =>
       simp at hq
       exact ⟨some t, VerifM.eval_ret hq,
-             fun t' ht' => by cases ht'; exact Atom.candidates_correct hmem (hb_sound rfl),
+             fun t' ht' => by cases ht'; exact Atom.candidates_correct Θ hmem (hb_sound rfl),
              fun t' ht' => by cases ht'; exact twf⟩
     | false =>
       simp at hq
@@ -504,7 +504,7 @@ theorem VerifM.eval_findMatchIn {lq : Term .value} {ctx : SpatialContext}
     continuations for the `some` and `none` branches. On `some v`, the
     postcondition state has the matched points-to consumed from `st.owns`, and
     the caller receives separate ownership of `lq ↦ v`. -/
-theorem VerifM.eval_findMatch {lq : Term .value}
+theorem VerifM.eval_findMatch (Θ : TinyML.TypeEnv) {lq : Term .value}
     {st : TransState} {ρ : VerifM.Env}
     {Q : Option (Term .value) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
@@ -512,9 +512,9 @@ theorem VerifM.eval_findMatch {lq : Term .value}
     (hlq : lq.wfIn st.decls)
     (hsome : ∀ v st', Q (some v) st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp ρ.env (.pointsTo lq v) ∗ st'.sl ρ ∗ R ⊢ Φ)
-    (hnone : Q none st ρ → st.sl ρ ∗ R ⊢ Φ) :
-    st.sl ρ ∗ R ⊢ Φ := by
+        SpatialAtom.interp Θ ρ.env (.pointsTo lq v) ∗ st'.sl Θ ρ ∗ R ⊢ Φ)
+    (hnone : Q none st ρ → st.sl Θ ρ ∗ R ⊢ Φ) :
+    st.sl Θ ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatch at h
   have hb := VerifM.eval_bind _ _ _ _ h
   have ⟨hk, howns, _, _⟩ := VerifM.eval_ctx hb
@@ -541,8 +541,8 @@ theorem VerifM.eval_findMatch {lq : Term .value}
     have ⟨hk3, _, _, _⟩ := VerifM.eval_ctx hb3
     have hk3' := hk3 hrest_wf
     have hQ : Q (some v) { st with owns := rest } ρ := VerifM.eval_ret hk3'
-    have hsplit := SpatialContext.interp_remove ρ.env st.owns n _ _ hrem
-    have hcong := SpatialAtom.pointsTo_congr (l := l) (l' := lq) (v := v) (v' := v) heq.symm rfl
+    have hsplit := SpatialContext.interp_remove Θ ρ.env st.owns n _ _ hrem
+    have hcong := SpatialAtom.pointsTo_congr Θ (l := l) (l' := lq) (v := v) (v' := v) heq.symm rfl
     -- goal: st.owns.interp ρ ∗ R ⊢ Φ
     -- st.owns.interp ρ ⊣⊢ (pointsTo l v).interp ρ ∗ rest.interp ρ
     --                ⊣⊢ (pointsTo lq v).interp ρ ∗ rest.interp ρ
@@ -560,7 +560,7 @@ def VerifM.findMatchForce (lq : Term .value) : VerifM (Term .value) := do
 
 /-- CPS correctness for `findMatchForce`: only a `some`-style continuation is
     required, since the `none` branch is discharged by the fatal error. -/
-theorem VerifM.eval_findMatchForce {lq : Term .value}
+theorem VerifM.eval_findMatchForce (Θ : TinyML.TypeEnv) {lq : Term .value}
     {st : TransState} {ρ : VerifM.Env}
     {Q : Term .value → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
@@ -568,11 +568,11 @@ theorem VerifM.eval_findMatchForce {lq : Term .value}
     (hlq : lq.wfIn st.decls)
     (hsome : ∀ v st', Q v st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp ρ.env (.pointsTo lq v) ∗ st'.sl ρ ∗ R ⊢ Φ) :
-    st.sl ρ ∗ R ⊢ Φ := by
+        SpatialAtom.interp Θ ρ.env (.pointsTo lq v) ∗ st'.sl Θ ρ ∗ R ⊢ Φ) :
+    st.sl Θ ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatchForce at h
   have hb := VerifM.eval_bind _ _ _ _ h
-  refine eval_findMatch (R := R) (Φ := Φ) hb hlq ?_ ?_
+  refine eval_findMatch Θ (R := R) (Φ := Φ) hb hlq ?_ ?_
   · intros v st' hQ hdecls hv
     simp at hQ
     exact hsome v st' (VerifM.eval_ret hQ) hdecls hv
@@ -598,7 +598,7 @@ def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
       | none => VerifM.tryCandidates a.candidates
 
 /-- Helper: resolution of a pure atom via formula matching or SMT candidates. -/
-private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
+private theorem VerifM.eval_resolve_pure (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
     {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (do
@@ -607,11 +607,11 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
       | none => VerifM.tryCandidates pred.candidates) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st' ρ', Q .none st' ρ' → st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl ρ' ∗ R ⊢ Φ)
+      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl Θ ρ' ∗ R ⊢ Φ)
     (hsome : ∀ v st' ρ', Q (.some v) st' ρ' → st.decls.Subset st'.decls →
       VerifM.Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
-      Atom.eval pred ρ' (v.eval ρ'.env) ∗ st'.sl ρ' ∗ R ⊢ Φ) :
-    st.sl ρ ∗ R ⊢ Φ := by
+      Atom.eval Θ pred ρ' (v.eval ρ'.env) ∗ st'.sl Θ ρ' ∗ R ⊢ Φ) :
+    st.sl Θ ρ ∗ R ⊢ Φ := by
     have hb1 := VerifM.eval_bind _ _ _ _ h
     have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
     cases hres : pred.resolve st.asserts with
@@ -619,10 +619,10 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
       simp [hres] at hctx_q
       have hq := VerifM.eval_ret hctx_q
       have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
-      have hpred : ⊢ Atom.eval pred ρ (t.eval ρ.env) := by
-        exact (Atom.resolve_correct hres ρ hholds).trans Atom.toItem_eval.1
-      have hframe : st.sl ρ ∗ R ⊢
-          Atom.eval pred ρ (t.eval ρ.env) ∗ st.sl ρ ∗ R := by
+      have hpred : ⊢ Atom.eval Θ pred ρ (t.eval ρ.env) := by
+        exact (Atom.resolve_correct Θ hres ρ hholds).trans (Atom.toItem_eval Θ).1
+      have hframe : st.sl Θ ρ ∗ R ⊢
+          Atom.eval Θ pred ρ (t.eval ρ.env) ∗ st.sl Θ ρ ∗ R := by
         istart
         iintro H
         isplitr [H]
@@ -632,7 +632,7 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
     | none =>
       simp [hres] at hctx_q
       obtain ⟨result, hq, hresult_eval, hresult_wf⟩ :=
-        eval_tryCandidates hctx_q (fun p hp => hp) hwf
+        eval_tryCandidates Θ hctx_q (fun p hp => hp) hwf
       cases hr : result with
       | none =>
         have hqnone : Q .none st ρ := by simpa [hr] using hq
@@ -640,10 +640,10 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
       | some t =>
         have htwf : t.wfIn st.decls := hresult_wf t hr
         have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
-        have hpred : ⊢ Atom.eval pred ρ (t.eval ρ.env) := by
-          exact (hresult_eval t hr).trans Atom.toItem_eval.1
-        have hframe : st.sl ρ ∗ R ⊢
-            Atom.eval pred ρ (t.eval ρ.env) ∗ st.sl ρ ∗ R := by
+        have hpred : ⊢ Atom.eval Θ pred ρ (t.eval ρ.env) := by
+          exact (hresult_eval t hr).trans (Atom.toItem_eval Θ).1
+        have hframe : st.sl Θ ρ ∗ R ⊢
+            Atom.eval Θ pred ρ (t.eval ρ.env) ∗ st.sl Θ ρ ∗ R := by
           istart
           iintro H
           isplitr [H]
@@ -651,26 +651,26 @@ private theorem VerifM.eval_resolve_pure {pred : Atom τ} {st : TransState} {ρ 
           · iexact H
         exact hframe.trans (hsome t st ρ hqsome (Signature.Subset.refl _) VerifM.Env.agreeOn_refl htwf)
 
-theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
+theorem VerifM.eval_resolve (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
     {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st' ρ', Q .none st' ρ' → st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl ρ' ∗ R ⊢ Φ)
+      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl Θ ρ' ∗ R ⊢ Φ)
     (hsome : ∀ v st' ρ', Q (.some v) st' ρ' → st.decls.Subset st'.decls →
       VerifM.Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
-      Atom.eval pred ρ' (v.eval ρ'.env) ∗ st'.sl ρ' ∗ R ⊢ Φ) :
-    st.sl ρ ∗ R ⊢ Φ := by
+      Atom.eval Θ pred ρ' (v.eval ρ'.env) ∗ st'.sl Θ ρ' ∗ R ⊢ Φ) :
+    st.sl Θ ρ ∗ R ⊢ Φ := by
   match pred, hwf, hsome, h with
   | .own l, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    refine VerifM.eval_findMatch (R := R) (Φ := Φ) h hwf ?_ ?_
+    refine VerifM.eval_findMatch Θ (R := R) (Φ := Φ) h hwf ?_ ?_
     · intros v st' hqsome hdecls hvwf
       have hsub : st.decls.Subset st'.decls := by rw [hdecls]; exact Signature.Subset.refl _
       have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
       have hsome' := hsome v st' ρ hqsome hsub VerifM.Env.agreeOn_refl hvwf'
-      have heq : SpatialAtom.interp ρ.env (.pointsTo l v) ⊢ Atom.eval (Atom.own l) ρ (v.eval ρ.env) := by
+      have heq : SpatialAtom.interp Θ ρ.env (.pointsTo l v) ⊢ Atom.eval Θ (Atom.own l) ρ (v.eval ρ.env) := by
         simp only [Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
@@ -678,13 +678,13 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
       exact hnone st ρ hqnone (Signature.Subset.refl _) VerifM.Env.agreeOn_refl
   | .isint t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    exact VerifM.eval_resolve_pure (pred := .isint t) h hwf hnone hsome
+    exact VerifM.eval_resolve_pure Θ (pred := .isint t) h hwf hnone hsome
   | .isbool t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    exact VerifM.eval_resolve_pure (pred := .isbool t) h hwf hnone hsome
+    exact VerifM.eval_resolve_pure Θ (pred := .isbool t) h hwf hnone hsome
   | .isinj tag arity t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    exact VerifM.eval_resolve_pure (pred := .isinj tag arity t) h hwf hnone hsome
+    exact VerifM.eval_resolve_pure Θ (pred := .isinj tag arity t) h hwf hnone hsome
   | .rel name t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
     have hb := VerifM.eval_bind _ _ _ _ h
@@ -698,10 +698,10 @@ theorem VerifM.eval_resolve {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
       simp at hafter
       have hdef : (SpecFn.isDefined name t).eval ρ.env := hok_sound rfl
       have hqsome : Q (some (SpecFn.call name t)) st ρ := VerifM.eval_ret hafter
-      have hpred : ⊢ Atom.eval (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ.env) :=
+      have hpred : ⊢ Atom.eval Θ (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ.env) :=
         pure_intro (PROP := iProp) ⟨hdef, rfl⟩
-      have hframe : st.sl ρ ∗ R ⊢
-          Atom.eval (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ.env) ∗ st.sl ρ ∗ R := by
+      have hframe : st.sl Θ ρ ∗ R ⊢
+          Atom.eval Θ (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ.env) ∗ st.sl Θ ρ ∗ R := by
         istart
         iintro H
         isplitr [H]

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -278,8 +278,8 @@ namespace Helpers
 theorem ctx_dup (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-      st.sl ρ ∗
+    st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗
         (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R)) := by
   iintro ⟨Howns, □HS, □HT, HR⟩
@@ -298,8 +298,8 @@ theorem ctx_dup (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.En
 theorem ctx_dup_flip (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-      st.sl ρ ∗
+    st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗
         (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))) := by
   iintro ⟨Howns, □HS, □HT, HR⟩
@@ -319,8 +319,8 @@ theorem ctx_push (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.E
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-      st.sl ρ ∗
+    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗
         (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (TinyML.ValHasType Θ v ty ∗ R)) := by
   iintro ⟨Howns, Hv, □HS, □HT, HR⟩
@@ -338,8 +338,8 @@ theorem ctx_push_flip (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : Ver
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-      st.sl ρ ∗
+    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+      st.sl Θ ρ ∗
         (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (TinyML.ValHasType Θ v ty ∗ R)) := by
   iintro ⟨Howns, Hv, □HT, □HS, HR⟩
@@ -383,8 +383,8 @@ def correctExpr (e : Expr) : Prop :=
     Δ_spec.Subset st.decls →
     VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
-      st'.sl ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢ Φ v) →
-    st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ
+      st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢ Φ v) →
+    st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ
 
 def correctBranch (branch : Binder × Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -403,9 +403,9 @@ def correctBranch (branch : Binder × Expr) : Prop :=
     VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
-      st.sl ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
+      st.sl Θ ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
 
 def correctBranches (branches : List (Binder × Expr)) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -423,11 +423,11 @@ def correctBranches (branches : List (Binder × Expr)) : Prop :=
     VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
       VerifM.eval (compileBranch Θ Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
-        st.sl ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
+        st.sl Θ ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
 
 def correctExprs (es : List Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -446,8 +446,8 @@ def correctExprs (es : List Expr) : Prop :=
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ'.env terms vs →
-       st'.sl ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
-    st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ
+       st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
+    st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ
 
 /-! #### Correctness Compatibility Lemmas -/
 
@@ -554,11 +554,11 @@ theorem compileVar_correct (x : String) (vty : TinyML.Typ) :
       ipure_intro
       trivial
     have hprep :
-        st.sl ρ ∗ (B.typedSubst Θ Γ γ ∗ R) ⊢
-          st.sl ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) .value ∗ R := by
+        st.sl Θ ρ ∗ (B.typedSubst Θ Γ γ ∗ R) ⊢
+          st.sl Θ ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) .value ∗ R := by
       exact sep_mono_r (sep_mono_l (true_intro.trans hvalue))
     have hpost' :
-        st.sl ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) .value ∗ R ⊢
+        st.sl Θ ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) .value ∗ R ⊢
           Φ (ρ.env.consts .value x'.name) := by
       simpa [hΓx] using
         (hpost (ρ.env.consts .value x'.name) ρ st (Term.const (.uninterpreted x'.name .value))
@@ -568,12 +568,12 @@ theorem compileVar_correct (x : String) (vty : TinyML.Typ) :
     have hΓ : Γ x = some t := hΓx
     have htv : t = vty := by simpa [hΓx] using hcheck
     have hprep :
-        st.sl ρ ∗ (B.typedSubst Θ Γ γ ∗ R) ⊢
-          st.sl ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty ∗ R := by
+        st.sl Θ ρ ∗ (B.typedSubst Θ Γ γ ∗ R) ⊢
+          st.sl Θ ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty ∗ R := by
       rw [← htv]
       exact sep_mono_r (sep_mono_l (htyped hΓ))
     have hpost' :
-        st.sl ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty ∗ R ⊢
+        st.sl Θ ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty ∗ R ⊢
           Φ (ρ.env.consts .value x'.name) :=
       hpost (ρ.env.consts .value x'.name) ρ st (Term.const (.uninterpreted x'.name .value))
         hΨ hwfv (by simp [Term.eval, Const.denote])
@@ -605,11 +605,11 @@ theorem compileInj_correct (tag arity : Nat) (payload : Expr)
         TinyML.ValHasType Θ (.inj tag arity v_p) (.sum ts) :=
       TinyML.ValHasType.inj hlen_ts hget_ts
     have hprep :
-        st_p.sl ρ_p ∗ TinyML.ValHasType Θ v_p payload.ty ∗ R ⊢
-          st_p.sl ρ_p ∗ TinyML.ValHasType Θ (.inj tag arity v_p) (.sum ts) ∗ R :=
+        st_p.sl Θ ρ_p ∗ TinyML.ValHasType Θ v_p payload.ty ∗ R ⊢
+          st_p.sl Θ ρ_p ∗ TinyML.ValHasType Θ (.inj tag arity v_p) (.sum ts) ∗ R :=
       sep_mono_r (sep_mono_l hinj)
     have hpost' :
-        st_p.sl ρ_p ∗ TinyML.ValHasType Θ (.inj tag arity v_p) (.sum ts) ∗ R ⊢
+        st_p.sl Θ ρ_p ∗ TinyML.ValHasType Θ (.inj tag arity v_p) (.sum ts) ∗ R ⊢
           Φ (.inj tag arity v_p) := by
       simpa [ts, hlen_ts] using
         (hpost (.inj tag arity v_p) ρ_p st_p _ hΨ_p
@@ -637,8 +637,8 @@ theorem compileCast_correct (e : Expr) (ty : TinyML.Typ)
     obtain hΨ := VerifM.eval_ret hΨ
     have hsub' : TinyML.Typ.Sub Θ e.ty ty := TinyML.Typ.sub_sound hsub
     have hprep :
-        st'.sl ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢
-          st'.sl ρ' ∗ TinyML.ValHasType Θ v ty ∗ R :=
+        st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢
+          st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v ty ∗ R :=
       sep_mono_r (sep_mono_l (TinyML.ValHasType.sub hsub'))
     exact hprep.trans <| hpost v ρ' st' se hΨ hse_wf heval_se
 
@@ -667,8 +667,8 @@ theorem compileAssert_correct (e : Expr)
   simp only [Expr.ty] at hpost
   subst hvtrue
   have hprep :
-      st₁.sl ρ_e ∗ TinyML.ValHasType Θ (.bool true) e.ty ∗ R ⊢
-        st₁.sl ρ_e ∗ TinyML.ValHasType Θ .unit .unit ∗ R :=
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ (.bool true) e.ty ∗ R ⊢
+        st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ .unit .unit ∗ R :=
     sep_mono_r (sep_mono_l (true_intro.trans (TinyML.ValHasType.unit_intro Θ)))
   exact SpatialContext.wp_assert <| hprep.trans <| hpost .unit ρ_e st₁ (Term.const .unit) hΨ_pure
     trivial
@@ -700,7 +700,7 @@ theorem compileRef_correct (e : Expr)
   have hwf_addConst : TransState.wf { st₁ with decls := st₁.decls.addConst c } :=
     TransState.freshConst.wf _ hwf_st₁
   have hwp :
-      st₁.sl ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (.ref (.val v_e)) Φ := by
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (.ref (.val v_e)) Φ := by
     istart
     iintro ⟨Howns, □Hty, HR⟩
     iapply (wp.ref_inv (I := fun w => TinyML.ValHasType Θ w e.ty))
@@ -733,9 +733,9 @@ theorem compileRef_correct (e : Expr)
         · ipure_intro
           rfl
         · iexact Hinv
-      have hsl_agree : st₁.sl ρ_e ⊢ st₂.sl ρ_e' := by
+      have hsl_agree : st₁.sl Θ ρ_e ⊢ st₂.sl Θ ρ_e' := by
         simp only [TransState.sl_eq, st₂]
-        apply (SpatialContext.interp_env_agree hwf_st₁.ownsWf ?_).1
+        apply (SpatialContext.interp_env_agree Θ hwf_st₁.ownsWf ?_).1
         exact Env.agreeOn_update_fresh_const (c := c) hfresh
       iapply (hpost (.loc loc) ρ_e' st₂ (Term.const (.uninterpreted c.name .value))
         hret hc_wf hval_eval)
@@ -774,7 +774,7 @@ theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
         (Term.const_wfIn_addConst_of_fresh (Δ := st₁.decls) (c := c)
           (VerifM.eval.wf hdecl_eval).namesDisjoint hc_fresh)
   have hwp :
-      st₁.sl ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (.deref (.val v_e)) Φ := by
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (.deref (.val v_e)) Φ := by
     rw [hannot]
     istart
     iintro ⟨Howns, Href, HR⟩
@@ -799,9 +799,9 @@ theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
         (fun φ hφ => Hcheck φ hφ)
       have hΨ_ret := VerifM.eval_ret heval_ret
       have hsv_wf : sv.wfIn st₃.decls := hst₃_decls ▸ hc_wf
-      have hsl_agree : st₁.sl ρ_e ⊢ st₃.sl ρ₂ := by
+      have hsl_agree : st₁.sl Θ ρ_e ⊢ st₃.sl Θ ρ₂ := by
         simp [TransState.sl_eq, st₂, hst₃_owns]
-        exact (SpatialContext.interp_env_agree (VerifM.eval.wf hdecl_eval).ownsWf
+        exact (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hdecl_eval).ownsWf
           (Env.agreeOn_update_fresh_const (c := c) hc_fresh)).1
       iapply (hpost w ρ₂ st₃ sv hΨ_ret hsv_wf hsv_eval)
       isplitl [Howns]
@@ -823,8 +823,8 @@ theorem compileStore_correct (loc val : Expr)
   obtain ⟨hannot, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_v : (compile Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl ρ ∗
+      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st.sl Θ ρ ∗
           (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))) :=
     Helpers.ctx_dup_flip Θ Δ_spec ρ_spec S B Γ st ρ γ R
@@ -838,9 +838,9 @@ theorem compileStore_correct (loc val : Expr)
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
   have heval_l : (compile Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
   have hlocStart :
-      st₁.sl ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
+      st₁.sl Θ ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
         (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl ρ_v ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+          st₁.sl Θ ρ_v ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (TinyML.ValHasType Θ v_v val.ty ∗ R)) :=
     Helpers.ctx_push_flip Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
   have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
@@ -852,10 +852,10 @@ theorem compileStore_correct (loc val : Expr)
   have hunit_wf : (Term.const .unit).wfIn st₂.decls := by
     simp [Term.wfIn, Const.wfIn]
   have hgoal :
-      st₂.sl ρ_l ∗ TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Φ .unit :=
+      st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Φ .unit :=
     hpost .unit ρ_l st₂ _ hret hunit_wf (by simp [Term.eval])
   have hwp :
-      st₂.sl ρ_l ∗ (TinyML.ValHasType Θ v_l loc.ty ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R)) ⊢
+      st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ v_l loc.ty ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R)) ⊢
         wp (.store (.val v_l) (.val v_v)) Φ := by
     rw [hannot]
     istart
@@ -894,8 +894,8 @@ theorem compileUnop_correct (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
   obtain ⟨t, hcompUnop, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
   obtain hΨ_e := VerifM.eval_ret hΨ_e
   have htyped :
-      st₁.sl ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢
-        st₁.sl ρ_e ∗ iprop(∃ w, ⌜TinyML.evalUnOp op v_e = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R :=
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢
+        st₁.sl Θ ρ_e ∗ iprop(∃ w, ⌜TinyML.evalUnOp op v_e = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R :=
     sep_mono_r (sep_mono_l (TinyML.evalUnOp_typed htypeOf))
   simp only [Expr.ty] at hpost
   refine htyped.trans ?_
@@ -904,12 +904,12 @@ theorem compileUnop_correct (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
   icases Hex with ⟨%w, %heval_op, Hwty⟩
   have ht_eval : t.eval ρ_e.env = w :=
     compileUnop_eval heval_se heval_op hcompUnop
-  have hq : st₁.sl ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w :=
+  have hq : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w :=
     by simpa [hty_eq] using
       (hpost w ρ_e st₁ t hΨ_e (compileUnop_wfIn hse_wf hcompUnop) ht_eval)
-  have hwp : st₁.sl ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (.unop op (.val v_e)) Φ :=
+  have hwp : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (.unop op (.val v_e)) Φ :=
     SpatialContext.wp_unop
-      (R := st₁.sl ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R)
+      (R := st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R)
       (Q := Φ) (op := op) (v := v_e) (res := w) hq heval_op
   iapply hwp
   isplitl [Howns]
@@ -927,8 +927,8 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
   simp only [compile] at heval
   have heval_r : (compile Θ Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl ρ ∗
+      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st.sl Θ ρ ∗
           (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
     Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
@@ -942,9 +942,9 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
   have hbwf_r : B.wfIn st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
   have heval_l : (compile Θ Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
   have hleftStart :
-      st₁.sl ρ_r ∗ TinyML.ValHasType Θ vr r.ty ∗
+      st₁.sl Θ ρ_r ∗ TinyML.ValHasType Θ vr r.ty ∗
         (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st₁.sl ρ_r ∗
+          st₁.sl Θ ρ_r ∗
             (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
               (TinyML.ValHasType Θ vr r.ty ∗ R)) :=
     Helpers.ctx_push Θ Δ_spec ρ_spec S B Γ st₁ ρ_r γ R vr r.ty
@@ -995,7 +995,7 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
         simpa using hΨ_post
       have hwp_int :
-          st₂.sl ρ_l ∗ (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
+          st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
             wp (.binop .div (.val vl) (.val vr)) Φ := by
         istart
         iintro H
@@ -1005,13 +1005,13 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
         icases Hvl_int with ⟨%a, %hvl⟩
         icases Hvr_int with ⟨%b, %hvr⟩
         subst hvl hvr
-        have hq : st₂.sl ρ_l ∗ R ⊢ Φ (.int (a / b)) := by
+        have hq : st₂.sl Θ ρ_l ∗ R ⊢ Φ (.int (a / b)) := by
           have htype : ⊢ TinyML.ValHasType Θ (.int (a / b)) .int := by
             iapply (TinyML.ValHasType.int Θ (.int (a / b))).2
             ipure_intro
             exact ⟨a / b, rfl⟩
           have hgoal :
-              st₂.sl ρ_l ∗ TinyML.ValHasType Θ (.int (a / b)) .int ∗ R ⊢ Φ (.int (a / b)) := by
+              st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ (.int (a / b)) .int ∗ R ⊢ Φ (.int (a / b)) := by
             simpa [hbty] using
               (hpost (.int (a / b)) ρ_l st₂ _ hΨ_post' hwf_bin
                 (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l]))
@@ -1054,7 +1054,7 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
         simpa using hΨ_post
       have hwp_int :
-          st₂.sl ρ_l ∗ (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
+          st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
             wp (.binop .mod (.val vl) (.val vr)) Φ := by
         istart
         iintro H
@@ -1064,13 +1064,13 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
         icases Hvl_int with ⟨%a, %hvl⟩
         icases Hvr_int with ⟨%b, %hvr⟩
         subst hvl hvr
-        have hq : st₂.sl ρ_l ∗ R ⊢ Φ (.int (a % b)) := by
+        have hq : st₂.sl Θ ρ_l ∗ R ⊢ Φ (.int (a % b)) := by
           have htype : ⊢ TinyML.ValHasType Θ (.int (a % b)) .int := by
             iapply (TinyML.ValHasType.int Θ (.int (a % b))).2
             ipure_intro
             exact ⟨a % b, rfl⟩
           have hgoal :
-              st₂.sl ρ_l ∗ TinyML.ValHasType Θ (.int (a % b)) .int ∗ R ⊢ Φ (.int (a % b)) := by
+              st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ (.int (a % b)) .int ∗ R ⊢ Φ (.int (a % b)) := by
             simpa [hbty] using
               (hpost (.int (a % b)) ρ_l st₂ _ hΨ_post' hwf_bin
                 (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l]))
@@ -1097,8 +1097,8 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       simpa [hndivmod] using hΨ_l'
     obtain ⟨t, hcompOp, hΨ_ndiv⟩ := VerifM.eval_bind_expectSome hΨ_ndiv
     have hprep :
-        st₂.sl ρ_l ∗ (TinyML.ValHasType Θ vl l.ty ∗ (TinyML.ValHasType Θ vr r.ty ∗ R)) ⊢
-          st₂.sl ρ_l ∗ ((TinyML.ValHasType Θ vl l.ty ∗ TinyML.ValHasType Θ vr r.ty) ∗ R) := by
+        st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ vl l.ty ∗ (TinyML.ValHasType Θ vr r.ty ∗ R)) ⊢
+          st₂.sl Θ ρ_l ∗ ((TinyML.ValHasType Θ vl l.ty ∗ TinyML.ValHasType Θ vr r.ty) ∗ R) := by
       iintro ⟨Howns, Hvl, Hvr, HR⟩
       isplitl [Howns]
       · iexact Howns
@@ -1108,15 +1108,15 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
           · iexact Hvr
         · iexact HR
     have htyped :
-        st₂.sl ρ_l ∗ (TinyML.ValHasType Θ vl l.ty ∗ (TinyML.ValHasType Θ vr r.ty ∗ R)) ⊢
-          st₂.sl ρ_l ∗ iprop(∃ w, ⌜TinyML.evalBinOp op vl vr = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R :=
+        st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ vl l.ty ∗ (TinyML.ValHasType Θ vr r.ty ∗ R)) ⊢
+          st₂.sl Θ ρ_l ∗ iprop(∃ w, ⌜TinyML.evalBinOp op vl vr = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R :=
       hprep.trans <|
         (sep_mono_r (sep_mono_l (TinyML.evalBinOp_typed
           (fun h => hndivmod (Or.inl h))
           (fun h => hndivmod (Or.inr h))
           htypeOf)) :
-          st₂.sl ρ_l ∗ ((TinyML.ValHasType Θ vl l.ty ∗ TinyML.ValHasType Θ vr r.ty) ∗ R) ⊢
-            st₂.sl ρ_l ∗ iprop(∃ w, ⌜TinyML.evalBinOp op vl vr = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R)
+          st₂.sl Θ ρ_l ∗ ((TinyML.ValHasType Θ vl l.ty ∗ TinyML.ValHasType Θ vr r.ty) ∗ R) ⊢
+            st₂.sl Θ ρ_l ∗ iprop(∃ w, ⌜TinyML.evalBinOp op vl vr = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R)
     have hwfst₂ : st₂.decls.wf := (VerifM.eval.wf hΨ_ndiv).namesDisjoint
     obtain hΨ_ndiv := VerifM.eval_ret hΨ_ndiv
     have hwf_sr_l : sr.wfIn st₂.decls :=
@@ -1126,12 +1126,12 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
     iintro ⟨Howns, Hex, HR⟩
     icases Hex with ⟨%w, %heval_op, Hwty⟩
     have ht_eval : t.eval ρ_l.env = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
-    have hq : st₂.sl ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w := by
+    have hq : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w := by
       simpa [hty_eq] using
         (hpost w ρ_l st₂ t hΨ_ndiv (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval)
-    have hwp : st₂.sl ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (.binop op (.val vl) (.val vr)) Φ :=
+    have hwp : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (.binop op (.val vl) (.val vr)) Φ :=
       SpatialContext.wp_binop
-        (R := st₂.sl ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R)
+        (R := st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R)
         (Q := Φ) (op := op) (vl := vl) (vr := vr) (res := w) hq heval_op
     iapply hwp
     isplitl [Howns]
@@ -1150,8 +1150,8 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
   simp only [Runtime.Expr.letIn_subst]
   have heval_e_outer : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl ρ ∗
+      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st.sl Θ ρ ∗
           (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
     Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
@@ -1166,8 +1166,8 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
   | none =>
     simp [hname] at hΨ_e
     have hdrop :
-        st₁.sl ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-          st₁.sl ρ_e ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          st₁.sl Θ ρ_e ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       iintro ⟨Howns, _Hv, □HS, □HT, HR⟩
       isplitl [Howns]
       · iexact Howns
@@ -1183,7 +1183,7 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
         let ⟨_, _, hΨ'⟩ := hΨ
         hpost v ρ' st' se hΨ' hs hw)
     have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ Runtime.Binder.none v_e
-    have hbody' : st₁.sl ρ_e ∗
+    have hbody' : st₁.sl Θ ρ_e ∗
           (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
             wp
               (Runtime.Expr.subst
@@ -1207,11 +1207,11 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
         owns := st₁.owns }
     set ρ_body := ρ_e.updateConst .value v.name v_e
     set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
-    suffices st₂.sl ρ_body ∗
+    suffices st₂.sl Θ ρ_body ∗
         (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
           wp (body.runtime.subst γ_body) Φ by
       have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ (.named x) v_e
-      have hbody' : st₂.sl ρ_body ∗
+      have hbody' : st₂.sl Θ ρ_body ∗
             (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
               wp
                 (Runtime.Expr.subst
@@ -1219,8 +1219,8 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
                   (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
                 Φ :=
         hsubst.symm ▸ this
-      have hinterp_eq : SpatialContext.interp ρ_e.env st₁.owns ⊢ SpatialContext.interp ρ_body.env st₁.owns :=
-        (SpatialContext.interp_env_agree (VerifM.eval.wf hΨ_e).ownsWf
+      have hinterp_eq : SpatialContext.interp Θ ρ_e.env st₁.owns ⊢ SpatialContext.interp Θ ρ_body.env st₁.owns :=
+        (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hΨ_e).ownsWf
           (Env.agreeOn_update_fresh_const hfresh)).1
       rw [Binder.runtime_of_name_some hname]
       exact (sep_mono_l hinterp_eq).trans <|
@@ -1266,9 +1266,9 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
       have h := Bindings.agreeOnLinked_cons (x := x) (γ := γ) hagree hρ_agree (hvty := (rfl : v.sort = .value))
       rwa [hρ_body_lookup] at h
     have hres :
-        st₂.sl ρ_body ∗
+        st₂.sl Θ ρ_body ∗
           (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-            st₂.sl ρ_body ∗
+            st₂.sl Θ ρ_body ∗
               (SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
                 Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body ∗ R) := by
       iintro ⟨Howns, Hve, □HS, □HT, HR⟩
@@ -1302,8 +1302,8 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
   simp only [compile] at heval
   have heval_cond : (compile Θ Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl ρ ∗
+      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st.sl Θ ρ ∗
           (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
     Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
@@ -1334,8 +1334,8 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
   let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
   let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
   have hbool_cases_bool :
-      st₁.sl ρ_c ∗ (TinyML.ValHasType Θ v_c .bool ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-        st₁.sl ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
+      st₁.sl Θ ρ_c ∗ (TinyML.ValHasType Θ v_c .bool ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+        st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
           (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     iintro ⟨Howns, Hv, □HS, □HT, HR⟩
     ihave Hv_bool := (TinyML.ValHasType.bool Θ v_c).1 $$ Hv
@@ -1350,8 +1350,8 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
           · iexact HT
           · iexact HR
   have hbool_cases :
-      st₁.sl ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-        st₁.sl ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
+      st₁.sl Θ ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+        st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
           (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     simpa [hcond_bool] using hbool_cases_bool
   refine hbool_cases.trans ?_
@@ -1365,7 +1365,7 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
         simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_c)
     have hwp :
-        st_els.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st_els.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
           wp (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_false
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
@@ -1373,8 +1373,8 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hels_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_els.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          st_els.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       simp [st_els, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -1393,7 +1393,7 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
         simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_ne)
     have hwp :
-        st_thn.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st_thn.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
           wp (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_true
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
@@ -1401,8 +1401,8 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hthn_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_thn.sl ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          st_thn.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       simp [st_thn, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -1434,8 +1434,8 @@ theorem compileTuple_correct (es : List Expr)
     exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
   refine SpatialContext.wp_tuple ?_
   have hstep :
-      st'.sl ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢
-        st'.sl ρ' ∗ TinyML.ValHasType Θ (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
+      st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢
+        st'.sl Θ ρ' ∗ TinyML.ValHasType Θ (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
     iintro ⟨Howns, Hvals, □HS, HR⟩
     isplitl [Howns]
     · iexact Howns
@@ -1463,7 +1463,7 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
     obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
     have heval_args : (compileExprs Θ Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpecMap.project
-      (P := st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ Δ_spec ρ_spec S γ ?_ hlookup ?_
+      (P := st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ Δ_spec ρ_spec S γ ?_ hlookup ?_
     · istart
       iintro ⟨_, □HS, _⟩
       iexact HS
@@ -1472,8 +1472,8 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
       refine SpatialContext.wp_bind_app ?_
       have hctx :
           spec.isPrecondFor Θ Δ_spec ρ_spec fval ∗
-              (st.sl ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-            st.sl ρ ∗
+              (st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+            st.sl Θ ρ ∗
               (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗
                 Bindings.typedSubst Θ B Γ γ ∗ (spec.isPrecondFor Θ Δ_spec ρ_spec fval ∗ R)) := by
         istart
@@ -1516,7 +1516,9 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
         (fun v st' ρ' t hΨ hwf heval => by
           have h := hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval
           rw [← hret_eq] at h
-          iintro ⟨Howns', HR', Hty⟩
+          iintro H
+          icases H with ⟨Howns', Hrest⟩
+          icases Hrest with ⟨HR', Hty⟩
           iapply h
           isplitl [Howns']
           · iexact Howns'
@@ -1551,8 +1553,8 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
         have := hsub_ty'.length_eq
         rw [Hlen]; exact this
       have happly' :
-          st_args.sl ρ_args ∗ R ⊢
-            PredTrans.apply (fun r => TinyML.ValHasType Θ r spec.retTy -∗ Φ r) spec.pred
+          st_args.sl Θ ρ_args ∗ R ⊢
+            PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r spec.retTy -∗ Φ r) spec.pred
               (Spec.argsEnv ρ_args spec.args vs) := by
         rw [heval_sargs_map] at happly
         exact happly
@@ -1646,7 +1648,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           have hsc_eval : se_scrut.eval ρ_scrut.env = Runtime.Val.inj tag ts.length v_payload := by
             exact heval_se.trans hval_eq
           have hbranch_entail :
-              st_scrut.sl ρ_scrut ∗
+              st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
                     (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
                 wp
@@ -1668,7 +1670,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
                   · iexact HT
                   · iexact HR
           have hmatch_entail :
-              st_scrut.sl ρ_scrut ∗
+              st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
                     (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
                 wp
@@ -1677,7 +1679,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
                       Runtime.Expr.fix Runtime.Binder.none [p.1.runtime] p.2.runtime) branches))
                   Φ :=
             SpatialContext.wp_match
-              (R := st_scrut.sl ρ_scrut ∗
+              (R := st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
                     (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R))
               (branch :=
@@ -1739,8 +1741,8 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
     have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁.env = payload := by
       simp [Term.eval, Const.denote, ρ₁, Env.updateConst]
     have hassume_bind₂ := VerifM.eval_bind _ _ _ _ heval_assumeAll
-    have hinterp_eq : SpatialContext.interp ρ.env st.owns ⊢ SpatialContext.interp ρ₁.env st.owns :=
-      (SpatialContext.interp_env_agree (VerifM.eval.wf heval_decl).ownsWf
+    have hinterp_eq : SpatialContext.interp Θ ρ.env st.owns ⊢ SpatialContext.interp Θ ρ₁.env st.owns :=
+      (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval_decl).ownsWf
         (Env.agreeOn_update_fresh_const hxv_fresh)).1
     have hagreeOn_st : Env.agreeOn st.decls ρ.env ρ₁.env :=
       Env.agreeOn_update_fresh_const hxv_fresh
@@ -1768,7 +1770,7 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
       have hspecInv₁ := specInvariants_mono hΔspec hρspec
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
-          st₂.sl ρ₁ ∗
+          st₂.sl Θ ρ₁ ∗
               (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B (Γ.extendBinder binder ty_i) γ ∗
                 (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
             wp (body.runtime.subst γ) Φ :=
@@ -1784,10 +1786,10 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
       refine BIBase.Entails.trans ?_ hBodyWp
       istart
       iintro ⟨⟨⟨⟨Howns, □HS⟩, □HT⟩, HR⟩, □Hpay⟩
-      -- spatial: Howns (st.sl ρ), HR; persistent: Hpay, HS, HT
-      -- goal: st₂.sl ρ₁ ∗ (S.satisfiedBy ∗ typedSubst extended ∗ (S.satisfiedBy ∗ R))
+      -- spatial: Howns (st.sl Θ ρ), HR; persistent: Hpay, HS, HT
+      -- goal: st₂.sl Θ ρ₁ ∗ (S.satisfiedBy ∗ typedSubst extended ∗ (S.satisfiedBy ∗ R))
       isplitl [Howns]
-      · have hsl_trans : st.sl ρ ⊢ st₂.sl ρ₁ := by
+      · have hsl_trans : st.sl Θ ρ ⊢ st₂.sl Θ ρ₁ := by
           simp only [TransState.sl_eq, hst₂_owns_eq]; exact hinterp_eq
         iapply hsl_trans
         iexact Howns
@@ -1829,7 +1831,7 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
       have hspecInv₁ := specInvariants_mono hΔspec hρspec
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
-          st₂.sl ρ₁ ∗
+          st₂.sl Θ ρ₁ ∗
               (SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
                 Bindings.typedSubst Θ ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) ∗
                 (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
@@ -1848,7 +1850,7 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
       istart
       iintro ⟨⟨⟨⟨Howns, □HS⟩, □HT⟩, HR⟩, □Hpay⟩
       isplitl [Howns]
-      · have hsl_trans : st.sl ρ ⊢ st₂.sl ρ₁ := by
+      · have hsl_trans : st.sl Θ ρ ⊢ st₂.sl Θ ρ₁ := by
           simp only [TransState.sl_eq, hst₂_owns_eq]; exact hinterp_eq
         iapply hsl_trans
         iexact Howns

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -65,9 +65,9 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
         (checkBody Θ Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
-          st''.sl ρ'' ∗ Q ∗
+          st''.sl Θ ρ'' ∗ Q ∗
             ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
-    st'.sl ρ' ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗ Q ⊢
+    st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗ Q ⊢
       (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval) -∗
         wp (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
   simp only [checkBody] at hbody_eval
@@ -140,7 +140,7 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
       SpecMap.satisfiedBy_eraseAll_updateAllBinder hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
-      st'.sl ρ' ∗ (S'.satisfiedBy Θ Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
+      st'.sl Θ ρ' ∗ (S'.satisfiedBy Θ Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
         wp (body.runtime.subst γ_body) P := by
     refine compile_correct body Θ Q S' B Γ st' ρ' γ_body Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hS'wf hΔwf hΔvars
@@ -155,8 +155,8 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     have hΨ' := VerifM.eval_ret hΨ
     dsimp only at hΨ'
     rw [← heval_se]
-    refine (show st''.sl ρ'' ∗ TinyML.ValHasType Θ (se.eval ρ''.env) body.ty ∗ Q ⊢
-        st''.sl ρ'' ∗ Q ∗
+    refine (show st''.sl Θ ρ'' ∗ TinyML.ValHasType Θ (se.eval ρ''.env) body.ty ∗ Q ⊢
+        st''.sl Θ ρ'' ∗ Q ∗
           ((TinyML.ValHasType Θ (se.eval ρ''.env) s.retTy -∗ P (se.eval ρ''.env)) -∗
             P (se.eval ρ''.env)) from ?_).trans (hΨ' _ hse_wf)
     iintro ⟨Howns, Hty, HQ⟩
@@ -189,7 +189,7 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
     (hΔspec : Δ_spec.Subset st.decls)
     (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ) :
     VerifM.eval (checkSpec Θ Δ_spec S e s) st ρ (fun _ _ _ => True) →
-    st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ Δ_spec ρ_spec v) := by
+    st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ Δ_spec ρ_spec v) := by
   intro heval
   -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
   have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
@@ -238,7 +238,7 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
       simp only [] at hsub; rw [hsub]
       have hbody' : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-          PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
           (Spec.argsEnv ρ_call s.args vs) ⊢
           SpecMap.satisfiedBy Θ Δ_spec ρ_spec S γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval -∗
             wp (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
@@ -273,7 +273,7 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
                 have hlen := hlen_typed
                 simp [List.length_map] at hlen
                 omega
-              iapply (PredTrans.apply_env_agree (ρ := Spec.argsEnv ρ_call s.args vs)
+              iapply (PredTrans.apply_env_agree Θ (ρ := Spec.argsEnv ρ_call s.args vs)
                 (ρ' := Spec.argsEnv ρ_spec s.args vs) hswf
                 (Spec.argsEnv_agreeOn (Δ := Δ_spec) (ρ₁ := ρ_call) (ρ₂ := ρ_spec)
                   (VerifM.Env.agreeOn_symm hagree_call) s.args vs hlen_vals_call))

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -53,10 +53,10 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def PredTrans.apply (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
-  Assertion.pre (fun post ρ' =>
+def PredTrans.apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
+  Assertion.pre Θ (fun post ρ' =>
     BIBase.forall fun v : Runtime.Val =>
-      Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+      Assertion.post Θ (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
   ) m ρ
 
 -- ---------------------------------------------------------------------------
@@ -99,17 +99,17 @@ theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
         (Signature.wf_declVar hwf'))
     h hsub hwf
 
-theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
+theorem PredTrans.apply_env_agree (Θ : TinyML.TypeEnv) {pt : PredTrans} {Φ : Runtime.Val → iProp}
     {ρ ρ' : VerifM.Env} {Δ : Signature}
     (hwf : pt.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') :
-    PredTrans.apply Φ pt ρ ⊢ PredTrans.apply Φ pt ρ' := by
+    PredTrans.apply Θ Φ pt ρ ⊢ PredTrans.apply Θ Φ pt ρ' := by
   unfold PredTrans.apply at ⊢
-  apply Assertion.pre_env_agree hwf hagree
+  apply Assertion.pre_env_agree Θ hwf hagree
   intro ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree_post
   apply forall_intro
   intro v
   exact (forall_elim v).trans <|
-    Assertion.post_env_agree hwf_post
+    Assertion.post_env_agree Θ hwf_post
       (VerifM.Env.agreeOn_declVar hagree_post)
       (fun _ _ _ _ _ _ => .rfl)
 
@@ -117,15 +117,15 @@ theorem PredTrans.apply_env_agree {pt : PredTrans} {Φ : Runtime.Val → iProp}
 -- Correctness
 -- ---------------------------------------------------------------------------
 
-theorem PredTrans.call_correct (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
+theorem PredTrans.call_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) R :
     pt.wfIn (Δ_base.declVars σ.dom) →
     σ.wfIn Δ_base st.decls →
     VerifM.eval (PredTrans.call σ pt) st ρ Ψ →
     (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
-      (st'.sl ρ' ∗ R ⊢ Φ v)) →
-    st.sl ρ ∗ R ⊢ PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+      (st'.sl Θ ρ' ∗ R ⊢ Φ v)) →
+    st.sl Θ ρ ∗ R ⊢ PredTrans.apply Θ Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
   intro hwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
@@ -134,7 +134,7 @@ theorem PredTrans.call_correct (pt : PredTrans) (Δ_base : Signature) (σ : Fini
   let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun post ρ' =>
       BIBase.forall fun v : Runtime.Val =>
-        Assertion.post (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+        Assertion.post Θ (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
   let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → VerifM.Env → Prop :=
     fun r st' ρ' =>
       match r with
@@ -142,12 +142,12 @@ theorem PredTrans.call_correct (pt : PredTrans) (Δ_base : Signature) (σ : Fini
           let resVar ← VerifM.decl (some postName) Srt.value
           let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
           Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
-  have hpre : st.sl ρ ∗ R ⊢ Assertion.pre Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
-    exact Assertion.prove_correct pt Δ_base σ retWf st ρ Ψcall Φpost R
+  have hpre : st.sl Θ ρ ∗ R ⊢ Assertion.pre Θ Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+    exact Assertion.prove_correct Θ pt Δ_base σ retWf st ρ Ψcall Φpost R
       (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree =>
         forall_intro fun v =>
           (forall_elim v).trans <|
-            Assertion.post_env_agree hwf_post
+            Assertion.post_env_agree Θ hwf_post
               (VerifM.Env.agreeOn_declVar hagree)
               (fun _ _ _ _ _ _ => .rfl))
       hσwf hwf hb
@@ -175,7 +175,7 @@ theorem PredTrans.call_correct (pt : PredTrans) (Δ_base : Signature) (σ : Fini
         have hwf₁' : Assertion.wfIn (fun _ _ => True) (Δ_base.declVars σ₂.dom) postBody := by
           simpa [σ₂, FiniteSubst.rename_source_eq] using hwf₁
         have hgrow := VerifM.eval.decls_grow (ρ₁.updateConst .value resVar.name v) hb3
-        have hassume := Assertion.assume_correct postBody Δ_base σ₂ (fun _ _ => True)
+        have hassume := Assertion.assume_correct Θ postBody Δ_base σ₂ (fun _ _ => True)
           { st₁ with decls := st₁.decls.addConst resVar }
           (ρ₁.updateConst .value resVar.name v)
           (fun a st' ρ' =>
@@ -200,12 +200,12 @@ theorem PredTrans.call_correct (pt : PredTrans) (Δ_base : Signature) (σ : Fini
               have := hagree.2.1 resVar (List.Mem.head _)
               simpa [Env.lookupConst, Env.updateConst] using this.symm)
         have hinterp_bi :
-            st₁.sl ρ₁ ⊣⊢ st₁.sl (ρ₁.updateConst .value resVar.name v) :=
-          SpatialContext.interp_env_agree (VerifM.eval.wf hcont).ownsWf
+            st₁.sl Θ ρ₁ ⊣⊢ st₁.sl Θ (ρ₁.updateConst .value resVar.name v) :=
+          SpatialContext.interp_env_agree Θ (VerifM.eval.wf hcont).ownsWf
             (Env.agreeOn_update_fresh_const (c := resVar) hfresh_decls)
         exact (sep_mono hinterp_bi.1 (by
           iintro HR
-          iexact HR)).trans <| hassume.trans <| Assertion.post_env_agree hwf₁'
+          iexact HR)).trans <| hassume.trans <| Assertion.post_env_agree Θ hwf₁'
           (by
             simpa [σ₂, VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₁.decls)
@@ -215,7 +215,7 @@ theorem PredTrans.call_correct (pt : PredTrans) (Δ_base : Signature) (σ : Fini
   simpa [PredTrans.apply, Φpost] using hpre
 
 
-theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
+theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
     (body : VerifM (Term .value))
     (st : TransState) (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (R : iProp) :
     pt.wfIn (Δ_base.declVars σ.dom) →
@@ -228,9 +228,9 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
       (fun result st'' ρ'' =>
         ∀ (S : iProp),
         result.wfIn st''.decls →
-        (st''.sl ρ'' ∗ Q ∗ (Φ (result.eval ρ''.env) -∗ S) ⊢ S)) →
-      st'.sl ρ' ∗ Q ⊢ R) →
-    st.sl ρ ∗ PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ⊢ R := by
+        (st''.sl Θ ρ'' ∗ Q ∗ (Φ (result.eval ρ''.env) -∗ S) ⊢ S)) →
+      st'.sl Θ ρ' ∗ Q ⊢ R) →
+    st.sl Θ ρ ∗ PredTrans.apply Θ Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ⊢ R := by
   intro hwf hσwf heval hbody
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind _ _ _ _ heval
@@ -240,10 +240,10 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
   let OuterQ : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun ⟨postName, postBody⟩ ρ' =>
       BIBase.forall fun v : Runtime.Val =>
-        Assertion.post (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
+        Assertion.post Θ (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
   let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
-  have hpost := Assertion.assume_correct pt Δ_base σ retWf
+  have hpost := Assertion.assume_correct Θ pt Δ_base σ retWf
     st ρ _ Φpost emp
     (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree => by
       refine wand_intro ?_
@@ -253,7 +253,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
       apply forall_intro
       intro v
       exact (forall_elim v).trans <|
-        Assertion.post_env_agree hwf_post
+        Assertion.post_env_agree Θ hwf_post
           (Env.agreeOn_symm (Env.agreeOn_declVar hagree))
           (fun _ _ _ _ _ _ => .rfl))
     hσwf hwf hb_grow
@@ -264,7 +264,7 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
       have hσ₁wf : σ₁.wfIn Δ_base st₁.decls :=
         ⟨hσ₁subst, hσ₁base, hσ₁use, hσ₁srcwf, hσ₁rangewf, hσ₁usewf, hσ₁basevars⟩
       have hcont_body := VerifM.eval_bind _ _ _ _ hcont
-      change st₁.sl ρ₁ ⊢ OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) -∗ R
+      change st₁.sl Θ ρ₁ ⊢ OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) -∗ R
       refine wand_intro ?_
       refine hbody st₁ ρ₁ _ hdsub_st hagree_st ?_
       refine (VerifM.eval.decls_grow ρ₁ hcont_body).mono ?_
@@ -311,14 +311,14 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
         { st₂ with
           decls := st₂.decls.addConst resVar
           asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st₂.asserts }
-      have hpre := @Assertion.prove_correct Unit postBody Δ_base σ₂ (fun _ _ => True)
+      have hpre := @Assertion.prove_correct Unit Θ postBody Δ_base σ₂ (fun _ _ => True)
         st₃
         (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
         _ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) (Φ (result.eval ρ₂.env) -∗ S)
         (fun _ _ _ _ _ _ => .rfl)
         hσ₂wf hwf_postBody' hb4
         (fun _ () st' ρ' hret _ _ => by
-          show st'.sl ρ' ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+          show st'.sl Θ ρ' ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
             (Φ (result.eval ρ₂.env) -∗ S)
           exact sep_elim_r)
       have hag_rename :=
@@ -334,30 +334,30 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
         apply Env.agreeOn_mono
           (FiniteSubst.rename_source_subset_rev σ₁ Δ_base ⟨postName, .value⟩ resVar.name)
         exact Env.agreeOn_update (Env.agreeOn_remove hag_eval)
-      have hpost_transport : Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+      have hpost_transport : Assertion.post Θ (fun () _ => Φ (result.eval ρ₂.env)) postBody
           (VerifM.Env.withEnv ρ₁ ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env))) ⊢
-          Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+          Assertion.post Θ (fun () _ => Φ (result.eval ρ₂.env)) postBody
             (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
               (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
-        exact Assertion.post_env_agree hwf_postBody'
+        exact Assertion.post_env_agree Θ hwf_postBody'
           (by
             simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv]
               using (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval')))
           (fun _ _ _ _ _ _ => .rfl)
-      have howns_agree : st₃.sl ρ₂
+      have howns_agree : st₃.sl Θ ρ₂
             ⊢
-          st₃.sl (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) := by
+          st₃.sl Θ (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) := by
         simpa using
-          (SpatialContext.interp_env_agree (VerifM.eval.wf hrest).ownsWf
+          (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hrest).ownsWf
             (Env.agreeOn_update_fresh_const hfresh_decls)).1
       have hpre_final :
-          st₂.sl ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
-            Assertion.pre (fun () _ => Φ (result.eval ρ₂.env) -∗ S) postBody
+          st₂.sl Θ ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+            Assertion.pre Θ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) postBody
               (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
                 (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
         have hinput :
-            st₂.sl ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
-              st₃.sl (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) ∗
+            st₂.sl Θ ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+              st₃.sl Θ (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) ∗
                 (Φ (result.eval ρ₂.env) -∗ S) := by
           iintro H
           icases H with ⟨Howns, Hwand⟩
@@ -368,13 +368,13 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
         exact hinput.trans hpre
       have hpost_final :
           OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) ⊢
-            Assertion.post (fun () _ => Φ (result.eval ρ₂.env)) postBody
+            Assertion.post Θ (fun () _ => Φ (result.eval ρ₂.env)) postBody
               (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
                 (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
         exact (forall_elim (result.eval ρ₂.env)).trans hpost_transport
       iintro H
       icases H with ⟨Howns, HQ, Hwand⟩
-      iapply (Assertion.pre_post_combine
+      iapply (Assertion.pre_post_combine Θ
         (ρ := VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
           (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env))
         (m := postBody)
@@ -395,8 +395,8 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
         iexact HQ
       )
   have hpre :
-      PredTrans.apply Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) =
-      Assertion.pre OuterQ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := rfl
+      PredTrans.apply Θ Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) =
+      Assertion.pre Θ OuterQ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := rfl
   rw [hpre]
   exact BIBase.Entails.trans
     (by
@@ -404,13 +404,13 @@ theorem PredTrans.implement_correct (pt : PredTrans) (Δ_base : Signature) (σ :
       icases H with ⟨Howns, Happ⟩
       isplitr [Howns]
       · iexact Happ
-      · have hpost' : st.sl ρ ∗ emp ⊢ Assertion.post Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+      · have hpost' : st.sl Θ ρ ∗ emp ⊢ Assertion.post Θ Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
           simpa [VerifM.Env.withEnv] using hpost
         iapply hpost'
         isplitl
         . iexact Howns
         . iemp_intro)
-    (Assertion.pre_post_combine
+    (Assertion.pre_post_combine Θ
       (ρ := VerifM.Env.withEnv ρ (σ.subst.eval ρ.env))
       (m := pt)
       (Φ := OuterQ)

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -435,14 +435,14 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (�
     (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
     {Q : Unit → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (ValDecl.checkExpr Θ Δ_spec S d) st ρ Q) :
-    (□ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ Φ) →
-    □ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
+    (□ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ Φ) →
+    □ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
   intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
   have hcomp :=
-    compile_correct d.body Θ iprop(□ st.sl ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ Δ_spec ρ_spec
+    compile_correct d.body Θ iprop(□ st.sl Θ ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ Δ_spec ρ_spec
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => Φ)
     hcompile
@@ -481,7 +481,7 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
     {Q : Spec → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (ValDecl.check Θ Δ_spec Γfn S d) st ρ Q) :
     ∃ spec, spec.wfIn Δ_spec ∧
-            (□ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ Δ_spec ρ_spec v)) ∧
+            (□ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ Δ_spec ρ_spec v)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.declMeta.spec with
@@ -534,7 +534,7 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
     (st : TransState) (ρ : VerifM.Env)
     (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ) :
     VerifM.eval (Program.check Θ Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
-    □ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
+    □ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ st ρ with
   | nil =>
     intro _
@@ -643,7 +643,7 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
         rw [hupd v]
         have hih := ih (S.insert n spec) (γ.update n v)
           (SpecMap.wfIn_insert hSwf hswf) st ρ hΔspec hρspec hcont'
-        have hstep : (□ st.sl ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ) ∗ spec.isPrecondFor Θ Δ_spec ρ_spec v ⊢
+        have hstep : (□ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ) ∗ spec.isPrecondFor Θ Δ_spec ρ_spec v ⊢
             pwp ((Typed.Program.runtime ds).subst (γ.update n v)) := by
           refine BIBase.Entails.trans ?_ hih
           istart
@@ -695,7 +695,7 @@ theorem Program.verify_correct (p : Untyped.Program (Spec.Body Untyped.Expr)) :
                        VerifM.Env.agreeOn_refl
                        hcheck
     rw [Runtime.Program.subst_id] at hcorrect
-    have hctx0 : (⊢ □ stRel.sl ρRel ∗
+    have hctx0 : (⊢ □ stRel.sl Θ ρRel ∗
         SpecMap.satisfiedBy Θ stRel.decls ρRel (∅ : SpecMap) Runtime.Subst.id) := by
       istart
       isplitl []

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -48,7 +48,7 @@ def isPrecondFor (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.E
   iprop(□ ∀ (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
       TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
-        PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+        PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
           (argsEnv ρ s.args vs) -∗
         wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
@@ -116,7 +116,7 @@ theorem isPrecondFor_intro (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec 
     iprop(□ ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
       (⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
         TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-        PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+        PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
           (argsEnv ρ s.args vs)) -∗
         wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ Δ_spec ρ_spec f := by
   unfold isPrecondFor
@@ -141,7 +141,7 @@ theorem isPrecondFor_fix {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : 
         ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
           TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
-          PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
               (argsEnv ρ s.args vs) -∗
           wp (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
     R ⊢ s.isPrecondFor Θ Δ_spec ρ_spec (.fix f args e) := by
@@ -149,7 +149,7 @@ theorem isPrecondFor_fix {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : 
       iprop(∃ ρ : VerifM.Env,
         ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
           TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-          PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
             (argsEnv ρ s.args vs))) (h.trans ?_)).trans ?_
   · istart
     iintro □HR
@@ -356,9 +356,9 @@ theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (Δ_base : Signature)
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.call Θ σ s sargs) st ρ Ψ →
     (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
-      st'.sl ρ' ∗ R ∗ TinyML.ValHasType Θ v s.retTy ⊢ Φ v) →
+      st'.sl Θ ρ' ∗ R ∗ TinyML.ValHasType Θ v s.retTy ⊢ Φ v) →
     @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
-    (st.sl ρ ∗ R ⊢ PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+    (st.sl Θ ρ ∗ R ⊢ PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
       (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) s.args
         (sargs.map fun p => p.2.eval ρ.env))) := by
   intro hwf hσwf hsargs heval hΨ
@@ -372,7 +372,7 @@ theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (Δ_base : Signature)
     ⟨hσ'subst, hσ'base, hσ'use, hσ'srcwf, hσ'rangewf, hσ'usewf, hσ'basevars⟩
   have hwf'' : s.pred.wfIn (Δ_base.declVars σ'.dom) :=
     PredTrans.wfIn_mono hwf hdom_sub hσ'srcwf
-  have hcall := PredTrans.call_correct s.pred Δ_base σ' st' ρ'
+  have hcall := PredTrans.call_correct Θ s.pred Δ_base σ' st' ρ'
     _ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) R
     hwf'' hσ'wf (VerifM.eval_bind _ _ _ _ hΨ')
     (fun v st'' ρ'' t hΨ'' htwf hteval => by
@@ -386,16 +386,16 @@ theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (Δ_base : Signature)
         VerifM.eval_assumeAll (VerifM.eval_bind _ _ _ _ hΨ'')
           (fun φ hφ => TinyML.typeConstraints_wfIn htwf φ hφ)
           (fun φ hφ => Hpure φ hφ)
-      ihave Harg : (st₃.sl ρ'' ∗ R ∗ TinyML.ValHasType Θ v s.retTy) $$ [HR Howns Hty]
+      ihave Harg : (st₃.sl Θ ρ'' ∗ R ∗ TinyML.ValHasType Θ v s.retTy) $$ [HR Howns Hty]
       · isplitr [Hty HR]
         · simp [TransState.sl, hst₃_owns]; iassumption
         · isplitl [HR]
           · iexact HR
           · iexact Hty
       iapply (hΨ v st₃ ρ'' t (VerifM.eval_ret hret) (hst₃_decls ▸ htwf) hteval) $$ Harg)
-  exact (sep_mono_l (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1).trans <|
-    (by simpa [howns] using hcall : st.sl ρ' ∗ R ⊢ _).trans <|
-    PredTrans.apply_env_agree hwf hagree
+  exact (sep_mono_l (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf hragree).1).trans <|
+    (by simpa [howns] using hcall : st.sl Θ ρ' ∗ R ⊢ _).trans <|
+    PredTrans.apply_env_agree Θ hwf hagree
 
 end CallCorrectness
 
@@ -558,10 +558,10 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
       VerifM.eval (body argVars) st' ρ'
         (fun result st'' ρ'' =>
           ∀ (S : iProp), result.wfIn st''.decls →
-            st''.sl ρ'' ∗ Q ∗ ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ Φ (result.eval ρ''.env)) -∗ S) ⊢ S) →
-      st'.sl ρ' ∗ Q ⊢ R) →
-    st.sl ρ ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-      PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+            st''.sl Θ ρ'' ∗ Q ∗ ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ Φ (result.eval ρ''.env)) -∗ S) ⊢ S) →
+      st'.sl Θ ρ' ∗ Q ⊢ R) →
+    st.sl Θ ρ ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
+      PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
         (Spec.argsEnv ρ_spec s.args vs) ⊢ R := by
   intro hswf hΔspec hρspec hΔwf hΔvars heval hbody
   simp only [Spec.implement] at heval
@@ -592,10 +592,10 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
         simp [List.length_map] at hlen_vals
         omega)
   have hst'_wf : st'.decls.wf := (VerifM.eval.wf hΨ).namesDisjoint
-  iapply (show st'.sl ρ' ∗
-        PredTrans.apply (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+  iapply (show st'.sl Θ ρ' ∗
+        PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
           (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) ⊢ R from
-    PredTrans.implement_correct s.pred Δ_spec σ' (body argVars) st' ρ'
+    PredTrans.implement_correct Θ s.pred Δ_spec σ' (body argVars) st' ρ'
       (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) R
       (PredTrans.wfIn_mono hswf hdom_sub hσ'srcwf)
       hσ'wf hΨ
@@ -613,12 +613,12 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
           exact Term.const_wfIn_of_mem hst'_wf (hmem_decls _ hav)
         · exact hbody_eval))
   isplitr [Happ]
-  · iapply (show st.sl ρ' ⊢ st'.sl ρ' by simp [howns, TransState.sl])
-    iapply (show st.sl ρ ⊢ st.sl ρ' by
+  · iapply (show st.sl Θ ρ' ⊢ st'.sl Θ ρ' by simp [howns, TransState.sl])
+    iapply (show st.sl Θ ρ ⊢ st.sl Θ ρ' by
       simpa [TransState.sl] using
-        (SpatialContext.interp_env_agree (VerifM.eval.wf heval).ownsWf hragree).1)
+        (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf hragree).1)
     iexact Howns
-  · iapply (PredTrans.apply_env_agree hswf (VerifM.Env.agreeOn_trans hag_base (by
+  · iapply (PredTrans.apply_env_agree Θ hswf (VerifM.Env.agreeOn_trans hag_base (by
         simpa [FiniteSubst.base, Signature.declVars] using VerifM.Env.agreeOn_symm hagree)))
     iexact Happ
 

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -136,20 +136,20 @@ theorem Env.agreeOn_update_fresh_binaryRel {ρ : Env} {b : FOL.BinaryRel}
 end VerifM
 
 /-- Semantic interpretation of a verifier context item. -/
-def CtxItem.interp (ρ : VerifM.Env) : CtxItem → iProp
+def CtxItem.interp (Θ : TinyML.TypeEnv) (ρ : VerifM.Env) : CtxItem → iProp
   | .pure φ => ⌜φ.eval ρ.env⌝
-  | .spatial a => a.interp ρ.env
+  | .spatial a => a.interp Θ ρ.env
 
 def CtxItem.purePart (i : CtxItem) (ρ : VerifM.Env) : Prop :=
   match i with
   | .pure φ => φ.eval ρ.env
   | .spatial _ => True
 
-def TransState.sl (st : TransState) (ρ : VerifM.Env) : iProp :=
-  SpatialContext.interp ρ.env st.owns
+def TransState.sl (Θ : TinyML.TypeEnv) (st : TransState) (ρ : VerifM.Env) : iProp :=
+  SpatialContext.interp Θ ρ.env st.owns
 
-@[simp] theorem TransState.sl_eq (st : TransState) (ρ : VerifM.Env) :
-    st.sl ρ = SpatialContext.interp ρ.env st.owns := rfl
+@[simp] theorem TransState.sl_eq (Θ : TinyML.TypeEnv) (st : TransState) (ρ : VerifM.Env) :
+    st.sl Θ ρ = SpatialContext.interp Θ ρ.env st.owns := rfl
 
 /-- Drop the non-persistent spatial part of the verifier state. -/
 def TransState.persist (st : TransState) : TransState :=
@@ -161,8 +161,8 @@ def TransState.persist (st : TransState) : TransState :=
 @[simp] theorem TransState.persist_asserts (st : TransState) :
     st.persist.asserts = st.asserts := rfl
 
-theorem TransState.sl_entails_persist (st : TransState) (ρ : VerifM.Env) :
-    st.sl ρ ⊢ □ st.persist.sl ρ := by
+theorem TransState.sl_entails_persist (Θ : TinyML.TypeEnv) (st : TransState) (ρ : VerifM.Env) :
+    st.sl Θ ρ ⊢ □ st.persist.sl Θ ρ := by
   istart
   iintro _
   imodintro


### PR DESCRIPTION
This PR prepares for subsequent support for owned references. It threads the typing environment through the verifier such that we will be able to add types to the owned atom and points-to assertion in subsequent PRs.