### PR TITLE
Owned type & owned operations

### DIFF
--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -226,7 +226,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
   | .app ⟨_, .var "not"⟩ args => err loc (.arityMismatch 1 args.length)
   | .app ⟨_, .var "ref"⟩ [⟨al, ak⟩] => do
     let arg' ← ExprKind.elaborate env al ak
-    .ok (.ref arg')
+    .ok (.ref false arg')
   | .app ⟨_, .var "ref"⟩ args => err loc (.arityMismatch 1 args.length)
   | .app ⟨_, .ctor name⟩ [⟨al, ak⟩] => do
     let arg' ← ExprKind.elaborate env al ak

--- a/Mica/SeparationLogic/LogicalRelation.lean
+++ b/Mica/SeparationLogic/LogicalRelation.lean
@@ -51,6 +51,7 @@ mutual
     | .arrow _ _  => iprop(False)
     | .tvar _     => iprop(False)
     | .ref t      => iprop(∃ l, ⌜v = .loc l⌝ ∗ locinv l (fun w => R w t))
+    | .owned _    => iprop(∃ l, ⌜v = .loc l⌝)
     | .named T args => k v T args
     | .tuple ts   => iprop(∃ vs, ⌜v = .tuple vs⌝ ∗ ValsRelBody R vs ts k)
     | .sum ts     =>
@@ -98,7 +99,7 @@ mutual
         · iapply (ValSumRelBody.mono_int R ts tag payload)
           · iexact Hk
           · iexact Hsum
-    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ | .ref _ =>
+    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ | .ref _ | .owned _ =>
         iintro _ H
         iexact H
 
@@ -170,7 +171,7 @@ mutual
         refine exists_ne fun payload => ?_
         refine sep_ne.ne (.of_eq rfl) ?_
         exact ValSumRelBody.dist hR hk ts tag payload
-    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ =>
+    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ | .owned _ =>
         exact Dist.rfl
 
   private theorem ValsRelBody.dist {n : Nat} {R S : ValShape} {k k' : RecCont}
@@ -317,7 +318,7 @@ mutual
       (hk : ∀ v T args, Persistent (k v T args)) : Persistent (ValRelBody R v t k) := by
     unfold ValRelBody
     match t with
-    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ =>
+    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ | .owned _ =>
         infer_instance
     | .ref _ =>
         have := locinv_persistent
@@ -426,6 +427,10 @@ theorem ValHasType.ref (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
     ValHasType Θ v (.ref t) ⊣⊢
       iprop(∃ l, ⌜v = .loc l⌝ ∗ locinv l (fun w => ValHasType Θ w t)) := by
   exact equiv_iff.mp (ValHasType.unfold Θ v (.ref t))
+
+theorem ValHasType.owned (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
+    ValHasType Θ v (.owned t) ⊣⊢ iprop(∃ l, ⌜v = .loc l⌝) := by
+  exact equiv_iff.mp (ValHasType.unfold Θ v (.owned t))
 
 theorem ValHasType.tuple (Θ : TypeEnv) (v : Runtime.Val) (ts : List Typ) :
     ValHasType Θ v (.tuple ts) ⊣⊢
@@ -966,7 +971,7 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
               · iexact Hwitness)
           iapply (ValsHaveTypes.of_getElem? (Θ := Θ) (vs := vs) (ts := ts) (n := n) (t := ty) hty)
           iexact Hvs
-      | unit | bool | int | sum _ | arrow _ _ | ref _ | empty | value | tvar _ | named _ _ =>
+      | unit | bool | int | sum _ | arrow _ _ | ref _ | owned _ | empty | value | tvar _ | named _ _ =>
           simp [UnOp.typeOf] at hty
 
 end TinyML
@@ -990,6 +995,7 @@ def typeConstraints (ty : TinyML.Typ) (t : Term .value) : List Formula :=
   match ty with
   | .int   => [.unpred .isInt t]
   | .bool  => [.unpred .isBool t]
+  | .owned _ => [.unpred .isLoc t]
   | .tuple ts =>
       .unpred .isTuple t ::
       typeConstraintsList ts (.unop .toValList t)
@@ -1013,6 +1019,9 @@ mutual
       simp [typeConstraints]
       simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
     | bool =>
+      simp [typeConstraints]
+      simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
+    | owned _ =>
       simp [typeConstraints]
       simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
     | tuple ts =>
@@ -1063,6 +1072,16 @@ mutual
       simp [typeConstraints] at hφ
       subst hφ
       simp [Formula.eval, ht]
+    | owned inner =>
+      refine (TinyML.ValHasType.owned Θ v inner).1.trans ?_
+      iintro Hty
+      icases Hty with ⟨%l, %hv⟩
+      subst v
+      ipure_intro
+      intro φ hφ
+      simp [typeConstraints] at hφ
+      subst hφ
+      simp [Formula.eval, hv]
     | tuple ts =>
       refine (TinyML.ValHasType.tuple Θ v ts).1.trans ?_
       iintro Hty

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -9,14 +9,14 @@ open TinyML
 
 namespace TinyML
 
-partial def Typ.print : Typ → String
+def Typ.print : Typ → String
   | .unit => "unit"
   | .bool => "bool"
   | .int => "int"
   | .sum ts => s!"sum ({", ".intercalate (ts.map Typ.print)})"
-  | .arrow t1 t2 => s!"{printArg t1} -> {Typ.print t2}"
-  | .ref t => s!"ref {printArg t}"
-  | .owned t => s!"owned {printArg t}"
+  | .arrow t1 t2 => s!"{wrapArg t1 (Typ.print t1)} -> {Typ.print t2}"
+  | .ref t => s!"ref {wrapArg t (Typ.print t)}"
+  | .owned t => s!"owned {wrapArg t (Typ.print t)}"
   | .empty => "empty"
   | .value => "value"
   | .tuple ts => s!"({", ".intercalate (ts.map Typ.print)})"
@@ -24,10 +24,10 @@ partial def Typ.print : Typ → String
   | .named T [] => T
   | .named T args => s!"{T} ({", ".intercalate (args.map Typ.print)})"
 where
-  printArg (t : Typ) : String :=
+  wrapArg (t : Typ) (s : String) : String :=
     match t with
-    | .unit | .bool | .int | .empty | .value | .tvar _ | .named _ [] => Typ.print t
-    | _ => s!"({Typ.print t})"
+    | .unit | .bool | .int | .empty | .value | .tvar _ | .named _ [] => s
+    | _ => s!"({s})"
 
 end TinyML
 

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -7,6 +7,30 @@ import Mica.TinyML.Spec
 
 open TinyML
 
+namespace TinyML
+
+partial def Typ.print : Typ → String
+  | .unit => "unit"
+  | .bool => "bool"
+  | .int => "int"
+  | .sum ts => s!"sum ({", ".intercalate (ts.map Typ.print)})"
+  | .arrow t1 t2 => s!"{printArg t1} -> {Typ.print t2}"
+  | .ref t => s!"ref {printArg t}"
+  | .owned t => s!"owned {printArg t}"
+  | .empty => "empty"
+  | .value => "value"
+  | .tuple ts => s!"({", ".intercalate (ts.map Typ.print)})"
+  | .tvar v => s!"'{v}"
+  | .named T [] => T
+  | .named T args => s!"{T} ({", ".intercalate (args.map Typ.print)})"
+where
+  printArg (t : Typ) : String :=
+    match t with
+    | .unit | .bool | .int | .empty | .value | .tvar _ | .named _ [] => Typ.print t
+    | _ => s!"({Typ.print t})"
+
+end TinyML
+
 namespace Untyped
 
 def BinOp.toString : TinyML.BinOp → String
@@ -145,7 +169,7 @@ def Pred.print : Spec.Pred → String
   | .own loc => s!"own {loc}"
 
 private def typString (ty : Typ) : String :=
-  toString (repr ty)
+  ty.print
 
 def Assert.print (inner : α → String) : Spec.Assert Untyped.Expr α → String
   | .ret a => s!"ret {inner a}"
@@ -199,7 +223,7 @@ def ValDecl.print {S : Type} [SpecPayloadPrinter S] (d : Untyped.ValDecl S) : St
 
 def TypeDecl.print (d : Untyped.TypeDecl) : String :=
   let payloads := (List.range d.body.payloads.length).zip d.body.payloads |>.map
-    (fun (i, ty) => s!"C{i} of {repr ty}")
+    (fun (i, ty) => s!"C{i} of {ty.print}")
   s!"type {d.name} = {" | ".intercalate payloads}"
 
 def Decl.print {S : Type} [SpecPayloadPrinter S] : Untyped.Decl S → String

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -126,7 +126,7 @@ private partial def printMul : Untyped.Expr → String
 private partial def printApp : Untyped.Expr → String
   | .app fn args => s!"{printApp fn} {" ".intercalate (args.map printUnary)}"
   | .unop .not e => s!"not {printAtom e}"
-  | .ref e => s!"ref {printAtom e}"
+  | .ref owned e => if owned then s!"ref {printAtom e} [@owned]" else s!"ref {printAtom e}"
   | .inj tag arity e => s!"(inj {tag}/{arity} {printAtom e})"
   | .assert e => s!"assert {printAtom e}"
   | e => printUnary e

--- a/Mica/TinyML/Typed.lean
+++ b/Mica/TinyML/Typed.lean
@@ -46,7 +46,7 @@ inductive Expr where
   | app (fn : Expr) (args : List Expr) (ty : Typ)
   | ifThenElse (cond thn els : Expr) (ty : Typ)
   | letIn (name : Binder) (bound body : Expr)
-  | ref    (e : Expr)
+  | ref    (owned : Bool) (e : Expr)
   | deref  (e : Expr) (ty : Typ)
   | store  (loc val : Expr)
   | assert (e : Expr)
@@ -124,9 +124,10 @@ mutual
       | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-    case ref.ref e1 e2 => exact match e1.decEq e2 with
-      | isTrue h => isTrue (by subst h; rfl)
-      | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case ref.ref o1 e1 o2 e2 => exact match decEq o1 o2, e1.decEq e2 with
+      | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+      | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case deref.deref e1 t1 e2 t2 => exact match e1.decEq e2, decEq t1 t2 with
       | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
       | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
@@ -210,7 +211,7 @@ def Expr.ty : Expr → Typ
   | .app _ _ ty => ty
   | .ifThenElse _ _ _ ty => ty
   | .letIn _ _ body => body.ty
-  | .ref e => .ref e.ty
+  | .ref owned e => if owned then .owned e.ty else .ref e.ty
   | .deref _ ty => ty
   | .store _ _ => .unit
   | .assert _ => .unit
@@ -268,7 +269,7 @@ mutual
     | .app fn args _ => .app fn.runtime (args.map Expr.runtime)
     | .ifThenElse c t e _ => .ifThenElse c.runtime t.runtime e.runtime
     | .letIn b bound body => .letIn (b.runtime) bound.runtime body.runtime
-    | .ref e => .ref e.runtime
+    | .ref _ e => .ref e.runtime
     | .deref e _ => .deref e.runtime
     | .store loc val => .store loc.runtime val.runtime
     | .assert e => .assert e.runtime

--- a/Mica/TinyML/Types.lean
+++ b/Mica/TinyML/Types.lean
@@ -13,6 +13,9 @@ inductive Typ where
   | sum (ts : List Typ)
   | arrow (t1 t2 : Typ)
   | ref (t: Typ)
+  /-- An owned reference. Its value interpretation records only that the value
+  is a location; points-to ownership lives in the ambient spatial context. -/
+  | owned (t : Typ)
   | empty   -- bottom type (uninhabited)
   | value   -- top type (all runtime values)
   | tuple (ts : List Typ)
@@ -33,6 +36,9 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
   | .ref s, .ref t => match s.decEq t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .owned s, .owned t => match s.decEq t with
+    | isTrue h => isTrue (by subst h; rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .tuple ss, .tuple ts => match typesDecEq ss ts with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -45,38 +51,41 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
     | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
     | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .unit, .bool | .unit, .int | .unit, .sum .. | .unit, .arrow ..
-  | .unit, .ref .. | .unit, .empty | .unit, .value | .unit, .tuple ..
+  | .unit, .ref .. | .unit, .owned .. | .unit, .empty | .unit, .value | .unit, .tuple ..
   | .unit, .tvar .. | .unit, .named ..
   | .bool, .unit | .bool, .int | .bool, .sum .. | .bool, .arrow ..
-  | .bool, .ref .. | .bool, .empty | .bool, .value | .bool, .tuple ..
+  | .bool, .ref .. | .bool, .owned .. | .bool, .empty | .bool, .value | .bool, .tuple ..
   | .bool, .tvar .. | .bool, .named ..
   | .int, .unit | .int, .bool | .int, .sum .. | .int, .arrow ..
-  | .int, .ref .. | .int, .empty | .int, .value | .int, .tuple ..
+  | .int, .ref .. | .int, .owned .. | .int, .empty | .int, .value | .int, .tuple ..
   | .int, .tvar .. | .int, .named ..
   | .sum .., .unit | .sum .., .bool | .sum .., .int
-  | .sum .., .arrow .. | .sum .., .ref .. | .sum .., .empty | .sum .., .value | .sum .., .tuple ..
-  | .sum .., .tvar .. | .sum .., .named ..
+  | .sum .., .arrow .. | .sum .., .ref .. | .sum .., .owned .. | .sum .., .empty
+  | .sum .., .value | .sum .., .tuple .. | .sum .., .tvar .. | .sum .., .named ..
   | .arrow .., .unit | .arrow .., .bool | .arrow .., .int
-  | .arrow .., .sum .. | .arrow .., .ref .. | .arrow .., .empty | .arrow .., .value | .arrow .., .tuple ..
-  | .arrow .., .tvar .. | .arrow .., .named ..
+  | .arrow .., .sum .. | .arrow .., .ref .. | .arrow .., .owned .. | .arrow .., .empty
+  | .arrow .., .value | .arrow .., .tuple .. | .arrow .., .tvar .. | .arrow .., .named ..
   | .ref .., .unit | .ref .., .bool | .ref .., .int
-  | .ref .., .sum .. | .ref .., .arrow .. | .ref .., .empty | .ref .., .value | .ref .., .tuple ..
-  | .ref .., .tvar .. | .ref .., .named ..
+  | .ref .., .sum .. | .ref .., .arrow .. | .ref .., .owned .. | .ref .., .empty
+  | .ref .., .value | .ref .., .tuple .. | .ref .., .tvar .. | .ref .., .named ..
+  | .owned .., .unit | .owned .., .bool | .owned .., .int
+  | .owned .., .sum .. | .owned .., .arrow .. | .owned .., .ref .. | .owned .., .empty
+  | .owned .., .value | .owned .., .tuple .. | .owned .., .tvar .. | .owned .., .named ..
   | .empty, .unit | .empty, .bool | .empty, .int | .empty, .sum ..
-  | .empty, .arrow .. | .empty, .ref .. | .empty, .value | .empty, .tuple ..
+  | .empty, .arrow .. | .empty, .ref .. | .empty, .owned .. | .empty, .value | .empty, .tuple ..
   | .empty, .tvar .. | .empty, .named ..
   | .value, .unit | .value, .bool | .value, .int | .value, .sum ..
-  | .value, .arrow .. | .value, .ref .. | .value, .empty | .value, .tuple ..
+  | .value, .arrow .. | .value, .ref .. | .value, .owned .. | .value, .empty | .value, .tuple ..
   | .value, .tvar .. | .value, .named ..
   | .tuple .., .unit | .tuple .., .bool | .tuple .., .int
-  | .tuple .., .sum .. | .tuple .., .arrow .. | .tuple .., .ref .. | .tuple .., .empty
-  | .tuple .., .value | .tuple .., .tvar .. | .tuple .., .named ..
+  | .tuple .., .sum .. | .tuple .., .arrow .. | .tuple .., .ref .. | .tuple .., .owned ..
+  | .tuple .., .empty | .tuple .., .value | .tuple .., .tvar .. | .tuple .., .named ..
   | .tvar .., .unit | .tvar .., .bool | .tvar .., .int | .tvar .., .sum ..
-  | .tvar .., .arrow .. | .tvar .., .ref .. | .tvar .., .empty | .tvar .., .value | .tvar .., .tuple ..
-  | .tvar .., .named ..
+  | .tvar .., .arrow .. | .tvar .., .ref .. | .tvar .., .owned .. | .tvar .., .empty
+  | .tvar .., .value | .tvar .., .tuple .. | .tvar .., .named ..
   | .named .., .unit | .named .., .bool | .named .., .int | .named .., .sum ..
-  | .named .., .arrow .. | .named .., .ref .. | .named .., .empty | .named .., .value | .named .., .tuple ..
-  | .named .., .tvar .. => isFalse (by intro h; cases h)
+  | .named .., .arrow .. | .named .., .ref .. | .named .., .owned .. | .named .., .empty
+  | .named .., .value | .named .., .tuple .. | .named .., .tvar .. => isFalse (by intro h; cases h)
 where
   typesDecEq : (as bs : List Typ) → Decidable (as = bs)
     | [], [] => isTrue rfl
@@ -106,6 +115,7 @@ def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
   | .sum ts => .sum (ts.map (Typ.subst _σ))
   | .arrow t1 t2 => .arrow (Typ.subst _σ t1) (Typ.subst _σ t2)
   | .ref t => .ref (Typ.subst _σ t)
+  | .owned t => .owned (Typ.subst _σ t)
   | .empty => .empty
   | .value => .value
   | .tuple ts => .tuple (ts.map (Typ.subst _σ))
@@ -144,6 +154,7 @@ mutual
     | .sum ts => 1 + Typ.weights ts
     | .arrow t1 t2 => 1 + Typ.weight t1 + Typ.weight t2
     | .ref t => 1 + Typ.weight t
+    | .owned t => 1 + Typ.weight t
     | .tuple ts => 1 + Typ.weights ts
     | .named _ args => 1 + Typ.weights args
 
@@ -160,6 +171,7 @@ mutual
     | .sum ts => 1 + Typ.depths ts
     | .arrow t1 t2 => 1 + max (Typ.depth t1) (Typ.depth t2)
     | .ref t => 1 + Typ.depth t
+    | .owned t => 1 + Typ.depth t
     | .tuple ts => 1 + Typ.depths ts
     | .named _ args => 1 + Typ.depths args
 
@@ -233,6 +245,8 @@ def Typ.subList (Θ : TypeEnv) : List Typ → List Typ → Bool :=
 /-! ## Subtyping relation -/
 
 mutual
+  -- Converting `owned A` to `ref A` allocates a shared invariant from the
+  -- spatial points-to assertion; it is a logical view shift, not subtyping.
   inductive Typ.Sub (Θ : TypeEnv) : Typ → Typ → Prop where
     | refl  : Typ.Sub Θ t t
     | bot   : Typ.Sub Θ .empty t
@@ -361,6 +375,7 @@ mutual
                                     else .value
     | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.meet Θ s1 t1) (Typ.join Θ s2 t2)
     | .ref s,       .ref t       => if s == t then .ref s else .value
+    | .owned s,     .owned t     => if s == t then .owned s else .value
     | .tuple ss,    .tuple ts    => if ss.length == ts.length
                                     then .tuple (Typ.joinList Θ ss ts)
                                     else .value
@@ -377,6 +392,7 @@ mutual
                                     else .empty
     | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.join Θ s1 t1) (Typ.meet Θ s2 t2)
     | .ref s,       .ref t       => if s == t then .ref s else .empty
+    | .owned s,     .owned t     => if s == t then .owned s else .empty
     | .tuple ss,    .tuple ts    => if ss.length == ts.length
                                     then .tuple (Typ.meetList Θ ss ts)
                                     else .empty

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -179,18 +179,18 @@ mutual
         let typedName := Typed.Binder.ofUntyped name (match name with | .named _ (some ty) => ty | _ => boundTy)
         let (bodyTy, body') ← infer Θ (extendTyped Γ typedName) body
         .ok (bodyTy, .letIn typedName bound' body')
-    | .ref e => do
+    | .ref owned e => do
         let (ty, e') ← infer Θ Γ e
-        .ok (.ref ty, .ref e')
+        .ok ((if owned then .owned ty else .ref ty), .ref owned e')
     | .deref e => do
         let (ty, e') ← infer Θ Γ e
         match ty with
-        | .ref inner => .ok (inner, .deref e' inner)
+        | .ref inner | .owned inner => .ok (inner, .deref e' inner)
         | _ => .error (.notARef ty)
     | .store loc val => do
         let (locTy, loc') ← infer Θ Γ loc
         match locTy with
-        | .ref inner =>
+        | .ref inner | .owned inner =>
             let val' ← check Θ Γ val inner
             .ok (.unit, .store loc' val')
         | _ => .error (.notARef locTy)
@@ -544,7 +544,7 @@ mutual
                 simp [typedName, Binder.ofUntyped_runtime]
               simp [Expr.runtime, Untyped.Expr.runtime, ihBound _ hbound, ihBody _ hbody,
                 hname_rt]
-    | .ref e => by
+    | .ref owned e => by
         let ih := infer_runtime Θ Γ e
         intro result h
         unfold Typed.infer at h
@@ -564,6 +564,9 @@ mutual
           case ref ty =>
             rcases (by simpa using hcont) with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ih _ hinfer]
+          case owned ty =>
+            rcases (by simpa using hcont) with ⟨rfl, rfl⟩
+            simp [Expr.runtime, Untyped.Expr.runtime, ih _ hinfer]
     | .store loc val => by
         let ihLoc := infer_runtime Θ Γ loc
         intro result h
@@ -573,6 +576,11 @@ mutual
         | mk locTy loc' =>
           cases locTy <;> simp at hcont
           case ref inner =>
+            let ihVal := check_runtime Θ Γ val inner
+            have ⟨val', hval, hcont⟩ := Except.bind_ok hcont
+            rcases (by simpa using hcont) with ⟨rfl, rfl⟩
+            simp [Expr.runtime, Untyped.Expr.runtime, ihLoc _ hloc, ihVal _ hval]
+          case owned inner =>
             let ihVal := check_runtime Θ Γ val inner
             have ⟨val', hval, hcont⟩ := Except.bind_ok hcont
             rcases (by simpa using hcont) with ⟨rfl, rfl⟩

--- a/Mica/TinyML/Untyped.lean
+++ b/Mica/TinyML/Untyped.lean
@@ -27,7 +27,7 @@ inductive Expr where
   | app (fn : Expr) (args : List Expr)
   | ifThenElse (cond thn els : Expr)
   | letIn (name : Binder) (bound body : Expr)
-  | ref    (e : Expr)
+  | ref    (owned : Bool) (e : Expr)
   | deref  (e : Expr)
   | store  (loc val : Expr)
   | assert (e : Expr)
@@ -95,9 +95,10 @@ mutual
       | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-    case ref.ref e1 e2 => exact match e1.decEq e2 with
-      | isTrue h => isTrue (by subst h; rfl)
-      | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case ref.ref o1 e1 o2 e2 => exact match decEq o1 o2, e1.decEq e2 with
+      | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+      | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case deref.deref e1 e2 => exact match e1.decEq e2 with
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -194,7 +195,7 @@ def Expr.runtime : Untyped.Expr → Runtime.Expr
   | .app fn args => .app fn.runtime (args.map Expr.runtime)
   | .ifThenElse c t e => .ifThenElse c.runtime t.runtime e.runtime
   | .letIn b bound body => .letIn (b.runtime) bound.runtime body.runtime
-  | .ref e => .ref e.runtime
+  | .ref _ e => .ref e.runtime
   | .deref e => .deref e.runtime
   | .store loc val => .store loc.runtime val.runtime
   | .assert e => .assert e.runtime

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -1592,7 +1592,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
   intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se
   obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
   cases hscrut_ty : scrut.ty with
-  | unit | bool | int | arrow _ _ | ref _ | empty | value | tuple _ | tvar _ | named _ _ =>
+  | unit | bool | int | arrow _ _ | ref _ | owned _ | empty | value | tuple _ | tvar _ | named _ _ =>
     simp only [hscrut_ty] at hΨ_scrut
     exact (VerifM.eval_fatal hΨ_scrut).elim
   | sum ts =>

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -200,10 +200,11 @@ mutual
         let se ← compile Θ Δ_spec S B Γ e
         if TinyML.Typ.sub Θ e.ty ty then pure se
         else VerifM.fatal s!"cast type mismatch"
-    | .ref e => do
+    | .ref false e => do
         let _ ← compile Θ Δ_spec S B Γ e
         let l ← VerifM.decl none .value
         pure (.const (.uninterpreted l.name .value))
+    | .ref true _ => VerifM.fatal "owned `ref` is not yet supported by the verifier"
     | .deref e ty => do
         VerifM.expectEq "deref type annotation mismatch" e.ty (.ref ty)
         let _ ← compile Θ Δ_spec S B Γ e
@@ -680,14 +681,14 @@ theorem compileFix_correct (self : Binder) (args : List Binder) (retTy : TinyML.
   simp only [compile] at heval
   exact (VerifM.eval_fatal heval).elim
 
-theorem compileRef_correct (e : Expr)
+theorem compileRefShared_correct (e : Expr)
     (ih : correctExpr e) :
-    correctExpr (.ref e) := by
+    correctExpr (.ref false e) := by
   intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  simp only [Expr.ty] at hpost
+  simp only [Expr.ty, Bool.false_eq_true, if_false] at hpost
   have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_ref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
@@ -747,6 +748,17 @@ theorem compileRef_correct (e : Expr)
           iexact Hinv
         · iexact HR
   exact hwp
+
+theorem compileRef_correct (owned : Bool) (e : Expr)
+    (ih : correctExpr e) :
+    correctExpr (.ref owned e) := by
+  cases owned with
+  | false => exact compileRefShared_correct e ih
+  | true =>
+    -- Owned `ref` is compiled to a fatal; correctness holds vacuously.
+    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
+    simp only [compile] at heval
+    exact (VerifM.eval_fatal heval).elim
 
 theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
     (ih : correctExpr e) :
@@ -2012,8 +2024,8 @@ theorem compile_correct (e : Expr) : correctExpr e := by
     simpa using compileAssert_correct e (compile_correct e)
   | fix self args retTy body =>
     simpa using compileFix_correct self args retTy body
-  | ref e =>
-    simpa using compileRef_correct e (compile_correct e)
+  | ref owned e =>
+    simpa using compileRef_correct owned e (compile_correct e)
   | deref e ty =>
     simpa using compileDeref_correct e ty (compile_correct e)
   | store loc val =>

--- a/Mica/Verifier/RelationalEncoding/Monad.lean
+++ b/Mica/Verifier/RelationalEncoding/Monad.lean
@@ -171,7 +171,7 @@ def encodeWith {M : Type} (ops : EncoderOps M)
       encodeMatchWith ops Γ δ v branches 0 k
   | .app _ _ _, _ => ops.error "relational encoding: only unary calls to named top-level functions are supported"
   | .fix .., _    => ops.error "relational encoding: nested `fix` is not supported"
-  | .ref _, _     => ops.error "relational encoding: heap allocation (`ref`) is not supported"
+  | .ref .., _    => ops.error "relational encoding: heap allocation (`ref`) is not supported"
   | .deref .., _  => ops.error "relational encoding: heap dereference is not supported"
   | .store .., _  => ops.error "relational encoding: heap store is not supported"
   | .assert _, _  => ops.error "relational encoding: `assert` is not supported"
@@ -323,7 +323,7 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
           intro _
           exact hops.call_ind hk
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
-  | .ifThenElse .., _ | .letIn .., _ | .ref _, _ | .deref .., _ | .store .., _
+  | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
   | .var _ _, [] | .var _ _, _ :: _ :: _ =>
       simp only [encodeWith]; exact hops.error_ind
@@ -344,7 +344,7 @@ theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
   simp only [encodeWith]
   exact ihBound hops fun _ => ihBody hops hk
 
-theorem ref (e : Typed.Expr) : EncodeWithInd (.ref e) :=
+theorem ref (owned : Bool) (e : Typed.Expr) : EncodeWithInd (.ref owned e) :=
   fun hops _ => hops.error_ind
 
 theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithInd (.deref e ty) :=
@@ -430,7 +430,7 @@ theorem encodeWith_ind_def : ∀ (e : Typed.Expr), EncodeWithInd e
   | .fix self args retTy body => Ind.fix self args retTy body
   | .letIn name bound body =>
       Ind.letIn name bound body (encodeWith_ind_def bound) (encodeWith_ind_def body)
-  | .ref e => Ind.ref e
+  | .ref owned e => Ind.ref owned e
   | .deref e ty => Ind.deref e ty
   | .store loc val => Ind.store loc val
   | .assert e => Ind.assert e
@@ -616,7 +616,7 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
           intro Δ''' hsub''' hΔ''' v' hv'
           exact hk (hsub''.trans hsub''') hΔ''' v' hv'
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
-  | .ifThenElse .., _ | .letIn .., _ | .ref _, _ | .deref .., _ | .store .., _
+  | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
   | .var _ _, [] | .var _ _, _ :: _ :: _ =>
       simp only [encodeWith]; exact hops.error_ind
@@ -643,7 +643,7 @@ theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
       (fun y w h => Term.wfIn_mono w (hδ y w h) hsub'' hΔ'') hv)
     (fun hsub''' hΔ''' w hw => hk (hsub''.trans hsub''') hΔ''' w hw)
 
-theorem ref (e : Typed.Expr) : EncodeWithIndSig (.ref e) :=
+theorem ref (owned : Bool) (e : Typed.Expr) : EncodeWithIndSig (.ref owned e) :=
   fun hops _ _ _ _ _ => hops.error_ind
 
 theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithIndSig (.deref e ty) :=
@@ -754,7 +754,7 @@ theorem encodeWith_indWithSig_def : ∀ (e : Typed.Expr), EncodeWithIndSig e
   | .letIn name bound body =>
       IndSig.letIn name bound body
         (encodeWith_indWithSig_def bound) (encodeWith_indWithSig_def body)
-  | .ref e => IndSig.ref e
+  | .ref owned e => IndSig.ref owned e
   | .deref e ty => IndSig.deref e ty
   | .store loc val => IndSig.store loc val
   | .assert e => IndSig.assert e
@@ -1123,7 +1123,7 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
           exact hops.call_binary (FunCtx.mem_of_lookup hlk) hv₁ hv₂ hevalv
             (EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk)
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
-  | .ifThenElse .., _ | .letIn .., _ | .ref _, _ | .deref .., _ | .store .., _
+  | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
   | .var _ _, [] | .var _ _, _ :: _ :: _ =>
       simp only [encodeWith]; exact hops.error_binary
@@ -1150,7 +1150,7 @@ theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
   exact ihBody hops (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
     (VarEnv.Agree.bindBinder henv_a hv₁ hv₂ hevalv) hka
 
-theorem ref (e : Typed.Expr) : EncodeWithBindBinary (.ref e) := by
+theorem ref (owned : Bool) (e : Typed.Expr) : EncodeWithBindBinary (.ref owned e) := by
   intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
 
 theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithBindBinary (.deref e ty) := by
@@ -1294,7 +1294,7 @@ theorem encodeWith_bind_binary_def : ∀ (e : Typed.Expr), EncodeWithBindBinary 
   | .letIn name bound body =>
       BindBinary.letIn name bound body
         (encodeWith_bind_binary_def bound) (encodeWith_bind_binary_def body)
-  | .ref e => BindBinary.ref e
+  | .ref owned e => BindBinary.ref owned e
   | .deref e ty => BindBinary.deref e ty
   | .store loc val => BindBinary.store loc val
   | .assert e => BindBinary.assert e


### PR DESCRIPTION
This PR adds an owned type `owned A` to the foundations of Mica, and parameterises the reference operations to handle both owned references and regular references. In subsequent PRs, frontend and verifier support will be added.