### PR TITLE
Performance optimization

### DIFF
--- a/Examples/recursive.ml
+++ b/Examples/recursive.ml
@@ -40,13 +40,13 @@ let rec triangle (n: int) : int =
 
 
 (* The [sum_squares] version requires a longer timeout. *)
-(* let rec sum_squares (n: int) : int =
+let rec sum_squares (n: int) : int =
   if n <= 0 then 0
   else sum_squares (n - 1) + n * n
 [@@spec fun x ->
   assert (x >= 0);
   ret (fun v ->
-    assert (v = (x * (x + 1) * (2 * x + 1)) / 6))];; *)
+    assert (v = (x * (x + 1) * (2 * x + 1)) / 6))];; 
 
 
 let rec sum_cubes (n: int) : int =

--- a/Mica/Engine/Driver.lean
+++ b/Mica/Engine/Driver.lean
@@ -24,9 +24,9 @@ structure Session where
 namespace Session
 
 -- `(set-option :smt.qi.eager_threshold 5.0)` Recursive functions are encoded
--- as quantified definitional axioms whose bodies references the function again.
+-- as quantified definitional axioms whose bodies reference the function again.
 -- Z3's default eager instantiation easily falls into a matching loop. It even
--- does so _before_  a check-sat is reached when entering a new scope.
+-- does so _before_ a check-sat is reached when entering a new scope.
 -- To avoid a severe performance penalty, we lower the default from 10.0 to 5.0.
 def preamble : String := s!"
 ;; preamble

--- a/Mica/Engine/Driver.lean
+++ b/Mica/Engine/Driver.lean
@@ -23,10 +23,16 @@ structure Session where
 
 namespace Session
 
+-- `(set-option :smt.qi.eager_threshold 5.0)` Recursive functions are encoded
+-- as quantified definitional axioms whose bodies references the function again.
+-- Z3's default eager instantiation easily falls into a matching loop. It even
+-- does so _before_  a check-sat is reached when entering a new scope.
+-- To avoid a severe performance penalty, we lower the default from 10.0 to 5.0.
 def preamble : String := s!"
 ;; preamble
 (set-logic ALL)
 (set-option :timeout 3000)
+(set-option :smt.qi.eager_threshold 5.0)
 
 (declare-sort Other 0)
 (declare-sort Loc 0)


### PR DESCRIPTION
This PR improves the performance of mica considerably by lowering the speculative eager instantiation of quantifiers. It improves the performance for slightly more complicated examples like `bst.ml` from over a minute (~90s) to less than a second.