### PR TITLE
Factor out primitive types

### DIFF
--- a/Mica/SeparationLogic/LogicalRelation.lean
+++ b/Mica/SeparationLogic/LogicalRelation.lean
@@ -34,6 +34,17 @@ abbrev RecIdx := LeibnizO (Runtime.Val × TypeName × List Typ)
 /-- The outer approximation ranges over closed value relations. -/
 abbrev ValShape := Runtime.Val → Typ → iProp
 
+/-- Interpret one primitive type as an Iris assertion over a runtime value. -/
+def PrimitiveType.valRelBody : PrimitiveType → Runtime.Val → iProp
+  | .unit, v => iprop(⌜v = .unit⌝)
+  | .bool, v => iprop(⌜∃ b, v = .bool b⌝)
+  | .int, v => iprop(⌜∃ n, v = .int n⌝)
+
+theorem PrimitiveType.valRelBody_persistent (p : PrimitiveType) (v : Runtime.Val) :
+    Persistent (p.valRelBody v) := by
+  unfold PrimitiveType.valRelBody
+  cases p <;> infer_instance
+
 /- One structural layer of the value relation.
 
 References use the outer approximation `R`; named types use the inner
@@ -43,9 +54,7 @@ the list/sum helpers below.
 mutual
   def ValRelBody (R : ValShape) (v : Runtime.Val) (t : Typ) (k : RecCont) : iProp :=
     match t with
-    | .unit       => iprop(⌜v = .unit⌝)
-    | .bool       => iprop(⌜∃ b, v = .bool b⌝)
-    | .int        => iprop(⌜∃ n, v = .int n⌝)
+    | .prim p     => p.valRelBody v
     | .value      => iprop(True)
     | .empty      => iprop(False)
     | .arrow _ _  => iprop(False)
@@ -99,7 +108,10 @@ mutual
         · iapply (ValSumRelBody.mono_int R ts tag payload)
           · iexact Hk
           · iexact Hsum
-    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ | .ref _ | .owned _ =>
+    | .prim _ =>
+        iintro _ H
+        iexact H
+    | .value | .empty | .arrow _ _ | .tvar _ | .ref _ | .owned _ =>
         iintro _ H
         iexact H
 
@@ -171,7 +183,9 @@ mutual
         refine exists_ne fun payload => ?_
         refine sep_ne.ne (.of_eq rfl) ?_
         exact ValSumRelBody.dist hR hk ts tag payload
-    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ | .owned _ =>
+    | .prim _ =>
+        exact Dist.rfl
+    | .value | .empty | .arrow _ _ | .tvar _ | .owned _ =>
         exact Dist.rfl
 
   private theorem ValsRelBody.dist {n : Nat} {R S : ValShape} {k k' : RecCont}
@@ -318,7 +332,9 @@ mutual
       (hk : ∀ v T args, Persistent (k v T args)) : Persistent (ValRelBody R v t k) := by
     unfold ValRelBody
     match t with
-    | .unit | .bool | .int | .value | .empty | .arrow _ _ | .tvar _ | .owned _ =>
+    | .prim _ =>
+        exact PrimitiveType.valRelBody_persistent _ v
+    | .value | .empty | .arrow _ _ | .tvar _ | .owned _ =>
         infer_instance
     | .ref _ =>
         have := locinv_persistent
@@ -396,16 +412,19 @@ instance (Θ : TypeEnv) (tag : Nat) (payload : Runtime.Val) (ts : List Typ) :
 /-! Per-type unfoldings -/
 
 theorem ValHasType.unit (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v .unit ⊣⊢ iprop(⌜v = .unit⌝) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v .unit)
+    ValHasType Θ v Typ.unit ⊣⊢ iprop(⌜v = .unit⌝) := by
+  change ValHasType Θ v (.prim .unit) ⊣⊢ iprop(⌜v = .unit⌝)
+  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.unit)
 
 theorem ValHasType.bool (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v .bool ⊣⊢ iprop(⌜∃ b, v = .bool b⌝) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v .bool)
+    ValHasType Θ v Typ.bool ⊣⊢ iprop(⌜∃ b, v = .bool b⌝) := by
+  change ValHasType Θ v (.prim .bool) ⊣⊢ iprop(⌜∃ b, v = .bool b⌝)
+  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.bool)
 
 theorem ValHasType.int (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v .int ⊣⊢ iprop(⌜∃ n, v = .int n⌝) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v .int)
+    ValHasType Θ v Typ.int ⊣⊢ iprop(⌜∃ n, v = .int n⌝) := by
+  change ValHasType Θ v (.prim .int) ⊣⊢ iprop(⌜∃ n, v = .int n⌝)
+  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.int)
 
 theorem ValHasType.value (Θ : TypeEnv) (v : Runtime.Val) :
     ValHasType Θ v .value ⊣⊢ iprop(True) := by
@@ -571,9 +590,23 @@ theorem ValHasType.inj {Θ : TypeEnv} {payload : Runtime.Val}
 
 /-- The canonical proof that `unit` has type `unit`. -/
 theorem ValHasType.unit_intro (Θ : TypeEnv) :
-    ⊢ ValHasType Θ .unit .unit := by
+    ⊢ ValHasType Θ .unit Typ.unit := by
   iapply (ValHasType.unit Θ .unit).2
   ipure_intro; rfl
+
+/-- The canonical proof that a Boolean literal has type `bool`. -/
+theorem ValHasType.bool_intro (Θ : TypeEnv) (b : Bool) :
+    ⊢ ValHasType Θ (.bool b) Typ.bool := by
+  iapply (ValHasType.bool Θ (.bool b)).2
+  ipure_intro
+  exact ⟨b, rfl⟩
+
+/-- The canonical proof that an integer literal has type `int`. -/
+theorem ValHasType.int_intro (Θ : TypeEnv) (n : Int) :
+    ⊢ ValHasType Θ (.int n) Typ.int := by
+  iapply (ValHasType.int Θ (.int n)).2
+  ipure_intro
+  exact ⟨n, rfl⟩
 
 mutual
   theorem ValHasType.sub {Θ : TypeEnv} {v : Runtime.Val} {t t' : Typ}
@@ -743,8 +776,7 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       iprop(∃ w, ⌜evalBinOp op v1 v2 = some w⌝ ∗ ValHasType Θ w ty) := by
   cases op with
   | add =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_arith (by simp) hty
       refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -756,12 +788,9 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.int Θ (Runtime.Val.int (a + b))).2
-        ipure_intro
-        exact ⟨a + b, rfl⟩
+      · exact ValHasType.int_intro Θ (a + b)
   | sub =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_arith (by simp) hty
       refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -773,12 +802,9 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.int Θ (Runtime.Val.int (a - b))).2
-        ipure_intro
-        exact ⟨a - b, rfl⟩
+      · exact ValHasType.int_intro Θ (a - b)
   | mul =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_arith (by simp) hty
       refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -790,16 +816,13 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.int Θ (Runtime.Val.int (a * b))).2
-        ipure_intro
-        exact ⟨a * b, rfl⟩
+      · exact ValHasType.int_intro Θ (a * b)
   | div =>
       cases (hndiv rfl)
   | mod =>
       cases (hnmod rfl)
   | eq =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
       refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -811,12 +834,9 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.bool Θ (Runtime.Val.bool (a == b))).2
-        ipure_intro
-        exact ⟨a == b, rfl⟩
+      · exact ValHasType.bool_intro Θ (a == b)
   | lt =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
       refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -828,12 +848,9 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.bool Θ (Runtime.Val.bool (a < b))).2
-        ipure_intro
-        exact ⟨a < b, rfl⟩
+      · exact ValHasType.bool_intro Θ (a < b)
   | le =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
       refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -845,12 +862,9 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.bool Θ (Runtime.Val.bool (a ≤ b))).2
-        ipure_intro
-        exact ⟨a ≤ b, rfl⟩
+      · exact ValHasType.bool_intro Θ (a ≤ b)
   | gt =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
       refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -862,12 +876,9 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.bool Θ (Runtime.Val.bool (a > b))).2
-        ipure_intro
-        exact ⟨a > b, rfl⟩
+      · exact ValHasType.bool_intro Θ (a > b)
   | ge =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
       refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -879,12 +890,9 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.bool Θ (Runtime.Val.bool (a ≥ b))).2
-        ipure_intro
-        exact ⟨a ≥ b, rfl⟩
+      · exact ValHasType.bool_intro Θ (a ≥ b)
   | and =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_bool (by simp) hty
       refine (sep_mono (ValHasType.bool Θ v1).1 (ValHasType.bool Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -896,12 +904,9 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.bool Θ (Runtime.Val.bool (a && b))).2
-        ipure_intro
-        exact ⟨a && b, rfl⟩
+      · exact ValHasType.bool_intro Θ (a && b)
   | or =>
-      cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_bool (by simp) hty
       refine (sep_mono (ValHasType.bool Θ v1).1 (ValHasType.bool Θ v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
@@ -913,9 +918,7 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipure_intro
         simp [evalBinOp]
-      · iapply (ValHasType.bool Θ (Runtime.Val.bool (a || b))).2
-        ipure_intro
-        exact ⟨a || b, rfl⟩
+      · exact ValHasType.bool_intro Θ (a || b)
 
 theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
     {v : Runtime.Val} {t ty : Typ}
@@ -924,8 +927,7 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
       iprop(∃ w, ⌜evalUnOp op v = some w⌝ ∗ ValHasType Θ w ty) := by
   cases op with
   | neg =>
-      cases t <;> simp [UnOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl⟩ := UnOp.typeOf_int rfl hty
       refine (ValHasType.int Θ v).1.trans ?_
       iintro Hv
       icases Hv with ⟨%n, %hv⟩
@@ -934,12 +936,9 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
       isplitr
       · ipure_intro
         simp [evalUnOp]
-      · iapply (ValHasType.int Θ (Runtime.Val.int (-n))).2
-        ipure_intro
-        exact ⟨-n, rfl⟩
+      · exact ValHasType.int_intro Θ (-n)
   | not =>
-      cases t <;> simp [UnOp.typeOf] at hty
-      subst hty
+      obtain ⟨rfl, rfl⟩ := UnOp.typeOf_bool rfl hty
       refine (ValHasType.bool Θ v).1.trans ?_
       iintro Hv
       icases Hv with ⟨%b, %hv⟩
@@ -948,9 +947,7 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
       isplitr
       · ipure_intro
         simp [evalUnOp]
-      · iapply (ValHasType.bool Θ (Runtime.Val.bool (!b))).2
-        ipure_intro
-        exact ⟨!b, rfl⟩
+      · exact ValHasType.bool_intro Θ (!b)
   | proj n =>
       cases t with
       | tuple ts =>
@@ -971,8 +968,8 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
               · iexact Hwitness)
           iapply (ValsHaveTypes.of_getElem? (Θ := Θ) (vs := vs) (ts := ts) (n := n) (t := ty) hty)
           iexact Hvs
-      | unit | bool | int | sum _ | arrow _ _ | ref _ | owned _ | empty | value | tvar _ | named _ _ =>
-          simp [UnOp.typeOf] at hty
+      | prim _ | sum _ | arrow _ _ | ref _ | owned _ | empty | value | tvar _ | named _ _ =>
+          simp [UnOp.typeOf, PrimitiveType.unOpTypeOf] at hty
 
 end TinyML
 
@@ -987,14 +984,50 @@ end TinyML
 
 namespace TinyML
 
+/-- Generate SMT formulas for a primitive TinyML type. -/
+def PrimitiveType.typeConstraints (p : PrimitiveType) (t : Term .value) : List Formula :=
+  match p with
+  | .int => [.unpred .isInt t]
+  | .bool => [.unpred .isBool t]
+  | .unit => []
+
+/-- Primitive type constraints only reference free variables of the constrained term. -/
+theorem PrimitiveType.typeConstraints_wfIn {p : PrimitiveType} {t : Term .value} {Δ : Signature}
+    (ht : t.wfIn Δ) : ∀ φ ∈ p.typeConstraints t, φ.wfIn Δ := by
+  cases p <;> simp [PrimitiveType.typeConstraints]
+  · simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
+  · simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
+
+/-- Primitive value typing entails the generated primitive type constraints. -/
+theorem PrimitiveType.typeConstraints_hold {p : PrimitiveType} {t : Term .value} {ρ : Env}
+    {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ = v) :
+    TinyML.ValHasType Θ v (.prim p) ⊢ ⌜∀ φ ∈ p.typeConstraints t, φ.eval ρ⌝ := by
+  cases p
+  · iintro _; ipure_intro; simp [PrimitiveType.typeConstraints]
+  · refine (TinyML.ValHasType.bool Θ v).1.trans ?_
+    iintro %h
+    rcases h with ⟨b, rfl⟩
+    ipure_intro
+    intro φ hφ
+    simp [PrimitiveType.typeConstraints] at hφ
+    rcases hφ with rfl
+    simp [Formula.eval, ht]
+  · refine (TinyML.ValHasType.int Θ v).1.trans ?_
+    iintro %h
+    rcases h with ⟨n, rfl⟩
+    ipure_intro
+    intro φ hφ
+    simp [PrimitiveType.typeConstraints] at hφ
+    rcases hφ with rfl
+    simp [Formula.eval, ht]
+
 mutual
 /-- Generate SMT formulas asserting that a value-sorted term has a given TinyML type.
     For `int`: `is-of_int(t)`, for `bool`: `is-of_bool(t)`,
     for `tuple ts`: `is-of_tuple(t)` plus recursive constraints on elements. -/
 def typeConstraints (ty : TinyML.Typ) (t : Term .value) : List Formula :=
   match ty with
-  | .int   => [.unpred .isInt t]
-  | .bool  => [.unpred .isBool t]
+  | .prim p => p.typeConstraints t
   | .owned _ => [.unpred .isLoc t]
   | .tuple ts =>
       .unpred .isTuple t ::
@@ -1015,12 +1048,8 @@ mutual
   theorem typeConstraints_wfIn {ty : TinyML.Typ} {t : Term .value} {Δ : Signature}
       (ht : t.wfIn Δ) : ∀ φ ∈ typeConstraints ty t, φ.wfIn Δ := by
     cases ty with
-    | int =>
-      simp [typeConstraints]
-      simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
-    | bool =>
-      simp [typeConstraints]
-      simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
+    | prim p =>
+      simpa [typeConstraints] using PrimitiveType.typeConstraints_wfIn (p := p) ht
     | owned _ =>
       simp [typeConstraints]
       simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
@@ -1054,24 +1083,8 @@ mutual
       {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ = v) :
       TinyML.ValHasType Θ v ty ⊢ ⌜∀ φ ∈ typeConstraints ty t, φ.eval ρ⌝ := by
     cases ty with
-    | int =>
-      refine (TinyML.ValHasType.int Θ v).1.trans ?_
-      iintro %h
-      rcases h with ⟨n, rfl⟩
-      ipure_intro
-      intro φ hφ
-      simp [typeConstraints] at hφ
-      subst hφ
-      simp [Formula.eval, ht]
-    | bool =>
-      refine (TinyML.ValHasType.bool Θ v).1.trans ?_
-      iintro %h
-      rcases h with ⟨b, rfl⟩
-      ipure_intro
-      intro φ hφ
-      simp [typeConstraints] at hφ
-      subst hφ
-      simp [Formula.eval, ht]
+    | prim p =>
+      simpa [typeConstraints] using PrimitiveType.typeConstraints_hold (p := p) (Θ := Θ) (v := v) ht
     | owned inner =>
       refine (TinyML.ValHasType.owned Θ v inner).1.trans ?_
       iintro Hty
@@ -1097,7 +1110,7 @@ mutual
         simp [Formula.eval, ht, hv]
       | tail _ hφ =>
         exact htail φ hφ
-    | unit | sum _ | ref _ | value | named _ _ =>
+    | sum _ | ref _ | value | named _ _ =>
       iintro _; ipure_intro; simp [typeConstraints]
     | arrow t1 t2 => exact (TinyML.ValHasType.arrow Θ v t1 t2).1.trans false_elim
     | empty => exact (TinyML.ValHasType.empty Θ v).1.trans false_elim

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -10,9 +10,7 @@ open TinyML
 namespace TinyML
 
 def Typ.print : Typ → String
-  | .unit => "unit"
-  | .bool => "bool"
-  | .int => "int"
+  | .prim p => p.print
   | .sum ts => s!"sum ({", ".intercalate (ts.map Typ.print)})"
   | .arrow t1 t2 => s!"{wrapArg t1 (Typ.print t1)} -> {Typ.print t2}"
   | .ref t => s!"ref {wrapArg t (Typ.print t)}"
@@ -26,7 +24,7 @@ def Typ.print : Typ → String
 where
   wrapArg (t : Typ) (s : String) : String :=
     match t with
-    | .unit | .bool | .int | .empty | .value | .tvar _ | .named _ [] => s
+    | .prim _ | .empty | .value | .tvar _ | .named _ [] => s
     | _ => s!"({s})"
 
 end TinyML

--- a/Mica/TinyML/Types.lean
+++ b/Mica/TinyML/Types.lean
@@ -6,10 +6,100 @@ namespace TinyML
 abbrev TyVar := String
 abbrev TypeName := String
 
-inductive Typ where
+/-- Primitive, non-structural TinyML types. -/
+inductive PrimitiveType where
   | unit
   | bool
   | int
+  deriving Repr, DecidableEq
+
+/-- Decidable equality for primitive types. -/
+protected def PrimitiveType.decEq (p q : PrimitiveType) : Decidable (p = q) :=
+  inferInstance
+
+/-- Pretty-print a primitive type. -/
+def PrimitiveType.print : PrimitiveType → String
+  | .unit => "unit"
+  | .bool => "bool"
+  | .int => "int"
+
+/-- Type primitive binary operators before lifting the result to `Typ`. -/
+def PrimitiveType.binOpTypeOf : BinOp → PrimitiveType → PrimitiveType → Option PrimitiveType
+  | .add,  .int,  .int  => some .int
+  | .sub,  .int,  .int  => some .int
+  | .mul,  .int,  .int  => some .int
+  | .div,  .int,  .int  => some .int
+  | .mod,  .int,  .int  => some .int
+  | .eq,   .int,  .int  => some .bool
+  | .lt,   .int,  .int  => some .bool
+  | .le,   .int,  .int  => some .bool
+  | .gt,   .int,  .int  => some .bool
+  | .ge,   .int,  .int  => some .bool
+  | .and,  .bool, .bool => some .bool
+  | .or,   .bool, .bool => some .bool
+  | _, _, _             => none
+
+/-- Type primitive unary operators before lifting the result to `Typ`. -/
+def PrimitiveType.unOpTypeOf : UnOp → PrimitiveType → Option PrimitiveType
+  | .neg, .int  => some .int
+  | .not, .bool => some .bool
+  | _, _        => none
+
+/-- Arithmetic binary operators require integer primitive inputs and produce integer. -/
+theorem PrimitiveType.binOpTypeOf_arith {op : BinOp} {p1 p2 p : PrimitiveType}
+    (hop : op = .add ∨ op = .sub ∨ op = .mul ∨ op = .div ∨ op = .mod)
+    (hty : PrimitiveType.binOpTypeOf op p1 p2 = some p) :
+    p1 = .int ∧ p2 = .int ∧ p = .int := by
+  rcases hop with rfl | rfl | rfl | rfl | rfl
+  all_goals
+    cases p1 <;> cases p2 <;> simp [PrimitiveType.binOpTypeOf] at hty
+    subst hty
+    simp
+
+/-- Integer comparison binary operators require integer primitive inputs and produce Boolean. -/
+theorem PrimitiveType.binOpTypeOf_compare {op : BinOp} {p1 p2 p : PrimitiveType}
+    (hop : op = .eq ∨ op = .lt ∨ op = .le ∨ op = .gt ∨ op = .ge)
+    (hty : PrimitiveType.binOpTypeOf op p1 p2 = some p) :
+    p1 = .int ∧ p2 = .int ∧ p = .bool := by
+  rcases hop with rfl | rfl | rfl | rfl | rfl
+  all_goals
+    cases p1 <;> cases p2 <;> simp [PrimitiveType.binOpTypeOf] at hty
+    subst hty
+    simp
+
+/-- Boolean binary operators require Boolean primitive inputs and produce Boolean. -/
+theorem PrimitiveType.binOpTypeOf_bool {op : BinOp} {p1 p2 p : PrimitiveType}
+    (hop : op = .and ∨ op = .or)
+    (hty : PrimitiveType.binOpTypeOf op p1 p2 = some p) :
+    p1 = .bool ∧ p2 = .bool ∧ p = .bool := by
+  rcases hop with rfl | rfl
+  all_goals
+    cases p1 <;> cases p2 <;> simp [PrimitiveType.binOpTypeOf] at hty
+    subst hty
+    simp
+
+/-- Integer unary operators require an integer primitive input and produce integer. -/
+theorem PrimitiveType.unOpTypeOf_int {op : UnOp} {p p' : PrimitiveType}
+    (hop : op = .neg)
+    (hty : PrimitiveType.unOpTypeOf op p = some p') :
+    p = .int ∧ p' = .int := by
+  subst hop
+  cases p <;> simp [PrimitiveType.unOpTypeOf] at hty
+  subst hty
+  simp
+
+/-- Boolean unary operators require a Boolean primitive input and produce Boolean. -/
+theorem PrimitiveType.unOpTypeOf_bool {op : UnOp} {p p' : PrimitiveType}
+    (hop : op = .not)
+    (hty : PrimitiveType.unOpTypeOf op p = some p') :
+    p = .bool ∧ p' = .bool := by
+  subst hop
+  cases p <;> simp [PrimitiveType.unOpTypeOf] at hty
+  subst hty
+  simp
+
+inductive Typ where
+  | prim (p : PrimitiveType)
   | sum (ts : List Typ)
   | arrow (t1 t2 : Typ)
   | ref (t: Typ)
@@ -23,8 +113,21 @@ inductive Typ where
   | named (T : TypeName) (args : List Typ)
   deriving Repr
 
+/-- Compatibility name for the unit primitive type. -/
+@[simp] def Typ.unit : Typ := .prim .unit
+/-- Compatibility name for the Boolean primitive type. -/
+@[simp] def Typ.bool : Typ := .prim .bool
+/-- Compatibility name for the integer primitive type. -/
+@[simp] def Typ.int : Typ := .prim .int
+
+def Typ.primDecEq (p q : PrimitiveType) : Decidable (Typ.prim p = Typ.prim q) :=
+  match PrimitiveType.decEq p q with
+  | isTrue h => isTrue (by subst h; rfl)
+  | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+
 def Typ.decEq : (a b : Typ) → Decidable (a = b)
-  | .unit, .unit | .bool, .bool | .int, .int | .empty, .empty | .value, .value => isTrue rfl
+  | .prim p, .prim q => Typ.primDecEq p q
+  | .empty, .empty | .value, .value => isTrue rfl
   | .sum ss, .sum ts => match typesDecEq ss ts with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -50,40 +153,34 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
     | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
     | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
     | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .unit, .bool | .unit, .int | .unit, .sum .. | .unit, .arrow ..
-  | .unit, .ref .. | .unit, .owned .. | .unit, .empty | .unit, .value | .unit, .tuple ..
-  | .unit, .tvar .. | .unit, .named ..
-  | .bool, .unit | .bool, .int | .bool, .sum .. | .bool, .arrow ..
-  | .bool, .ref .. | .bool, .owned .. | .bool, .empty | .bool, .value | .bool, .tuple ..
-  | .bool, .tvar .. | .bool, .named ..
-  | .int, .unit | .int, .bool | .int, .sum .. | .int, .arrow ..
-  | .int, .ref .. | .int, .owned .. | .int, .empty | .int, .value | .int, .tuple ..
-  | .int, .tvar .. | .int, .named ..
-  | .sum .., .unit | .sum .., .bool | .sum .., .int
+  | .prim _, .sum .. | .prim _, .arrow ..
+  | .prim _, .ref .. | .prim _, .owned .. | .prim _, .empty | .prim _, .value | .prim _, .tuple ..
+  | .prim _, .tvar .. | .prim _, .named ..
+  | .sum .., .prim _
   | .sum .., .arrow .. | .sum .., .ref .. | .sum .., .owned .. | .sum .., .empty
   | .sum .., .value | .sum .., .tuple .. | .sum .., .tvar .. | .sum .., .named ..
-  | .arrow .., .unit | .arrow .., .bool | .arrow .., .int
+  | .arrow .., .prim _
   | .arrow .., .sum .. | .arrow .., .ref .. | .arrow .., .owned .. | .arrow .., .empty
   | .arrow .., .value | .arrow .., .tuple .. | .arrow .., .tvar .. | .arrow .., .named ..
-  | .ref .., .unit | .ref .., .bool | .ref .., .int
+  | .ref .., .prim _
   | .ref .., .sum .. | .ref .., .arrow .. | .ref .., .owned .. | .ref .., .empty
   | .ref .., .value | .ref .., .tuple .. | .ref .., .tvar .. | .ref .., .named ..
-  | .owned .., .unit | .owned .., .bool | .owned .., .int
+  | .owned .., .prim _
   | .owned .., .sum .. | .owned .., .arrow .. | .owned .., .ref .. | .owned .., .empty
   | .owned .., .value | .owned .., .tuple .. | .owned .., .tvar .. | .owned .., .named ..
-  | .empty, .unit | .empty, .bool | .empty, .int | .empty, .sum ..
+  | .empty, .prim _ | .empty, .sum ..
   | .empty, .arrow .. | .empty, .ref .. | .empty, .owned .. | .empty, .value | .empty, .tuple ..
   | .empty, .tvar .. | .empty, .named ..
-  | .value, .unit | .value, .bool | .value, .int | .value, .sum ..
+  | .value, .prim _ | .value, .sum ..
   | .value, .arrow .. | .value, .ref .. | .value, .owned .. | .value, .empty | .value, .tuple ..
   | .value, .tvar .. | .value, .named ..
-  | .tuple .., .unit | .tuple .., .bool | .tuple .., .int
+  | .tuple .., .prim _
   | .tuple .., .sum .. | .tuple .., .arrow .. | .tuple .., .ref .. | .tuple .., .owned ..
   | .tuple .., .empty | .tuple .., .value | .tuple .., .tvar .. | .tuple .., .named ..
-  | .tvar .., .unit | .tvar .., .bool | .tvar .., .int | .tvar .., .sum ..
+  | .tvar .., .prim _ | .tvar .., .sum ..
   | .tvar .., .arrow .. | .tvar .., .ref .. | .tvar .., .owned .. | .tvar .., .empty
   | .tvar .., .value | .tvar .., .tuple .. | .tvar .., .named ..
-  | .named .., .unit | .named .., .bool | .named .., .int | .named .., .sum ..
+  | .named .., .prim _ | .named .., .sum ..
   | .named .., .arrow .. | .named .., .ref .. | .named .., .owned .. | .named .., .empty
   | .named .., .value | .named .., .tuple .. | .named .., .tvar .. => isFalse (by intro h; cases h)
 where
@@ -109,9 +206,7 @@ This is currently structural-only scaffolding. It becomes meaningfully
 variable-sensitive once `Typ` grows `tvar`/`named`.
 -/
 def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
-  | .unit => .unit
-  | .bool => .bool
-  | .int => .int
+  | .prim p => .prim p
   | .sum ts => .sum (ts.map (Typ.subst _σ))
   | .arrow t1 t2 => .arrow (Typ.subst _σ t1) (Typ.subst _σ t2)
   | .ref t => .ref (Typ.subst _σ t)
@@ -150,7 +245,7 @@ def TypeName.unfold (Θ : TypeEnv) (T : TypeName) (args : List Typ) : Option Typ
 mutual
   @[reducible]
   def Typ.weight : Typ → Nat
-    | .unit | .bool | .int | .empty | .value | .tvar _ => 1
+    | .prim _ | .empty | .value | .tvar _ => 1
     | .sum ts => 1 + Typ.weights ts
     | .arrow t1 t2 => 1 + Typ.weight t1 + Typ.weight t2
     | .ref t => 1 + Typ.weight t
@@ -167,7 +262,7 @@ end
 mutual
   @[reducible]
   def Typ.depth : Typ → Nat
-    | .unit | .bool | .int | .empty | .value | .tvar _ => 1
+    | .prim _ | .empty | .value | .tvar _ => 1
     | .sum ts => 1 + Typ.depths ts
     | .arrow t1 t2 => 1 + max (Typ.depth t1) (Typ.depth t2)
     | .ref t => 1 + Typ.depth t
@@ -413,24 +508,75 @@ end
 /-! ## Operator typing -/
 
 def BinOp.typeOf : BinOp → Typ → Typ → Option Typ
-  | .add,  .int,  .int  => some .int
-  | .sub,  .int,  .int  => some .int
-  | .mul,  .int,  .int  => some .int
-  | .div,  .int,  .int  => some .int
-  | .mod,  .int,  .int  => some .int
-  | .eq,   .int,  .int  => some .bool
-  | .lt,   .int,  .int  => some .bool
-  | .le,   .int,  .int  => some .bool
-  | .gt,   .int,  .int  => some .bool
-  | .ge,   .int,  .int  => some .bool
-  | .and,  .bool, .bool => some .bool
-  | .or,   .bool, .bool => some .bool
-  | _, _, _             => none
+  | op, .prim p1, .prim p2 => (PrimitiveType.binOpTypeOf op p1 p2).map Typ.prim
+  | _, _, _ => none
+
+/-- Arithmetic binary operators require integer inputs and produce an integer. -/
+theorem BinOp.typeOf_arith {op : BinOp} {t1 t2 ty : Typ}
+    (hop : op = .add ∨ op = .sub ∨ op = .mul ∨ op = .div ∨ op = .mod)
+    (hty : BinOp.typeOf op t1 t2 = some ty) :
+    t1 = Typ.int ∧ t2 = Typ.int ∧ ty = Typ.int := by
+  rcases hop with rfl | rfl | rfl | rfl | rfl
+  all_goals
+    cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
+    rename_i p1 p2
+    rcases hty with ⟨p, hprim, rfl⟩
+    obtain ⟨rfl, rfl, rfl⟩ := PrimitiveType.binOpTypeOf_arith (by simp) hprim
+    simp [Typ.int]
+
+/-- Integer comparison binary operators require integer inputs and produce a Boolean. -/
+theorem BinOp.typeOf_compare {op : BinOp} {t1 t2 ty : Typ}
+    (hop : op = .eq ∨ op = .lt ∨ op = .le ∨ op = .gt ∨ op = .ge)
+    (hty : BinOp.typeOf op t1 t2 = some ty) :
+    t1 = Typ.int ∧ t2 = Typ.int ∧ ty = Typ.bool := by
+  rcases hop with rfl | rfl | rfl | rfl | rfl
+  all_goals
+    cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
+    rename_i p1 p2
+    rcases hty with ⟨p, hprim, rfl⟩
+    obtain ⟨rfl, rfl, rfl⟩ := PrimitiveType.binOpTypeOf_compare (by simp) hprim
+    simp [Typ.int, Typ.bool]
+
+/-- Boolean binary operators require Boolean inputs and produce a Boolean. -/
+theorem BinOp.typeOf_bool {op : BinOp} {t1 t2 ty : Typ}
+    (hop : op = .and ∨ op = .or)
+    (hty : BinOp.typeOf op t1 t2 = some ty) :
+    t1 = Typ.bool ∧ t2 = Typ.bool ∧ ty = Typ.bool := by
+  rcases hop with rfl | rfl
+  all_goals
+    cases t1 <;> cases t2 <;> simp [BinOp.typeOf] at hty
+    rename_i p1 p2
+    rcases hty with ⟨p, hprim, rfl⟩
+    obtain ⟨rfl, rfl, rfl⟩ := PrimitiveType.binOpTypeOf_bool (by simp) hprim
+    simp [Typ.bool]
 
 def UnOp.typeOf : UnOp → Typ → Option Typ
-  | .neg, .int       => some .int
-  | .not, .bool      => some .bool
+  | op, .prim p => (PrimitiveType.unOpTypeOf op p).map Typ.prim
   | .proj n, .tuple ts => ts[n]?
   | _, _             => none
+
+/-- Integer unary operators require an integer input and produce an integer. -/
+theorem UnOp.typeOf_int {op : UnOp} {t ty : Typ}
+    (hop : op = .neg)
+    (hty : UnOp.typeOf op t = some ty) :
+    t = Typ.int ∧ ty = Typ.int := by
+  subst hop
+  cases t <;> simp [UnOp.typeOf] at hty
+  rename_i p
+  rcases hty with ⟨p', hprim, rfl⟩
+  obtain ⟨rfl, rfl⟩ := PrimitiveType.unOpTypeOf_int rfl hprim
+  simp [Typ.int]
+
+/-- Boolean unary operators require a Boolean input and produce a Boolean. -/
+theorem UnOp.typeOf_bool {op : UnOp} {t ty : Typ}
+    (hop : op = .not)
+    (hty : UnOp.typeOf op t = some ty) :
+    t = Typ.bool ∧ ty = Typ.bool := by
+  subst hop
+  cases t <;> simp [UnOp.typeOf] at hty
+  rename_i p
+  rcases hty with ⟨p', hprim, rfl⟩
+  obtain ⟨rfl, rfl⟩ := PrimitiveType.unOpTypeOf_bool rfl hprim
+  simp [Typ.bool]
 
 end TinyML

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -494,9 +494,7 @@ theorem compileConst_correct (c : TinyML.Const) :
     isplitl [Howns]
     · iexact Howns
     · isplitl []
-      · iapply (TinyML.ValHasType.int Θ (.int n)).2
-        ipure_intro
-        exact ⟨n, rfl⟩
+      · exact TinyML.ValHasType.int_intro Θ n
       · iexact HR
   | bool b =>
     simp only [compile] at heval
@@ -512,9 +510,7 @@ theorem compileConst_correct (c : TinyML.Const) :
     isplitl [Howns]
     · iexact Howns
     · isplitl []
-      · iapply (TinyML.ValHasType.bool Θ (.bool b)).2
-        ipure_intro
-        exact ⟨b, rfl⟩
+      · exact TinyML.ValHasType.bool_intro Θ b
       · iexact HR
   | unit =>
     simp only [compile] at heval
@@ -530,9 +526,7 @@ theorem compileConst_correct (c : TinyML.Const) :
     isplitl [Howns]
     · iexact Howns
     · isplitl []
-      · iapply (TinyML.ValHasType.unit Θ .unit).2
-        ipure_intro
-        rfl
+      · exact TinyML.ValHasType.unit_intro Θ
       · iexact HR
 
 theorem compileVar_correct (x : String) (vty : TinyML.Typ) :
@@ -990,7 +984,7 @@ theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
-  | unit | bool | int | sum _ | arrow _ _ | empty | value | tuple _ | tvar _ | named _ _ =>
+  | prim _ | sum _ | arrow _ _ | empty | value | tuple _ | tvar _ | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -1173,7 +1167,7 @@ theorem compileStore_correct (loc val : Expr)
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
-  | unit | bool | int | sum _ | arrow _ _ | empty | value | tuple _ | tvar _ | named _ _ =>
+  | prim _ | sum _ | arrow _ _ | empty | value | tuple _ | tvar _ | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -1271,12 +1265,8 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       simpa [hdivmod] using hΨ_l'
     rcases hdivmod with hdiv | hmod
     · subst hdiv
-      have hlty : l.ty = .int := by
-        revert htypeOf
-        cases l.ty <;> simp [TinyML.BinOp.typeOf]
-      have hrty : r.ty = .int := by
-        revert htypeOf
-        cases r.ty <;> simp [TinyML.BinOp.typeOf, hlty]
+      obtain ⟨hlty, hrty, hty_int⟩ :=
+        TinyML.BinOp.typeOf_arith (op := .div) (by simp) htypeOf
       have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
         simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
           (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
@@ -1285,9 +1275,6 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       simp [Formula.eval, Term.eval, Const.denote] at hne_zero
       rw [hsr_ρ_l] at hne_zero
       obtain hΨ_post := VerifM.eval_ret hΨ_post
-      have hty_int : ty = .int := by
-        rw [hlty, hrty] at htypeOf
-        simpa [TinyML.BinOp.typeOf] using htypeOf.symm
       have hbty : bty = .int := hty_eq.symm.trans hty_int
       have hwf_sr_l : sr.wfIn st₂.decls :=
         Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
@@ -1296,7 +1283,8 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
         simpa using hΨ_post
       have hwp_int :
-          st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
+          st₂.sl Θ ρ_l ∗
+              (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
             wp (.binop .div (.val vl) (.val vr)) Φ := by
         istart
         iintro H
@@ -1308,9 +1296,7 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
         subst hvl hvr
         have hq : st₂.sl Θ ρ_l ∗ R ⊢ Φ (.int (a / b)) := by
           have htype : ⊢ TinyML.ValHasType Θ (.int (a / b)) .int := by
-            iapply (TinyML.ValHasType.int Θ (.int (a / b))).2
-            ipure_intro
-            exact ⟨a / b, rfl⟩
+            exact TinyML.ValHasType.int_intro Θ (a / b)
           have hgoal :
               st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ (.int (a / b)) .int ∗ R ⊢ Φ (.int (a / b)) := by
             simpa [hbty] using
@@ -1330,12 +1316,8 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
           · iexact HR
       simpa [hlty, hrty] using hwp_int
     · subst hmod
-      have hlty : l.ty = .int := by
-        revert htypeOf
-        cases l.ty <;> simp [TinyML.BinOp.typeOf]
-      have hrty : r.ty = .int := by
-        revert htypeOf
-        cases r.ty <;> simp [TinyML.BinOp.typeOf, hlty]
+      obtain ⟨hlty, hrty, hty_int⟩ :=
+        TinyML.BinOp.typeOf_arith (op := .mod) (by simp) htypeOf
       have hassert_wf : (Formula.not (.eq .int (.unop .toInt sr) (.const (.i 0)))).wfIn st₂.decls := by
         simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn] using
           (Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint)
@@ -1344,9 +1326,6 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       simp [Formula.eval, Term.eval, Const.denote] at hne_zero
       rw [hsr_ρ_l] at hne_zero
       obtain hΨ_post := VerifM.eval_ret hΨ_post
-      have hty_int : ty = .int := by
-        rw [hlty, hrty] at htypeOf
-        simpa [TinyML.BinOp.typeOf] using htypeOf.symm
       have hbty : bty = .int := hty_eq.symm.trans hty_int
       have hwf_sr_l : sr.wfIn st₂.decls :=
         Term.wfIn_mono sr hsr_wf hdecls_l (VerifM.eval.wf hΨ_div).namesDisjoint
@@ -1355,7 +1334,8 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
         simpa using hΨ_post
       have hwp_int :
-          st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
+          st₂.sl Θ ρ_l ∗
+              (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
             wp (.binop .mod (.val vl) (.val vr)) Φ := by
         istart
         iintro H
@@ -1367,9 +1347,7 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
         subst hvl hvr
         have hq : st₂.sl Θ ρ_l ∗ R ⊢ Φ (.int (a % b)) := by
           have htype : ⊢ TinyML.ValHasType Θ (.int (a % b)) .int := by
-            iapply (TinyML.ValHasType.int Θ (.int (a % b))).2
-            ipure_intro
-            exact ⟨a % b, rfl⟩
+            exact TinyML.ValHasType.int_intro Θ (a % b)
           have hgoal :
               st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ (.int (a % b)) .int ∗ R ⊢ Φ (.int (a % b)) := by
             simpa [hbty] using
@@ -1635,7 +1613,9 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
   let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
   let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
   have hbool_cases_bool :
-      st₁.sl Θ ρ_c ∗ (TinyML.ValHasType Θ v_c .bool ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+      st₁.sl Θ ρ_c ∗
+          (TinyML.ValHasType Θ v_c .bool ∗
+            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
         st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
           (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     iintro ⟨Howns, Hv, □HS, □HT, HR⟩
@@ -1893,7 +1873,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
   intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se
   obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
   cases hscrut_ty : scrut.ty with
-  | unit | bool | int | arrow _ _ | ref _ | owned _ | empty | value | tuple _ | tvar _ | named _ _ =>
+  | prim _ | arrow _ _ | ref _ | owned _ | empty | value | tuple _ | tvar _ | named _ _ =>
     simp only [hscrut_ty] at hΨ_scrut
     exact (VerifM.eval_fatal hΨ_scrut).elim
   | sum ts =>


### PR DESCRIPTION
This PR is a simple refactoring that factors out primitive types into their own inductive to reduce the overhead of adding additional types.