### PR TITLE
Support for qualified paths in the frontend

### DIFF
--- a/Examples/qualified_paths.ml
+++ b/Examples/qualified_paths.ml
@@ -1,0 +1,21 @@
+(* `Int.min` and `Int.max` are qualified paths registered in the prelude
+   resolver; they route to the user-declared top-level values `int_min`
+   and `int_max`. The body of `clamp` uses the qualified forms,
+   exercising the resolver from a value position. *)
+
+let int_min (x : int) (y : int) : int = if x <= y then x else y
+[@@spec fun x y ->
+  ret (fun v -> if x <= y then assert (v = x) else assert (v = y))];;
+
+let int_max (x : int) (y : int) : int = if x <= y then y else x
+[@@spec fun x y ->
+  ret (fun v -> if x <= y then assert (v = y) else assert (v = x))];;
+
+let clamp (lo : int) (hi : int) (x : int) : int =
+  Int.max (Int.min x hi) lo
+[@@spec fun lo hi x ->
+  assert (lo <= hi);
+  ret (fun v ->
+    assert (lo <= v);
+    assert (v <= hi))]
+;;

--- a/Mica/Frontend.lean
+++ b/Mica/Frontend.lean
@@ -5,4 +5,5 @@ import Mica.Frontend.Elaborate
 import Mica.Frontend.Lexer
 import Mica.Frontend.Parser
 import Mica.Frontend.Printer
+import Mica.Frontend.Resolver
 import Mica.Frontend.SpecParser

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -16,6 +16,32 @@ abbrev TypeConstructor := String
 abbrev TypeVariable    := String
 abbrev FieldName       := String
 
+/-- A nonempty list of identifier segments in a (possibly) qualified path:
+`Int.min` is `⟨"Int", ["min"]⟩`; an unqualified `foo` is `⟨"foo", []⟩`. -/
+structure Path where
+  head : String
+  tail : List String := []
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+namespace Path
+
+def single (s : String) : Path := ⟨s, []⟩
+
+def segments (p : Path) : List String := p.head :: p.tail
+
+def isQualified (p : Path) : Bool := !p.tail.isEmpty
+
+/-- Final segment of the path (the value/type/constructor name). -/
+def last (p : Path) : String :=
+  (p.head :: p.tail).getLast (by simp)
+
+def toString (p : Path) : String :=
+  String.intercalate "." p.segments
+
+instance : ToString Path := ⟨Path.toString⟩
+
+end Path
+
 -- Locations
 
 structure Position where
@@ -56,7 +82,7 @@ inductive BinOp where
 mutual
   inductive TypKind where
     | var (name : TypeVariable)
-    | con (name : TypeConstructor) (args : List Typ)
+    | con (path : Path) (args : List Typ)
     | arrow (dom cod : Typ)
     | tuple (components : List Typ)
 
@@ -73,7 +99,7 @@ mutual
     | wildcard
     | binder (name : Option Var) (ty : Option Typ)
     | const (c : Const)
-    | ctor (name : Constructor) (payload : Option Pattern)
+    | ctor (path : Path) (payload : Option Pattern)
     | tuple (pats : List Pattern)
 
   structure Pattern where
@@ -82,8 +108,8 @@ mutual
 
   inductive ExprKind where
     | const (c : Const)
-    | var (name : Var)
-    | ctor (name : Constructor)
+    | var (path : Path)
+    | ctor (path : Path)
     | app (fn : Expr) (args : List Expr)
     | binop (op : BinOp) (lhs rhs : Expr)
     | unop (op : UnOp) (e : Expr)

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -1,5 +1,6 @@
 -- SUMMARY: Elaboration of surface syntax into the verifier's core language, with frontend-specific checks.
 import Mica.Frontend.AST
+import Mica.Frontend.Resolver
 import Mica.Frontend.SpecParser
 import Mica.TinyML.Common
 import Mica.TinyML.Untyped
@@ -30,6 +31,7 @@ inductive ElaborateErrorKind where
   | bareSpecialIdentifier (name : String)
   | missingMatchBranch (tag : Nat) (arity : Nat)
   | emptyMatch
+  | unsupportedPath (path : Path)
   | internalError (desc : String)
   deriving Inhabited
 
@@ -55,6 +57,7 @@ def ElaborateErrorKind.toString : ElaborateErrorKind → String
   | .missingMatchBranch tag arity =>
     s!"missing match branch for constructor {tag} (of {arity})"
   | .emptyMatch => "empty match expression"
+  | .unsupportedPath path => s!"unsupported qualified path '{path}'"
   | .internalError desc => s!"internal error: {desc}"
 
 def ElaborateError.toString (e : ElaborateError) : String :=
@@ -68,10 +71,13 @@ instance : ToString ElaborateError := ⟨ElaborateError.toString⟩
 
 
 structure ElabEnv where
-  types   : List TypeConstructor                             := []
-  ctors   : List (Constructor × (Nat × Nat))                := []
-  fields  : List (FieldName × (TypeConstructor × Nat))      := []
-  records : List (TypeConstructor × List FieldName)         := []
+  types    : List TypeConstructor                             := []
+  ctors    : List (Constructor × (Nat × Nat))                := []
+  fields   : List (FieldName × (TypeConstructor × Nat))      := []
+  records  : List (TypeConstructor × List FieldName)         := []
+  /-- The prelude path registry. Single shared instance across elaboration;
+  feature lanes register entries in `stdResolver`. -/
+  resolver : Resolver                                         := stdResolver
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -97,8 +103,18 @@ private def applyTypAttr (loc : Location) (t : TinyML.Typ) : String → ElabM Ti
 mutual
 def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyML.Typ
   | .var v => .ok (.tvar v)
-  | .con name args => do
+  | .con path args => do
     let args' ← Typ.elaborateList env args
+    -- Qualified paths route through the resolver; an alias must point to a
+    -- single-segment target (avoids unbounded chasing).
+    let name ← if path.isQualified then
+      match env.resolver.type_ path with
+      | some (.alias aliasPath) =>
+        if aliasPath.isQualified then
+          err loc (.unsupportedPath path)
+        else .ok aliasPath.head
+      | none => err loc (.unsupportedPath path)
+    else .ok path.head
     match name with
     | "int"  => if args'.isEmpty then .ok .int  else err loc (.arityMismatch 0 args'.length)
     | "bool" => if args'.isEmpty then .ok .bool else err loc (.arityMismatch 0 args'.length)
@@ -245,31 +261,53 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
   | .const .unit     => .ok (.const .unit)
   | .const (.char _) => err loc .unsupportedChar
 
-  | .var name =>
-    match name with
-    | "ref" | "not" => err loc (.bareSpecialIdentifier name)
-    | _ =>
-      match List.lookup name env.ctors with
-      | some (tag, arity) => .ok (.inj tag arity (.const .unit))
-      | none => .ok (.var name)
+  | .var path =>
+    if path.isQualified then
+      match env.resolver.value path with
+      | some (.userVar n) => .ok (.var n)
+      | none => err loc (.unsupportedPath path)
+    else
+      let name := path.head
+      match name with
+      | "ref" | "not" => err loc (.bareSpecialIdentifier name)
+      | _ =>
+        match List.lookup name env.ctors with
+        | some (tag, arity) => .ok (.inj tag arity (.const .unit))
+        | none => .ok (.var name)
 
-  | .ctor name => elaborateCtorLookup env loc name none
+  | .ctor path =>
+    if path.isQualified then
+      match env.resolver.ctor path with
+      | some (.aliased n) => elaborateCtorLookup env loc n none
+      | none => err loc (.unsupportedPath path)
+    else
+      elaborateCtorLookup env loc path.head none
 
   | .app fn args =>
     match fn.kind with
-    | .var "not" =>
-      match args with
-      | [arg] => do
-        let arg' ← Expr.elaborate env arg
-        .ok (.unop .not arg')
-      | _ => err loc (.arityMismatch 1 args.length)
-    | .var "ref" =>
-      match args with
-      | [arg] => do
-        let arg' ← Expr.elaborate env arg
-        .ok (.ref false arg')
-      | _ => err loc (.arityMismatch 1 args.length)
-    | .ctor name =>
+    | .var path =>
+      if !path.isQualified && path.head == "not" then
+        match args with
+        | [arg] => do
+          let arg' ← Expr.elaborate env arg
+          .ok (.unop .not arg')
+        | _ => err loc (.arityMismatch 1 args.length)
+      else if !path.isQualified && path.head == "ref" then
+        match args with
+        | [arg] => do
+          let arg' ← Expr.elaborate env arg
+          .ok (.ref false arg')
+        | _ => err loc (.arityMismatch 1 args.length)
+      else do
+        let fn' ← Expr.elaborate env fn
+        let args' ← Expr.elaborateList env args
+        .ok (.app fn' args')
+    | .ctor path => do
+      let name ← if path.isQualified then
+        match env.resolver.ctor path with
+        | some (.aliased n) => .ok n
+        | none => err loc (.unsupportedPath path)
+      else .ok path.head
       match args with
       | [arg] => do
         let arg' ← Expr.elaborate env arg
@@ -417,7 +455,12 @@ def MatchArm.elaborateList (env : ElabEnv)
   | ⟨pat, body⟩ :: arms => do
     let body' ← Expr.elaborate env body
     let (ctorName, binder) ← match pat.kind with
-      | .ctor name payload => do
+      | .ctor path payload => do
+        let name ← if path.isQualified then
+          match env.resolver.ctor path with
+          | some (.aliased n) => .ok n
+          | none => err pat.loc (.unsupportedPath path)
+        else .ok path.head
         let binder ← match payload with
           | some p => do
             let b ← patternToBinder p

--- a/Mica/Frontend/OUTLINE.md
+++ b/Mica/Frontend/OUTLINE.md
@@ -5,4 +5,5 @@
 - `Lexer.lean` — Lexical analysis for the OCaml frontend, including tokens and lexer errors.
 - `Parser.lean` — Parsing of frontend tokens into surface syntax trees, with integrated frontend errors.
 - `Printer.lean` — Pretty-printing of frontend syntax back into OCaml-like concrete syntax.
+- `Resolver.lean` — Central registry resolving qualified prelude paths to values, types, and constructors.
 - `SpecParser.lean` — Structural translation from elaborated TinyML terms into the specification language.

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -19,6 +19,7 @@ inductive ParseErrorKind where
   | invalidRecordField
   | nonPositiveProjIndex
   | letRecNoArgs
+  | nonFinalLowercaseSegment (segment : String)
   deriving Repr, Inhabited
 
 structure ParseError where
@@ -34,6 +35,7 @@ def ParseError.toString (e : ParseError) : String :=
   | .invalidRecordField => s!"{loc}: expected field name (identifier) before '=' in record literal"
   | .nonPositiveProjIndex => s!"{loc}: projection index must be at least 1 (projections are 1-based)"
   | .letRecNoArgs => s!"{loc}: let rec without arguments is not supported"
+  | .nonFinalLowercaseSegment seg => s!"{loc}: qualified path segment '{seg}' is lowercase, but only the final component of a module path may be lowercase"
 
 instance : ToString ParseError := ⟨ParseError.toString⟩
 
@@ -89,6 +91,41 @@ private def expectConstructor (st : ParserState) : Except ParseError (String × 
     if name.front.isUpper then .ok (name, advance st)
     else .error { loc := peekLoc st, kind := .unexpectedToken "constructor name (uppercase)" (.ident name) }
   | t => .error { loc := peekLoc st, kind := .unexpectedToken "constructor name" t }
+
+/-- Gather a (possibly qualified) path starting with an already-consumed `head`
+identifier. If `head` is uppercase, look ahead for `.dot .ident` runs and append
+them. If `head` is lowercase, the path is always a single segment (a lowercase
+leading ident never starts a qualified path; `x.field` stays as postfix field
+access). The lookahead requires the token after `.dot` to be an identifier; a
+trailing `.dot` (e.g. before a numeric projection `.1`) is left untouched.
+
+In a module path only the final component may be lowercase (it is the
+value/type/constructor name); every earlier segment is a module and must be
+uppercase. So a lowercase segment terminates the path, and a lowercase segment
+followed by a further `.ident` (e.g. `Foo.bar.baz`) is rejected. -/
+private partial def collectPathTail
+    (head : String) (acc : List String) : ParserState → Except ParseError (Path × ParserState)
+  | st =>
+    if !head.front.isUpper then .ok ({ head, tail := acc.reverse }, st)
+    else
+      match peekTok st with
+      | .dot =>
+        match peekTok (advance st) with
+        | .ident next =>
+          let st' := advance (advance st)
+          if next.front.isUpper then
+            collectPathTail head (next :: acc) st'
+          else
+            -- A lowercase segment must be the final component of the path.
+            match peekTok st' with
+            | .dot =>
+              match peekTok (advance st') with
+              | .ident _ =>
+                .error { loc := peekLoc (advance st), kind := .nonFinalLowercaseSegment next }
+              | _ => .ok ({ head, tail := (next :: acc).reverse }, st')
+            | _ => .ok ({ head, tail := (next :: acc).reverse }, st')
+        | _ => .ok ({ head, tail := acc.reverse }, st)
+      | _ => .ok ({ head, tail := acc.reverse }, st)
 
 /-- Span from `start` location to the end of the last consumed token. -/
 private def spanTo (start : Location) (st : ParserState) : Location :=
@@ -156,12 +193,13 @@ private partial def parseTypeAtom : Parser Typ := fun st =>
     if name.front == '\'' then
       let varName := name.toRawSubstring.drop 1 |>.toString
       .ok (mkTyp p (advance st) (.var varName), advance st)
-    else
-      .ok (mkTyp p (advance st) (.con name []), advance st)
+    else do
+      let (path, st') ← collectPathTail name [] (advance st)
+      .ok (mkTyp p st' (.con path []), st')
   | .lparen =>
     let st' := advance st
     if peekTok st' == .rparen then
-      .ok (mkTyp p (advance st') (.con "unit" []), advance st')
+      .ok (mkTyp p (advance st') (.con (Path.single "unit") []), advance st')
     else do
       let (t1, st') ← parseType st'
       match peekTok st' with
@@ -174,9 +212,9 @@ private partial def parseTypeAtom : Parser Typ := fun st =>
         match peekTok st' with
         | .ident name =>
           let args := t1 :: rest
-          let st'' := advance st'
+          let (path, st'') ← collectPathTail name [] (advance st')
           let loc : Location := { start := p.start, stop := (spanTo p st'').stop }
-          .ok ({ loc, kind := .con name args }, st'')
+          .ok ({ loc, kind := .con path args }, st'')
         | t => .error { loc := peekLoc st', kind := .unexpectedToken "type constructor after '(T1,T2,...)'" t }
       | t => .error { loc := peekLoc st', kind := .unexpectedToken "')' or ',' in type" t }
   | t =>
@@ -189,7 +227,7 @@ private partial def parseTypeAppSuffix (arg : Typ) : Parser Typ := fun st =>
       let startLoc := arg.loc
       let st' := advance st
       let loc : Location := { start := startLoc.start, stop := (spanTo startLoc st').stop }
-      parseTypeAppSuffix { loc, kind := .con name [arg] } st'
+      parseTypeAppSuffix { loc, kind := .con (Path.single name) [arg] } st'
     else .ok (arg, st)
   | _ => .ok (arg, st)
 
@@ -248,15 +286,15 @@ private partial def parsePattern : Parser Pattern := fun st =>
   | .underscore =>
     .ok (mkPat p (advance st) .wildcard, advance st)
   | .ident name =>
-    if name.front.isUpper then
-      -- constructor pattern
-      let st' := advance st
+    if name.front.isUpper then do
+      -- constructor pattern (possibly qualified, e.g. `Option.Some x`)
+      let (path, st') ← collectPathTail name [] (advance st)
       match peekTok st' with
       | .ident _ | .underscore | .intLit _ | .charLit _ | .kw_true | .kw_false | .lparen => do
         let (payload, st'') ← parsePattern st'
-        .ok (mkPat p st'' (.ctor name (some payload)), st'')
+        .ok (mkPat p st'' (.ctor path (some payload)), st'')
       | _ =>
-        .ok (mkPat p st' (.ctor name none), st')
+        .ok (mkPat p st' (.ctor path none), st')
     else
       -- plain binder (no type annotation here; annotated form is `(x : T)`)
       .ok (mkPat p (advance st) (.binder (some name) none), advance st)
@@ -550,11 +588,12 @@ where
     | .charLit c => .ok (mkExpr p (advance st) (.const (.char c)), advance st)
     | .kw_true   => .ok (mkExpr p (advance st) (.const (.bool true)), advance st)
     | .kw_false  => .ok (mkExpr p (advance st) (.const (.bool false)), advance st)
-    | .ident name =>
-      if name.front.isUpper then
-        .ok (mkExpr p (advance st) (.ctor name), advance st)
+    | .ident name => do
+      let (path, st') ← collectPathTail name [] (advance st)
+      if path.last.front.isUpper then
+        .ok (mkExpr p st' (.ctor path), st')
       else
-        .ok (mkExpr p (advance st) (.var name), advance st)
+        .ok (mkExpr p st' (.var path), st')
     | .lbrace => parseRecord st
     | .lparen =>
       let st' := advance st

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -71,9 +71,9 @@ private partial def BinOp.rightAssoc : BinOp → Bool
 partial def Typ.print (t : Typ) : String :=
   let base := match t.kind with
     | .var name => s!"'{name}"
-    | .con name [] => name
-    | .con name [arg] => s!"{printAppArg arg} {name}"
-    | .con name args => s!"({joinWith ", " (args.map Typ.print)}) {name}"
+    | .con path [] => path.toString
+    | .con path [arg] => s!"{printAppArg arg} {path.toString}"
+    | .con path args => s!"({joinWith ", " (args.map Typ.print)}) {path.toString}"
     | .arrow dom cod =>
       let domStr := match dom.kind with
         | .arrow _ _ => parens (Typ.print dom)
@@ -105,8 +105,8 @@ partial def Pattern.print (p : Pattern) : String :=
   | .binder none none => "_"
   | .binder none (some ty) => s!"(_ : {Typ.print ty})"
   | .const c => Const.print c
-  | .ctor name none => name
-  | .ctor name (some pat) => s!"{name} {parenIf (!Pattern.isAtom pat) (Pattern.print pat)}"
+  | .ctor path none => path.toString
+  | .ctor path (some pat) => s!"{path.toString} {parenIf (!Pattern.isAtom pat) (Pattern.print pat)}"
   | .tuple pats => parens (joinWith ", " (pats.map Pattern.print))
 
 -- ---------------------------------------------------------------------------
@@ -131,8 +131,8 @@ private partial def Expr.printPrec (e : Expr) (outerPrec : Nat) : String :=
     baseStr ++ joinWith "" (e.attrs.map printAttr)
   else match e.kind with
   | .const c => Const.print c
-  | .var name => name
-  | .ctor name => name
+  | .var path => path.toString
+  | .ctor path => path.toString
   | .annot inner ty => s!"({Expr.printPrec inner 0} : {Typ.print ty})"
   | .tuple es => parens (joinWith ", " (es.map fun x => Expr.printPrec x 0))
   | .record fields => "{ " ++ fmtFields fields ++ " }"

--- a/Mica/Frontend/Resolver.lean
+++ b/Mica/Frontend/Resolver.lean
@@ -1,0 +1,47 @@
+-- SUMMARY: Central registry resolving qualified prelude paths to values, types, and constructors.
+import Mica.Frontend.AST
+import Mica.TinyML.Types
+
+/-!
+This file is the single frontend entry point for prelude qualified paths
+(`Module.foo`, `Module.Submodule.bar`).
+
+Three independent namespaces:
+
+* values — `Resolver.value`: paths used in expression position;
+* types — `Resolver.type_`: paths used as type constructors;
+* ctors — `Resolver.ctor`: paths used as data constructors.
+-/
+
+namespace Frontend
+
+inductive ResolvedValue where
+  | userVar (name : String)
+  deriving Repr, Inhabited
+
+inductive ResolvedType where
+  | alias (path : Path)
+  deriving Repr, Inhabited
+
+inductive ResolvedCtor where
+  | aliased (name : Constructor)
+  deriving Repr, Inhabited
+
+structure Resolver where
+  values : List (Path × ResolvedValue) := []
+  types  : List (Path × ResolvedType)  := []
+  ctors  : List (Path × ResolvedCtor)  := []
+  deriving Inhabited
+
+def Resolver.value (r : Resolver) (p : Path) : Option ResolvedValue := List.lookup p r.values
+def Resolver.type_ (r : Resolver) (p : Path) : Option ResolvedType  := List.lookup p r.types
+def Resolver.ctor  (r : Resolver) (p : Path) : Option ResolvedCtor  := List.lookup p r.ctors
+
+def stdResolver : Resolver := {
+  values := [
+    (⟨"Int", ["min"]⟩, .userVar "int_min"),
+    (⟨"Int", ["max"]⟩, .userVar "int_max"),
+  ]
+}
+
+end Frontend


### PR DESCRIPTION
This PR adds basic support for qualified paths to the frontend. It allows parsing functions like `Int.min` and mapping them to some verifier-internal definitions. 