### PR TITLE
Intrinsics support

### DIFF
--- a/Examples/qualified_paths.ml
+++ b/Examples/qualified_paths.ml
@@ -1,16 +1,3 @@
-(* `Int.min` and `Int.max` are qualified paths registered in the prelude
-   resolver; they route to the user-declared top-level values `int_min`
-   and `int_max`. The body of `clamp` uses the qualified forms,
-   exercising the resolver from a value position. *)
-
-let int_min (x : int) (y : int) : int = if x <= y then x else y
-[@@spec fun x y ->
-  ret (fun v -> if x <= y then assert (v = x) else assert (v = y))];;
-
-let int_max (x : int) (y : int) : int = if x <= y then y else x
-[@@spec fun x y ->
-  ret (fun v -> if x <= y then assert (v = y) else assert (v = x))];;
-
 let clamp (lo : int) (hi : int) (x : int) : int =
   Int.max (Int.min x hi) lo
 [@@spec fun lo hi x ->

--- a/Main.lean
+++ b/Main.lean
@@ -5,6 +5,7 @@ import Mica.Frontend.Printer
 import Mica.Frontend.Elaborate
 import Mica.Verifier.Programs
 import Mica.Engine.Driver
+import Mica.Stdlib
 
 private def bold (s : String) : String := s!"\x1b[1m{s}\x1b[0m"
 
@@ -35,6 +36,17 @@ private def parseArgs : List String → Options → Options
     else if opts.file.isSome then { opts with error := some "multiple files provided" }
     else parseArgs rest { opts with file := some arg }
 
+open Iris Iris.BI in
+/-- Soundness of the verifier as actually configured by the CLI: a successful
+    `Program.verify Stdlib.registry` run guarantees the program's weakest
+    precondition holds under the registry-derived `wp` context. Instantiates the
+    generic `Program.verify_correct` at the concrete stdlib registry, discharging
+    its obligations from `Stdlib.registry_sound`. -/
+theorem verify_sound (p : Untyped.Program (Spec.Body Untyped.Expr)) :
+    Smt.Strategy.checks (Program.verify Stdlib.registry p)
+      (⊢ pwp (Stdlib.registry.wpCtx) (Untyped.Program.runtime p)) :=
+  Program.verify_correct Stdlib.registry Stdlib.registry_sound p
+
 def main (args : List String) : IO Unit := do
   let opts := parseArgs args {}
   if let some e := opts.error then
@@ -53,7 +65,7 @@ def main (args : List String) : IO Unit := do
         IO.Process.exit 1
     if opts.printOcaml then
       IO.println (Frontend.Program.print frontendProg)
-    let untypedProg ← match Frontend.Program.elaborate frontendProg with
+    let untypedProg ← match Frontend.Program.elaborate Stdlib.stdResolver frontendProg with
       | .ok prog => pure prog
       | .error e => do
         IO.eprintln s!"elaboration error: {e}"
@@ -62,7 +74,7 @@ def main (args : List String) : IO Unit := do
       IO.println (Untyped.Program.print untypedProg)
     if opts.noCheck then
       return
-    let strategy := Program.verify untypedProg
+    let strategy := Program.verify Stdlib.registry untypedProg
     let logMode : Smt.LogMode :=
       if opts.smtCmdsOnly then .script
       else if opts.verbose then .trace

--- a/Mica.lean
+++ b/Mica.lean
@@ -5,3 +5,4 @@ import Mica.TinyML
 import Mica.Verifier
 import Mica.SeparationLogic
 import Mica.Frontend
+import Mica.Stdlib

--- a/Mica/FOL/Variables.lean
+++ b/Mica/FOL/Variables.lean
@@ -384,6 +384,15 @@ structure SymbolSubset (Δ₁ Δ₂ : Signature) : Prop where
 theorem Subset.refl (Δ : Signature) : Δ.Subset Δ :=
   ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
+/-- The empty signature is a subset of any signature. -/
+theorem empty_subset (Δ : Signature) : Signature.empty.Subset Δ :=
+  ⟨fun _ h => by simp [Signature.empty] at h,
+   fun _ h => by simp [Signature.empty] at h,
+   fun _ h => by simp [Signature.empty] at h,
+   fun _ h => by simp [Signature.empty] at h,
+   fun _ h => by simp [Signature.empty] at h,
+   fun _ h => by simp [Signature.empty] at h⟩
+
 theorem SymbolSubset.refl (Δ : Signature) : Δ.SymbolSubset Δ :=
   ⟨fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h, fun _ h => h⟩
 
@@ -1059,6 +1068,18 @@ theorem Env.agreeOn_trans {Δ : Signature}
    fun b hb => (h₁₂.2.2.2.1 b hb).trans (h₂₃.2.2.2.1 b hb),
    fun u hu => (h₁₂.2.2.2.2.1 u hu).trans (h₂₃.2.2.2.2.1 u hu),
    fun b hb => (h₁₂.2.2.2.2.2 b hb).trans (h₂₃.2.2.2.2.2 b hb)⟩
+
+/-- Base-signature agreement is stable under extending each side: if `ρ₁` and
+    `ρ₂` agree on `Δ`, and each moves to an environment agreeing on a larger
+    signature (`Δ ⊆ Δ₁`, `Δ ⊆ Δ₂`), then the two extended environments still
+    agree on `Δ`. -/
+theorem Env.agreeOn_of_extensions {Δ Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ ρ₁' ρ₂' : Env}
+    (hsub₁ : Δ.Subset Δ₁) (hsub₂ : Δ.Subset Δ₂)
+    (hbase : Env.agreeOn Δ ρ₁ ρ₂)
+    (h₁ : Env.agreeOn Δ₁ ρ₁ ρ₁') (h₂ : Env.agreeOn Δ₂ ρ₂ ρ₂') :
+    Env.agreeOn Δ ρ₁' ρ₂' :=
+  Env.agreeOn_trans (Env.agreeOn_symm (Env.agreeOn_mono hsub₁ h₁))
+    (Env.agreeOn_trans hbase (Env.agreeOn_mono hsub₂ h₂))
 
 theorem Env.agreeOn_addVars_cons (Δ : Signature) (v : Var) (vs : List Var) (ρ ρ' : Env) :
     Env.agreeOn (Δ.addVars (v :: vs)) ρ ρ' ↔ Env.agreeOn ((Δ.addVar v).addVars vs) ρ ρ' :=

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -71,13 +71,11 @@ instance : ToString ElaborateError := ⟨ElaborateError.toString⟩
 
 
 structure ElabEnv where
-  types    : List TypeConstructor                             := []
+  types    : List TypeConstructor                            := []
   ctors    : List (Constructor × (Nat × Nat))                := []
   fields   : List (FieldName × (TypeConstructor × Nat))      := []
   records  : List (TypeConstructor × List FieldName)         := []
-  /-- The prelude path registry. Single shared instance across elaboration;
-  feature lanes register entries in `stdResolver`. -/
-  resolver : Resolver                                         := stdResolver
+  resolver : Resolver
 
 -- ---------------------------------------------------------------------------
 -- Helpers
@@ -265,6 +263,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     if path.isQualified then
       match env.resolver.value path with
       | some (.userVar n) => .ok (.var n)
+      | some (.primitive n ty) => .ok (.prim n ty)
       | none => err loc (.unsupportedPath path)
     else
       let name := path.head
@@ -626,8 +625,8 @@ private def elaborateDecls (env : ElabEnv) :
     | some decl => .ok (decl :: rest)
     | none => .ok rest
 
-def Program.elaborate (prog : Frontend.Program) :
+def Program.elaborate (resolver : Resolver) (prog : Frontend.Program) :
     ElabM (Untyped.Program (Spec.Body Untyped.Expr)) :=
-  elaborateDecls {} prog
+  elaborateDecls { resolver } prog
 
 end Frontend

--- a/Mica/Frontend/Resolver.lean
+++ b/Mica/Frontend/Resolver.lean
@@ -17,6 +17,7 @@ namespace Frontend
 
 inductive ResolvedValue where
   | userVar (name : String)
+  | primitive (name : String) (ty : TinyML.Typ)
   deriving Repr, Inhabited
 
 inductive ResolvedType where
@@ -37,11 +38,5 @@ def Resolver.value (r : Resolver) (p : Path) : Option ResolvedValue := List.look
 def Resolver.type_ (r : Resolver) (p : Path) : Option ResolvedType  := List.lookup p r.types
 def Resolver.ctor  (r : Resolver) (p : Path) : Option ResolvedCtor  := List.lookup p r.ctors
 
-def stdResolver : Resolver := {
-  values := [
-    (⟨"Int", ["min"]⟩, .userVar "int_min"),
-    (⟨"Int", ["max"]⟩, .userVar "int_max"),
-  ]
-}
 
 end Frontend

--- a/Mica/OUTLINE.md
+++ b/Mica/OUTLINE.md
@@ -5,5 +5,6 @@
 - `FOL.lean` — Bundle for `FOL/`, containing first-order logic with Tarski semantics, targeting SMT encoding.
 - `Frontend.lean` — Bundle for `Frontend/`, containing the lexer, parser, elaborator, and spec parser for the OCaml surface syntax.
 - `SeparationLogic.lean` — Bundle for `SeparationLogic/`, containing Iris-based separation logic reasoning principles for TinyML.
+- `Stdlib.lean` — The concrete stdlib: the intrinsic registry, its soundness aggregate, and the prelude resolver.
 - `TinyML.lean` — Bundle for `TinyML/`, containing the core IR in three stages: Untyped (surface), Typed (elaborated), Runtime (operational semantics).
 - `Verifier.lean` — Bundle for `Verifier/`, containing the verifier itself, stratified into monadic layers with correctness proofs.

--- a/Mica/SeparationLogic/Axioms.lean
+++ b/Mica/SeparationLogic/Axioms.lean
@@ -33,7 +33,9 @@ abbrev iProp := IProp Sig
 axiom pointsTo : Runtime.Location → Runtime.Val → iProp
 notation:50 l " ↦ " v:51 => pointsTo l v
 
-axiom wp : Runtime.Expr → (Runtime.Val → iProp) → iProp
+abbrev WpCtx := String → List Runtime.Val → (Runtime.Val → iProp) → iProp
+
+axiom wp : WpCtx → Runtime.Expr → (Runtime.Val → iProp) → iProp
 
 axiom locinv : Runtime.Location → (Runtime.Val → iProp) → iProp
 /- We don't have invariants yet, but the idea is the encoding of locinv is
@@ -52,124 +54,127 @@ axiom locinv_contractive (l : Runtime.Location) :
 attribute [instance] locinv_contractive
 
 /-- Weakest precondition for a list of expressions, evaluated right-to-left.
-    `wps [e1, e2, e3] Q` first evaluates `e3`, then `e2`, then `e1`,
+    `wps wctx [e1, e2, e3] Q` first evaluates `e3`, then `e2`, then `e1`,
     and passes `[v1, v2, v3]` (in original order) to `Q`. -/
-noncomputable def wps : Runtime.Exprs → (Runtime.Vals → iProp) → iProp
+noncomputable def wps (wctx : WpCtx) : Runtime.Exprs → (Runtime.Vals → iProp) → iProp
   | [], Q => Q []
-  | e :: es, Q => wps es (fun vs => wp e (fun v => Q (v :: vs)))
+  | e :: es, Q => wps wctx es (fun vs => wp wctx e (fun v => Q (v :: vs)))
 
 /-! ## Core axioms -/
 
 axiom pointsTo.exclusive (l : Runtime.Location) (v1 v2 : Runtime.Val) :
     l ↦ v1 ∗ l ↦ v2 ⊢ (False : iProp)
 
-axiom wp.val {v : Runtime.Val} {Q : Runtime.Val → iProp} :
-    Q v ⊢ wp (.val v) Q
+axiom wp.val {wctx : WpCtx} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
+    Q v ⊢ wp wctx (.val v) Q
 
-axiom wp.bind {k : TinyML.K} {e : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    wp e (fun v => wp (k.fill (.val v)) Q) ⊢ wp (k.fill e) Q
+axiom wp.bind {wctx : WpCtx} {k : TinyML.K} {e : Runtime.Expr} {Q : Runtime.Val → iProp} :
+    wp wctx e (fun v => wp wctx (k.fill (.val v)) Q) ⊢ wp wctx (k.fill e) Q
 
-axiom wp.wand {e : Runtime.Expr} {P Q : Runtime.Val → iProp} :
-    (∀ v, P v -∗ Q v) ∗ wp e P ⊢ wp e Q
+axiom wp.wand {wctx : WpCtx} {e : Runtime.Expr} {P Q : Runtime.Val → iProp} :
+    (∀ v, P v -∗ Q v) ∗ wp wctx e P ⊢ wp wctx e Q
 
-axiom wp.app {fn : Runtime.Expr} {args : Runtime.Exprs} {P : Runtime.Val → iProp} :
-    wps args (fun vs => wp fn (fun fv =>
-      wp (.app (.val fv) (vs.map Runtime.Expr.val)) P)) ⊢
-    wp (.app fn args) P
+axiom wp.app {wctx : WpCtx} {fn : Runtime.Expr} {args : Runtime.Exprs} {P : Runtime.Val → iProp} :
+    wps wctx args (fun vs => wp wctx fn (fun fv =>
+      wp wctx (.app (.val fv) (vs.map Runtime.Expr.val)) P)) ⊢
+    wp wctx (.app fn args) P
 
-axiom wp.func {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
+axiom wp.func {wctx : WpCtx} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     (P : Runtime.Val → iProp) :
-    P (.fix f args e) ⊢ wp (.fix f args e) P
+    P (.fix f args e) ⊢ wp wctx (.fix f args e) P
 
-axiom wp.fix {vs : List Runtime.Val} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
+axiom wp.fix {wctx : WpCtx} {vs : List Runtime.Val} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp} :
-      wp (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P
-    ⊢ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P
+      wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P
+    ⊢ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P
 
-axiom wp.fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
+axiom wp.fix' {wctx : WpCtx} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp} :
     □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-        Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
+        Φ P vs -∗ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
       ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-        Φ P vs -∗ wp (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)
-    ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp), Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
+        Φ P vs -∗ wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)
+    ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp), Φ P vs -∗ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
 
-axiom wp.unop {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iProp} :
+axiom wp.unop {wctx : WpCtx} {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iProp} :
     TinyML.evalUnOp op v = some res →
-    Q res ⊢ wp (.unop op (.val v)) Q
+    Q res ⊢ wp wctx (.unop op (.val v)) Q
 
-axiom wp.binop {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val → iProp} :
+axiom wp.binop {wctx : WpCtx} {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val → iProp} :
     TinyML.evalBinOp op vl vr = some res →
-    Q res ⊢ wp (.binop op (.val vl) (.val vr)) Q
+    Q res ⊢ wp wctx (.binop op (.val vl) (.val vr)) Q
 
-axiom wp.if_true {thn els : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    wp thn Q ⊢ wp (.ifThenElse (.val (.bool true)) thn els) Q
+axiom wp.if_true {wctx : WpCtx} {thn els : Runtime.Expr} {Q : Runtime.Val → iProp} :
+    wp wctx thn Q ⊢ wp wctx (.ifThenElse (.val (.bool true)) thn els) Q
 
-axiom wp.if_false {thn els : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    wp els Q ⊢ wp (.ifThenElse (.val (.bool false)) thn els) Q
+axiom wp.if_false {wctx : WpCtx} {thn els : Runtime.Expr} {Q : Runtime.Val → iProp} :
+    wp wctx els Q ⊢ wp wctx (.ifThenElse (.val (.bool false)) thn els) Q
 
 /-- `assert true` returns unit; `assert false` is stuck. -/
-axiom wp.assert {P : Runtime.Val → iProp} :
-    P .unit ⊢ wp (.assert (.val (.bool true))) P
+axiom wp.assert {wctx : WpCtx} {P : Runtime.Val → iProp} :
+    P .unit ⊢ wp wctx (.assert (.val (.bool true))) P
 
 /-- A tuple expression evaluates each component (right-to-left) and wraps the results. -/
-axiom wp.tuple {vs : Runtime.Vals} {Q : Runtime.Val → iProp} :
-    Q (.tuple vs) ⊢ wp (.tuple (vs.map Runtime.Expr.val)) Q
+axiom wp.tuple {wctx : WpCtx} {vs : Runtime.Vals} {Q : Runtime.Val → iProp} :
+    Q (.tuple vs) ⊢ wp wctx (.tuple (vs.map Runtime.Expr.val)) Q
 
 /-- An injection expression evaluates its payload and wraps it with the given tag and arity. -/
-axiom wp.inj {tag arity : Nat} {payload : Runtime.Val} {Q : Runtime.Val → iProp} :
-    Q (.inj tag arity payload) ⊢ wp (.inj tag arity (.val payload)) Q
+axiom wp.inj {wctx : WpCtx} {tag arity : Nat} {payload : Runtime.Val} {Q : Runtime.Val → iProp} :
+    Q (.inj tag arity payload) ⊢ wp wctx (.inj tag arity (.val payload)) Q
+
+axiom wp.prim {wctx : WpCtx} {n : String} {vs : List Runtime.Val} {Q : Runtime.Val → iProp} :
+    wctx n vs Q ⊢ wp wctx (.app (.val (.prim n)) (vs.map Runtime.Expr.val)) Q
 
 /-- A match expression evaluates the scrutinee, then dispatches to the appropriate branch. -/
-axiom wp.match_ {tag arity : Nat} {payload : Runtime.Val} {branches : Runtime.Exprs}
+axiom wp.match_ {wctx : WpCtx} {tag arity : Nat} {payload : Runtime.Val} {branches : Runtime.Exprs}
     {branch : Runtime.Expr} {Q : Runtime.Val → iProp} :
     branches[tag]? = some branch →
-    wp (.app branch [.val payload]) Q ⊢
-    wp (.match_ (.val (.inj tag arity payload)) branches) Q
+    wp wctx (.app branch [.val payload]) Q ⊢
+    wp wctx (.match_ (.val (.inj tag arity payload)) branches) Q
 
 /-! ## Heap operations -/
 
 /-- `ref e` allocates a fresh location, stores the value, and returns the location. -/
-axiom wp.ref {v : Runtime.Val} {Q : Runtime.Val → iProp} :
+axiom wp.ref {wctx : WpCtx} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
     iprop(∀ (l : Runtime.Location), l ↦ v -∗ Q (.loc l)) ⊢
-    wp (.ref (.val v)) Q
+    wp wctx (.ref (.val v)) Q
 
 /-- `deref e` reads the value stored at the location. Reading preserves ownership. -/
-axiom wp.deref {l : Runtime.Location} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
-    l ↦ v ∗ (l ↦ v -∗ Q v) ⊢ wp (.deref (.val (.loc l))) Q
+axiom wp.deref {wctx : WpCtx} {l : Runtime.Location} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
+    l ↦ v ∗ (l ↦ v -∗ Q v) ⊢ wp wctx (.deref (.val (.loc l))) Q
 
 /-- `store loc val` updates the value at the location. -/
-axiom wp.store {l : Runtime.Location} {old v : Runtime.Val} {Q : Runtime.Val → iProp} :
-    l ↦ old ∗ (l ↦ v -∗ Q .unit) ⊢ wp (.store (.val (.loc l)) (.val v)) Q
+axiom wp.store {wctx : WpCtx} {l : Runtime.Location} {old v : Runtime.Val} {Q : Runtime.Val → iProp} :
+    l ↦ old ∗ (l ↦ v -∗ Q .unit) ⊢ wp wctx (.store (.val (.loc l)) (.val v)) Q
 
 
 /-- `ref e` allocates a fresh location, stores the value, and returns the location. -/
-axiom wp.ref_inv {v : Runtime.Val} {I: Runtime.Val → iProp} {Q : Runtime.Val → iProp} :
+axiom wp.ref_inv {wctx : WpCtx} {v : Runtime.Val} {I: Runtime.Val → iProp} {Q : Runtime.Val → iProp} :
     iprop((□ I v) ∗ ∀ (l : Runtime.Location), locinv l I -∗ Q (.loc l)) ⊢
-    wp (.ref (.val v)) Q
+    wp wctx (.ref (.val v)) Q
 
 /-- `deref e` reads the value stored at the location. Reading preserves ownership. -/
-axiom wp.deref_inv {l : Runtime.Location} {I: Runtime.Val → iProp} {Q : Runtime.Val → iProp} :
-    locinv l I ∗ (∀ v, I v -∗ Q v) ⊢ wp (.deref (.val (.loc l))) Q
+axiom wp.deref_inv {wctx : WpCtx} {l : Runtime.Location} {I: Runtime.Val → iProp} {Q : Runtime.Val → iProp} :
+    locinv l I ∗ (∀ v, I v -∗ Q v) ⊢ wp wctx (.deref (.val (.loc l))) Q
 
 /-- `store loc val` updates the value at the location. -/
-axiom wp.store_inv {l : Runtime.Location} {v: Runtime.Val} {Q : Runtime.Val → iProp} :
-    locinv l I ∗ (□ I v) ∗ Q .unit ⊢ wp (.store (.val (.loc l)) (.val v)) Q
+axiom wp.store_inv {wctx : WpCtx} {l : Runtime.Location} {v: Runtime.Val} {Q : Runtime.Val → iProp} :
+    locinv l I ∗ (□ I v) ∗ Q .unit ⊢ wp wctx (.store (.val (.loc l)) (.val v)) Q
 
 
 /-! ## Derived lemmas -/
 
-@[simp] theorem wps_nil {Q : Runtime.Vals → iProp} : wps [] Q = Q [] := rfl
-@[simp] theorem wps_cons {e : Runtime.Expr} {es : Runtime.Exprs} {Q : Runtime.Vals → iProp} :
-    wps (e :: es) Q = wps es (fun vs => wp e (fun v => Q (v :: vs))) := rfl
+@[simp] theorem wps_nil {wctx : WpCtx} {Q : Runtime.Vals → iProp} : wps wctx [] Q = Q [] := rfl
+@[simp] theorem wps_cons {wctx : WpCtx} {e : Runtime.Expr} {es : Runtime.Exprs} {Q : Runtime.Vals → iProp} :
+    wps wctx (e :: es) Q = wps wctx es (fun vs => wp wctx e (fun v => Q (v :: vs))) := rfl
 
 -- Derived monotonicity as an entailment
-theorem wp.mono {e : Runtime.Expr} {P Q : Runtime.Val → iProp}
-    (h : ∀ v, P v ⊢ Q v) : wp e P ⊢ wp e Q :=
+theorem wp.mono {wctx : WpCtx} {e : Runtime.Expr} {P Q : Runtime.Val → iProp}
+    (h : ∀ v, P v ⊢ Q v) : wp wctx e P ⊢ wp wctx e Q :=
   emp_sep.2.trans (sep_mono_l (forall_intro fun v => wand_intro (emp_sep.1.trans (h v)))) |>.trans wp.wand
 
-theorem wps.mono {es : Runtime.Exprs} {P Q : Runtime.Vals → iProp}
-    (h : ∀ vs, P vs ⊢ Q vs) : wps es P ⊢ wps es Q := by
+theorem wps.mono {wctx : WpCtx} {es : Runtime.Exprs} {P Q : Runtime.Vals → iProp}
+    (h : ∀ vs, P vs ⊢ Q vs) : wps wctx es P ⊢ wps wctx es Q := by
   induction es generalizing P Q with
   | nil => exact h []
   | cons e es ih =>
@@ -178,32 +183,32 @@ theorem wps.mono {es : Runtime.Exprs} {P Q : Runtime.Vals → iProp}
 
 /-- Program-level weakest precondition: every declaration evaluates safely,
     and each result is substituted into the remaining program. -/
-noncomputable def pwp : Runtime.Program → iProp
+noncomputable def pwp (wctx : WpCtx) : Runtime.Program → iProp
   | [] => emp
   | ⟨b, e⟩ :: rest =>
-    wp e (fun v => pwp (Runtime.Program.subst rest (Runtime.Subst.updateBinder b v .id)))
+    wp wctx e (fun v => pwp wctx (Runtime.Program.subst rest (Runtime.Subst.updateBinder b v .id)))
 termination_by prog => prog.length
 decreasing_by
   simp [Runtime.Program.subst_length]
 
-@[simp] theorem pwp_nil : pwp [] = (emp : iProp) := by
+@[simp] theorem pwp_nil {wctx : WpCtx} : pwp wctx [] = (emp : iProp) := by
   simp [pwp]
 
-@[simp] theorem pwp_cons {b : Runtime.Binder} {e : Runtime.Expr} {rest : Runtime.Program} :
-    pwp ({ name := b, body := e } :: rest) =
-      wp e (fun v => pwp (Runtime.Program.subst rest (Runtime.Subst.updateBinder b v .id))) := by
+@[simp] theorem pwp_cons {wctx : WpCtx} {b : Runtime.Binder} {e : Runtime.Expr} {rest : Runtime.Program} :
+    pwp wctx ({ name := b, body := e } :: rest) =
+      wp wctx e (fun v => pwp wctx (Runtime.Program.subst rest (Runtime.Subst.updateBinder b v .id))) := by
   simp [pwp]
 
 /-- Derived wp rule for let-bindings (desugared to immediately-applied fix). -/
-theorem wp.letIn {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    wp bound (fun v => wp (body.subst (Runtime.Subst.id.updateBinder b v)) Q) ⊢
-    wp (Runtime.Expr.letIn b bound body) Q := by
+theorem wp.letIn {wctx : WpCtx} {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.Val → iProp} :
+    wp wctx bound (fun v => wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q) ⊢
+    wp wctx (Runtime.Expr.letIn b bound body) Q := by
   simp only [Runtime.Expr.letIn]
   istart
   iintro Hbound
   iapply wp.app
   simp only [wps_cons, wps_nil]
-  iapply (wp.wand (P := fun v => wp (body.subst (Runtime.Subst.id.updateBinder b v)) Q))
+  iapply (wp.wand (P := fun v => wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q))
   isplitl []
   · iintro %v Hv
     iapply wp.func
@@ -214,10 +219,10 @@ theorem wp.letIn {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.V
   · iexact Hbound
 
 /-- Applying a single-argument lambda `(fun b -> body)` to a value reduces to substituting. -/
-theorem wp.app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Runtime.Val}
+theorem wp.app_lambda_single {wctx : WpCtx} {b : Runtime.Binder} {body : Runtime.Expr} {v : Runtime.Val}
     {Φ : Runtime.Val → iProp} :
-    wp (body.subst (Runtime.Subst.id.updateBinder b v)) Φ ⊢
-    wp (.app (.fix .none [b] body) [.val v]) Φ := by
+    wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Φ ⊢
+    wp wctx (.app (.fix .none [b] body) [.val v]) Φ := by
   istart
   iintro Hwp
   iapply wp.app

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -6,33 +6,35 @@ open Iris Iris.BI
 /-! # Primitive Laws with Spatial Contexts
 
 Lifted versions of the wp axioms from `Axioms.lean`, stated in terms of
-spatial contexts. Each rule has the form `ctx.interp ρ ⊢ wp e Q` given
+spatial contexts. Each rule has the form `ctx.interp ρ ⊢ wp wctx e Q` given
 appropriate premises, where the context may change between premise and
 conclusion for stateful operations. -/
 
 namespace SpatialContext
 
+variable {wctx : WpCtx}
+
 private theorem wp_bind_tuple_aux {left : Runtime.Exprs} {es : Runtime.Exprs} {right : Runtime.Vals}
     {Q : Runtime.Val → iProp} :
-    wps es (fun vs => wp (.tuple (left ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) ⊢
-    wp (.tuple (left ++ es ++ right.map Runtime.Expr.val)) Q := by
+    wps wctx es (fun vs => wp wctx (.tuple (left ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) ⊢
+    wp wctx (.tuple (left ++ es ++ right.map Runtime.Expr.val)) Q := by
   induction es generalizing left with
   | nil =>
       simp
   | cons e es ih =>
       simp only [wps_cons]
       have hmono :
-          wps es (fun vs =>
-            wp e (fun v =>
-              wp (.tuple (left ++ (v :: vs).map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q)) ⊢
-          wps es (fun vs =>
-            wp (.tuple ((left ++ [e]) ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) := by
+          wps wctx es (fun vs =>
+            wp wctx e (fun v =>
+              wp wctx (.tuple (left ++ (v :: vs).map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q)) ⊢
+          wps wctx es (fun vs =>
+            wp wctx (.tuple ((left ++ [e]) ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) := by
         apply wps.mono
         intro vs
         have hbind :
-            wp e (fun v =>
-              wp (.tuple (left ++ (v :: vs).map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) ⊢
-            wp (.tuple ((left ++ [e]) ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q := by
+            wp wctx e (fun v =>
+              wp wctx (.tuple (left ++ (v :: vs).map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) ⊢
+            wp wctx (.tuple ((left ++ [e]) ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q := by
           simpa [TinyML.K.fill, List.map_cons, List.append_assoc] using
             (wp.bind (k := TinyML.K.tupleK left .hole (vs ++ right)))
         exact hbind
@@ -42,15 +44,15 @@ private theorem wp_bind_tuple_aux {left : Runtime.Exprs} {es : Runtime.Exprs} {r
 theorem wp_val {v : Runtime.Val} {Q : Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢ Q v) :
-    R ⊢ wp (.val v) Q :=
+    R ⊢ wp wctx (.val v) Q :=
   h.trans wp.val
 
 /-- Unary operation under evaluation: first evaluate the operand, then take the
     head unary-operation step. -/
 theorem wp_bind_unop {op : TinyML.UnOp} {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp e (fun v => wp (.unop op (.val v)) Q)) :
-    R ⊢ wp (.unop op e) Q :=
+    (h : R ⊢ wp wctx e (fun v => wp wctx (.unop op (.val v)) Q)) :
+    R ⊢ wp wctx (.unop op e) Q :=
   h.trans (wp.bind (k := TinyML.K.unop op .hole))
 
 /-- Unary operation at values: context unchanged. -/
@@ -58,7 +60,7 @@ theorem wp_unop {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iP
     {R : iProp}
     (h : R ⊢ Q res) :
     TinyML.evalUnOp op v = some res →
-    R ⊢ wp (.unop op (.val v)) Q := by
+    R ⊢ wp wctx (.unop op (.val v)) Q := by
   intro heval
   exact h.trans (wp.unop heval)
 
@@ -66,12 +68,12 @@ theorem wp_unop {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iP
     left operand, then take the head binary-operation step. -/
 theorem wp_bind_binop {op : TinyML.BinOp} {l r : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp r (fun vr => wp l (fun vl =>
-      wp (.binop op (.val vl) (.val vr)) Q))) :
-    R ⊢ wp (.binop op l r) Q := by
+    (h : R ⊢ wp wctx r (fun vr => wp wctx l (fun vl =>
+      wp wctx (.binop op (.val vl) (.val vr)) Q))) :
+    R ⊢ wp wctx (.binop op l r) Q := by
   have hr :
-      wp r (fun vr => wp l (fun vl => wp (.binop op (.val vl) (.val vr)) Q)) ⊢
-      wp r (fun vr => wp (.binop op l (.val vr)) Q) := by
+      wp wctx r (fun vr => wp wctx l (fun vl => wp wctx (.binop op (.val vl) (.val vr)) Q)) ⊢
+      wp wctx r (fun vr => wp wctx (.binop op l (.val vr)) Q) := by
     apply wp.mono
     intro vr
     exact wp.bind (k := TinyML.K.binopL op .hole vr)
@@ -82,7 +84,7 @@ theorem wp_binop {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val 
     {R : iProp}
     (h : R ⊢ Q res) :
     TinyML.evalBinOp op vl vr = some res →
-    R ⊢ wp (.binop op (.val vl) (.val vr)) Q := by
+    R ⊢ wp wctx (.binop op (.val vl) (.val vr)) Q := by
   intro heval
   apply h.trans
   iapply (wp.binop heval)
@@ -91,30 +93,30 @@ theorem wp_binop {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val 
     appropriate branch head step. -/
 theorem wp_bind_if {cond thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp cond (fun v => wp (.ifThenElse (.val v) thn els) Q)) :
-    R ⊢ wp (.ifThenElse cond thn els) Q :=
+    (h : R ⊢ wp wctx cond (fun v => wp wctx (.ifThenElse (.val v) thn els) Q)) :
+    R ⊢ wp wctx (.ifThenElse cond thn els) Q :=
   h.trans (wp.bind (k := TinyML.K.ifCond .hole thn els))
 
 /-- Conditional on `true`: context unchanged. -/
 theorem wp_if_true {thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp thn Q) :
-    R ⊢ wp (.ifThenElse (.val (.bool true)) thn els) Q :=
+    (h : R ⊢ wp wctx thn Q) :
+    R ⊢ wp wctx (.ifThenElse (.val (.bool true)) thn els) Q :=
   h.trans wp.if_true
 
 /-- Conditional on `false`: context unchanged. -/
 theorem wp_if_false {thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp els Q) :
-    R ⊢ wp (.ifThenElse (.val (.bool false)) thn els) Q :=
+    (h : R ⊢ wp wctx els Q) :
+    R ⊢ wp wctx (.ifThenElse (.val (.bool false)) thn els) Q :=
   h.trans wp.if_false
 
 /-- Reference allocation under evaluation: first evaluate the payload, then
     allocate. -/
 theorem wp_bind_ref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp e (fun v => wp (.ref (.val v)) Q)) :
-    R ⊢ wp (.ref e) Q :=
+    (h : R ⊢ wp wctx e (fun v => wp wctx (.ref (.val v)) Q)) :
+    R ⊢ wp wctx (.ref e) Q :=
   h.trans (wp.bind (k := TinyML.K.ref .hole))
 
 /-- Reference allocation at values. The continuation receives fresh ownership in
@@ -130,7 +132,7 @@ theorem wp_ref (Θ : TinyML.TypeEnv) {v : Runtime.Val} {Q : Runtime.Val → iPro
     (h : ∀ loc,
       newctx.interp Θ (ρ.updateConst .value name (.loc loc)) ∗ R ⊢
       Q (.loc loc)) :
-    ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R  ⊢ wp (.ref (.val v)) Q := by
+    ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R  ⊢ wp wctx (.ref (.val v)) Q := by
   have hforall : ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R ⊢
       BIBase.forall fun (loc : Runtime.Location) => loc ↦ v -∗ Q (.loc loc) := by
     apply forall_intro
@@ -176,8 +178,8 @@ theorem wp_ref (Θ : TinyML.TypeEnv) {v : Runtime.Val} {Q : Runtime.Val → iPro
     the resulting value. -/
 theorem wp_bind_deref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp e (fun v => wp (.deref (.val v)) Q)) :
-    R ⊢ wp (.deref e) Q :=
+    (h : R ⊢ wp wctx e (fun v => wp wctx (.deref (.val v)) Q)) :
+    R ⊢ wp wctx (.deref e) Q :=
   h.trans (wp.bind (k := TinyML.K.deref .hole))
 
 /-- Dereference at values: the context must contain a matching points-to.
@@ -196,7 +198,7 @@ theorem wp_deref (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     remove ctx n = some (.pointsTo lt vt ty, rest) →
     Term.eval ρ lt = v →
     v = .loc loc →
-    ctx.interp Θ ρ ∗ R ⊢ wp (.deref (.val v)) Q := by
+    ctx.interp Θ ρ ∗ R ⊢ wp wctx (.deref (.val v)) Q := by
   intro hrem hlt hv
   subst hv
   -- Split the context and rewrite the selected atom to a raw points-to fact.
@@ -233,12 +235,12 @@ theorem wp_deref (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     location expression, then take the head store step. -/
 theorem wp_bind_store {loc val : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp val (fun vv => wp loc (fun vl =>
-      wp (.store (.val vl) (.val vv)) Q))) :
-    R ⊢ wp (.store loc val) Q := by
+    (h : R ⊢ wp wctx val (fun vv => wp wctx loc (fun vl =>
+      wp wctx (.store (.val vl) (.val vv)) Q))) :
+    R ⊢ wp wctx (.store loc val) Q := by
   have hloc :
-      wp val (fun vv => wp loc (fun vl => wp (.store (.val vl) (.val vv)) Q)) ⊢
-      wp val (fun vv => wp (.store loc (.val vv)) Q) := by
+      wp wctx val (fun vv => wp wctx loc (fun vl => wp wctx (.store (.val vl) (.val vv)) Q)) ⊢
+      wp wctx val (fun vv => wp wctx (.store loc (.val vv)) Q) := by
     apply wp.mono
     intro vv
     exact wp.bind (k := TinyML.K.storeL .hole vv)
@@ -255,7 +257,7 @@ theorem wp_store (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     vloc = .loc loc →
     Term.eval ρ vt_new = vnew →
     ctx.interp Θ ρ ∗ TinyML.ValHasType Θ vnew ty ∗ R ⊢
-      wp (.store (.val vloc) (.val vnew)) Q := by
+      wp wctx (.store (.val vloc) (.val vnew)) Q := by
   intro hrem hlt hvloc hvnew
   subst hvloc
   have hsplit : ctx.interp Θ ρ ⊢
@@ -291,38 +293,38 @@ theorem wp_store (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     the head assert step. -/
 theorem wp_bind_assert {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp e (fun v => wp (.assert (.val v)) Q)) :
-    R ⊢ wp (.assert e) Q :=
+    (h : R ⊢ wp wctx e (fun v => wp wctx (.assert (.val v)) Q)) :
+    R ⊢ wp wctx (.assert e) Q :=
   h.trans (wp.bind (k := TinyML.K.assert .hole))
 
 /-- Assert on `true`: context unchanged. -/
 theorem wp_assert {Q : Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢ Q .unit) :
-    R ⊢ wp (.assert (.val (.bool true))) Q :=
+    R ⊢ wp wctx (.assert (.val (.bool true))) Q :=
   h.trans wp.assert
 
 /-- Injection under evaluation: first evaluate the payload, then take the head
     injection step. -/
 theorem wp_bind_inj {tag arity : Nat} {payload : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp payload (fun v => wp (.inj tag arity (.val v)) Q)) :
-    R ⊢ wp (.inj tag arity payload) Q :=
+    (h : R ⊢ wp wctx payload (fun v => wp wctx (.inj tag arity (.val v)) Q)) :
+    R ⊢ wp wctx (.inj tag arity payload) Q :=
   h.trans (wp.bind (k := TinyML.K.injK tag arity .hole))
 
 /-- Injection at values: context unchanged. -/
 theorem wp_inj {tag arity : Nat} {payload : Runtime.Val} {Q : Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢ Q (.inj tag arity payload)) :
-    R ⊢ wp (.inj tag arity (.val payload)) Q :=
+    R ⊢ wp wctx (.inj tag arity (.val payload)) Q :=
   h.trans wp.inj
 
 /-- Tuple under evaluation: evaluate the components right-to-left, then take
     the head tuple step on the resulting values. -/
 theorem wp_bind_tuple {es : Runtime.Exprs} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wps es (fun vs => wp (.tuple (vs.map Runtime.Expr.val)) Q)) :
-    R ⊢ wp (.tuple es) Q := by
+    (h : R ⊢ wps wctx es (fun vs => wp wctx (.tuple (vs.map Runtime.Expr.val)) Q)) :
+    R ⊢ wp wctx (.tuple es) Q := by
   apply h.trans
   simpa using (wp_bind_tuple_aux (left := []) (es := es) (right := []) (Q := Q))
 
@@ -330,24 +332,24 @@ theorem wp_bind_tuple {es : Runtime.Exprs} {Q : Runtime.Val → iProp}
 theorem wp_tuple {vs : Runtime.Vals} {Q : Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢ Q (.tuple vs)) :
-    R ⊢ wp (.tuple (vs.map Runtime.Expr.val)) Q :=
+    R ⊢ wp wctx (.tuple (vs.map Runtime.Expr.val)) Q :=
   h.trans wp.tuple
 
 /-- Match under evaluation: first evaluate the scrutinee, then dispatch on the
     resulting injected value. -/
 theorem wp_bind_match {scrut : Runtime.Expr} {branches : Runtime.Exprs} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp scrut (fun v => wp (.match_ (.val v) branches) Q)) :
-    R ⊢ wp (.match_ scrut branches) Q :=
+    (h : R ⊢ wp wctx scrut (fun v => wp wctx (.match_ (.val v) branches) Q)) :
+    R ⊢ wp wctx (.match_ scrut branches) Q :=
   h.trans (wp.bind (k := TinyML.K.matchK branches .hole))
 
 /-- Match on an injected value: context unchanged. -/
 theorem wp_match {tag arity : Nat} {payload : Runtime.Val} {branches : Runtime.Exprs}
     {branch : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp (.app branch [.val payload]) Q) :
+    (h : R ⊢ wp wctx (.app branch [.val payload]) Q) :
     branches[tag]? = some branch →
-    R ⊢ wp (.match_ (.val (.inj tag arity payload)) branches) Q := by
+    R ⊢ wp wctx (.match_ (.val (.inj tag arity payload)) branches) Q := by
   intro hbranch
   exact h.trans (wp.match_ hbranch)
 
@@ -355,16 +357,16 @@ theorem wp_match {tag arity : Nat} {payload : Runtime.Val} {branches : Runtime.E
 theorem wp_func {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Q : Runtime.Val → iProp} {R : iProp}
     (h : R ⊢ Q (.fix f args e)) :
-    R ⊢ wp (.fix f args e) Q :=
+    R ⊢ wp wctx (.fix f args e) Q :=
   h.trans (wp.func Q)
 
 /-- Application under evaluation: first evaluate the arguments right-to-left,
     then the function, then take the head application step. -/
 theorem wp_bind_app {fn : Runtime.Expr} {args : Runtime.Exprs} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wps args (fun vs => wp fn (fun fv =>
-      wp (.app (.val fv) (vs.map Runtime.Expr.val)) Q))) :
-    R ⊢ wp (.app fn args) Q :=
+    (h : R ⊢ wps wctx args (fun vs => wp wctx fn (fun fv =>
+      wp wctx (.app (.val fv) (vs.map Runtime.Expr.val)) Q))) :
+    R ⊢ wp wctx (.app fn args) Q :=
   h.trans wp.app
 
 /-- Fixpoint unfolding: spatially lifted version of `wp.fix`. -/
@@ -372,9 +374,9 @@ theorem wp_fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Ex
     {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp}
     R
     (h : R ⊢
-      (wp (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
+      (wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
     R ⊢
-      (wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
+      (wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
   h.trans (wp.fix (Φ := Φ))
 
 /-- Fixpoint unfolding with a continuation-indexed invariant. -/
@@ -383,37 +385,42 @@ theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.E
     {R : iProp}
     (h : R ⊢
       □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
+          Φ P vs -∗ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
         ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
+          Φ P vs -∗ wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
     R ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
+          Φ P vs -∗ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
   h.trans (wp.fix' (Φ := Φ))
 
 /-- Let-bindings: evaluate the bound expression, then continue in the body with
     the resulting value substituted. -/
 theorem wp_letIn {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp bound (fun v => wp (body.subst (Runtime.Subst.id.updateBinder b v)) Q)) :
-    R ⊢ wp (Runtime.Expr.letIn b bound body) Q :=
+    (h : R ⊢ wp wctx bound (fun v => wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q)) :
+    R ⊢ wp wctx (Runtime.Expr.letIn b bound body) Q :=
   h.trans wp.letIn
 
+theorem wp_prim {n : String} {vs : List Runtime.Val} {Q : Runtime.Val → iProp}
+    {R : iProp}
+    (h : R ⊢ wctx n vs Q) :
+    R ⊢ wp wctx (.app (.val (.prim n)) (vs.map Runtime.Expr.val)) Q :=
+  h.trans wp.prim
 
 theorem wp_app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Runtime.Val}
     {Φ : Runtime.Val → iProp} {R : iProp}
-    (h : R ⊢ wp (body.subst (Runtime.Subst.id.updateBinder b v)) Φ) :
-    R ⊢ wp (.app (.fix .none [b] body) [.val v]) Φ :=
+    (h : R ⊢ wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Φ) :
+    R ⊢ wp wctx (.app (.fix .none [b] body) [.val v]) Φ :=
   h.trans wp.app_lambda_single
 
 
 /-- Strengthen the postcondition of a `wp` using a persistent resource:
-    if `R` (persistent) entails `wp e P`, and `R` together with `P v` entails `Q v`,
-    then `R` entails `wp e Q`. -/
+    if `R` (persistent) entails `wp wctx e P`, and `R` together with `P v` entails `Q v`,
+    then `R` entails `wp wctx e Q`. -/
 theorem wp_strengthen_persistent
     {R : iProp} [Iris.BI.Persistent R] {e : Runtime.Expr}
     {P Q : Runtime.Val → iProp}
-    (hwp : R ⊢ wp e P) (hpost : ∀ v, R ⊢ P v -∗ Q v) :
-    R ⊢ wp e Q := by
+    (hwp : R ⊢ wp wctx e P) (hpost : ∀ v, R ⊢ P v -∗ Q v) :
+    R ⊢ wp wctx e Q := by
   iintro □HR
   iapply wp.wand
   isplitr

--- a/Mica/SeparationLogic/ProofModePatterns.lean
+++ b/Mica/SeparationLogic/ProofModePatterns.lean
@@ -203,7 +203,7 @@ example (P Q : iProp) : P ∗ (P -∗ Q) ⊢ Q := by
   iexact HP
 
 /-- Apply an external lemma. The lemma must conclude with an entailment. -/
-example (v : Runtime.Val) (Q : Runtime.Val → iProp) : Q v ⊢ wp (.val v) Q := by
+example (wctx : WpCtx) (v : Runtime.Val) (Q : Runtime.Val → iProp) : Q v ⊢ wp wctx (.val v) Q := by
   istart
   iintro HQ
   iapply wp.val

--- a/Mica/Stdlib.lean
+++ b/Mica/Stdlib.lean
@@ -1,0 +1,47 @@
+-- SUMMARY: The concrete stdlib: the intrinsic registry, its soundness aggregate, and the prelude resolver.
+import Mica.Verifier.Intrinsic
+import Mica.Stdlib.IntStd
+import Mica.Frontend.Resolver
+
+open Iris Iris.BI
+
+namespace Stdlib
+
+open Verifier
+
+def registry : Registry := [Intrinsics.intMax, Intrinsics.intMin]
+
+theorem registry_sound : Registry.Sound registry := by
+  simp [registry, Registry.Sound, Registry.SoundIn]
+  -- Keep `registry` above as the single place where declared intrinsics are
+  -- listed. Do not repeat concrete intrinsic names in this proof: infer each
+  -- local dependency fragment, then prove only that it is contained in the
+  -- registry.
+  repeat apply And.intro
+  all_goals
+    try trivial
+    apply IntrinsicSound.mono
+    · infer_instance
+    · simp
+
+theorem registry_wf : Registry.Wf registry := by
+  simp only [registry, Registry.Wf, Registry.WfFrom, Signature.extendWithSym,
+    Signature.empty, Signature.addConst, Signature.addUnary, Signature.addBinary,
+    Signature.allNames]
+  simp
+
+private def resolvedType (i : Intrinsic) : TinyML.Typ :=
+  i.argTysList.foldr TinyML.Typ.arrow i.resultTy
+
+private def resolverEntry (i : Intrinsic) :
+    Option (Frontend.Path × Frontend.ResolvedValue) :=
+  i.path.map (fun (head, tail) =>
+    (⟨head, tail⟩, .primitive i.name (resolvedType i)))
+
+/-- The prelude resolver: which surface qualified paths route to which built-in
+    primitives. Derived from `registry`; injected into the frontend by `Main`. -/
+def stdResolver : Frontend.Resolver := {
+  values := registry.filterMap resolverEntry
+}
+
+end Stdlib

--- a/Mica/Stdlib/IntStd.lean
+++ b/Mica/Stdlib/IntStd.lean
@@ -1,0 +1,380 @@
+-- SUMMARY: Integer-arithmetic intrinsics (`Int.min`, `Int.max`) and their soundness instances.
+import Mica.Verifier.Intrinsic
+
+open Iris Iris.BI
+
+namespace Stdlib
+
+open Verifier
+
+namespace Intrinsics
+
+/-! ## FOL symbols and their defining axioms
+
+`Int.min` / `Int.max` are uninterpreted binary FOL function symbols at the
+value sort. Their standard interpretation is Lean's `min` / `max` on the
+integer projection of the value (matching FOL's `toInt`, which sends
+non-integer values to `0`), so the interpretation is *total*: it agrees with
+the defining axiom for every value, not only the integer ones. -/
+
+/-- Integer projection of a runtime value, matching FOL's `toInt`. -/
+private def valInt : Runtime.Val → Int
+  | .int n => n
+  | _      => 0
+
+@[simp] private theorem valInt_int (n : Int) : valInt (.int n) = n := rfl
+
+@[simp] private theorem toInt_eq_valInt (ρ : Env) (v : Runtime.Val) :
+    UnOp.eval ρ .toInt v = valInt v := rfl
+
+/-- FOL symbol for `Int.min`. -/
+def intMinSym : FOL.Symbol .two where
+  name   := "int_min"
+  interp := fun (a, b) => .int (min (valInt a) (valInt b))
+
+/-- FOL symbol for `Int.max`. -/
+def intMaxSym : FOL.Symbol .two where
+  name   := "int_max"
+  interp := fun (a, b) => .int (max (valInt a) (valInt b))
+
+@[simp] theorem intMinSym_name : intMinSym.name = "int_min" := rfl
+@[simp] theorem intMaxSym_name : intMaxSym.name = "int_max" := rfl
+
+private def intMinTerm (x y : Term .value) : Term .value :=
+  .binop (.uninterpreted intMinSym.name .value .value .value) x y
+
+private def intMaxTerm (x y : Term .value) : Term .value :=
+  .binop (.uninterpreted intMaxSym.name .value .value .value) x y
+
+/-- Defining axiom for `Int.min`: `toInt (int_min x y) = ite (x ≤ y) x y`,
+    stated over the integer projection so it constrains all values. -/
+def intMinDefAxiom : Formula :=
+  .forall_ "x" .value <| .forall_ "y" .value <|
+    .eq .int
+      (.unop .toInt (intMinTerm (.var .value "x") (.var .value "y")))
+      (.ite (.binop .ge (.unop .toInt (.var .value "y")) (.unop .toInt (.var .value "x")))
+            (.unop .toInt (.var .value "x"))
+            (.unop .toInt (.var .value "y")))
+
+/-- Defining axiom for `Int.max`: `toInt (int_max x y) = ite (x ≥ y) x y`. -/
+def intMaxDefAxiom : Formula :=
+  .forall_ "x" .value <| .forall_ "y" .value <|
+    .eq .int
+      (.unop .toInt (intMaxTerm (.var .value "x") (.var .value "y")))
+      (.ite (.binop .ge (.unop .toInt (.var .value "x")) (.unop .toInt (.var .value "y")))
+            (.unop .toInt (.var .value "x"))
+            (.unop .toInt (.var .value "y")))
+
+/-! ## Generic helpers shared by both intrinsics -/
+
+/-- Evaluating a binop over a symbol the environment respects yields the
+    symbol's standard interpretation. -/
+private theorem binop_eval_respects (ρ : Env) (s : FOL.Symbol .two)
+    (a b : Term .value) (hρ : ρ.respects (some s)) :
+    (Term.binop (.uninterpreted s.name .value .value .value) a b).eval ρ
+      = s.interp (a.eval ρ, b.eval ρ) := by
+  have hbin : ρ.binary .value .value .value s.name = fun p q => s.interp (p, q) := hρ
+  simp only [Term.eval, BinOp.eval, hbin]
+
+/-- Respect for an arity-two symbol survives a `Env.updateConst` (it never
+    touches the binary table). -/
+private theorem respects_updateConstE {ρ : Env} {s : FOL.Symbol .two}
+    {τ : Srt} {x : String} {v : τ.denote} (h : ρ.respects (some s)) :
+    (ρ.updateConst τ x v).respects (some s) := by
+  show (ρ.updateConst τ x v).binary .value .value .value s.name = _
+  rw [Env.updateConst_binary]; exact h
+
+/-- Respect survives the argument-binding fold. -/
+private theorem respects_argsEnv {s : FOL.Symbol .two} :
+    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
+      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
+  | [], _, _, h => h
+  | _ :: _, [], _, h => h
+  | (name, _) :: rest, v :: vs, ρ, h => by
+      simp only [Spec.argsEnv]
+      refine respects_argsEnv rest vs ?_
+      rw [VerifM.Env.updateConst_env]; exact respects_updateConstE h
+
+/-- Apply a `.ret (s, .assert φ ...)` spec at a value, discharging the asserted
+    `φ` as a pure side condition. -/
+private theorem assert_ret_apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
+    (s : String) (ρ : VerifM.Env) (φ : Formula) (v : Runtime.Val)
+    (hφ : φ.eval (ρ.updateConst .value s v).env) :
+    PredTrans.apply Θ Φ (.ret (s, .assert φ (.ret ()))) ρ ⊢ Φ v := by
+  simp only [PredTrans.apply, Assertion.pre, Assertion.post]
+  refine (forall_elim v).trans ?_
+  iintro Hw
+  iapply Hw
+  ipure_intro
+  exact hφ
+
+/-- Shape lemma: every length-mismatched two-int argument list makes the
+    typing premise inconsistent. -/
+private theorem off_shape_two {Θ : TinyML.TypeEnv} {vs : List Runtime.Val}
+    (P : iProp) (hlen : vs.length ≠ 2) :
+    TinyML.ValsHaveTypes Θ vs [TinyML.Typ.int, TinyML.Typ.int] ⊢ P := by
+  refine TinyML.ValsHaveTypes.length_eq.trans ?_
+  iintro %h
+  simp at h; omega
+
+private theorem min_axiom_eval (ρ : Env)
+    (hρ : ρ.binary .value .value .value "int_min"
+      = fun a b => intMinSym.interp (a, b)) (x y : Runtime.Val) :
+    (UnOp.eval ρ .toInt (ρ.binary .value .value .value "int_min" x y))
+      = (bif BinOp.eval ρ .ge (UnOp.eval ρ .toInt y) (UnOp.eval ρ .toInt x) then
+          UnOp.eval ρ .toInt x else UnOp.eval ρ .toInt y) := by
+  rw [hρ]
+  simp only [UnOp.eval, BinOp.eval, Bool.cond_decide]
+  change valInt (intMinSym.interp (x, y)) =
+    (if valInt x ≤ valInt y then valInt x else valInt y)
+  by_cases h : valInt x ≤ valInt y
+  · simp [intMinSym, h]
+  · have hyx : valInt y ≤ valInt x := by omega
+    simp [intMinSym, h, min_eq_right hyx]
+
+private theorem max_axiom_eval (ρ : Env)
+    (hρ : ρ.binary .value .value .value "int_max"
+      = fun a b => intMaxSym.interp (a, b)) (x y : Runtime.Val) :
+    (UnOp.eval ρ .toInt (ρ.binary .value .value .value "int_max" x y))
+      = (bif BinOp.eval ρ .ge (UnOp.eval ρ .toInt x) (UnOp.eval ρ .toInt y) then
+          UnOp.eval ρ .toInt x else UnOp.eval ρ .toInt y) := by
+  rw [hρ]
+  simp only [UnOp.eval, BinOp.eval, Bool.cond_decide]
+  change valInt (intMaxSym.interp (x, y)) =
+    (if valInt y ≤ valInt x then valInt x else valInt y)
+  by_cases h : valInt y ≤ valInt x
+  · simp [intMaxSym, h]
+  · have hxy : valInt x ≤ valInt y := by omega
+    simp [intMaxSym, h, max_eq_right hxy]
+
+/-! ## `Int.min` -/
+
+/-- `Int.min`: arity-two integer intrinsic. Its spec ties the result to the
+    `int_min` FOL symbol; the defining axiom pins that symbol down for the
+    solver, while the standard interpretation pins it down for the soundness
+    bridge. -/
+def intMin : Intrinsic where
+  arity    := .two
+  name     := "int_min"
+  path     := some ("Int", ["min"])
+  reduce   := fun (a, b) v =>
+    ∃ x y : Int, a = .int x ∧ b = .int y ∧ v = .int (min x y)
+  wp       := fun (a, b) Q =>
+    iprop(∃ x y : Int, ⌜a = .int x ∧ b = .int y⌝ ∗ Q (.int (min x y)))
+  spec     :=
+    { args  := [("a", .int), ("b", .int)]
+      retTy := .int
+      pred  := .ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (intMinTerm (.var .value ("a")) (.var .value ("b"))))
+          (.ret ())) }
+  folSym   := some intMinSym
+  axioms   := [intMinDefAxiom]
+
+@[simp] theorem intMin_folSym : intMin.folSym = some intMinSym := rfl
+@[simp] theorem intMin_arity : intMin.arity = .two := rfl
+
+@[simp] theorem intMin_toWp (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
+    intMin.toWp [a, b] Q =
+      iprop(∃ x y : Int, ⌜a = .int x ∧ b = .int y⌝ ∗ Q (.int (min x y))) :=
+  Intrinsic.toWp_two_of_arity _ _ _ _ _ _ _ _ _ _
+
+private theorem intMin_base_wf :
+    PredTrans.wfIn
+      ((Intrinsic.sigOf [intMin]).declVars (Spec.argVars intMin.specArgs)) intMin.spec.pred := by
+  apply PredTrans.checkWf_ok
+  rfl
+
+private theorem intMin_assert_eval (ρ : VerifM.Env) (x y : Int)
+    (hρ : ρ.env.respects (some intMinSym)) :
+    (Formula.eq .value (.var .value "ret")
+      (intMinTerm (.var .value ("a")) (.var .value ("b")))).eval
+      ((Spec.argsEnv ρ intMin.specArgs [.int x, .int y]).updateConst
+        .value "ret" (.int (min x y))).env := by
+  have hargs := respects_argsEnv intMin.specArgs [.int x, .int y] hρ
+  have hbin : (Spec.argsEnv ρ intMin.specArgs [.int x, .int y]).env.binary
+      .value .value .value "int_min" = fun a b => intMinSym.interp (a, b) := by
+    simpa [Env.respects, intMinSym] using hargs
+  show Runtime.Val.int (min x y) =
+    (Spec.argsEnv ρ intMin.specArgs [.int x, .int y]).env.binary
+      .value .value .value "int_min" (.int x) (.int y)
+  simp [hbin, intMinSym]
+
+instance : IntrinsicSound [intMin] intMin where
+  axiomWf := by
+    intro Δ hsub hwf φ hφ
+    simp only [intMin, List.mem_singleton] at hφ
+    subst hφ
+    have hbase : intMinDefAxiom.wfIn (Intrinsic.sigOf [intMin]) := by
+      simp [intMinDefAxiom, intMinTerm, Intrinsic.sigOf, Intrinsic.foldSig, intMin, intMinSym,
+        Formula.wfIn, Term.wfIn, BinOp.wfIn, UnOp.wfIn, Signature.extendWithSym,
+        Signature.empty, Signature.addBinary, Signature.declVar, Signature.addVar,
+        Signature.remove]
+    exact Formula.wfIn_mono intMinDefAxiom hbase hsub hwf
+  proof := by
+    intro ρ hdeps φ hφ
+    simp only [intMin, List.mem_singleton] at hφ
+    subst hφ
+    have hmin : ρ.respects (some intMinSym) := hdeps intMin (by simp)
+    simp only [Env.respects] at hmin
+    simp only [intMinDefAxiom, Formula.eval]
+    intro x y
+    have hb : ((ρ.updateConst .value "x" x).updateConst .value "y" y).binary
+        .value .value .value "int_min" = fun a b => intMinSym.interp (a, b) := by
+      rw [Env.updateConst_binary, Env.updateConst_binary]
+      simpa [intMinSym] using hmin
+    simpa [intMinTerm, Term.eval, Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "x" ≠ "y" by decide)] using
+      min_axiom_eval (((ρ.updateConst .value "x" x).updateConst .value "y" y)) hb x y
+  specWf := by
+    intro Δ hsub hwf
+    exact PredTrans.wfIn_mono intMin_base_wf
+      (Signature.Subset.declVars hsub (Spec.argVars intMin.specArgs))
+      (Signature.wf_declVars hwf)
+  bridge := by
+    intro Θ vs ρ Φ hρ
+    simp only [intMin_folSym, Env.respects] at hρ
+    show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.int, TinyML.Typ.int] ∗ _ ⊢ _
+    match vs with
+    | [] => exact (sep_mono_l (off_shape_two _ (by simp))).trans sep_elim_l
+    | [_] => exact (sep_mono_l (off_shape_two _ (by simp))).trans sep_elim_l
+    | _ :: _ :: _ :: _ => exact (sep_mono_l (off_shape_two _ (by simp))).trans sep_elim_l
+    | [v1, v2] =>
+      iintro ⟨Hvs, Hpred⟩
+      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v1 [v2] _ _).1 $$ Hvs
+      icases Hcons with ⟨Hv1, Hvs2⟩
+      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
+      icases Hcons2 with ⟨Hv2, _⟩
+      ihave Hv1eq := (TinyML.ValHasType.int Θ v1).1 $$ Hv1
+      ipure Hv1eq
+      ihave Hv2eq := (TinyML.ValHasType.int Θ v2).1 $$ Hv2
+      ipure Hv2eq
+      obtain ⟨x, rfl⟩ := Hv1eq
+      obtain ⟨y, rfl⟩ := Hv2eq
+      rw [intMin_toWp]
+      iexists x
+      iexists y
+      isplitr [Hpred]
+      · ipure_intro; exact ⟨rfl, rfl⟩
+      · refine (assert_ret_apply Θ _ "ret" _ _ (.int (min x y)) ?_).trans ?_
+        · exact intMin_assert_eval ρ x y hρ
+        · iintro Hwand
+          iapply Hwand
+          change ⊢ TinyML.ValHasType Θ (.int (min x y)) TinyML.Typ.int
+          exact TinyML.ValHasType.int_intro Θ (min x y)
+
+/-! ## `Int.max` -/
+
+/-- `Int.max`: arity-two integer intrinsic, mirroring `Int.min`. -/
+def intMax : Intrinsic where
+  arity    := .two
+  name     := "int_max"
+  path     := some ("Int", ["max"])
+  reduce   := fun (a, b) v =>
+    ∃ x y : Int, a = .int x ∧ b = .int y ∧ v = .int (max x y)
+  wp       := fun (a, b) Q =>
+    iprop(∃ x y : Int, ⌜a = .int x ∧ b = .int y⌝ ∗ Q (.int (max x y)))
+  spec     :=
+    { args  := [("a", .int), ("b", .int)]
+      retTy := .int
+      pred  := .ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (intMaxTerm (.var .value ("a")) (.var .value ("b"))))
+          (.ret ())) }
+  folSym   := some intMaxSym
+  axioms   := [intMaxDefAxiom]
+
+@[simp] theorem intMax_folSym : intMax.folSym = some intMaxSym := rfl
+@[simp] theorem intMax_arity : intMax.arity = .two := rfl
+
+@[simp] theorem intMax_toWp (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
+    intMax.toWp [a, b] Q =
+      iprop(∃ x y : Int, ⌜a = .int x ∧ b = .int y⌝ ∗ Q (.int (max x y))) :=
+  Intrinsic.toWp_two_of_arity _ _ _ _ _ _ _ _ _ _
+
+private theorem intMax_base_wf :
+    PredTrans.wfIn
+      ((Intrinsic.sigOf [intMax]).declVars (Spec.argVars intMax.specArgs)) intMax.spec.pred := by
+  apply PredTrans.checkWf_ok
+  rfl
+
+private theorem intMax_assert_eval (ρ : VerifM.Env) (x y : Int)
+    (hρ : ρ.env.respects (some intMaxSym)) :
+    (Formula.eq .value (.var .value "ret")
+      (intMaxTerm (.var .value ("a")) (.var .value ("b")))).eval
+      ((Spec.argsEnv ρ intMax.specArgs [.int x, .int y]).updateConst
+        .value "ret" (.int (max x y))).env := by
+  have hargs := respects_argsEnv intMax.specArgs [.int x, .int y] hρ
+  have hbin : (Spec.argsEnv ρ intMax.specArgs [.int x, .int y]).env.binary
+      .value .value .value "int_max" = fun a b => intMaxSym.interp (a, b) := by
+    simpa [Env.respects, intMaxSym] using hargs
+  show Runtime.Val.int (max x y) =
+    (Spec.argsEnv ρ intMax.specArgs [.int x, .int y]).env.binary
+      .value .value .value "int_max" (.int x) (.int y)
+  simp [hbin, intMaxSym]
+
+instance : IntrinsicSound [intMax] intMax where
+  axiomWf := by
+    intro Δ hsub hwf φ hφ
+    simp only [intMax, List.mem_singleton] at hφ
+    subst hφ
+    have hbase : intMaxDefAxiom.wfIn (Intrinsic.sigOf [intMax]) := by
+      simp [intMaxDefAxiom, intMaxTerm, Intrinsic.sigOf, Intrinsic.foldSig, intMax, intMaxSym,
+        Formula.wfIn, Term.wfIn, BinOp.wfIn, UnOp.wfIn,
+        Signature.extendWithSym, Signature.empty, Signature.addBinary,
+        Signature.declVar, Signature.addVar, Signature.remove]
+    exact Formula.wfIn_mono intMaxDefAxiom hbase hsub hwf
+  proof := by
+    intro ρ hdeps φ hφ
+    simp only [intMax, List.mem_singleton] at hφ
+    subst hφ
+    have hmax : ρ.respects (some intMaxSym) := hdeps intMax (by simp)
+    simp only [Env.respects] at hmax
+    simp only [intMaxDefAxiom, Formula.eval]
+    intro x y
+    have hb : ((ρ.updateConst .value "x" x).updateConst .value "y" y).binary
+        .value .value .value "int_max" = fun a b => intMaxSym.interp (a, b) := by
+      rw [Env.updateConst_binary, Env.updateConst_binary]
+      simpa [intMaxSym] using hmax
+    simpa [intMaxTerm, Term.eval, Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "x" ≠ "y" by decide)] using
+      max_axiom_eval (((ρ.updateConst .value "x" x).updateConst .value "y" y)) hb x y
+  specWf := by
+    intro Δ hsub hwf
+    exact PredTrans.wfIn_mono intMax_base_wf
+      (Signature.Subset.declVars hsub (Spec.argVars intMax.specArgs))
+      (Signature.wf_declVars hwf)
+  bridge := by
+    intro Θ vs ρ Φ hρ
+    simp only [intMax_folSym, Env.respects] at hρ
+    show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.int, TinyML.Typ.int] ∗ _ ⊢ _
+    match vs with
+    | [] => exact (sep_mono_l (off_shape_two _ (by simp))).trans sep_elim_l
+    | [_] => exact (sep_mono_l (off_shape_two _ (by simp))).trans sep_elim_l
+    | _ :: _ :: _ :: _ => exact (sep_mono_l (off_shape_two _ (by simp))).trans sep_elim_l
+    | [v1, v2] =>
+      iintro ⟨Hvs, Hpred⟩
+      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v1 [v2] _ _).1 $$ Hvs
+      icases Hcons with ⟨Hv1, Hvs2⟩
+      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
+      icases Hcons2 with ⟨Hv2, _⟩
+      ihave Hv1eq := (TinyML.ValHasType.int Θ v1).1 $$ Hv1
+      ipure Hv1eq
+      ihave Hv2eq := (TinyML.ValHasType.int Θ v2).1 $$ Hv2
+      ipure Hv2eq
+      obtain ⟨x, rfl⟩ := Hv1eq
+      obtain ⟨y, rfl⟩ := Hv2eq
+      rw [intMax_toWp]
+      iexists x
+      iexists y
+      isplitr [Hpred]
+      · ipure_intro; exact ⟨rfl, rfl⟩
+      · refine (assert_ret_apply Θ _ "ret" _ _ (.int (max x y)) ?_).trans ?_
+        · exact intMax_assert_eval ρ x y hρ
+        · iintro Hwand
+          iapply Hwand
+          change ⊢ TinyML.ValHasType Θ (.int (max x y)) TinyML.Typ.int
+          exact TinyML.ValHasType.int_intro Θ (max x y)
+
+end Intrinsics
+end Stdlib

--- a/Mica/Stdlib/OUTLINE.md
+++ b/Mica/Stdlib/OUTLINE.md
@@ -1,0 +1,3 @@
+**Mica/Stdlib**
+
+- `IntStd.lean` — Integer-arithmetic intrinsics (`Int.min`, `Int.max`) and their soundness instances.

--- a/Mica/TinyML/OpSem.lean
+++ b/Mica/TinyML/OpSem.lean
@@ -88,63 +88,73 @@ theorem K.comp_fill (k1 k2 : K) (e : Runtime.Expr) :
     (k1.comp k2).fill e = k1.fill (k2.fill e) := by
   induction k1 <;> simp_all [K.comp, K.fill]
 
+abbrev PrimCtx := String → List Runtime.Val → Runtime.Val → Prop
+
 /-! ## Head reduction -/
 
-inductive Head : Runtime.Expr → Heap → Runtime.Expr → Heap → Prop where
+inductive Head (ctx : PrimCtx) : Runtime.Expr → Heap → Runtime.Expr → Heap → Prop where
   /-- A `fix` expression wraps itself as a value. -/
-  | fixIntro : Head (.fix f args body) μ (.val (.fix f args body)) μ
+  | fixIntro : Head ctx (.fix f args body) μ (.val (.fix f args body)) μ
 
   /-- Beta reduction: apply a fixpoint to a list of argument values. -/
   | beta : args.length = vs.length →
-           Head (.app (.val (.fix f args body)) (vs.map Runtime.Expr.val)) μ
+           Head ctx (.app (.val (.fix f args body)) (vs.map Runtime.Expr.val)) μ
                 (body.subst ((Runtime.Subst.id.updateBinder f (.fix f args body)).updateAllBinder args vs)) μ
 
   /-- Unary operator applied to a value. -/
   | unop : evalUnOp op v = some w →
-           Head (.unop op (.val v)) μ (.val w) μ
+           Head ctx (.unop op (.val v)) μ (.val w) μ
 
   /-- Binary operator applied to two values. -/
   | binop : evalBinOp op v1 v2 = some w →
-            Head (.binop op (.val v1) (.val v2)) μ (.val w) μ
+            Head ctx (.binop op (.val v1) (.val v2)) μ (.val w) μ
 
   /-- Conditional on true. -/
-  | ifTrue  : Head (.ifThenElse (.val (.bool true))  thn els) μ thn μ
+  | ifTrue  : Head ctx (.ifThenElse (.val (.bool true))  thn els) μ thn μ
   /-- Conditional on false. -/
-  | ifFalse : Head (.ifThenElse (.val (.bool false)) thn els) μ els μ
+  | ifFalse : Head ctx (.ifThenElse (.val (.bool false)) thn els) μ els μ
 
   /-- Allocate a fresh location. -/
   | ref : Heap.Fresh l μ →
-          Head (.ref (.val v)) μ (.val (.loc l)) (μ.update l v)
+          Head ctx (.ref (.val v)) μ (.val (.loc l)) (μ.update l v)
 
   /-- Dereference a location. -/
   | deref : μ.lookup l = some v →
-            Head (.deref (.val (.loc l))) μ (.val v) μ
+            Head ctx (.deref (.val (.loc l))) μ (.val v) μ
 
   /-- Write to a location. -/
   | store :
     μ.lookup l = some w →
-    Head (.store (.val (.loc l)) (.val v)) μ (.val .unit) (μ.update l v)
+    Head ctx (.store (.val (.loc l)) (.val v)) μ (.val .unit) (μ.update l v)
 
   /-- Assert succeeds on true; false is stuck (no rule). -/
-  | assertOk : Head (.assert (.val (.bool true))) μ (.val .unit) μ
+  | assertOk : Head ctx (.assert (.val (.bool true))) μ (.val .unit) μ
 
   /-- A tuple of values reduces to a tuple value. -/
-  | tuple : Head (.tuple (vs.map Runtime.Expr.val)) μ (.val (.tuple vs)) μ
+  | tuple : Head ctx (.tuple (vs.map Runtime.Expr.val)) μ (.val (.tuple vs)) μ
 
   /-- Injection of a value becomes a value. -/
-  | injVal : Head (.inj tag arity (.val v)) μ (.val (.inj tag arity v)) μ
+  | injVal : Head ctx (.inj tag arity (.val v)) μ (.val (.inj tag arity v)) μ
 
   /-- Match on an injected value: select the branch and apply it to the payload. -/
   | match_ : (h : i < branches.length) → n = branches.length →
-             Head (.match_ (.val (.inj i n v)) branches) μ (.app (branches[i]) [.val v]) μ
+             Head ctx (.match_ (.val (.inj i n v)) branches) μ (.app (branches[i]) [.val v]) μ
+
+  /-- Primitive call: the registry-derived context relates the name and argument
+      values to a result value. Unbound names are not in the relation, making
+      the call stuck. -/
+  | primStep {n vs v} :
+      ctx n vs v →
+      Head ctx (.app (.val (.prim n)) (vs.map Runtime.Expr.val)) μ (.val v) μ
 
 /-! ## Contextual step -/
 
-inductive Step : Runtime.Expr → Heap → Runtime.Expr → Heap → Prop where
-  | ctx : ∀ (k : K), Head e μ e' μ' → Step (k.fill e) μ (k.fill e') μ'
+inductive Step (ctx : PrimCtx) : Runtime.Expr → Heap → Runtime.Expr → Heap → Prop where
+  | ctx : ∀ (k : K), Head ctx e μ e' μ' → Step ctx (k.fill e) μ (k.fill e') μ'
 
 /-- A single step can be lifted into any surrounding context. -/
-theorem Step.lift_ctx (k : K) (h : Step e μ e' μ') : Step (k.fill e) μ (k.fill e') μ' := by
+theorem Step.lift_ctx {ctx : PrimCtx} (k : K) (h : Step ctx e μ e' μ') :
+    Step ctx (k.fill e) μ (k.fill e') μ' := by
   cases h with
   | ctx k0 hhead =>
     rw [← K.comp_fill, ← K.comp_fill]
@@ -152,19 +162,19 @@ theorem Step.lift_ctx (k : K) (h : Step e μ e' μ') : Step (k.fill e) μ (k.fil
 
 /-! ## Multi-step reduction -/
 
-inductive Steps : Runtime.Expr → Heap → Runtime.Expr → Heap → Prop where
-  | refl : Steps e μ e μ
-  | step : Step e μ e'' μ'' → Steps e'' μ'' e' μ' → Steps e μ e' μ'
+inductive Steps (ctx : PrimCtx) : Runtime.Expr → Heap → Runtime.Expr → Heap → Prop where
+  | refl : Steps ctx e μ e μ
+  | step : Step ctx e μ e'' μ'' → Steps ctx e'' μ'' e' μ' → Steps ctx e μ e' μ'
 
-theorem Steps.trans (h1 : Steps e μ e'' μ'') (h2 : Steps e'' μ'' e' μ') :
-    Steps e μ e' μ' := by
+theorem Steps.trans {ctx : PrimCtx} (h1 : Steps ctx e μ e'' μ'') (h2 : Steps ctx e'' μ'' e' μ') :
+    Steps ctx e μ e' μ' := by
   induction h1 with
   | refl => exact h2
   | step hs _ ih => exact Steps.step hs (ih h2)
 
 /-- Multi-step reduction can be lifted into any surrounding context. -/
-theorem Steps.lift_ctx (k : K) (h : Steps e μ e' μ') :
-    Steps (k.fill e) μ (k.fill e') μ' := by
+theorem Steps.lift_ctx {ctx : PrimCtx} (k : K) (h : Steps ctx e μ e' μ') :
+    Steps ctx (k.fill e) μ (k.fill e') μ' := by
   induction h with
   | refl => exact Steps.refl
   | step hs _ ih => exact Steps.step (hs.lift_ctx k) ih

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -138,6 +138,7 @@ private partial def printUnary : Untyped.Expr → String
 private partial def printAtom : Untyped.Expr → String
   | .const c => printConst c
   | .var name => name
+  | .prim name _ => name
   | .fix self args _ body => printFix self args body
   | .tuple es => s!"({", ".intercalate (es.map printOr)})"
   | e => s!"({printExpr e})"

--- a/Mica/TinyML/RuntimeExpr.lean
+++ b/Mica/TinyML/RuntimeExpr.lean
@@ -27,6 +27,10 @@ mutual
     | loc (l : Location)
     | fix (self : Binder) (args : List Binder) (body : Expr)
     | tuple (vs : List Val)
+    /-- Reference to a built-in primitive function, indexed by name. The
+        registry-derived context determines the operational and WP behavior of
+        each name. -/
+    | prim (name : String)
 
   inductive Expr where
     | val (v : Val)
@@ -102,6 +106,9 @@ mutual
       | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case tuple.tuple vs1 vs2 =>
       exact match valsDecEq vs1 vs2 with
+      | isTrue h => isTrue (by subst h; rfl)
+      | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case prim.prim n1 n2 => exact match decEq n1 n2 with
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
 

--- a/Mica/TinyML/Typed.lean
+++ b/Mica/TinyML/Typed.lean
@@ -40,6 +40,9 @@ instance : LawfulBEq Binder where
 inductive Expr where
   | const (c : Const)
   | var (name : Var) (ty : Typ)
+  /-- Reference to a built-in primitive, indexed by name. The carried type is
+      the arrow type from the registry. -/
+  | prim (name : String) (ty : Typ)
   | unop (op : UnOp) (e : Expr) (ty : Typ)
   | binop (op : BinOp) (lhs rhs : Expr) (ty : Typ)
   | fix (self : Binder) (args : List Binder) (retTy : Typ) (body : Expr)
@@ -80,6 +83,10 @@ mutual
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case var.var n1 t1 n2 t2 => exact match decEq n1 n2, decEq t1 t2 with
+      | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+      | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case prim.prim n1 t1 n2 t2 => exact match decEq n1 n2, decEq t1 t2 with
       | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
       | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -205,6 +212,7 @@ def arrowOfArgs : List Binder → Typ → Typ
 def Expr.ty : Expr → Typ
   | .const c => Const.ty c
   | .var _ ty => ty
+  | .prim _ ty => ty
   | .unop _ _ ty => ty
   | .binop _ _ _ ty => ty
   | .fix _ args retTy _ => arrowOfArgs args retTy
@@ -263,6 +271,7 @@ mutual
   def Expr.runtime : Typed.Expr → Runtime.Expr
     | .const c => .val (Runtime.Val.ofConst c)
     | .var x _ => .var x
+    | .prim n _ => .val (.prim n)
     | .unop op e _ => .unop op e.runtime
     | .binop op l r _ => .binop op l.runtime r.runtime
     | .fix self args _ body => .fix (self.runtime) (args.map (·.runtime)) body.runtime

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -140,6 +140,7 @@ mutual
         match Γ x with
         | some ty => .ok (ty, .var x ty)
         | none => .error (.undefinedVar x)
+    | .prim n ty => .ok (ty, .prim n ty)
     | .unop op e => do
         let (argTy, e') ← infer Θ Γ e
         match TinyML.UnOp.typeOf op argTy with
@@ -409,6 +410,11 @@ mutual
         intro result h
         simp [Typed.infer] at h
         split at h <;> cases h
+        simp [Expr.runtime, Untyped.Expr.runtime]
+    | .prim n ty => by
+        intro result h
+        simp [Typed.infer] at h
+        rcases h with ⟨rfl, rfl⟩
         simp [Expr.runtime, Untyped.Expr.runtime]
     | .unop op e => by
         let ih := infer_runtime Θ Γ e

--- a/Mica/TinyML/Untyped.lean
+++ b/Mica/TinyML/Untyped.lean
@@ -21,6 +21,10 @@ instance : LawfulBEq Binder where
 inductive Expr where
   | const (c : Const)
   | var (name : Var)
+  /-- Reference to a built-in primitive, indexed by name. Resolved from a
+      qualified path by the frontend; the carried type is the arrow type the
+      registry assigns to the primitive. -/
+  | prim (name : String) (ty : Typ)
   | unop (op : UnOp) (e : Expr)
   | binop (op : BinOp) (lhs rhs : Expr)
   | fix (self : Binder) (args : List Binder) (retTy : Option Typ) (body : Expr)
@@ -63,6 +67,10 @@ mutual
     case var.var n1 n2 => exact match decEq n1 n2 with
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case prim.prim n1 t1 n2 t2 => exact match decEq n1 n2, decEq t1 t2 with
+      | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+      | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case unop.unop o1 e1 o2 e2 => exact match decEq o1 o2, e1.decEq e2 with
       | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
       | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
@@ -189,6 +197,7 @@ def Binder.runtime : Untyped.Binder → Runtime.Binder
 def Expr.runtime : Untyped.Expr → Runtime.Expr
   | .const c => .val (Runtime.Val.ofConst c)
   | .var x => .var x
+  | .prim n _ => .val (.prim n)
   | .unop op e => .unop op e.runtime
   | .binop op l r => .binop op l.runtime r.runtime
   | .fix self args _ body => .fix (self.runtime) (args.map (·.runtime)) body.runtime

--- a/Mica/Verifier.lean
+++ b/Mica/Verifier.lean
@@ -5,6 +5,7 @@ import Mica.Verifier.Monad
 import Mica.Verifier.Bindings
 import Mica.Verifier.Utils
 import Mica.Verifier.Assertions
+import Mica.Verifier.Intrinsic
 import Mica.Verifier.Expressions
 import Mica.Verifier.RelationalEncoding
 import Mica.Verifier.Functions

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -12,6 +12,7 @@ import Mica.Verifier.SpecMaps
 import Mica.Engine.Driver
 import Mica.Base.Fresh
 import Mathlib.Data.Finmap
+import Mica.Verifier.Intrinsic
 
 open Iris Iris.BI
 open Typed
@@ -105,7 +106,7 @@ theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : VerifM.En
 /-! ### Compiler and Top-Level Verifier -/
 
 mutual
-  def compile (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
+  def compile (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
     | .const (.int n)  => pure (.unop .ofInt  (.const (.i n)))
     | .const (.bool b) => pure (.unop .ofBool (.const (.b b)))
     | .const .unit     => pure (Term.const .unit)
@@ -114,7 +115,7 @@ mutual
         VerifM.expectEq s!"type annotation mismatch for variable: {x}" (Γ x |>.getD .value) vty
         pure (.const (.uninterpreted x'.name .value))
     | .unop op e uty => do
-        let se ← compile Θ Δ_spec S B Γ e
+        let se ← compile reg Θ Δ_spec S B Γ e
         let ty ← VerifM.expectSome
           s!"type error: operator {repr op} cannot be applied to {repr e.ty}"
           (TinyML.UnOp.typeOf op e.ty)
@@ -124,12 +125,12 @@ mutual
           (compileUnop op se)
         pure t
     | .assert e => do
-        let sl ← compile Θ Δ_spec S B Γ e
+        let sl ← compile reg Θ Δ_spec S B Γ e
         VerifM.assert (Formula.eq .bool (Term.unop .toBool sl) (Term.const (.b true)))
         pure (Term.const .unit)
     | .binop op l r bty => do
-        let sr ← compile Θ Δ_spec S B Γ r
-        let sl ← compile Θ Δ_spec S B Γ l
+        let sr ← compile reg Θ Δ_spec S B Γ r
+        let sl ← compile reg Θ Δ_spec S B Γ l
         let ty ← VerifM.expectSome
           s!"type error: operator {repr op} cannot be applied to {repr l.ty} and {repr r.ty}"
           (TinyML.BinOp.typeOf op l.ty r.ty)
@@ -145,50 +146,60 @@ mutual
             (compileOp op sl sr)
           pure t
     | .letIn b e body => do
-        let se ← compile Θ Δ_spec S B Γ e
+        let se ← compile reg Θ Δ_spec S B Γ e
         VerifM.expectEq "let type annotation mismatch" b.ty e.ty
         match b.name with
-        | none => compile Θ Δ_spec S B Γ body
+        | none => compile reg Θ Δ_spec S B Γ body
         | some x =>
           let x' ← VerifM.decl (some x) .value
           VerifM.assume (.pure (Formula.eq .value (.const (.uninterpreted x'.name .value)) se))
-          compile Θ Δ_spec (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
+          compile reg Θ Δ_spec (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
     | .ifThenElse cond thn els ty => do
-        let sc ← compile Θ Δ_spec S B Γ cond
+        let sc ← compile reg Θ Δ_spec S B Γ cond
         VerifM.expectEq "if condition type mismatch" cond.ty .bool
         VerifM.expectEq "if branch type annotation mismatch" thn.ty ty
         VerifM.expectEq "if branch type annotation mismatch" els.ty ty
         let branch ← VerifM.all [true, false]
         if branch then do
           VerifM.assume (.pure (.not (.eq .value sc (.unop .ofBool (.const (.b false))))))
-          compile Θ Δ_spec S B Γ thn
+          compile reg Θ Δ_spec S B Γ thn
         else do
           VerifM.assume (.pure (.eq .value sc (.unop .ofBool (.const (.b false)))))
-          compile Θ Δ_spec S B Γ els
+          compile reg Θ Δ_spec S B Γ els
     | .app (.var f fty) args aty => do
         let spec ← VerifM.expectSome s!"no spec for function {f}" (S.lookup f)
-        let sterms ← compileExprs Θ Δ_spec S B Γ args
+        let sterms ← compileExprs reg Θ Δ_spec S B Γ args
         let sargs := (args.map Expr.ty).zip sterms
         VerifM.expectEq "app type annotation mismatch" spec.retTy aty
         VerifM.expectEq "app type annotation mismatch"
           fty (Typed.arrowOfArgs (spec.args.map fun arg => Binder.named arg.1 arg.2) spec.retTy)
         let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) spec sargs
         pure result
+    | .app (.prim n _) args aty => do
+        let i ← VerifM.expectSome s!"unknown primitive `{n}`"
+          (reg.lookup? n)
+        let spec := i.spec
+        VerifM.expectEq "primitive return type mismatch" i.resultTy aty
+        let sterms ← compileExprs reg Θ Δ_spec S B Γ args
+        let sargs := (args.map Expr.ty).zip sterms
+        let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) spec sargs
+        pure result
+    | .prim n _ => VerifM.fatal s!"primitive `{n}` must be applied"
     | .tuple es => do
-        let terms ← compileExprs Θ Δ_spec S B Γ es
+        let terms ← compileExprs reg Θ Δ_spec S B Γ es
         pure (.unop .ofValList (Terms.toValList terms))
     | .inj tag arity payload => do
         if tag ≥ arity then VerifM.fatal "inj tag out of range"
         else
-          let s ← compile Θ Δ_spec S B Γ payload
+          let s ← compile reg Θ Δ_spec S B Γ payload
           pure (.unop (.mkInj tag arity) s)
     | .match_ scrut branches ty => do
-        let sc ← compile Θ Δ_spec S B Γ scrut
+        let sc ← compile reg Θ Δ_spec S B Γ scrut
         match scrut.ty with
         | .sum ts =>
           if ts.length ≠ branches.length then VerifM.fatal "match arity mismatch"
           else if ∀ br ∈ branches, br.2.ty = ty then do
-            let actions := compileBranches Θ Δ_spec S B Γ sc ts branches 0
+            let actions := compileBranches reg Θ Δ_spec S B Γ sc ts branches 0
             let i ← VerifM.all (List.range actions.length)
             match actions[i]? with
             | some m => m
@@ -197,15 +208,15 @@ mutual
             VerifM.fatal "match branch type annotation mismatch"
         | _ => VerifM.fatal "match on non-sum type"
     | .cast e ty => do
-        let se ← compile Θ Δ_spec S B Γ e
+        let se ← compile reg Θ Δ_spec S B Γ e
         if TinyML.Typ.sub Θ e.ty ty then pure se
         else VerifM.fatal s!"cast type mismatch"
     | .ref false e => do
-        let _ ← compile Θ Δ_spec S B Γ e
+        let _ ← compile reg Θ Δ_spec S B Γ e
         let l ← VerifM.decl none .value
         pure (.const (.uninterpreted l.name .value))
     | .ref true e => do
-        let v ← compile Θ Δ_spec S B Γ e
+        let v ← compile reg Θ Δ_spec S B Γ e
         let l ← VerifM.decl none .value
         let sl := Term.const (.uninterpreted l.name .value)
         VerifM.assume (.spatial (.pointsTo sl v e.ty))
@@ -214,13 +225,13 @@ mutual
         match e.ty with
         | .owned ty' => do
             VerifM.expectEq "deref type annotation mismatch" ty' ty
-            let lq ← compile Θ Δ_spec S B Γ e
+            let lq ← compile reg Θ Δ_spec S B Γ e
             let v ← VerifM.findMatchForce lq ty
             VerifM.assume (.spatial (.pointsTo lq v ty))
             pure v
         | .ref ty' => do
             VerifM.expectEq "deref type annotation mismatch" ty' ty
-            let _ ← compile Θ Δ_spec S B Γ e
+            let _ ← compile reg Θ Δ_spec S B Γ e
             let v ← VerifM.decl none .value
             let sv := Term.const (.uninterpreted v.name .value)
             VerifM.assumeAll (TinyML.typeConstraints ty sv)
@@ -230,21 +241,21 @@ mutual
         match loc.ty with
         | .owned ty => do
             VerifM.expectEq "store location type mismatch" ty val.ty
-            let v ← compile Θ Δ_spec S B Γ val
-            let lq ← compile Θ Δ_spec S B Γ loc
+            let v ← compile reg Θ Δ_spec S B Γ val
+            let lq ← compile reg Θ Δ_spec S B Γ loc
             let _ ← VerifM.findMatchForce lq val.ty
             VerifM.assume (.spatial (.pointsTo lq v val.ty))
             pure (Term.const .unit)
         | .ref ty => do
             VerifM.expectEq "store location type mismatch" ty val.ty
-            let _ ← compile Θ Δ_spec S B Γ val
-            let _ ← compile Θ Δ_spec S B Γ loc
+            let _ ← compile reg Θ Δ_spec S B Γ val
+            let _ ← compile reg Θ Δ_spec S B Γ loc
             pure (Term.const .unit)
         | _ => VerifM.fatal "store location is not a reference"
     | .app _ _ _ | .fix _ _ _ _ => VerifM.fatal "unsupported expression"
 
   /-- Compile a single match branch: assume the scrutinee is `mkInj i n payload`, then compile the body. -/
-  def compileBranch (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  def compileBranch (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
       (sc : Term .value) (n : Nat) (i : Nat) (ty_i : TinyML.Typ)
       : Binder × Expr → VerifM (Term .value)
     | (binder, body) => do
@@ -254,35 +265,35 @@ mutual
         VerifM.assumeAll (TinyML.typeConstraints ty_i (.const (.uninterpreted xv.name .value)))
         match binder.name with
         | some x =>
-          compile Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body
+          compile reg Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body
         | none =>
-          compile Θ Δ_spec S B (Γ.extendBinder binder ty_i) body
+          compile reg Θ Δ_spec S B (Γ.extendBinder binder ty_i) body
 
-  def compileBranches (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  def compileBranches (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
       (sc : Term .value) (ts : List TinyML.Typ) :
       List (Binder × Expr) → Nat → List (VerifM (Term .value))
     | [], _ => []
     | branch :: rest, i =>
-      compileBranch Θ Δ_spec S B Γ sc ts.length i (ts[i]?.getD .value) branch
-        :: compileBranches Θ Δ_spec S B Γ sc ts rest (i + 1)
+      compileBranch reg Θ Δ_spec S B Γ sc ts.length i (ts[i]?.getD .value) branch
+        :: compileBranches reg Θ Δ_spec S B Γ sc ts rest (i + 1)
 
-  def compileExprs (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : List Expr → VerifM (List (Term .value))
+  def compileExprs (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : List Expr → VerifM (List (Term .value))
     | [] => pure []
     | e :: es => do
-      let rest ← compileExprs Θ Δ_spec S B Γ es
-      let se ← compile Θ Δ_spec S B Γ e
+      let rest ← compileExprs reg Θ Δ_spec S B Γ es
+      let se ← compile reg Θ Δ_spec S B Γ e
       pure (se :: rest)
 end
 
 /-! ### Helper lemmas -/
 
-theorem compileBranches_length_get (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+theorem compileBranches_length_get (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (ts : List TinyML.Typ)
     (branches : List (Binder × Expr)) (idx : Nat) :
-    (compileBranches Θ Δ_spec S B Γ sc ts branches idx).length = branches.length ∧
+    (compileBranches reg Θ Δ_spec S B Γ sc ts branches idx).length = branches.length ∧
     ∀ j, j < branches.length →
-      (compileBranches Θ Δ_spec S B Γ sc ts branches idx)[j]? =
-        branches[j]?.map (fun branch => compileBranch Θ Δ_spec S B Γ sc ts.length (idx + j) (ts[idx + j]?.getD .value) branch) := by
+      (compileBranches reg Θ Δ_spec S B Γ sc ts branches idx)[j]? =
+        branches[j]?.map (fun branch => compileBranch reg Θ Δ_spec S B Γ sc ts.length (idx + j) (ts[idx + j]?.getD .value) branch) := by
   induction branches generalizing idx with
   | nil => exact ⟨rfl, fun j hj => absurd hj (Nat.not_lt_zero _)⟩
   | cons b bs ih =>
@@ -300,13 +311,13 @@ theorem compileBranches_length_get (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (
 
 namespace Helpers
 
-theorem ctx_dup (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_dup (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl Θ ρ ∗
-        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
-          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R)) := by
+        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R)) := by
   iintro ⟨Howns, □HS, □HT, HR⟩
   isplitl [Howns]
   · iexact Howns
@@ -320,13 +331,13 @@ theorem ctx_dup (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.En
           · iexact HT
           · iexact HR
 
-theorem ctx_dup_flip (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_dup_flip (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl Θ ρ ∗
-        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
-          (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))) := by
+        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+          (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R))) := by
   iintro ⟨Howns, □HS, □HT, HR⟩
   isplitl [Howns]
   · iexact Howns
@@ -340,13 +351,13 @@ theorem ctx_dup_flip (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : Veri
           · iexact HS
           · iexact HR
 
-theorem ctx_push (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_push (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl Θ ρ ∗
-        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (TinyML.ValHasType Θ v ty ∗ R)) := by
   iintro ⟨Howns, Hv, □HS, □HT, HR⟩
   isplitl [Howns]
@@ -359,13 +370,13 @@ theorem ctx_push (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.E
         · iexact Hv
         · iexact HR
 
-theorem ctx_push_flip (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_push_flip (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
       st.sl Θ ρ ∗
-        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (TinyML.ValHasType Θ v ty ∗ R)) := by
   iintro ⟨Howns, Hv, □HT, □HS, HR⟩
   isplitl [Howns]
@@ -395,11 +406,11 @@ private theorem specInvariants_mono
   refine ⟨hΔspec.trans hdecls, VerifM.Env.agreeOn_trans hρspec ?_⟩
   exact VerifM.Env.agreeOn_mono hΔspec hagree
 
-def correctExpr (e : Expr) : Prop :=
+def correctExpr (reg : Verifier.Registry) (e : Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
   (Δ_spec : Signature) (ρ_spec : VerifM.Env)
   (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
-    VerifM.eval (compile Θ Δ_spec S B Γ e) st ρ Ψ →
+    VerifM.eval (compile reg Θ Δ_spec S B Γ e) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
     S.wfIn Δ_spec →
@@ -407,18 +418,20 @@ def correctExpr (e : Expr) : Prop :=
     Δ_spec.vars = [] →
     Δ_spec.Subset st.decls →
     VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
+    Verifier.Registry.symSubset reg Δ_spec →
+    Verifier.Registry.symAgree reg ρ_spec.env →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
       st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢ Φ v) →
-    st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (e.runtime.subst γ) Φ
+    st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (reg.wpCtx) (e.runtime.subst γ) Φ
 
-def correctBranch (branch : Binder × Expr) : Prop :=
+def correctBranch (reg : Verifier.Registry) (branch : Binder × Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp),
-    VerifM.eval (compileBranch Θ Δ_spec S B Γ sc n i ty_i branch) st ρ Ψ →
+    VerifM.eval (compileBranch reg Θ Δ_spec S B Γ sc n i ty_i branch) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
     S.wfIn Δ_spec →
@@ -426,13 +439,15 @@ def correctBranch (branch : Binder × Expr) : Prop :=
     Δ_spec.vars = [] →
     Δ_spec.Subset st.decls →
     VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
+    Verifier.Registry.symSubset reg Δ_spec →
+    Verifier.Registry.symAgree reg ρ_spec.env →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
-      st.sl Θ ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
+      st.sl Θ ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (reg.wpCtx) (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
 
-def correctBranches (branches : List (Binder × Expr)) : Prop :=
+def correctBranches (reg : Verifier.Registry) (branches : List (Binder × Expr)) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n : Nat) (ts : List TinyML.Typ) (idx : Nat)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
@@ -446,21 +461,23 @@ def correctBranches (branches : List (Binder × Expr)) : Prop :=
     Δ_spec.vars = [] →
     Δ_spec.Subset st.decls →
     VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
+    Verifier.Registry.symSubset reg Δ_spec →
+    Verifier.Registry.symAgree reg ρ_spec.env →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
-      VerifM.eval (compileBranch Θ Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
+      VerifM.eval (compileBranch reg Θ Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
-        st.sl Θ ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
+        st.sl Θ ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (reg.wpCtx) (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
 
-def correctExprs (es : List Expr) : Prop :=
+def correctExprs (reg : Verifier.Registry) (es : List Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (Ψ : List (Term .value) → TransState → VerifM.Env → Prop)
     (Φ : List Runtime.Val → iProp),
-    VerifM.eval (compileExprs Θ Δ_spec S B Γ es) st ρ Ψ →
+    VerifM.eval (compileExprs reg Θ Δ_spec S B Γ es) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
     S.wfIn Δ_spec →
@@ -468,17 +485,19 @@ def correctExprs (es : List Expr) : Prop :=
     Δ_spec.vars = [] →
     Δ_spec.Subset st.decls →
     VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
+    Verifier.Registry.symSubset reg Δ_spec →
+    Verifier.Registry.symAgree reg ρ_spec.env →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ'.env terms vs →
-       st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
-    st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps (es.map (fun e => e.runtime.subst γ)) Φ
+       st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
+    st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps (reg.wpCtx) (es.map (fun e => e.runtime.subst γ)) Φ
 
 /-! #### Correctness Compatibility Lemmas -/
 
-theorem compileConst_correct (c : TinyML.Const) :
-    correctExpr (.const c) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hpost
+theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
+    correctExpr reg (.const c) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hΔreg hρreg hpost
   cases c with
   | int n =>
     simp only [compile] at heval
@@ -529,9 +548,9 @@ theorem compileConst_correct (c : TinyML.Const) :
       · exact TinyML.ValHasType.unit_intro Θ
       · iexact HR
 
-theorem compileVar_correct (x : String) (vty : TinyML.Typ) :
-    correctExpr (.var x vty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hpost
+theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.Typ) :
+    correctExpr reg (.var x vty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hΔreg hρreg hpost
   simp only [compile] at heval
   obtain ⟨x', hbind, heval⟩ := VerifM.eval_bind_expectSome heval
   obtain ⟨hcheck, hcont⟩ := VerifM.eval_bind_expectEq heval
@@ -598,10 +617,10 @@ theorem compileVar_correct (x : String) (vty : TinyML.Typ) :
         hΨ hwfv (by simp [Term.eval, Const.denote])
     exact SpatialContext.wp_val <| (sep_mono_r sep_elim_r).trans <| hprep.trans <| hpost'
 
-theorem compileInj_correct (tag arity : Nat) (payload : Expr)
-    (ihPayload : correctExpr payload) :
-    correctExpr (.inj tag arity payload) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload : Expr)
+    (ihPayload : correctExpr reg payload) :
+    correctExpr reg (.inj tag arity payload) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
@@ -610,9 +629,9 @@ theorem compileInj_correct (tag arity : Nat) (payload : Expr)
     exact (VerifM.eval_fatal heval).elim
   · push_neg at htag
     simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
-    have heval_p : (compile Θ Δ_spec S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    have heval_p : (compile reg Θ Δ_spec S B Γ payload).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
     refine SpatialContext.wp_bind_inj <| ihPayload Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+      (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
     intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p
     obtain ⟨_hdecls_p, _hagreeOn_p, hΨ_p⟩ := hΨ_p
     obtain hΨ_p := VerifM.eval_ret hΨ_p
@@ -636,15 +655,15 @@ theorem compileInj_correct (tag arity : Nat) (payload : Expr)
           (by simp [Term.eval, UnOp.eval, heval_se_p]))
     exact SpatialContext.wp_inj <| hprep.trans hpost'
 
-theorem compileCast_correct (e : Expr) (ty : TinyML.Typ)
-    (ih : correctExpr e) :
-    correctExpr (.cast e ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileCast_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.Typ)
+    (ih : correctExpr reg e) :
+    correctExpr reg (.cast e ty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   simp only [compile] at heval
-  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   simp [Expr.runtime]
-  refine ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+  refine ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v ρ' st' se hΨ hse_wf heval_se
   obtain ⟨_, _, hΨ⟩ := hΨ
   cases hsub : TinyML.Typ.sub Θ e.ty ty with
@@ -661,16 +680,16 @@ theorem compileCast_correct (e : Expr) (ty : TinyML.Typ)
       sep_mono_r (sep_mono_l (TinyML.ValHasType.sub hsub'))
     exact hprep.trans <| hpost v ρ' st' se hΨ hse_wf heval_se
 
-theorem compileAssert_correct (e : Expr)
-    (ih : correctExpr e) :
-    correctExpr (.assert e) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileAssert_correct (reg : Verifier.Registry) (e : Expr)
+    (ih : correctExpr reg e) :
+    correctExpr reg (.assert e) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_assert <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_, _, hΨ_e⟩ := hΨ_e
   let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
@@ -693,23 +712,29 @@ theorem compileAssert_correct (e : Expr)
     trivial
     (by simp [Term.eval])
 
-theorem compileFix_correct (self : Binder) (args : List Binder) (retTy : TinyML.Typ) (body : Expr) :
-    correctExpr (.fix self args retTy body) := by
+theorem compileFix_correct (reg : Verifier.Registry) (self : Binder) (args : List Binder) (retTy : TinyML.Typ) (body : Expr) :
+    correctExpr reg (.fix self args retTy body) := by
   intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
   simp only [compile] at heval
   exact (VerifM.eval_fatal heval).elim
 
-theorem compileRefShared_correct (e : Expr)
-    (ih : correctExpr e) :
-    correctExpr (.ref false e) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compilePrim_correct (reg : Verifier.Registry) (n : String) (ty : TinyML.Typ) :
+    correctExpr reg (.prim n ty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
+  simp only [compile] at heval
+  exact (VerifM.eval_fatal heval).elim
+
+theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
+    (ih : correctExpr reg e) :
+    correctExpr reg (.ref false e) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty, Bool.false_eq_true, if_false] at hpost
-  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_ref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hwf_st₁ := VerifM.eval.wf hΨ_e
@@ -719,7 +744,7 @@ theorem compileRefShared_correct (e : Expr)
   have hwf_addConst : TransState.wf { st₁ with decls := st₁.decls.addConst c } :=
     TransState.freshConst.wf _ hwf_st₁
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (.ref (.val v_e)) Φ := by
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (reg.wpCtx) (.ref (.val v_e)) Φ := by
     istart
     iintro ⟨Howns, □Hty, HR⟩
     iapply (wp.ref_inv (I := fun w => TinyML.ValHasType Θ w e.ty))
@@ -767,17 +792,17 @@ theorem compileRefShared_correct (e : Expr)
         · iexact HR
   exact hwp
 
-theorem compileRefOwned_correct (e : Expr)
-    (ih : correctExpr e) :
-    correctExpr (.ref true e) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
+    (ih : correctExpr reg e) :
+    correctExpr reg (.ref true e) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty, if_true] at hpost
-  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_ref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
@@ -788,7 +813,7 @@ theorem compileRefOwned_correct (e : Expr)
   have hc_fresh : c.name ∉ st₁.decls.allNames :=
     TransState.freshConst_fresh st₁ none .value
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (.ref (.val v_e)) Φ := by
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (reg.wpCtx) (.ref (.val v_e)) Φ := by
     refine SpatialContext.wp_ref Θ
       (ctx := st₁.owns) (ρ := ρ_e.env) (R := R) (Δ := st₁.decls)
       (vt := se) (ty := e.ty) (name := c.name)
@@ -829,26 +854,26 @@ theorem compileRefOwned_correct (e : Expr)
       · iexact HR
   exact hwp
 
-theorem compileRef_correct (owned : Bool) (e : Expr)
-    (ih : correctExpr e) :
-    correctExpr (.ref owned e) := by
+theorem compileRef_correct (reg : Verifier.Registry) (owned : Bool) (e : Expr)
+    (ih : correctExpr reg e) :
+    correctExpr reg (.ref owned e) := by
   cases owned with
-  | false => exact compileRefShared_correct e ih
-  | true => exact compileRefOwned_correct e ih
+  | false => exact compileRefShared_correct reg e ih
+  | true => exact compileRefOwned_correct reg e ih
 
-theorem compileDerefShared_correct (e : Expr) (ty : TinyML.Typ)
+theorem compileDerefShared_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.Typ)
     (href : e.ty = .ref ty)
-    (ih : correctExpr e) :
-    correctExpr (.deref e ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+    (ih : correctExpr reg e) :
+    correctExpr reg (.deref e ty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, href] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_deref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e _hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
@@ -863,7 +888,7 @@ theorem compileDerefShared_correct (e : Expr) (ty : TinyML.Typ)
         (Term.const_wfIn_addConst_of_fresh (Δ := st₁.decls) (c := c)
           (VerifM.eval.wf hdecl_eval).namesDisjoint hc_fresh)
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (.deref (.val v_e)) Φ := by
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (reg.wpCtx) (.deref (.val v_e)) Φ := by
     rw [href]
     istart
     iintro ⟨Howns, Href, HR⟩
@@ -883,7 +908,7 @@ theorem compileDerefShared_correct (e : Expr) (ty : TinyML.Typ)
       ihave Hcheck := TinyML.typeConstraints_hold (ty := ty) (t := sv)
         (ρ := ρ₂.env) (Θ := Θ) (v := w) hsv_eval $$ Hw
       ipure Hcheck
-      obtain ⟨st₃, hst₃_decls, hst₃_owns, heval_ret⟩ := VerifM.eval_assumeAll hassume_eval
+      obtain ⟨st₃, hst₃_decls, hst₃_owns, _, heval_ret⟩ := VerifM.eval_assumeAll hassume_eval
         (fun φ hφ => TinyML.typeConstraints_wfIn hc_wf φ hφ)
         (fun φ hφ => Hcheck φ hφ)
       have hΨ_ret := VerifM.eval_ret heval_ret
@@ -901,26 +926,26 @@ theorem compileDerefShared_correct (e : Expr) (ty : TinyML.Typ)
         · iexact HR
   exact hwp
 
-theorem compileDerefOwned_correct (e : Expr) (ty : TinyML.Typ)
+theorem compileDerefOwned_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.Typ)
     (howned : e.ty = .owned ty)
-    (ih : correctExpr e) :
-    correctExpr (.deref e ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+    (ih : correctExpr reg e) :
+    correctExpr reg (.deref e ty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, howned] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_deref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hfind_eval := VerifM.eval_bind _ _ _ _ hΨ_e
   rw [howned]
   refine VerifM.eval_findMatchForce Θ
     (R := TinyML.ValHasType Θ v_e (.owned ty) ∗ R)
-    (Φ := wp (.deref (.val v_e)) Φ) hfind_eval hse_wf ?_
+    (Φ := wp (reg.wpCtx) (.deref (.val v_e)) Φ) hfind_eval hse_wf ?_
   intro v st₂ hQ hdecls hv_wf
   have hassume_eval := VerifM.eval_bind _ _ _ _ hQ
   have hatom_wf : (SpatialAtom.pointsTo se v ty).wfIn st₂.decls := by
@@ -933,7 +958,7 @@ theorem compileDerefOwned_correct (e : Expr) (ty : TinyML.Typ)
     exact hv_wf
   have hwp :
       SpatialAtom.interp Θ ρ_e.env (.pointsTo se v ty) ∗ st₂.sl Θ ρ_e ∗
-        (TinyML.ValHasType Θ v_e (.owned ty) ∗ R) ⊢ wp (.deref (.val v_e)) Φ := by
+        (TinyML.ValHasType Θ v_e (.owned ty) ∗ R) ⊢ wp (reg.wpCtx) (.deref (.val v_e)) Φ := by
     simp only [SpatialAtom.interp]
     istart
     iintro ⟨Hatom, Howns, _Howned, HR⟩
@@ -964,14 +989,14 @@ theorem compileDerefOwned_correct (e : Expr) (ty : TinyML.Typ)
         · iexact HR
   exact hwp
 
-theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
-    (ih : correctExpr e) :
-    correctExpr (.deref e ty) := by
+theorem compileDeref_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.Typ)
+    (ih : correctExpr reg e) :
+    correctExpr reg (.deref e ty) := by
   cases hty : e.ty with
   | ref ty' =>
       by_cases heq : ty' = ty
       · have href : e.ty = .ref ty := by simpa [heq] using hty
-        exact compileDerefShared_correct e ty href ih
+        exact compileDerefShared_correct reg e ty href ih
       · intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
@@ -979,7 +1004,7 @@ theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
   | owned ty' =>
       by_cases heq : ty' = ty
       · have howned : e.ty = .owned ty := by simpa [heq] using hty
-        exact compileDerefOwned_correct e ty howned ih
+        exact compileDerefOwned_correct reg e ty howned ih
       · intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
@@ -989,41 +1014,41 @@ theorem compileDeref_correct (e : Expr) (ty : TinyML.Typ)
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
 
-theorem compileStoreShared_correct (loc val : Expr)
+theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
     (href : loc.ty = .ref val.ty)
-    (ihVal : correctExpr val) (ihLoc : correctExpr loc) :
-    correctExpr (.store loc val) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+    (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
+    correctExpr reg (.store loc val) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, href] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_v : (compile Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_v : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))) :=
-    Helpers.ctx_dup_flip Θ Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R))) :=
+    Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_)
+    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
   have hagree_v : B.agreeOnLinked ρ_v.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
-  have heval_l : (compile Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
+  have heval_l : (compile reg Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
   have hlocStart :
       st₁.sl Θ ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
-        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl Θ ρ_v ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+          st₁.sl Θ ρ_v ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (TinyML.ValHasType Θ v_v val.ty ∗ R)) :=
-    Helpers.ctx_push_flip Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
+    Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
   have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
   refine hlocStart.trans <| ihLoc Θ (TinyML.ValHasType Θ v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 ?_
+    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 hΔreg hρreg ?_
   intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
   obtain hret := VerifM.eval_ret hΨ_l
@@ -1034,7 +1059,7 @@ theorem compileStoreShared_correct (loc val : Expr)
     hpost .unit ρ_l st₂ _ hret hunit_wf (by simp [Term.eval])
   have hwp :
       st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ v_l loc.ty ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R)) ⊢
-        wp (.store (.val v_l) (.val v_v)) Φ := by
+        wp (reg.wpCtx) (.store (.val v_l) (.val v_v)) Φ := by
     rw [href]
     istart
     iintro ⟨Howns, Hloc, #Hval, HR⟩
@@ -1055,41 +1080,41 @@ theorem compileStoreShared_correct (loc val : Expr)
           · iexact HR
   exact hwp
 
-theorem compileStoreOwned_correct (loc val : Expr)
+theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
     (howned : loc.ty = .owned val.ty)
-    (ihVal : correctExpr val) (ihLoc : correctExpr loc) :
-    correctExpr (.store loc val) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+    (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
+    correctExpr reg (.store loc val) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, howned] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_v : (compile Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_v : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))) :=
-    Helpers.ctx_dup_flip Θ Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R))) :=
+    Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_)
+    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
   have hagree_v : B.agreeOnLinked ρ_v.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
-  have heval_l : (compile Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
+  have heval_l : (compile reg Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
   have hlocStart :
       st₁.sl Θ ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
-        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl Θ ρ_v ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+          st₁.sl Θ ρ_v ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (TinyML.ValHasType Θ v_v val.ty ∗ R)) :=
-    Helpers.ctx_push_flip Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
+    Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
   have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
   refine hlocStart.trans <| ihLoc Θ (TinyML.ValHasType Θ v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 ?_
+    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 hΔreg hρreg ?_
   intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨_hdecls_l, _hagreeOn_l, hΨ_l⟩ := hΨ_l
   have hfind_eval := VerifM.eval_bind _ _ _ _ hΨ_l
@@ -1101,7 +1126,7 @@ theorem compileStoreOwned_correct (loc val : Expr)
   rw [howned]
   refine VerifM.eval_findMatchForce Θ
     (R := TinyML.ValHasType Θ v_l (.owned val.ty) ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R))
-    (Φ := wp (.store (.val v_l) (.val v_v)) Φ) hfind_eval hsl_wf ?_
+    (Φ := wp (reg.wpCtx) (.store (.val v_l) (.val v_v)) Φ) hfind_eval hsl_wf ?_
   intro old st₃ hQ hdecls hold_wf
   have hassume_eval := VerifM.eval_bind _ _ _ _ hQ
   have hatom_wf : (SpatialAtom.pointsTo sl sv val.ty).wfIn st₃.decls := by
@@ -1114,7 +1139,7 @@ theorem compileStoreOwned_correct (loc val : Expr)
   have hwp :
       SpatialAtom.interp Θ ρ_l.env (.pointsTo sl old val.ty) ∗ st₃.sl Θ ρ_l ∗
         (TinyML.ValHasType Θ v_l (.owned val.ty) ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R)) ⊢
-          wp (.store (.val v_l) (.val v_v)) Φ := by
+          wp (reg.wpCtx) (.store (.val v_l) (.val v_v)) Φ := by
     simp only [SpatialAtom.interp]
     istart
     iintro ⟨Hatom, Howns, _Howned, #HnewTy, HR⟩
@@ -1147,14 +1172,14 @@ theorem compileStoreOwned_correct (loc val : Expr)
         · iexact HR
   exact hwp
 
-theorem compileStore_correct (loc val : Expr)
-    (ihVal : correctExpr val) (ihLoc : correctExpr loc) :
-    correctExpr (.store loc val) := by
+theorem compileStore_correct (reg : Verifier.Registry) (loc val : Expr)
+    (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
+    correctExpr reg (.store loc val) := by
   cases hty : loc.ty with
   | ref ty =>
       by_cases heq : ty = val.ty
       · have href : loc.ty = .ref val.ty := by simpa [heq] using hty
-        exact compileStoreShared_correct loc val href ihVal ihLoc
+        exact compileStoreShared_correct reg loc val href ihVal ihLoc
       · intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
@@ -1162,7 +1187,7 @@ theorem compileStore_correct (loc val : Expr)
   | owned ty =>
       by_cases heq : ty = val.ty
       · have howned : loc.ty = .owned val.ty := by simpa [heq] using hty
-        exact compileStoreOwned_correct loc val howned ihVal ihLoc
+        exact compileStoreOwned_correct reg loc val howned ihVal ihLoc
       · intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
@@ -1172,16 +1197,16 @@ theorem compileStore_correct (loc val : Expr)
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
 
-theorem compileUnop_correct (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
-    (ih : correctExpr e) :
-    correctExpr (.unop op e uty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
+    (ih : correctExpr reg e) :
+    correctExpr reg (.unop op e uty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_e : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_unop <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_, _, hΨ_e⟩ := hΨ_e
   obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
@@ -1202,7 +1227,7 @@ theorem compileUnop_correct (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
   have hq : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w :=
     by simpa [hty_eq] using
       (hpost w ρ_e st₁ t hΨ_e (compileUnop_wfIn hse_wf hcompUnop) ht_eval)
-  have hwp : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (.unop op (.val v_e)) Φ :=
+  have hwp : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (reg.wpCtx) (.unop op (.val v_e)) Φ :=
     SpatialContext.wp_unop
       (R := st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R)
       (Q := Φ) (op := op) (v := v_e) (res := w) hq heval_op
@@ -1213,40 +1238,40 @@ theorem compileUnop_correct (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
     · iexact Hwty
     · iexact HR
 
-theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
-    (ihR : correctExpr r) (ihL : correctExpr l) :
-    correctExpr (.binop op l r bty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
+    (ihR : correctExpr reg r) (ihL : correctExpr reg l) :
+    correctExpr reg (.binop op l r bty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_r : (compile Θ Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_r : (compile reg Θ Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+    Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_binop <| hstart.trans <|
-    ihR Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    ihR Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr
   obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
   have hagree_r : B.agreeOnLinked ρ_r.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
   have hbwf_r : B.wfIn st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
-  have heval_l : (compile Θ Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
+  have heval_l : (compile reg Θ Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
   have hleftStart :
       st₁.sl Θ ρ_r ∗ TinyML.ValHasType Θ vr r.ty ∗
-        (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
           st₁.sl Θ ρ_r ∗
-            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
               (TinyML.ValHasType Θ vr r.ty ∗ R)) :=
-    Helpers.ctx_push Θ Δ_spec ρ_spec S B Γ st₁ ρ_r γ R vr r.ty
+    Helpers.ctx_push reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_r γ R vr r.ty
   have hspecInv_r := specInvariants_mono hΔspec hρspec hdecls_r hagreeOn_r
   refine hleftStart.trans <|
     ihL Θ (TinyML.ValHasType Θ vr r.ty ∗ R) S B Γ st₁ ρ_r γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hSwf hΔwf hΔvars hspecInv_r.1 hspecInv_r.2 ?_
+      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hSwf hΔwf hΔvars hspecInv_r.1 hspecInv_r.2 hΔreg hρreg ?_
   intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
   obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
@@ -1285,7 +1310,7 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       have hwp_int :
           st₂.sl Θ ρ_l ∗
               (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
-            wp (.binop .div (.val vl) (.val vr)) Φ := by
+            wp (reg.wpCtx) (.binop .div (.val vl) (.val vr)) Φ := by
         istart
         iintro H
         icases H with ⟨Howns, Hvl, Hvr, HR⟩
@@ -1336,7 +1361,7 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       have hwp_int :
           st₂.sl Θ ρ_l ∗
               (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
-            wp (.binop .mod (.val vl) (.val vr)) Φ := by
+            wp (reg.wpCtx) (.binop .mod (.val vl) (.val vr)) Φ := by
         istart
         iintro H
         icases H with ⟨Howns, Hvl, Hvr, HR⟩
@@ -1408,7 +1433,7 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
     have hq : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w := by
       simpa [hty_eq] using
         (hpost w ρ_l st₂ t hΨ_ndiv (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval)
-    have hwp : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (.binop op (.val vl) (.val vr)) Φ :=
+    have hwp : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (reg.wpCtx) (.binop op (.val vl) (.val vr)) Φ :=
       SpatialContext.wp_binop
         (R := st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R)
         (Q := Φ) (op := op) (vl := vl) (vr := vr) (res := w) hq heval_op
@@ -1419,23 +1444,23 @@ theorem compileBinop_correct (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
       · iexact Hwty
       · iexact HR
 
-theorem compileLetIn_correct (b : Binder) (e body : Expr)
-    (ihE : correctExpr e) (ihBody : correctExpr body) :
-    correctExpr (.letIn b e body) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Expr)
+    (ihE : correctExpr reg e) (ihBody : correctExpr reg body) :
+    correctExpr reg (.letIn b e body) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.letIn_subst]
-  have heval_e_outer : (compile Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_e_outer : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
-  refine (hstart.trans <| ihE Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_).trans wp.letIn
+          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+    Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+  refine (hstart.trans <| ihE Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_).trans wp.letIn
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e
   obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
@@ -1445,8 +1470,8 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
   | none =>
     simp [hname] at hΨ_e
     have hdrop :
-        st₁.sl Θ ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-          st₁.sl Θ ρ_e ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          st₁.sl Θ ρ_e ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       iintro ⟨Howns, _Hv, □HS, □HT, HR⟩
       isplitl [Howns]
       · iexact Howns
@@ -1457,14 +1482,14 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
           · iexact HR
     have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
     have hbody := hdrop.trans <| ihBody Θ R S B Γ st₁ ρ_e γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hSwf hΔwf hΔvars hspecInv_e.1 hspecInv_e.2
+      (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hSwf hΔwf hΔvars hspecInv_e.1 hspecInv_e.2 hΔreg hρreg
       (fun v ρ' st' se hΨ hs hw =>
         let ⟨_, _, hΨ'⟩ := hΨ
         hpost v ρ' st' se hΨ' hs hw)
     have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ Runtime.Binder.none v_e
     have hbody' : st₁.sl Θ ρ_e ∗
-          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-            wp
+          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+            wp (reg.wpCtx)
               (Runtime.Expr.subst
                 (Runtime.Subst.updateBinder Runtime.Binder.none v_e Runtime.Subst.id)
                 (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
@@ -1487,12 +1512,12 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
     set ρ_body := ρ_e.updateConst .value v.name v_e
     set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
     suffices st₂.sl Θ ρ_body ∗
-        (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-          wp (body.runtime.subst γ_body) Φ by
+        (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          wp (reg.wpCtx) (body.runtime.subst γ_body) Φ by
       have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ (.named x) v_e
       have hbody' : st₂.sl Θ ρ_body ∗
-            (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-              wp
+            (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+              wp (reg.wpCtx)
                 (Runtime.Expr.subst
                   (Runtime.Subst.updateBinder (.named x) v_e Runtime.Subst.id)
                   (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
@@ -1507,7 +1532,7 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
           using hbody'
     have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
       Env.agreeOn_update_fresh_const hfresh
-    have hΨ_body : (compile Θ Δ_spec (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
+    have hΨ_body : (compile reg Θ Δ_spec (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
       have hdecl_eval := VerifM.eval_bind _ _ _ _ hΨ_e
       have hdecl := VerifM.eval_decl hdecl_eval
       have h := hdecl v_e
@@ -1546,9 +1571,9 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
       rwa [hρ_body_lookup] at h
     have hres :
         st₂.sl Θ ρ_body ∗
-          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
             st₂.sl Θ ρ_body ∗
-              (SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
+              (SpecMap.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
                 Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body ∗ R) := by
       iintro ⟨Howns, Hve, □HS, □HT, HR⟩
       isplitl [Howns]
@@ -1566,29 +1591,29 @@ theorem compileLetIn_correct (b : Binder) (e body : Expr)
     have hspecInv_body := specInvariants_mono hspecInv_e.1 hspecInv_e.2
       (Signature.Subset.subset_addConst st₁.decls v) hagreeOn_body_e
     refine hres.trans <| ihBody Θ R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ (SpecMap.wfIn_erase hSwf) hΔwf hΔvars hspecInv_body.1 hspecInv_body.2 ?_
+      (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ (SpecMap.wfIn_erase hSwf) hΔwf hΔvars hspecInv_body.1 hspecInv_body.2 hΔreg hρreg ?_
     intro v' ρ' st' se' hΨ hs hw
     obtain ⟨_, _, hΨ'⟩ := hΨ
     exact hpost v' ρ' st' se' hΨ' hs hw
 
-theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
-    (ihCond : correctExpr cond) (ihThn : correctExpr thn) (ihEls : correctExpr els) :
-    correctExpr (.ifThenElse cond thn els ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr) (ty : TinyML.Typ)
+    (ihCond : correctExpr reg cond) (ihThn : correctExpr reg thn) (ihEls : correctExpr reg els) :
+    correctExpr reg (.ifThenElse cond thn els ty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_cond : (compile Θ Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_cond : (compile reg Θ Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+    Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_if <| hstart.trans <|
-    ihCond Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    ihCond Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c
   obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
   have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
@@ -1615,9 +1640,9 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
   have hbool_cases_bool :
       st₁.sl Θ ρ_c ∗
           (TinyML.ValHasType Θ v_c .bool ∗
-            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
         st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     iintro ⟨Howns, Hv, □HS, □HT, HR⟩
     ihave Hv_bool := (TinyML.ValHasType.bool Θ v_c).1 $$ Hv
     icases Hv_bool with ⟨%b, %hv⟩
@@ -1631,9 +1656,9 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
           · iexact HT
           · iexact HR
   have hbool_cases :
-      st₁.sl Θ ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+      st₁.sl Θ ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
         st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     simpa [hcond_bool] using hbool_cases_bool
   refine hbool_cases.trans ?_
   istart
@@ -1641,21 +1666,21 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
   icases Hbool with %hbool
   rcases hbool with hfalse_val | htrue_val
   · subst hfalse_val
-    have heval_els : (compile Θ Δ_spec S B Γ els).eval st_els ρ_c Ψ :=
+    have heval_els : (compile reg Θ Δ_spec S B Γ els).eval st_els ρ_c Ψ :=
       hfalse_cont hwf_eq (by
         simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_c)
     have hwp :
-        st_els.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          wp (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
+        st_els.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          wp (reg.wpCtx) (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_false
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
-        ihEls Θ R S B Γ st_els ρ_c γ Δ_spec ρ_spec Ψ Φ heval_els hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2
+        ihEls Θ R S B Γ st_els ρ_c γ Δ_spec ρ_spec Ψ Φ heval_els hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hels_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_els.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          st_els.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       simp [st_els, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -1669,21 +1694,21 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
     have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by
       rw [heval_c]
       simp
-    have heval_thn : (compile Θ Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
+    have heval_thn : (compile reg Θ Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
       htrue_cont hwf_ne (by
         simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_ne)
     have hwp :
-        st_thn.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          wp (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
+        st_thn.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          wp (reg.wpCtx) (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_true
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
-        ihThn Θ R S B Γ st_thn ρ_c γ Δ_spec ρ_spec Ψ Φ heval_thn hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2
+        ihThn Θ R S B Γ st_thn ρ_c γ Δ_spec ρ_spec Ψ Φ heval_thn hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hthn_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_thn.sl Θ ρ_c ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          st_thn.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       simp [st_thn, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -1694,17 +1719,17 @@ theorem compileIfThenElse_correct (cond thn els : Expr) (ty : TinyML.Typ)
         · iexact HT
         · iexact HR
 
-theorem compileTuple_correct (es : List Expr)
-    (ihEs : correctExprs es) :
-    correctExpr (.tuple es) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
+    (ihEs : correctExprs reg es) :
+    correctExpr reg (.tuple es) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
-  have heval_es : (compileExprs Θ Δ_spec S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_es : (compileExprs reg Θ Δ_spec S B Γ es).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_tuple <| ihEs Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro vs ρ' st' terms hΨ hwf_terms heval_terms
   obtain ⟨_, _, hΨ⟩ := hΨ
   obtain hΨ := VerifM.eval_ret hΨ
@@ -1715,7 +1740,7 @@ theorem compileTuple_correct (es : List Expr)
     exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
   refine SpatialContext.wp_tuple ?_
   have hstep :
-      st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) ⊢
+      st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) ⊢
         st'.sl Θ ρ' ∗ TinyML.ValHasType Θ (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
     iintro ⟨Howns, Hvals, □HS, HR⟩
     isplitl [Howns]
@@ -1731,10 +1756,11 @@ theorem compileTuple_correct (es : List Expr)
     hpost (Runtime.Val.tuple vs) ρ' st' (.unop .ofValList (Terms.toValList terms))
       hΨ hwf_tuple heval_tuple
 
-theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
-    (ihArgs : correctExprs args) :
-    correctExpr (.app fn args aty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
+    (ihArgs : correctExprs reg args) :
+    correctExpr reg (.app fn args aty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst, List.map_map]
@@ -1742,9 +1768,9 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
   | var f fty =>
     simp only [compile] at heval
     obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
-    have heval_args : (compileExprs Θ Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpecMap.project
-      (P := st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ Δ_spec ρ_spec S γ ?_ hlookup ?_
+    have heval_args : (compileExprs reg Θ Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpecMap.project (wctx := reg.wpCtx)
+      (P := st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ Δ_spec ρ_spec S γ ?_ hlookup ?_
     · istart
       iintro ⟨_, □HS, _⟩
       iexact HS
@@ -1752,11 +1778,11 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
       simp [Expr.runtime, Runtime.Expr.subst, hγf]
       refine SpatialContext.wp_bind_app ?_
       have hctx :
-          spec.isPrecondFor Θ Δ_spec ρ_spec fval ∗
-              (st.sl Θ ρ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ∗
+              (st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
             st.sl Θ ρ ∗
-              (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗
-                Bindings.typedSubst Θ B Γ γ ∗ (spec.isPrecondFor Θ Δ_spec ρ_spec fval ∗ R)) := by
+              (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗
+                Bindings.typedSubst Θ B Γ γ ∗ (spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ∗ R)) := by
         istart
         iintro ⟨□Hspec, Howns, □HS, □HT, HR⟩
         isplitl [Howns]
@@ -1769,8 +1795,8 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
               · iexact Hspec
               · iexact HR
       refine hctx.trans <|
-        ihArgs Θ (spec.isPrecondFor Θ Δ_spec ρ_spec fval ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
-          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+        ihArgs Θ (spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
       intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
       obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
       let typedArgs := (args.map Expr.ty).zip sargs
@@ -1853,23 +1879,128 @@ theorem compileApp_correct (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
         isplitl [Howns]
         · iexact Howns
         · iexact HR
+  | prim n fty =>
+    simp only [compile] at heval
+    obtain ⟨i, hilookup, heval⟩ := VerifM.eval_bind_expectSome heval
+    obtain ⟨hret_eq, heval⟩ := VerifM.eval_bind_expectEq heval
+    have heval_args : (compileExprs reg Θ Δ_spec S B Γ args).eval st ρ _ :=
+      VerifM.eval_bind _ _ _ _ heval
+    have hi_mem : i ∈ reg := Verifier.Registry.mem_of_lookup? hilookup
+    have hbridge := Verifier.Registry.Sound.get hSound hi_mem
+    simp only [Expr.runtime, Runtime.Expr.subst_val]
+    refine SpatialContext.wp_bind_app ?_
+    refine ihArgs Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
+    obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
+    let spec := i.spec
+    let typedArgs := (args.map Expr.ty).zip sargs
+    have hlen_sargs : sargs.length = vs.length := by
+      simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
+    have hΔspec_args : Δ_spec.Subset st_args.decls := hΔspec.trans hdecls_args
+    have hst_args_wf : st_args.decls.wf := (VerifM.eval.wf hΨ_args).namesDisjoint
+    have hwf_pred :
+        spec.pred.wfIn ((Δ_spec.declVars (FiniteSubst.base Δ_spec).dom).declVars
+          (Spec.argVars spec.args)) := by
+      simpa [spec, FiniteSubst.base, Signature.declVars] using
+        hbridge.specWf Δ_spec (hΔreg i hi_mem) hΔwf
+    have hbase_wf : (FiniteSubst.base Δ_spec).wf Δ_spec st_args.decls :=
+      FiniteSubst.base_wfIn hΔspec_args hΔwf hst_args_wf hΔvars
+    have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
+      intro p hp
+      have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
+      exact hsargs_wf _ hp''
+    have hcall_eval : VerifM.eval (Spec.call Θ (FiniteSubst.base Δ_spec) spec typedArgs) st_args ρ_args
+        (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind _ _ _ _ hΨ_args
+    have hcall := Spec.call_correct Θ spec Δ_spec (FiniteSubst.base Δ_spec) typedArgs st_args ρ_args
+      (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
+      hwf_pred hbase_wf htypedArgs_wf hcall_eval
+      (fun v st' ρ' t hΨ hwf heval => by
+        have hret_eq' : spec.retTy = aty := by
+          simpa [spec, Verifier.Intrinsic.resultTy] using hret_eq
+        have h := hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval
+        rw [← hret_eq'] at h
+        iintro H
+        icases H with ⟨Howns', Hrest⟩
+        icases Hrest with ⟨HR', Hty⟩
+        iapply h
+        isplitl [Howns']
+        · iexact Howns'
+        · isplitl [Hty]
+          · iexact Hty
+          · iexact HR')
+    obtain ⟨hsub_ty, happly⟩ := hcall
+    refine SpatialContext.wp_val ?_
+    refine BIBase.Entails.trans ?_ wp.prim
+    show _ ⊢ (reg.wpCtx) n vs Φ
+    have hctx_eq : (reg.wpCtx) n vs Φ = i.toWp vs Φ := by
+      simp only [Verifier.Registry.wpCtx, hilookup]
+    rw [hctx_eq]
+    istart
+    iintro ⟨Howns, Hvals, _HS, HR⟩
+    iintuitionistic Hvals
+    ihave Hlen := TinyML.ValsHaveTypes.length_eq $$ Hvals
+    ipure Hlen
+    have hlen_typed : (args.map Expr.ty).length = sargs.length := by
+      rw [← Hlen]; exact hlen_sargs.symm
+    have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) i.argTysList := by
+      have hspec_snd : i.specArgs.map Prod.snd = i.argTysList := rfl
+      have hfst : typedArgs.map Prod.fst = args.map Expr.ty := by
+        simpa [typedArgs] using
+          (List.map_fst_zip (l₁ := args.map Expr.ty) (l₂ := sargs)
+            (Nat.le_of_eq hlen_typed))
+      simpa [spec, hspec_snd, hfst] using hsub_ty
+    have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args.env) = vs := by
+      have hsnd :
+          List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
+        simpa using
+          (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
+            (Nat.le_of_eq hlen_typed.symm))
+      calc
+        typedArgs.map (fun p => p.2.eval ρ_args.env)
+            = sargs.map (fun t => t.eval ρ_args.env) := by
+                simpa [typedArgs, List.map_map] using
+                  congrArg (List.map (fun t => t.eval ρ_args.env)) hsnd
+        _ = vs := Terms.Eval.map_eval heval_sargs
+    have happly' :
+        st_args.sl Θ ρ_args ∗ R ⊢
+          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r i.resultTy -∗ Φ r) i.spec.pred
+            (Spec.argsEnv ρ_args i.specArgs vs) := by
+      rw [heval_sargs_map] at happly
+      simpa [spec, Verifier.Intrinsic.specArgs] using happly
+    have hagree_ρ_args : VerifM.Env.agreeOn Δ_spec ρ_spec ρ_args :=
+      VerifM.Env.agreeOn_trans hρspec (VerifM.Env.agreeOn_mono hΔspec hagreeOn_args)
+    have hρ_args_reg : ρ_args.env.respects i.folSym :=
+      Env.respects_of_agreeOn_extendWithSym (hρreg i hi_mem) (hΔreg i hi_mem) hagree_ρ_args
+    iapply (show
+        TinyML.ValsHaveTypes Θ vs i.argTysList ∗
+          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r i.resultTy -∗ Φ r) i.spec.pred
+            (Spec.argsEnv ρ_args i.specArgs vs) ⊢ i.toWp vs Φ from
+        hbridge.bridge Θ vs ρ_args Φ hρ_args_reg)
+    isplitl [Hvals]
+    · iapply (TinyML.ValsHaveTypes.sub hsub_ty')
+      iexact Hvals
+    · iapply happly'
+      isplitl [Howns]
+      · iexact Howns
+      · iexact HR
   | _ =>
     simp only [compile] at heval
     exact (VerifM.eval_fatal heval).elim
 
-theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (ty : TinyML.Typ)
-    (ihScrut : correctExpr scrut) (ihBranches : correctBranches branches) :
-    correctExpr (.match_ scrut branches ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches : List (Binder × Expr)) (ty : TinyML.Typ)
+    (ihScrut : correctExpr reg scrut) (ihBranches : correctBranches reg branches) :
+    correctExpr reg (.match_ scrut branches ty) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
-  have heval_scrut : (compile Θ Δ_spec S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_scrut : (compile reg Θ Δ_spec S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_match <| BIBase.Entails.trans ?_ <|
-    ihScrut Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
-  · exact Helpers.ctx_dup Θ Δ_spec ρ_spec S B Γ st ρ γ R
+    ihScrut Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  · exact Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se
   obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
   cases hscrut_ty : scrut.ty with
@@ -1885,12 +2016,12 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
       by_cases htys : ∀ br ∈ branches, br.2.ty = ty
       · have hΨ_scrut' :
             (do
-              let i ← VerifM.all (List.range (compileBranches Θ Δ_spec S B Γ se_scrut ts branches 0).length)
-              match (compileBranches Θ Δ_spec S B Γ se_scrut ts branches 0)[i]? with
+              let i ← VerifM.all (List.range (compileBranches reg Θ Δ_spec S B Γ se_scrut ts branches 0).length)
+              match (compileBranches reg Θ Δ_spec S B Γ se_scrut ts branches 0)[i]? with
               | some m => m
               | none => VerifM.fatal "match branch index out of range").eval st_scrut ρ_scrut Ψ := by
           simpa [if_pos hlen, if_pos htys] using hΨ_scrut
-        have hcb := compileBranches_length_get Θ Δ_spec S B Γ se_scrut ts branches 0
+        have hcb := compileBranches_length_get reg Θ Δ_spec S B Γ se_scrut ts branches 0
         have hactions_len := hcb.1
         have heval_all := VerifM.eval_bind _ _ _ _ hΨ_scrut'
         have hall := VerifM.eval_all heval_all
@@ -1902,7 +2033,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           icases Hscrut_sum with ⟨%tag, %v_payload, %hval_eq, Hsum⟩
           ihave %htag_bound := TinyML.ValSumRel.bound $$ Hsum
           have htag_branches : tag < branches.length := hlen ▸ htag_bound
-          have htag_range : tag ∈ List.range (compileBranches Θ Δ_spec S B Γ se_scrut ts branches 0).length := by
+          have htag_range : tag ∈ List.range (compileBranches reg Θ Δ_spec S B Γ se_scrut ts branches 0).length := by
             rw [hactions_len]
             exact List.mem_range.mpr htag_branches
           have heval_tag := hall tag htag_range
@@ -1915,7 +2046,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           have hspecInv_scrut := specInvariants_mono hΔspec hρspec hdecls_scrut hagreeOn_scrut
           have hbranch_wp := ihBranches Θ R S B Γ se_scrut ts.length ts 0
             st_scrut ρ_scrut γ Δ_spec ρ_spec Ψ Φ
-            hagree_scrut hbwf_scrut hSwf hΔwf hΔvars hspecInv_scrut.1 hspecInv_scrut.2 hse_wf
+            hagree_scrut hbwf_scrut hSwf hΔwf hΔvars hspecInv_scrut.1 hspecInv_scrut.2 hΔreg hρreg hse_wf
             (fun j hj v ρ' st' se hΨ hse_wf hse_eval => by
               iintro ⟨Hsl, Hv, □HS, HR⟩
               iapply (hpost v ρ' st' se hΨ hse_wf hse_eval)
@@ -1931,8 +2062,8 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           have hbranch_entail :
               st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-                wp
+                    (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+                wp (reg.wpCtx)
                   ((Runtime.Expr.subst γ
                         (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime)).app
                     [Runtime.Expr.val v_payload])
@@ -1953,8 +2084,8 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           have hmatch_entail :
               st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-                wp
+                    (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+                wp (reg.wpCtx)
                   ((Runtime.Expr.val (Runtime.Val.inj tag ts.length v_payload)).match_
                     (List.map (Runtime.Expr.subst γ ∘ fun p =>
                       Runtime.Expr.fix Runtime.Binder.none [p.1.runtime] p.2.runtime) branches))
@@ -1962,7 +2093,7 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
             SpatialContext.wp_match
               (R := st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R))
+                    (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R))
               (branch :=
                 Runtime.Expr.subst γ
                   (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime))
@@ -1983,10 +2114,10 @@ theorem compileMatch_correct (scrut : Expr) (branches : List (Binder × Expr)) (
           simpa [if_pos hlen, if_neg htys] using hΨ_scrut
         exact (VerifM.eval_fatal hΨ_bad).elim
 
-theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
-    (ihBody : correctExpr body) :
-    correctBranch (binder, body) := by
-  intro Θ R S B Γ sc n i ty_i st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf hpost payload hsc_eval
+theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) (body : Expr)
+    (ihBody : correctExpr reg body) :
+    correctBranch reg (binder, body) := by
+  intro Θ R S B Γ sc n i ty_i st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost payload hsc_eval
   simp only [compileBranch] at heval
   by_cases hty : binder.ty = ty_i
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
@@ -2036,7 +2167,7 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
         (t := Term.const (.uninterpreted xv.name .value))
         (ρ := ρ₁.env) (Θ := Θ) (v := payload) hxv_eval $$ Hpay
     ipure Hcheck
-    obtain ⟨st₂, hst₂_decls, hst₂_owns, heval_body'⟩ := VerifM.eval_assumeAll hassume_bind₂
+    obtain ⟨st₂, hst₂_decls, hst₂_owns, _, heval_body'⟩ := VerifM.eval_assumeAll hassume_bind₂
       (fun φ hφ => TinyML.typeConstraints_wfIn hxv_wf φ hφ)
       (fun φ hφ => Hcheck φ hφ)
     have hst₂_owns_eq : st₂.owns = st.owns := hst₂_owns
@@ -2046,17 +2177,18 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
       have hagree₁ : B.agreeOnLinked ρ₁.env γ :=
         Bindings.agreeOnLinked_env_agree hagree hagreeOn_st hbwf
       have hbwf₁ : B.wfIn st₂.decls := hst₂_decls ▸ fun p hp => List.Mem.tail _ (hbwf p hp)
-      have heval_body'' : (compile Θ Δ_spec S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+      have heval_body'' : (compile reg Θ Δ_spec S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, hname] using heval_body'
       have hspecInv₁ := specInvariants_mono hΔspec hρspec
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
           st₂.sl Θ ρ₁ ∗
-              (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B (Γ.extendBinder binder ty_i) γ ∗
-                (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-            wp (body.runtime.subst γ) Φ :=
-        ihBody Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Δ_spec ρ_spec Ψ Φ
+              (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B (Γ.extendBinder binder ty_i) γ ∗
+                (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+            wp (reg.wpCtx) (body.runtime.subst γ) Φ :=
+        ihBody Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Δ_spec ρ_spec Ψ Φ
           heval_body'' hagree₁ hbwf₁ hSwf hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
+          hΔreg hρreg
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
       rw [Binder.runtime_of_name_none hname]
       simp only [Runtime.Expr.subst_fix]
@@ -2107,19 +2239,20 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
         have h := Bindings.agreeOnLinked_cons (x := x) (v := xv) (γ := γ) hagree hagreeOn_B (hvty := rfl)
         rwa [hρ₁_lookup] at h
       have heval_body'' :
-          (compile Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+          (compile reg Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, TinyML.TyCtx.extendBinder, hname] using heval_body'
       have hspecInv₁ := specInvariants_mono hΔspec hρspec
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
           st₂.sl Θ ρ₁ ∗
-              (SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
+              (SpecMap.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
                 Bindings.typedSubst Θ ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) ∗
-                (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-            wp (body.runtime.subst (Runtime.Subst.update γ x payload)) Φ :=
-        ihBody Θ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
+                (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+            wp (reg.wpCtx) (body.runtime.subst (Runtime.Subst.update γ x payload)) Φ :=
+        ihBody Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
           (Runtime.Subst.update γ x payload) Δ_spec ρ_spec Ψ Φ heval_body'' hagree₁ hbwf₂ (SpecMap.wfIn_erase hSwf)
           hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
+          hΔreg hρreg
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
       rw [Binder.runtime_of_name_some hname]
       simp only [Runtime.Expr.subst_fix]
@@ -2152,37 +2285,37 @@ theorem compileSingleBranch_correct (binder : Binder) (body : Expr)
   · have hexpect := VerifM.eval_bind _ _ _ _ heval
     exact False.elim (hty (VerifM.eval_expectEq hexpect).1)
 
-theorem compileBranchesCons_correct (b : Binder × Expr) (bs : List (Binder × Expr))
-    (ihHead : correctBranch b) (ihTail : correctBranches bs) :
-    correctBranches (b :: bs) := by
-  intro Θ R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf hpost j hj
+theorem compileBranchesCons_correct (reg : Verifier.Registry) (b : Binder × Expr) (bs : List (Binder × Expr))
+    (ihHead : correctBranch reg b) (ihTail : correctBranches reg bs) :
+    correctBranches reg (b :: bs) := by
+  intro Θ R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost j hj
   cases j with
   | zero =>
     simp only [Nat.add_zero, List.getElem_cons_zero]
     intro heval
     exact ihHead Θ R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Δ_spec ρ_spec Ψ Φ
-      heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf (by simpa using hpost 0 hj)
+      heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf (by simpa using hpost 0 hj)
   | succ k =>
     have hk : k < bs.length := by simp at hj; omega
     have hidx : idx + (k + 1) = (idx + 1) + k := by omega
     simp only [hidx, List.getElem_cons_succ]
     exact ihTail Θ R S B Γ sc n ts (idx + 1) st ρ γ Δ_spec ρ_spec Ψ Φ
-      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf
+      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf
       (by
         intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
         simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
       k hk
 
-theorem compileExprsCons_correct (e : Expr) (rest : List Expr)
-    (ihE : correctExpr e) (ihRest : correctExprs rest) :
-    correctExprs (e :: rest) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : List Expr)
+    (ihE : correctExpr reg e) (ihRest : correctExprs reg rest) :
+    correctExprs reg (e :: rest) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [compileExprs] at heval
   simp only [List.map, wps_cons]
-  have heval_rest : (compileExprs Θ Δ_spec S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+  have heval_rest : (compileExprs reg Θ Δ_spec S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine BIBase.Entails.trans ?_ <|
-    ihRest Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
-      (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec ?_
+    ihRest Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   · iintro ⟨Hsl, □HS, □HT, HR⟩
     isplitl [Hsl]
     · iexact Hsl
@@ -2200,12 +2333,12 @@ theorem compileExprsCons_correct (e : Expr) (rest : List Expr)
   have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
   have hbwf_vs : B.wfIn st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
-  have heval_e : (compile Θ Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
   have hspecInv_vs := specInvariants_mono hΔspec hρspec hdecls_vs hagreeOn_vs
   refine BIBase.Entails.trans ?_ <|
-    ihE Θ (TinyML.ValsHaveTypes Θ vs (rest.map Expr.ty) ∗ (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ R))
+    ihE Θ (TinyML.ValsHaveTypes Θ vs (rest.map Expr.ty) ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R))
     S B Γ st_vs ρ_vs γ Δ_spec ρ_spec _ _
-    (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hSwf hΔwf hΔvars hspecInv_vs.1 hspecInv_vs.2 ?_
+    (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hSwf hΔwf hΔvars hspecInv_vs.1 hspecInv_vs.2 hΔreg hρreg ?_
   · iintro ⟨Hsl, Hvs, □HS, □HT, □HSpare, HR⟩
     isplitl [Hsl]
     · iexact Hsl
@@ -2252,14 +2385,14 @@ theorem compileExprsCons_correct (e : Expr) (rest : List Expr)
         · iexact HSpare
         · iexact HR)
 
-theorem compileBranchesNil_correct :
-    correctBranches [] := by
-  intro Θ R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hsc_wf hpost j hj
+theorem compileBranchesNil_correct (reg : Verifier.Registry) :
+    correctBranches reg [] := by
+  intro Θ R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost j hj
   exact absurd hj (Nat.not_lt_zero _)
 
-theorem compileExprsNil_correct :
-    correctExprs [] := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hpost
+theorem compileExprsNil_correct (reg : Verifier.Registry) :
+    correctExprs reg [] := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [compileExprs] at heval
   simp only [List.map, wps]
   obtain heval := VerifM.eval_ret heval
@@ -2279,60 +2412,66 @@ theorem compileExprsNil_correct :
 /-! #### Correctness Theorem -/
 
 mutual
-theorem compile_correct (e : Expr) : correctExpr e := by
+theorem compile_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (e : Expr) : correctExpr reg e := by
   cases e with
   | const c =>
-    simpa using compileConst_correct c
+    simpa using compileConst_correct reg c
   | var x vty =>
-    simpa using compileVar_correct x vty
+    simpa using compileVar_correct reg x vty
+  | prim n ty =>
+    simpa using compilePrim_correct reg n ty
   | inj tag arity payload =>
-    simpa using compileInj_correct tag arity payload (compile_correct payload)
+    simpa using compileInj_correct reg tag arity payload (compile_correct reg hSound payload)
   | cast e ty =>
-    simpa using compileCast_correct e ty (compile_correct e)
+    simpa using compileCast_correct reg e ty (compile_correct reg hSound e)
   | assert e =>
-    simpa using compileAssert_correct e (compile_correct e)
+    simpa using compileAssert_correct reg e (compile_correct reg hSound e)
   | fix self args retTy body =>
-    simpa using compileFix_correct self args retTy body
+    simpa using compileFix_correct reg self args retTy body
   | ref owned e =>
-    simpa using compileRef_correct owned e (compile_correct e)
+    simpa using compileRef_correct reg owned e (compile_correct reg hSound e)
   | deref e ty =>
-    simpa using compileDeref_correct e ty (compile_correct e)
+    simpa using compileDeref_correct reg e ty (compile_correct reg hSound e)
   | store loc val =>
-    simpa using compileStore_correct loc val (compile_correct val) (compile_correct loc)
+    simpa using compileStore_correct reg loc val (compile_correct reg hSound val) (compile_correct reg hSound loc)
   | unop op e uty =>
-    simpa using compileUnop_correct op e uty (compile_correct e)
+    simpa using compileUnop_correct reg op e uty (compile_correct reg hSound e)
   | binop op l r bty =>
-    simpa using compileBinop_correct op l r bty (compile_correct r) (compile_correct l)
+    simpa using compileBinop_correct reg op l r bty (compile_correct reg hSound r) (compile_correct reg hSound l)
   | letIn b e body =>
-    simpa using compileLetIn_correct b e body (compile_correct e) (compile_correct body)
+    simpa using compileLetIn_correct reg b e body (compile_correct reg hSound e) (compile_correct reg hSound body)
   | ifThenElse cond thn els ty =>
-    simpa using compileIfThenElse_correct cond thn els ty
-      (compile_correct cond) (compile_correct thn) (compile_correct els)
+    simpa using compileIfThenElse_correct reg cond thn els ty
+      (compile_correct reg hSound cond) (compile_correct reg hSound thn) (compile_correct reg hSound els)
   | app fn args aty =>
-    simpa using compileApp_correct fn args aty (compileExprs_correct args)
+    simpa using compileApp_correct reg hSound fn args aty (compileExprs_correct reg hSound args)
   | tuple es =>
-    simpa using compileTuple_correct es (compileExprs_correct es)
+    simpa using compileTuple_correct reg es (compileExprs_correct reg hSound es)
   | match_ scrut branches ty =>
-    simpa using compileMatch_correct scrut branches ty
-      (compile_correct scrut) (compileBranches_correct branches)
+    simpa using compileMatch_correct reg scrut branches ty
+      (compile_correct reg hSound scrut) (compileBranches_correct reg hSound branches)
 
-theorem compileBranch_correct (branch : Binder × Expr) : correctBranch branch := by
+theorem compileBranch_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (branch : Binder × Expr) : correctBranch reg branch := by
   obtain ⟨binder, body⟩ := branch
-  simpa using compileSingleBranch_correct binder body (compile_correct body)
+  simpa using compileSingleBranch_correct reg binder body (compile_correct reg hSound body)
 
-theorem compileBranches_correct (branches : List (Binder × Expr)) : correctBranches branches := by
+theorem compileBranches_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (branches : List (Binder × Expr)) : correctBranches reg branches := by
   match branches with
   | [] =>
-    exact compileBranchesNil_correct
+    exact compileBranchesNil_correct reg
   | b :: bs =>
-    simpa using compileBranchesCons_correct b bs
-      (compileBranch_correct b) (compileBranches_correct bs)
+    simpa using compileBranchesCons_correct reg b bs
+      (compileBranch_correct reg hSound b) (compileBranches_correct reg hSound bs)
 
-theorem compileExprs_correct (es : List Expr) : correctExprs es := by
+theorem compileExprs_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (es : List Expr) : correctExprs reg es := by
   match es with
   | [] =>
-    exact compileExprsNil_correct
+    exact compileExprsNil_correct reg
   | e :: rest =>
-    simpa using compileExprsCons_correct e rest
-      (compile_correct e) (compileExprs_correct rest)
+    simpa using compileExprsCons_correct reg e rest
+      (compile_correct reg hSound e) (compileExprs_correct reg hSound rest)
 end

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -11,6 +11,7 @@ import Mica.Verifier.Expressions
 import Mica.Engine.Driver
 import Mica.Base.Fresh
 import Mathlib.Data.Finmap
+import Mica.Verifier.Intrinsic
 
 open Iris Iris.BI
 open Typed
@@ -18,18 +19,18 @@ open Typed
 
 /-- Compile the body of a specification under its argument context and
     check that the inferred return type is a subtype of the declared one. -/
-def checkBody (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (s : Spec)
+def checkBody (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (s : Spec)
     (argNames : List String) (body : Expr)
     (argVars : List FOL.Const) : VerifM (Term .value) := do
   let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
   let Γ := (argNames.zip (s.args.map Prod.snd)).foldl
     (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
-  let se ← compile Θ Δ_spec S B Γ body
+  let se ← compile reg Θ Δ_spec S B Γ body
   if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
   else VerifM.fatal s!"checkSpec: return type mismatch"
   pure se
 
-def checkSpec (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
+def checkSpec (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
   let (fb, argNames, body) ← match e with
     | .fix fb argBinders _ body => do
       match extractArgNames argBinders s.args with
@@ -38,12 +39,13 @@ def checkSpec (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (e : Exp
     | _ => VerifM.fatal "checkSpec: expected function"
   let S' := SpecMap.eraseAll argNames (S.insertBinder fb s)
   VerifM.persist
-  Spec.implement Δ_spec s (checkBody Θ Δ_spec S' s argNames body)
+  Spec.implement Δ_spec s (checkBody reg Θ Δ_spec S' s argNames body)
 
 /-- Soundness of `checkBody`: given argument variables supplied by
     `Spec.implement_correct` and a successful `checkBody` evaluation, the
     compiled body's `wp` holds. -/
-theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
+theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (hswf : s.wfIn Δ_spec) (hSwf : S.wfIn Δ_spec)
@@ -58,18 +60,20 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     {argVars : List FOL.Const} {st' : TransState} {ρ' : VerifM.Env} {Q : iProp}
     (hΔspec : Δ_spec.Subset st'.decls)
     (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ')
+    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
     (hargVars_mem : ∀ v ∈ argVars, v ∈ st'.decls.consts)
     (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
     (hargVars_lookup : List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs)
     (hbody_eval : VerifM.eval
-        (checkBody Θ Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
+        (checkBody reg Θ Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
           st''.sl Θ ρ'' ∗ Q ∗
             ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
     st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗ Q ⊢
-      (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval) -∗
-        wp (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
+      (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval) -∗
+        wp (reg.wpCtx) (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
   simp only [checkBody] at hbody_eval
   obtain ⟨hargNames_len, _, hbs_eq⟩ := extractArgNames_spec hext
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_def ▸ hbs_eq
@@ -128,23 +132,23 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
     rw [hsnd]
     iassumption
   have hS'_sat :
-      S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
-        S'.satisfiedBy Θ Δ_spec ρ_spec γ_body := by
+      S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ⊢
+        S'.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ_body := by
     have hinsert :
-        S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
-          (S.insertBinder fb s).satisfiedBy Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) :=
+        S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ⊢
+          (S.insertBinder fb s).satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) :=
       SpecMap.satisfiedBy_insertBinder_updateBinder
     have herase :
-        (S.insertBinder fb s).satisfiedBy Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) ⊢
-          S'.satisfiedBy Θ Δ_spec ρ_spec ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
+        (S.insertBinder fb s).satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) ⊢
+          S'.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
       SpecMap.satisfiedBy_eraseAll_updateAllBinder hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
-      st'.sl Θ ρ' ∗ (S'.satisfiedBy Θ Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
-        wp (body.runtime.subst γ_body) P := by
-    refine compile_correct body Θ Q S' B Γ st' ρ' γ_body Δ_spec ρ_spec _ _
+      st'.sl Θ ρ' ∗ (S'.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
+        wp (reg.wpCtx) (body.runtime.subst γ_body) P := by
+    refine compile_correct reg hSound body Θ Q S' B Γ st' ρ' γ_body Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hS'wf hΔwf hΔvars
-      hΔspec hρspec ?_
+      hΔspec hρspec hΔreg hρreg ?_
     intro v ρ'' st'' se hΨ hse_wf heval_se
     obtain ⟨_, _, hΨ⟩ := hΨ
     by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
@@ -180,16 +184,19 @@ theorem checkBody_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
         iexact Hvals
       · iexact HQ
 
-theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
+theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (hswf : s.wfIn Δ_spec) (hSwf : S.wfIn Δ_spec)
     (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
     (st : TransState) (ρ : VerifM.Env)
     (hΔspec : Δ_spec.Subset st.decls)
-    (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ) :
-    VerifM.eval (checkSpec Θ Δ_spec S e s) st ρ (fun _ _ _ => True) →
-    st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (e.runtime.subst γ) (fun v => s.isPrecondFor Θ Δ_spec ρ_spec v) := by
+    (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
+    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env) :
+    VerifM.eval (checkSpec reg Θ Δ_spec S e s) st ρ (fun _ _ _ => True) →
+    st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ wp (reg.wpCtx) (e.runtime.subst γ) (fun v => s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec v) := by
   intro heval
   -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
   have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
@@ -240,8 +247,8 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
       have hbody' : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
           PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
           (Spec.argsEnv ρ_call s.args vs) ⊢
-          SpecMap.satisfiedBy Θ Δ_spec ρ_spec S γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval -∗
-            wp (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
+          SpecMap.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec S γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval -∗
+            wp (reg.wpCtx) (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
         iintro H
         icases H with ⟨Htyped', Hpred'⟩
         iintuitionistic Htyped'
@@ -249,16 +256,16 @@ theorem checkSpec_correct (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Sp
           simpa using hΔspec
         ihave Hwand := Spec.implement_correct Θ s _ Δ_spec ρ_spec (TransState.persist st) ρ vs P
           (TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
-            (S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval) -∗
-              wp (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
+            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval) -∗
+              wp (reg.wpCtx) (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
           hswf hΔspec_persist hρspec hΔwf hΔvars himpl
           (fun argVars st' ρ' Q hst_sub hρ_agree hargVars_mem hargVars_sort hargVars_lookup hbody_eval => by
             have hΔspec' : Δ_spec.Subset st'.decls := hΔspec_persist.trans hst_sub
             have hρspec' : VerifM.Env.agreeOn Δ_spec ρ_spec ρ' := by
               exact VerifM.Env.agreeOn_trans hρspec (VerifM.Env.agreeOn_mono hΔspec_persist hρ_agree)
             iintro ⟨Hsl, HQ⟩ Htyped''
-            iapply (checkBody_correct Θ S s γ Δ_spec ρ_spec hswf hSwf hΔwf hΔvars fb argBinders body argNames
-              hext bs rfl fval vs P hΔspec' hρspec' hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
+            iapply (checkBody_correct reg hSound Θ S s γ Δ_spec ρ_spec hswf hSwf hΔwf hΔvars fb argBinders body argNames
+              hext bs rfl fval vs P hΔspec' hρspec' hΔreg hρreg hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
             isplitl [Hsl]
             · iexact Hsl
             · isplitl [Htyped'']

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -1,0 +1,862 @@
+-- SUMMARY: Data model for verifier intrinsics, with generic theorems characterizing the effect of registry setup.
+import Mica.TinyML.OpSem
+import Mica.SeparationLogic.Axioms
+import Mica.Verifier.PredicateTransformers
+import Mica.Verifier.Specifications
+import Mica.FOL.Formulas
+
+open Iris Iris.BI
+
+/-! # Intrinsic framework
+
+A `Registry` is a list of intrinsics; the verifier derives from it the two
+total contexts that lower layers consume: `TinyML.PrimCtx` (OpSem) and
+`WpCtx` (separation logic). Each entry contributes one FOL symbol (or
+none), a list of FOL axioms, and the runtime/wp/spec facets of a built-in
+function.
+
+Theorems in this module are proved for *every possible registry*: induction
+on the list, with a per-intrinsic step that case-analyzes on arity and on
+whether a FOL symbol is present. No theorem mentions any particular
+intrinsic by name.
+-/
+
+/-! ## Arity and FOL symbols -/
+
+/-- Arity of an intrinsic. Extend as needed. -/
+inductive Arity
+  | zero
+  | one
+  | two
+  deriving DecidableEq, Repr
+
+/-- The shape of a tuple of `n` elements of type `α` indexed by an `Arity`. -/
+abbrev Arity.tup : Arity → Type → Type
+  | .zero, _ => Unit
+  | .one,  α => α
+  | .two,  α => α × α
+
+/-- A FOL symbol attached to an intrinsic: a function symbol of the given
+    arity at the value sort, together with its standard interpretation. -/
+structure FOL.Symbol (n : Arity) where
+  name   : String
+  interp : Arity.tup n (Srt.value).denote → (Srt.value).denote
+
+/-! ## Extending signatures and environments with an FOL symbol -/
+
+/-- Extend a signature with the FOL symbol from `s` (if any). -/
+def Signature.extendWithSym : ∀ {n : Arity}, Signature → Option (FOL.Symbol n) → Signature
+  | _,     Δ, none        => Δ
+  | .zero, Δ, some s      => Δ.addConst ⟨s.name, .value⟩
+  | .one,  Δ, some s      => Δ.addUnary ⟨s.name, .value, .value⟩
+  | .two,  Δ, some s      => Δ.addBinary ⟨s.name, .value, .value, .value⟩
+
+/-- Extending a signature is a subset extension. -/
+theorem Signature.subset_extendWithSym {n : Arity} (Δ : Signature)
+    (s : Option (FOL.Symbol n)) : Δ.Subset (Δ.extendWithSym s) := by
+  cases s with
+  | none => exact Signature.Subset.refl _
+  | some s' =>
+    cases n with
+    | zero => exact Signature.Subset.subset_addConst _ _
+    | one  => exact Signature.Subset.subset_addUnary _ _
+    | two  => exact Signature.Subset.subset_addBinary _ _
+
+@[simp] theorem Signature.extendWithSym_vars {n : Arity} (Δ : Signature)
+    (s : Option (FOL.Symbol n)) : (Δ.extendWithSym s).vars = Δ.vars := by
+  cases s with
+  | none => rfl
+  | some _ =>
+    cases n <;> rfl
+
+/-- `extendWithSym` is monotone in the base signature. -/
+theorem Signature.extendWithSym_mono {n : Arity} {Δ Δ' : Signature}
+    (h : Δ.Subset Δ') (s : Option (FOL.Symbol n)) :
+    (Δ.extendWithSym s).Subset (Δ'.extendWithSym s) := by
+  cases s with
+  | none => exact h
+  | some s' =>
+    cases n with
+    | zero =>
+      refine ⟨fun _ hx => h.vars _ hx,
+              fun c hc => ?_,
+              fun _ hu => h.unary _ hu,
+              fun _ hb => h.binary _ hb,
+              fun _ hu => h.unaryRel _ hu,
+              fun _ hb => h.binaryRel _ hb⟩
+      simp only [Signature.extendWithSym, Signature.addConst, List.mem_cons] at hc ⊢
+      exact hc.imp_right (h.consts _)
+    | one =>
+      refine ⟨fun _ hx => h.vars _ hx,
+              fun _ hc => h.consts _ hc,
+              fun u hu => ?_,
+              fun _ hb => h.binary _ hb,
+              fun _ hu => h.unaryRel _ hu,
+              fun _ hb => h.binaryRel _ hb⟩
+      simp only [Signature.extendWithSym, Signature.addUnary, List.mem_cons] at hu ⊢
+      exact hu.imp_right (h.unary _)
+    | two =>
+      refine ⟨fun _ hx => h.vars _ hx,
+              fun _ hc => h.consts _ hc,
+              fun _ hu => h.unary _ hu,
+              fun b hb => ?_,
+              fun _ hu => h.unaryRel _ hu,
+              fun _ hb => h.binaryRel _ hb⟩
+      simp only [Signature.extendWithSym, Signature.addBinary, List.mem_cons] at hb ⊢
+      exact hb.imp_right (h.binary _)
+
+/-- If the base signature and the symbol being added are already contained in
+    a target signature, extending the base with that symbol stays contained in
+    the target. -/
+theorem Signature.extendWithSym_subset_of_subset_of_sym {n : Arity} {Δ Δ' : Signature}
+    {s : Option (FOL.Symbol n)}
+    (hbase : Δ.Subset Δ')
+    (hsym : (Signature.empty.extendWithSym s).Subset Δ') :
+    (Δ.extendWithSym s).Subset Δ' := by
+  cases s with
+  | none => exact hbase
+  | some s' =>
+    cases n with
+    | zero =>
+      refine ⟨fun _ hx => hbase.vars _ hx,
+              fun c hc => ?_,
+              fun _ hu => hbase.unary _ hu,
+              fun _ hb => hbase.binary _ hb,
+              fun _ hu => hbase.unaryRel _ hu,
+              fun _ hb => hbase.binaryRel _ hb⟩
+      simp only [Signature.extendWithSym, Signature.addConst, List.mem_cons] at hc
+      cases hc with
+      | inl hc =>
+        subst hc
+        exact hsym.consts _ (by simp [Signature.extendWithSym, Signature.addConst])
+      | inr hc => exact hbase.consts _ hc
+    | one =>
+      refine ⟨fun _ hx => hbase.vars _ hx,
+              fun _ hc => hbase.consts _ hc,
+              fun u hu => ?_,
+              fun _ hb => hbase.binary _ hb,
+              fun _ hu => hbase.unaryRel _ hu,
+              fun _ hb => hbase.binaryRel _ hb⟩
+      simp only [Signature.extendWithSym, Signature.addUnary, List.mem_cons] at hu
+      cases hu with
+      | inl hu =>
+        subst hu
+        exact hsym.unary _ (by simp [Signature.extendWithSym, Signature.addUnary])
+      | inr hu => exact hbase.unary _ hu
+    | two =>
+      refine ⟨fun _ hx => hbase.vars _ hx,
+              fun _ hc => hbase.consts _ hc,
+              fun _ hu => hbase.unary _ hu,
+              fun b hb => ?_,
+              fun _ hu => hbase.unaryRel _ hu,
+              fun _ hb => hbase.binaryRel _ hb⟩
+      simp only [Signature.extendWithSym, Signature.addBinary, List.mem_cons] at hb
+      cases hb with
+      | inl hb =>
+        subst hb
+        exact hsym.binary _ (by simp [Signature.extendWithSym, Signature.addBinary])
+      | inr hb => exact hbase.binary _ hb
+
+/-- Extend an environment with the standard interpretation of `s` (if any). -/
+def Env.extendWithSym : ∀ {n : Arity}, Env → Option (FOL.Symbol n) → Env
+  | _,     ρ, none        => ρ
+  | .zero, ρ, some s      => ρ.updateConst .value s.name (s.interp ())
+  | .one,  ρ, some s      => ρ.updateUnary .value .value s.name s.interp
+  | .two,  ρ, some s      => ρ.updateBinary .value .value .value s.name
+                                            (fun a b => s.interp (a, b))
+
+/-- `ρ.respects s` says `ρ`'s entry at the value-sort/arity slot of `s` is
+    the standard interpretation of `s`. Vacuously true for `none`. -/
+def Env.respects : ∀ {n : Arity}, Env → Option (FOL.Symbol n) → Prop
+  | _,     _, none        => True
+  | .zero, ρ, some s      => ρ.lookupConst .value s.name = s.interp ()
+  | .one,  ρ, some s      => ρ.unary .value .value s.name = s.interp
+  | .two,  ρ, some s      => ρ.binary .value .value .value s.name
+                                = (fun a b => s.interp (a, b))
+
+/-- The post-extension environment respects the symbol it was extended with. -/
+theorem Env.respects_extendWithSym {n : Arity} (ρ : Env) (s : Option (FOL.Symbol n)) :
+    (ρ.extendWithSym s).respects s := by
+  cases s with
+  | none => trivial
+  | some s' =>
+    cases n with
+    | zero => simp [Env.respects, Env.extendWithSym, Env.lookupConst, Env.updateConst]
+    | one  => simp [Env.respects, Env.extendWithSym, Env.updateUnary]
+    | two  => simp [Env.respects, Env.extendWithSym, Env.updateBinary]
+
+/-- Respect for a symbol is preserved by moving to an environment that agrees
+    on a signature containing that symbol. -/
+theorem Env.respects_of_agreeOn_extendWithSym {n : Arity} {Δ : Signature}
+    {ρ ρ' : Env} {s : Option (FOL.Symbol n)}
+    (hrespects : ρ.respects s)
+    (hsub : (Signature.empty.extendWithSym s).Subset Δ)
+    (hagree : Env.agreeOn Δ ρ ρ') :
+    ρ'.respects s := by
+  cases s with
+  | none => trivial
+  | some s' =>
+    cases n with
+    | zero =>
+      have hmem : ⟨s'.name, .value⟩ ∈ Δ.consts :=
+        hsub.consts _ (by simp [Signature.extendWithSym, Signature.empty, Signature.addConst])
+      have heq := hagree.2.1 ⟨s'.name, .value⟩ hmem
+      simpa [Env.respects, Env.lookupConst] using heq.symm.trans hrespects
+    | one =>
+      have hmem : ⟨s'.name, .value, .value⟩ ∈ Δ.unary :=
+        hsub.unary _ (by simp [Signature.extendWithSym, Signature.empty, Signature.addUnary])
+      have heq := hagree.2.2.1 ⟨s'.name, .value, .value⟩ hmem
+      simpa [Env.respects] using heq.symm.trans hrespects
+    | two =>
+      have hmem : ⟨s'.name, .value, .value, .value⟩ ∈ Δ.binary :=
+        hsub.binary _ (by simp [Signature.extendWithSym, Signature.empty, Signature.addBinary])
+      have heq := hagree.2.2.2.1 ⟨s'.name, .value, .value, .value⟩ hmem
+      simpa [Env.respects] using heq.symm.trans hrespects
+
+/-! ## The intrinsic structure -/
+
+namespace Verifier
+
+/-- A single intrinsic: name, typing, runtime, separation-logic, and SMT
+    facets. The `name` field is the payload of the `Val.prim` constructor;
+    surface-level qualified paths are resolved to this string. -/
+structure Intrinsic where
+  arity    : Arity
+  name     : String
+  /-- Optional surface module path used by concrete stdlibs to build frontend resolvers. -/
+  path     : Option (String × List String)
+  reduce   : Arity.tup arity Runtime.Val → Runtime.Val → Prop
+  wp       : Arity.tup arity Runtime.Val → (Runtime.Val → iProp) → iProp
+  /-- The intrinsic's specification, the single source of its argument names/
+      types, return type, and predicate transformer. -/
+  spec     : Spec
+  folSym   : Option (FOL.Symbol arity)
+  axioms   : List Formula
+
+/-- A registry is a list of intrinsics. -/
+abbrev Registry := List Intrinsic
+
+namespace Intrinsic
+
+/-- Extending an environment with an intrinsic's fresh FOL symbol preserves
+    agreement on the prefix signature. -/
+theorem agreeOn_extend_fresh (i : Intrinsic) {Δ : Signature} (ρ : Env)
+    (hfresh : match i.folSym with | none => True | some sym => sym.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (ρ.extendWithSym i.folSym) := by
+  cases i with
+  | mk arity name path reduce wp spec folSym axioms =>
+    cases arity with
+    | zero =>
+      cases folSym with
+      | none => exact Env.agreeOn_refl
+      | some s =>
+        simpa [Env.extendWithSym] using
+          (Env.agreeOn_update_fresh_const (ρ := ρ) (c := ⟨s.name, .value⟩)
+            (u := s.interp ()) (Δ := Δ) hfresh)
+    | one =>
+      cases folSym with
+      | none => exact Env.agreeOn_refl
+      | some s =>
+        simpa [Env.extendWithSym] using
+          (Env.agreeOn_update_fresh_unary (ρ := ρ) (u := ⟨s.name, .value, .value⟩)
+            (f := s.interp) (Δ := Δ) hfresh)
+    | two =>
+      cases folSym with
+      | none => exact Env.agreeOn_refl
+      | some s =>
+        simpa [Env.extendWithSym] using
+          (Env.agreeOn_update_fresh_binary (ρ := ρ)
+            (b := ⟨s.name, .value, .value, .value⟩)
+            (f := fun a b => s.interp (a, b)) (Δ := Δ) hfresh)
+
+/-- The intrinsic's argument types, in left-to-right order. Read off the spec. -/
+def argTysList (i : Intrinsic) : List TinyML.Typ :=
+  i.spec.args.map Prod.snd
+
+/-- The intrinsic's result type. Read off the spec. -/
+def resultTy (i : Intrinsic) : TinyML.Typ :=
+  i.spec.retTy
+
+/-- Adapter from the list-shaped argument call (used by OpSem and `wp`) to
+    the arity-shaped representation. Out-of-shape calls produce the empty
+    relation. -/
+def toReduce (i : Intrinsic) :
+    List Runtime.Val → Runtime.Val → Prop :=
+  fun vs v =>
+    match i.arity, i.reduce, vs with
+    | .zero, r, []          => r () v
+    | .one,  r, [a]         => r a v
+    | .two,  r, [a, b]      => r (a, b) v
+    | _,     _, _           => False
+
+/-- Adapter from the list-shaped argument call to the arity-shaped `wp`
+    field. Out-of-shape calls produce `False`. -/
+def toWp (i : Intrinsic) :
+    List Runtime.Val → (Runtime.Val → iProp) → iProp :=
+  fun vs Q =>
+    match i.arity, i.wp, vs with
+    | .zero, w, []          => w () Q
+    | .one,  w, [a]         => w a Q
+    | .two,  w, [a, b]      => w (a, b) Q
+    | _,     _, _           => iprop(False)
+
+/-- Unfolding lemma for `toWp` at arity-two, two args. The intrinsic's
+    `arity` field is destructured explicitly so that the dependent `wp`
+    field's match reduces. -/
+theorem toWp_two_of_arity (name : String)
+    (path : Option (String × List String))
+    (reduce : Arity.tup .two Runtime.Val → Runtime.Val → Prop)
+    (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
+    (spec : Spec) (folSym : Option (FOL.Symbol .two)) (axioms : List Formula)
+    (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
+    (Intrinsic.mk .two name path reduce wp spec folSym axioms).toWp [a, b] Q
+      = wp (a, b) Q := rfl
+
+/-- Unfolding lemma for `toWp` at arity-one, one arg. -/
+theorem toWp_one_of_arity (name : String)
+    (path : Option (String × List String))
+    (reduce : Arity.tup .one Runtime.Val → Runtime.Val → Prop)
+    (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
+    (spec : Spec) (folSym : Option (FOL.Symbol .one)) (axioms : List Formula)
+    (a : Runtime.Val) (Q : Runtime.Val → iProp) :
+    (Intrinsic.mk .one name path reduce wp spec folSym axioms).toWp [a] Q
+      = wp a Q := rfl
+
+/-- Unfolding lemma for `toWp` at arity-zero, no args. -/
+theorem toWp_zero_of_arity (name : String)
+    (path : Option (String × List String))
+    (reduce : Arity.tup .zero Runtime.Val → Runtime.Val → Prop)
+    (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
+    (spec : Spec) (folSym : Option (FOL.Symbol .zero)) (axioms : List Formula)
+    (Q : Runtime.Val → iProp) :
+    (Intrinsic.mk .zero name path reduce wp spec folSym axioms).toWp [] Q
+      = wp () Q := rfl
+
+/-- Fold a registry fragment's FOL symbols into a starting signature. The
+    general fold underlying `sigOf` and the registry-derived signatures. -/
+def foldSig (Δ : Signature) : List Intrinsic → Signature
+  | []        => Δ
+  | i :: rest => foldSig (Δ.extendWithSym i.folSym) rest
+
+/-- The FOL signature intrinsic axioms are expressed in: the empty signature
+    extended with the FOL symbols of a registry fragment. The fragment may
+    include the intrinsic whose axioms are being checked. -/
+def sigOf (fragment : List Intrinsic) : Signature :=
+  foldSig Signature.empty fragment
+
+/-! ### Spec→wp bridge
+
+`compile` routes a `.prim n args` call through `Spec.call` against the
+intrinsic's spec. The resulting `PredTrans.apply` obligation must be bridged
+to the `i.toWp` iProp consumed by the registry-derived `wp.prim` axiom. The
+bridge is one of the per-intrinsic obligations captured by `IntrinsicSound`
+below. The aggregate over the registry is the def `Registry.Sound`. -/
+
+/-- Argument list for the spec view: the spec's own argument names paired with
+    their types. -/
+def specArgs (i : Intrinsic) : List (String × TinyML.Typ) :=
+  i.spec.args
+
+end Intrinsic
+
+/-- Per-intrinsic soundness obligation, discharged together for each intrinsic
+    and aggregated over a registry by `Registry.Sound`. It bundles the two
+    spec→wp bridge facts (`specWf`, `bridge`) with the two axiom facts
+    (`axiomWf`, `proof`).
+
+    `specWf`/`bridge` are independent of `fragment`: from a `PredTrans.apply`
+    obligation against `i.spec` (the shape produced by `Spec.call_correct`) and
+    the typing of the arguments, `bridge` derives `i.toWp` — the iProp the
+    `wp.prim` axiom demands of the registry-derived context. Both take the
+    symbol's declaration / interpretation as an explicit side condition: `i.spec`
+    may mention `i.folSym`, so it is only well-formed in a signature declaring
+    that symbol, and the bridge only holds when the environment interprets the
+    symbol by its standard interpretation. These side conditions are discharged
+    by the caller from the registry-derived signature/environment.
+
+    `axiomWf`/`proof` are stated against the dependency `fragment`: each axiom is
+    well-formed in the signature supplied by the fragment, and is satisfied by
+    every environment that respects every FOL symbol in the fragment. -/
+class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Prop where
+  specWf :
+    ∀ (Δ : Signature), (Signature.empty.extendWithSym i.folSym).Subset Δ → Δ.wf →
+      PredTrans.wfIn (Δ.declVars (Spec.argVars i.specArgs)) i.spec.pred
+  bridge :
+    ∀ (Θ : TinyML.TypeEnv) (vs : List Runtime.Val) (ρ : VerifM.Env)
+      (Φ : Runtime.Val → iProp),
+    ρ.env.respects i.folSym →
+    TinyML.ValsHaveTypes Θ vs i.argTysList ∗
+      PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r i.resultTy -∗ Φ r) i.spec.pred
+        (Spec.argsEnv ρ i.specArgs vs) ⊢ i.toWp vs Φ
+  axiomWf : ∀ {Δ : Signature}, (Intrinsic.sigOf fragment).Subset Δ → Δ.wf →
+            ∀ φ ∈ i.axioms, Formula.wfIn φ Δ
+  proof : ∀ ρ : Env,
+            (∀ d ∈ fragment, ρ.respects d.folSym) →
+            ∀ φ ∈ i.axioms, Formula.eval ρ φ
+
+namespace Registry
+
+/-- Resolve a name to its intrinsic: the first registry entry whose `name`
+    matches. The single lookup shared by the operational-semantics and `wp`
+    contexts, so the two agree on which entry a name selects. -/
+def lookup? (R : Registry) (n : String) : Option Intrinsic :=
+  R.find? (·.name == n)
+
+theorem mem_of_lookup? {R : Registry} {n : String} {i : Intrinsic}
+    (h : R.lookup? n = some i) : i ∈ R :=
+  List.mem_of_find?_eq_some h
+
+/-- Build the operational-semantics context from a registry. -/
+def primCtx (R : Registry) : TinyML.PrimCtx :=
+  fun n vs v =>
+    match R.lookup? n with
+    | some i => i.toReduce vs v
+    | none   => False
+
+/-- Build the `wp` context from a registry. Names not in `R` map to the
+    `False` iProp. -/
+def wpCtx (R : Registry) : WpCtx :=
+  fun n vs Q =>
+    match R.lookup? n with
+    | some i => i.toWp vs Q
+    | none   => iprop(False)
+
+/-- The aggregated FOL environment: each intrinsic's FOL symbol receives
+    its standard interpretation. -/
+def stdEnv (R : Registry) : Env :=
+  R.foldl (fun ρ i => ρ.extendWithSym i.folSym) Env.empty
+
+/-- Extend an arbitrary base environment with a registry. -/
+def foldEnv (ρ : Env) (R : Registry) : Env :=
+  R.foldl (fun ρ i => ρ.extendWithSym i.folSym) ρ
+
+/-- A target signature contains every FOL symbol contributed by a registry. -/
+def symSubset (R : Registry) (Δ : Signature) : Prop :=
+  ∀ i ∈ R, (Signature.empty.extendWithSym i.folSym).Subset Δ
+
+/-- An environment gives every registry FOL symbol its standard interpretation. -/
+def symAgree (R : Registry) (ρ : Env) : Prop :=
+  ∀ i ∈ R, ρ.respects i.folSym
+
+/-- Folding intrinsic symbols into a larger starting signature gives a larger
+    final signature. -/
+theorem foldSig_mono (R : Registry) {Δ Δ' : Signature} (h : Δ.Subset Δ') :
+    (Intrinsic.foldSig Δ R).Subset (Intrinsic.foldSig Δ' R) := by
+  induction R generalizing Δ Δ' with
+  | nil => exact h
+  | cons i rest ih =>
+    exact ih (Signature.extendWithSym_mono h _)
+
+/-- Folding intrinsic symbols preserves the starting signature as a subset. -/
+theorem subset_foldSig (R : Registry) (Δ : Signature) :
+    Δ.Subset (Intrinsic.foldSig Δ R) := by
+  induction R generalizing Δ with
+  | nil => exact Signature.Subset.refl _
+  | cons i rest ih =>
+    exact (Signature.subset_extendWithSym Δ i.folSym).trans (ih _)
+
+/-- The signature for a registry contains the FOL symbol of every member,
+    independent of where that member appears in the list. -/
+theorem extendWithSym_subset_sigOf_of_mem {R : Registry} {i : Intrinsic}
+    (hi : i ∈ R) :
+    (Signature.empty.extendWithSym i.folSym).Subset (Intrinsic.sigOf R) := by
+  induction R with
+  | nil => cases hi
+  | cons j rest ih =>
+    cases hi with
+    | head =>
+      exact subset_foldSig rest (Signature.empty.extendWithSym i.folSym)
+    | tail _ hmem =>
+      exact (ih hmem).trans
+        (foldSig_mono rest (Signature.empty_subset (Signature.empty.extendWithSym j.folSym)))
+
+/-- Registry-fragment signatures are monotone with respect to membership
+    inclusion, not list order. -/
+theorem sigOf_subset_of_subset {deps R : Registry} (hsub : deps ⊆ R) :
+    (Intrinsic.sigOf deps).Subset (Intrinsic.sigOf R) := by
+  suffices h :
+      ∀ (todo : Registry) (Δ : Signature),
+        Δ.Subset (Intrinsic.sigOf R) →
+        (∀ i ∈ todo, i ∈ R) →
+        (Intrinsic.foldSig Δ todo).Subset (Intrinsic.sigOf R) by
+    exact h deps Signature.empty (Signature.empty_subset _) hsub
+  intro todo
+  induction todo with
+  | nil =>
+    intro Δ hΔ _
+    exact hΔ
+  | cons i rest ih =>
+    intro Δ hΔ hmem
+    apply ih
+    · exact Signature.extendWithSym_subset_of_subset_of_sym hΔ
+        (extendWithSym_subset_sigOf_of_mem (hmem i (by simp)))
+    · intro d hd
+      exact hmem d (List.mem_cons_of_mem _ hd)
+
+/-- Registry well-formedness relative to an existing signature: each FOL
+    symbol is fresh for the prefix signature before it is added. -/
+def WfFrom : Signature → Registry → Prop
+  | _, [] => True
+  | Δ, i :: rest =>
+      (match i.folSym with | none => True | some sym => sym.name ∉ Δ.allNames) ∧
+      WfFrom (Δ.extendWithSym i.folSym) rest
+
+abbrev Wf (R : Registry) : Prop := WfFrom Signature.empty R
+
+/-- Every intrinsic in `todo` is sound against the full registry fragment `R`. -/
+def SoundIn (R : Registry) : Registry → Prop
+  | [] => True
+  | i :: rest => IntrinsicSound R i ∧ SoundIn R rest
+
+abbrev Sound (R : Registry) : Prop := SoundIn R R
+
+/-- Recover a member's soundness obligation from the aggregate, stated against
+    the full fragment `R`. -/
+theorem SoundIn.get {R todo : Registry} (h : SoundIn R todo) :
+    ∀ i ∈ todo, IntrinsicSound R i := by
+  induction todo with
+  | nil => intro _ hi; cases hi
+  | cons j rest ih =>
+    rcases h with ⟨hj, hrest⟩
+    intro i hi
+    cases hi with
+    | head => exact hj
+    | tail _ hmem => exact ih hrest i hmem
+
+/-- Recover a member's soundness obligation from a sound registry. -/
+theorem Sound.get {R : Registry} (h : Sound R) {i : Intrinsic} (hi : i ∈ R) :
+    IntrinsicSound R i := SoundIn.get h i hi
+
+theorem stdEnv_eq_foldEnv (R : Registry) : stdEnv R = foldEnv Env.empty R := rfl
+
+/-- Folding a well-formed registry into an environment preserves agreement
+    on the starting signature. -/
+theorem foldEnv_agreeOn_base {Δ : Signature} {R : Registry} (ρ : Env)
+    (hWf : WfFrom Δ R) :
+    Env.agreeOn Δ ρ (foldEnv ρ R) := by
+  induction R generalizing Δ ρ with
+  | nil =>
+    exact Env.agreeOn_refl
+  | cons i rest ih =>
+    rcases hWf with ⟨hfresh, hrest⟩
+    simp only [foldEnv, List.foldl_cons]
+    have hstep : Env.agreeOn Δ ρ (ρ.extendWithSym i.folSym) :=
+      i.agreeOn_extend_fresh ρ hfresh
+    have htail : Env.agreeOn (Δ.extendWithSym i.folSym)
+        (ρ.extendWithSym i.folSym) (foldEnv (ρ.extendWithSym i.folSym) rest) :=
+      ih (ρ := ρ.extendWithSym i.folSym) hrest
+    exact Env.agreeOn_trans hstep
+      (Env.agreeOn_mono (Signature.subset_extendWithSym Δ i.folSym) htail)
+
+/-- Folding a well-formed registry makes the final environment respect every
+    symbol introduced by the registry. -/
+theorem foldEnv_respects {Δ : Signature} {R : Registry} (ρ : Env)
+    (hWf : WfFrom Δ R) :
+    ∀ i ∈ R, (foldEnv ρ R).respects i.folSym := by
+  induction R generalizing Δ ρ with
+  | nil =>
+    intro i hi; cases hi
+  | cons i rest ih =>
+    rcases hWf with ⟨hfresh, hrest⟩
+    intro j hj
+    simp only [foldEnv, List.foldl_cons]
+    cases hj with
+    | head =>
+      have hrespects : (ρ.extendWithSym i.folSym).respects i.folSym :=
+        Env.respects_extendWithSym ρ i.folSym
+      refine Env.respects_of_agreeOn_extendWithSym (Δ := Δ.extendWithSym i.folSym) hrespects ?_ ?_
+      · exact Signature.extendWithSym_mono (Signature.empty_subset _) _
+      · exact foldEnv_agreeOn_base (ρ.extendWithSym i.folSym) hrest
+    | tail _ hjrest =>
+      exact ih (ρ := ρ.extendWithSym i.folSym) hrest j hjrest
+
+theorem stdEnv_respects {R : Registry} (hWf : Wf R) :
+    ∀ i ∈ R, (stdEnv R).respects i.folSym := by
+  simpa [stdEnv_eq_foldEnv] using foldEnv_respects (Δ := Signature.empty) Env.empty hWf
+
+/-- Generic registry axiom satisfaction: if the registry is sound by subset,
+    and the chosen environment respects every registered symbol, then every
+    registered axiom evaluates to true in that environment. -/
+theorem satisfies_of_respects {R : Registry}
+    (hSound : Sound R)
+    (hRespect : ∀ i ∈ R, ρ.respects i.folSym) :
+    ∀ i ∈ R, ∀ φ ∈ i.axioms, Formula.eval ρ φ := by
+  suffices h :
+      ∀ todo, SoundIn R todo →
+        ∀ i ∈ todo, ∀ φ ∈ i.axioms, Formula.eval ρ φ by
+    exact h R hSound
+  intro todo
+  induction todo with
+  | nil =>
+    intro _ i hi
+    cases hi
+  | cons i rest ih =>
+    intro hSoundIn
+    rcases hSoundIn with ⟨hiSound, hrestSound⟩
+    intro j hj
+    cases hj with
+    | head =>
+      intro φ hφ
+      exact hiSound.proof ρ (fun d hd => hRespect d hd) φ hφ
+    | tail _ hjrest =>
+      intro φ hφ
+      exact ih hrestSound j hjrest φ hφ
+
+theorem stdEnv_satisfies {R : Registry} (hSound : Sound R) (hWf : Wf R) :
+    ∀ i ∈ R, ∀ φ ∈ i.axioms, Formula.eval (stdEnv R) φ :=
+  satisfies_of_respects hSound (stdEnv_respects hWf)
+
+end Registry
+
+/-- Intrinsic soundness is monotone in the dependency fragment: once an
+    intrinsic is sound against the symbols it actually needs, it is sound
+    against any larger fragment containing those dependencies. -/
+theorem IntrinsicSound.mono {deps deps' : Registry} {i : Intrinsic}
+    (h : IntrinsicSound deps i) (hsub : deps ⊆ deps') :
+    IntrinsicSound deps' i where
+  specWf := h.specWf
+  bridge := h.bridge
+  axiomWf := by
+    intro Δ hsig hwf φ hφ
+    exact h.axiomWf ((Registry.sigOf_subset_of_subset hsub).trans hsig) hwf φ hφ
+  proof := by
+    intro ρ hdeps' φ hφ
+    exact h.proof ρ (fun d hd => hdeps' d (hsub hd)) φ hφ
+
+/-! ## SMT setup loop -/
+
+namespace Intrinsic
+
+/-- Declare this intrinsic's FOL symbol (if any) into the verifier. -/
+def declFOLSym (i : Intrinsic) : VerifM Unit :=
+  match i.arity, i.folSym with
+  | _,     none   => pure ()
+  | .zero, some s => VerifM.declConstExact ⟨s.name, .value⟩
+  | .one,  some s => VerifM.declUnaryExact ⟨s.name, .value, .value⟩
+  | .two,  some s => VerifM.declBinaryExact ⟨s.name, .value, .value, .value⟩
+
+end Intrinsic
+
+namespace Registry
+
+/-- Declare every registered intrinsic's FOL symbol. -/
+def declFOLSyms : Registry → VerifM Unit
+  | []         => pure ()
+  | i :: rest  => do i.declFOLSym; declFOLSyms rest
+
+/-- Assume every registered intrinsic axiom. -/
+def assumeAxioms : Registry → VerifM Unit
+  | []         => pure ()
+  | i :: rest  => do VerifM.assumeAll i.axioms; assumeAxioms rest
+
+/-- Declare all registered intrinsic FOL symbols first, then assume all
+    intrinsic axioms. This keeps axiom validity independent of registry order:
+    axioms may mention any symbol in the registry, not just earlier entries. -/
+def introduceRegistry (R : Registry) : VerifM Unit := do
+  declFOLSyms R
+  assumeAxioms R
+
+end Registry
+
+/-! ## Generic theorems for any registry
+
+Proved by induction on the list and case-analysis on arity. No specific
+intrinsic is named. -/
+
+namespace Intrinsic
+
+/-- Effect of `declFOLSym`: extends the signature with `i`'s FOL symbol,
+    leaves owns and asserts untouched, and produces a post-decl environment
+    that respects `i.folSym` (when present), agreeing with the original on
+    the original signature. -/
+theorem eval_declFOLSym (i : Intrinsic) {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (heval : VerifM.eval i.declFOLSym st ρ Q) :
+    ∃ ρ' : VerifM.Env,
+      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      ρ'.env.respects i.folSym ∧
+      Q () { st with decls := st.decls.extendWithSym i.folSym } ρ' := by
+  cases i with
+  | mk arity name path reduce wp spec folSym axioms =>
+    cases arity with
+    | zero =>
+      cases folSym with
+      | none =>
+        simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
+        refine ⟨ρ, VerifM.Env.agreeOn_refl, by simp [Env.respects], ?_⟩
+        exact VerifM.eval_ret heval
+      | some s =>
+        simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
+        obtain ⟨hfresh, hcont⟩ := VerifM.eval_declConstExact heval
+        refine ⟨ρ.updateConst .value s.name (s.interp ()),
+                VerifM.Env.agreeOn_update_fresh (c := ⟨s.name, .value⟩) hfresh,
+                ?_, ?_⟩
+        · simp [Env.respects, VerifM.Env.updateConst, Env.lookupConst, Env.updateConst]
+        · exact hcont (s.interp ())
+    | one =>
+      cases folSym with
+      | none =>
+        simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
+        refine ⟨ρ, VerifM.Env.agreeOn_refl, by simp [Env.respects], ?_⟩
+        exact VerifM.eval_ret heval
+      | some s =>
+        simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
+        obtain ⟨hfresh, hcont⟩ := VerifM.eval_declUnaryExact heval
+        refine ⟨ρ.updateUnary .value .value s.name s.interp,
+                VerifM.Env.agreeOn_update_fresh_unary (u := ⟨s.name, .value, .value⟩) hfresh,
+                ?_, ?_⟩
+        · simp [Env.respects, VerifM.Env.updateUnary, Env.updateUnary]
+        · exact hcont s.interp
+    | two =>
+      cases folSym with
+      | none =>
+        simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
+        refine ⟨ρ, VerifM.Env.agreeOn_refl, by simp [Env.respects], ?_⟩
+        exact VerifM.eval_ret heval
+      | some s =>
+        simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
+        obtain ⟨hfresh, hcont⟩ := VerifM.eval_declBinaryExact heval
+        refine ⟨ρ.updateBinary .value .value .value s.name (fun a b => s.interp (a, b)),
+                VerifM.Env.agreeOn_update_fresh_binary (b := ⟨s.name, .value, .value, .value⟩) hfresh,
+                ?_, ?_⟩
+        · simp [Env.respects, VerifM.Env.updateBinary, Env.updateBinary]
+        · exact hcont (fun a b => s.interp (a, b))
+
+end Intrinsic
+
+namespace Registry
+
+/-- Effect of the declaration pass on a registry. It declares every registered
+    FOL symbol before any intrinsic axiom is assumed. -/
+theorem eval_declFOLSyms (R : Registry)
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (heval : VerifM.eval (declFOLSyms R) st ρ Q) :
+    ∃ st' ρ',
+      st.decls.Subset st'.decls ∧
+      (Intrinsic.foldSig st.decls R).Subset st'.decls ∧
+      st'.decls.vars = st.decls.vars ∧
+      st'.owns = st.owns ∧
+      st'.asserts = st.asserts ∧
+      (∀ ρ'' : VerifM.Env, VerifM.Env.agreeOn st'.decls ρ' ρ'' →
+        ∀ d ∈ R, ρ''.env.respects d.folSym) ∧
+      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      Q () st' ρ' := by
+  induction R generalizing st ρ Q with
+  | nil =>
+    simp only [declFOLSyms] at heval
+    refine ⟨st, ρ, Signature.Subset.refl _, ?_, rfl, rfl, rfl, ?_,
+            VerifM.Env.agreeOn_refl, VerifM.eval_ret heval⟩
+    · exact Signature.Subset.refl _
+    · intro _ _ d hd
+      cases hd
+  | cons i rest ih =>
+    simp only [declFOLSyms] at heval
+    have h1 := VerifM.eval_bind _ _ _ _ heval
+    obtain ⟨ρ1, hag1, hiRespect, hcont⟩ := Intrinsic.eval_declFOLSym i h1
+    set st1 : TransState := { st with decls := st.decls.extendWithSym i.folSym }
+    obtain ⟨st', ρ', hsub2, hdep2, hvars2, howns2, hass2, hrestStable, hag2, hQ⟩ :=
+      ih hcont
+    have hsub1 : st.decls.Subset st1.decls := Signature.subset_extendWithSym _ _
+    have hiStable :
+        ∀ ρ'' : VerifM.Env, VerifM.Env.agreeOn st'.decls ρ' ρ'' →
+          ρ''.env.respects i.folSym := by
+      intro ρ'' hag
+      refine Env.respects_of_agreeOn_extendWithSym (Δ := st1.decls) hiRespect ?_ ?_
+      · exact Signature.extendWithSym_mono (Signature.empty_subset _) _
+      · exact VerifM.Env.agreeOn_trans hag2 (VerifM.Env.agreeOn_mono hsub2 hag)
+    have hvars1 : st1.decls.vars = st.decls.vars := by
+      simp [st1]
+    refine ⟨st', ρ', hsub1.trans hsub2, ?_, hvars2.trans hvars1, howns2, hass2, ?_,
+            VerifM.Env.agreeOn_trans hag1 (VerifM.Env.agreeOn_mono hsub1 hag2), hQ⟩
+    · exact hdep2
+    · intro ρ'' hag d hd
+      cases hd with
+      | head => exact hiStable ρ'' hag
+      | tail _ hmem => exact hrestStable ρ'' hag d hmem
+
+/-- Effect of the axiom-assumption pass. Each intrinsic is checked against the
+    full registry fragment, so axiom dependencies need not follow list order. -/
+theorem eval_assumeAxioms_in (full todo : Registry)
+    (hSound : SoundIn full todo)
+    {st : TransState} {ρ : VerifM.Env}
+    (hSig : (Intrinsic.sigOf full).Subset st.decls)
+    (hRespect :
+      ∀ ρ' : VerifM.Env, VerifM.Env.agreeOn st.decls ρ ρ' →
+        ∀ d ∈ full, ρ'.env.respects d.folSym)
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (heval : VerifM.eval (assumeAxioms todo) st ρ Q) :
+    ∃ st',
+      st'.decls = st.decls ∧
+      st'.owns = st.owns ∧
+      (∃ extra, st'.asserts = extra ++ st.asserts) ∧
+      Q () st' ρ := by
+  induction todo generalizing st Q with
+  | nil =>
+    simp only [assumeAxioms] at heval
+    refine ⟨st, rfl, rfl, ⟨[], by simp⟩, VerifM.eval_ret heval⟩
+  | cons i rest ih =>
+    simp only [assumeAxioms] at heval
+    have h1 := VerifM.eval_bind _ _ _ _ heval
+    rcases hSound with ⟨hiSound, hrestSound⟩
+    have hwfAxioms : ∀ φ ∈ i.axioms, φ.wfIn st.decls := fun φ hφ =>
+      hiSound.axiomWf hSig (VerifM.eval.wf h1).namesDisjoint φ hφ
+    have hevalAxioms : ∀ φ ∈ i.axioms, φ.eval ρ.env :=
+      hiSound.proof ρ.env (fun d hd => hRespect ρ VerifM.Env.agreeOn_refl d hd)
+    obtain ⟨st1, hdecls1, howns1, hass1, hcont⟩ :=
+      VerifM.eval_assumeAll h1 hwfAxioms hevalAxioms
+    have hSig1 : (Intrinsic.sigOf full).Subset st1.decls := by
+      rw [hdecls1]
+      exact hSig
+    have hRespect1 :
+        ∀ ρ' : VerifM.Env, VerifM.Env.agreeOn st1.decls ρ ρ' →
+          ∀ d ∈ full, ρ'.env.respects d.folSym := by
+      intro ρ' hag d hd
+      exact hRespect ρ' (by rwa [hdecls1] at hag) d hd
+    obtain ⟨st', hdecls2, howns2, ⟨extra2, hass2⟩, hQ⟩ :=
+      ih hrestSound hSig1 hRespect1 hcont
+    refine ⟨st', hdecls2.trans hdecls1, howns2.trans howns1,
+            ⟨extra2 ++ i.axioms.reverse, ?_⟩, hQ⟩
+    rw [hass2, hass1, List.append_assoc]
+
+/-- Effect of `introduceRegistry` on a whole registry. All symbols are declared
+    first; all axioms are assumed afterward against the full registry
+    signature. -/
+theorem eval_introduceRegistry (R : Registry)
+    (hSound : Sound R)
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (heval : VerifM.eval (introduceRegistry R) st ρ Q) :
+    ∃ st' ρ',
+      st.decls.Subset st'.decls ∧
+      (Intrinsic.sigOf R).Subset st'.decls ∧
+      st'.decls.vars = st.decls.vars ∧
+      st'.owns = st.owns ∧
+      (∃ extra, st'.asserts = extra ++ st.asserts) ∧
+      (∀ ρ'' : VerifM.Env, VerifM.Env.agreeOn st'.decls ρ' ρ'' →
+        ∀ d ∈ R, ρ''.env.respects d.folSym) ∧
+      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      Q () st' ρ' := by
+  unfold introduceRegistry at heval
+  have hdecls := VerifM.eval_bind _ _ _ _ heval
+  obtain ⟨st1, ρ1, hsub1, hfold1, hvars1, howns1, hass1, hstable, hag1, hcont⟩ :=
+    eval_declFOLSyms R hdecls
+  have hsig1 : (Intrinsic.sigOf R).Subset st1.decls := by
+    exact (foldSig_mono R (Signature.empty_subset st.decls)).trans hfold1
+  obtain ⟨st', hdecls2, howns2, ⟨extra, hass2⟩, hQ⟩ :=
+    eval_assumeAxioms_in R R hSound hsig1 hstable hcont
+  refine ⟨st', ρ1, ?_, ?_, ?_, howns2.trans howns1, ?_, ?_, hag1, hQ⟩
+  · rw [hdecls2]
+    exact hsub1
+  · rw [hdecls2]
+    exact hsig1
+  · rw [hdecls2]
+    exact hvars1
+  · refine ⟨extra, ?_⟩
+    rw [hass2, hass1]
+  · intro ρ'' hag d hd
+    exact hstable ρ'' (by rwa [hdecls2] at hag) d hd
+
+end Registry
+
+end Verifier

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -81,6 +81,11 @@ def VerifM.expectSome (msg : String) (x : Option α) : VerifM α := do
   | some x => pure x
   | none => VerifM.fatal msg
 
+/-- Declare a constant with a specific name, failing if a different name was assigned. -/
+def VerifM.declConstExact (c : FOL.Const) : VerifM Unit := do
+  let c' ← VerifM.decl (some c.name) c.sort
+  VerifM.expectEq "declConstExact" c'.name c.name
+
 /-- Declare a unary relation with a specific name, failing if a different name was assigned. -/
 def VerifM.declUnaryRelExact (u : FOL.UnaryRel) : VerifM Unit := do
   let u' ← VerifM.declUnaryRel (some u.name) u.arg
@@ -745,6 +750,27 @@ theorem VerifM.eval_expectSome
     simp [hx] at h
     exact ⟨y, rfl, VerifM.eval_ret h⟩
 
+theorem VerifM.eval_declConstExact {c : FOL.Const} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (VerifM.declConstExact c) st ρ Q) :
+    c.name ∉ st.decls.allNames ∧
+    ∀ v, Q () { st with decls := st.decls.addConst c } (ρ.updateConst c.sort c.name v) := by
+  simp only [VerifM.declConstExact] at h
+  have hbind := VerifM.eval_decl (VerifM.eval_bind _ _ _ _ h)
+  have hname : Fresh.freshNumbers c.name st.decls.allNames = c.name := by
+    have hcont0 := hbind default
+    obtain ⟨heq, _⟩ := VerifM.eval_expectEq hcont0
+    simpa using heq
+  refine ⟨?_, ?_⟩
+  · have := st.freshConst_fresh (some c.name) c.sort
+    simpa [TransState.freshConst, hname] using this
+  · intro v
+    obtain ⟨_, hq⟩ := VerifM.eval_expectEq (hbind v)
+    have hceq : st.freshConst (some c.name) c.sort = c := by
+      cases c; simp [TransState.freshConst, hname]
+    rw [hceq] at hq
+    exact hq
+
 theorem VerifM.eval_declUnaryRelExact {u : FOL.UnaryRel} {st : TransState} {ρ : VerifM.Env}
     {Q : Unit → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.declUnaryRelExact u) st ρ Q) :
@@ -893,12 +919,13 @@ theorem VerifM.eval_assumeAll {φs : List Formula}
     (h : VerifM.eval (VerifM.assumeAll φs) st ρ P) :
     (∀ φ ∈ φs, φ.wfIn st.decls) →
     (∀ φ ∈ φs, φ.eval ρ.env) →
-    ∃ st', st'.decls = st.decls ∧ st'.owns = st.owns ∧ P () st' ρ := by
+    ∃ st', st'.decls = st.decls ∧ st'.owns = st.owns ∧
+           st'.asserts = φs.reverse ++ st.asserts ∧ P () st' ρ := by
   induction φs generalizing st with
   | nil =>
     intro _ _
     simp only [VerifM.assumeAll] at h
-    exact ⟨st, rfl, rfl, VerifM.eval_ret h⟩
+    exact ⟨st, rfl, rfl, by simp, VerifM.eval_ret h⟩
   | cons φ φs ih =>
     intro hwf heval
     simp only [VerifM.assumeAll] at h
@@ -907,10 +934,11 @@ theorem VerifM.eval_assumeAll {φs : List Formula}
     have hcont := hassume
       (hwf φ (List.mem_cons_self ..))
       (heval φ (List.mem_cons_self ..))
-    obtain ⟨st', hst', howns, hp⟩ := ih hcont
+    obtain ⟨st', hst', howns, hass, hp⟩ := ih hcont
       (fun ψ hψ => hwf ψ (List.mem_cons_of_mem _ hψ))
       (fun ψ hψ => heval ψ (List.mem_cons_of_mem _ hψ))
-    exact ⟨st', by rw [hst'], by rw [howns], hp⟩
+    refine ⟨st', by rw [hst'], by rw [howns], ?_, hp⟩
+    rw [hass]; simp [List.reverse_cons, List.append_assoc]
 
 
 /-! ### Top-level corollary -/

--- a/Mica/Verifier/OUTLINE.md
+++ b/Mica/Verifier/OUTLINE.md
@@ -5,6 +5,7 @@
 - `Bindings.lean` — Verifier variable-to-constant bindings, their semantic linkage to runtime substitutions, and typing/lookup lemmas.
 - `Expressions.lean` — Compilation of typed TinyML expressions into verifier terms, with weakest-precondition correctness proofs.
 - `Functions.lean` — Verification of function bodies against specifications, including the soundness of specification checking.
+- `Intrinsic.lean` — Data model for verifier intrinsics, with generic theorems characterizing the effect of registry setup.
 - `Monad.lean` — Verification monad with SMT operations, branching, and its operational and semantic correctness interfaces.
 - `PredicateTransformers.lean` — Predicate transformers for function specifications, together with their semantics and call and implementation protocols.
 - `Programs.lean` — End-to-end preparation and verification of programs, from typed elaboration to program-level soundness.

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -9,14 +9,15 @@ import Mica.Verifier.RelationalEncoding
 import Mica.Verifier.PredicateTransformers
 import Mica.Verifier.Specifications
 import Mica.Engine.Driver
+import Mica.Verifier.Intrinsic
 
 open Iris Iris.BI
 open Typed
 open Verifier.RelationalEncoding (FunCtx)
 
-private def parseSpec (Γfn : FunCtx) (cb : (Spec.Body Typed.Expr)) :
+private def parseSpec (reg : Verifier.Registry) (Γfn : FunCtx) (cb : (Spec.Body Typed.Expr)) :
     Except String SpecPredicate :=
-  SpecTranslation.translate Γfn cb
+  SpecTranslation.translate (Verifier.Intrinsic.sigOf reg) Γfn cb
 
 /-- Extract typed argument names from a function's argument list. -/
 private def extractArgs : List Binder → List String → Except String (List (String × TinyML.Typ))
@@ -145,8 +146,9 @@ private def assembleFrom : RelationSpec → Typed.Program (Spec.Body Typed.Expr)
       assembleFrom acc' ds
 
 /-- Assemble the global relation signature and function-name map for a typed program. -/
-def assemble (prog : Typed.Program (Spec.Body Typed.Expr)) : VerifM RelationSpec :=
-  assembleFrom RelationSpec.empty prog
+def assemble (prog : Typed.Program (Spec.Body Typed.Expr)) : VerifM RelationSpec := do
+  let Δ ← VerifM.ctx (fun st => (st.decls, st.owns))
+  assembleFrom { RelationSpec.empty with delta := Δ } prog
 
 private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr)) :
     ∀ (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
@@ -161,12 +163,14 @@ private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr
       VerifM.eval (assembleFrom acc prog) st ρ Q →
       ∃ result stRel ρRel,
         stRel.decls.vars = [] ∧ stRel.owns = [] ∧
+        st.decls.Subset stRel.decls ∧ VerifM.Env.agreeOn st.decls ρ ρRel ∧
         result.delta = stRel.decls ∧ Q result stRel ρRel := by
   induction prog with
   | nil =>
     intro acc st ρ Q hacc howns hvars _ _ _ _ heval
     simp only [assembleFrom] at heval
-    exact ⟨acc, st, ρ, hvars, howns, hacc, VerifM.eval_ret heval⟩
+    exact ⟨acc, st, ρ, hvars, howns, Signature.Subset.refl _, VerifM.Env.agreeOn_refl,
+      hacc, VerifM.eval_ret heval⟩
   | cons d ds ih =>
     intro acc st ρ Q hacc howns hvars hwf hΓwf hsplit hdet heval
     simp only [assembleFrom] at heval
@@ -249,7 +253,7 @@ private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr
           rw [hρ3_env_eq]
           exact Skolemize.bundle_eval_updateBinaryRel
             hinfoEq hsplit hΓwf_acc hΔwf_acc hf hdet R ax hmem
-        obtain ⟨st4, hst4_decls, hst4_owns, hpure_pre⟩ :=
+        obtain ⟨st4, hst4_decls, hst4_owns, _, hpure_pre⟩ :=
           VerifM.eval_assumeAll hbind7 hax_wf hax_eval
         -- Reestablish invariants and apply IH.
         have hst4_owns_eq : st4.owns = [] := by rw [hst4_owns]; exact howns
@@ -322,28 +326,47 @@ private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr
             simp only [SpecFn.evalRelates, SpecFn.rel, Env.updateBinaryRel] at h₁ h₂
             exact Skolemize.bundle_semrel_functional
               hinfoEq hΓwf_acc hΔwf_acc hf ρ.env hdet vin y₁ y₂ h₁ h₂
-        exact ih info.spec st4 ρ3 hnewAcc_delta hst4_owns_eq hst4_vars hst4_wf
+        obtain ⟨result, stRel, ρRel, hvarsRel, hownsRel, hsubRel, hagRel, hresD, hQ⟩ :=
+          ih info.spec st4 ρ3 hnewAcc_delta hst4_owns_eq hst4_vars hst4_wf
           hnewΓwf hsplit_new hdet_new (VerifM.eval_ret hpure_pre)
+        have hsub_old : st.decls.Subset st4.decls := by
+          rw [hst4_decls, hst3_decls, ← hacc]
+          exact hΔext_sub
+        have hag_old : VerifM.Env.agreeOn st.decls ρ ρ3 := by
+          rw [← hacc]
+          exact hagree_old
+        exact ⟨result, stRel, ρRel, hvarsRel, hownsRel, hsub_old.trans hsubRel,
+          VerifM.Env.agreeOn_trans hag_old (VerifM.Env.agreeOn_mono hsub_old hagRel),
+          hresD, hQ⟩
 
 theorem assemble_correct (typed : Typed.Program (Spec.Body Typed.Expr))
+    {st : TransState} {ρ : VerifM.Env}
     {Q : RelationSpec → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (RelationSpec.assemble typed) TransState.empty VerifM.Env.empty Q) :
+    (hvars0 : st.decls.vars = [])
+    (howns0 : st.owns = [])
+    (hwf0 : st.decls.wf)
+    (heval : VerifM.eval (RelationSpec.assemble typed) st ρ Q) :
     ∃ spec0 : RelationSpec, ∃ stRel ρRel,
       stRel.decls.vars = [] ∧
       stRel.owns = [] ∧
+      st.decls.Subset stRel.decls ∧
+      VerifM.Env.agreeOn st.decls ρ ρRel ∧
       Q { spec0 with delta := stRel.decls } stRel ρRel := by
   unfold RelationSpec.assemble at heval
-  have hempty_Γwf : FunCtx.wfIn empty.functionMap TransState.empty.decls :=
+  have hctx := VerifM.eval_bind _ _ _ _ heval
+  obtain ⟨hassembleFrom, hownsWf, _, _⟩ := VerifM.eval_ctx hctx
+  have hrest := hassembleFrom hownsWf
+  have hempty_Γwf : FunCtx.wfIn empty.functionMap st.decls :=
     ⟨fun _ _ h => (List.not_mem_nil h).elim, fun _ _ h => (List.not_mem_nil h).elim⟩
-  have hempty_split : FunCtx.splitCompatible empty.functionMap VerifM.Env.empty.env :=
+  have hempty_split : FunCtx.splitCompatible empty.functionMap ρ.env :=
     fun _ _ h => (List.not_mem_nil h).elim
   have hempty_det : Relation.BinaryRelDet
-      empty.functionMap VerifM.Env.empty.env VerifM.Env.empty.env :=
+      empty.functionMap ρ.env ρ.env :=
     fun _ _ h => (List.not_mem_nil h).elim
-  obtain ⟨result, stRel, ρRel, hvars, howns, hresD, hQ⟩ :=
-    assembleFrom_correct typed empty TransState.empty VerifM.Env.empty
-      rfl rfl rfl Signature.wf_empty hempty_Γwf hempty_split hempty_det heval
-  refine ⟨result, stRel, ρRel, hvars, howns, ?_⟩
+  obtain ⟨result, stRel, ρRel, hvars, howns, hsub, hag, hresD, hQ⟩ :=
+    assembleFrom_correct typed { empty with delta := st.decls } st ρ
+      rfl howns0 hvars0 hwf0 hempty_Γwf hempty_split hempty_det hrest
+  refine ⟨result, stRel, ρRel, hvars, howns, hsub, hag, ?_⟩
   obtain ⟨_, _, _, _⟩ := result
   simp only at hresD; subst hresD
   exact hQ
@@ -352,12 +375,12 @@ end RelationSpec
 
 /-- Check an individual declaration. Each declaration's `checkSpec` runs inside a `seq` bracket so its
     declarations and assertions don't pollute subsequent verifications. -/
-def ValDecl.check (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
+def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) : VerifM Spec := do
   let specExpr ← match d.declMeta.spec with
     | some e => .ret e
     | none => .fatal "declaration has no spec"
-  let sp ← match parseSpec Γfn specExpr with
+  let sp ← match parseSpec reg Γfn specExpr with
   | .ok a => .ret a
   | .error msg => .fatal msg
   let spec ← match Spec.complete sp d.body with
@@ -366,36 +389,36 @@ def ValDecl.check (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
   let () ← match Spec.checkWf spec Δ_spec with
     | .ok () => .ret ()
     | .error msg => .fatal msg
-  VerifM.seq (checkSpec Θ Δ_spec S d.body spec) (pure spec)
+  VerifM.seq (checkSpec reg Θ Δ_spec S d.body spec) (pure spec)
 
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
-def ValDecl.checkExpr (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) : VerifM Unit :=
-  VerifM.seq (do let _ ← compile Θ Δ_spec S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
+def ValDecl.checkExpr (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) : VerifM Unit :=
+  VerifM.seq (do let _ ← compile reg Θ Δ_spec S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
 
 /-- Verify all declarations in a program, accumulating specs as we go. -/
-def Program.check (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx) :
+def Program.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx) :
     SpecMap → Typed.Program (Spec.Body Typed.Expr) → VerifM Unit
   | _, [] => pure ()
   | S, d :: ds => do
     match d.name.name, d.declMeta.spec with
     | none, none =>
-      ValDecl.checkExpr Θ Δ_spec S d
-      Program.check Θ Δ_spec Γfn S ds
+      ValDecl.checkExpr reg Θ Δ_spec S d
+      Program.check reg Θ Δ_spec Γfn S ds
     | some n, none =>
     -- Named declaration without a spec: skip if it's a function definition
     -- (no code executes), otherwise check it. Erase any old spec for this
     -- name since the new binding shadows it.
       if d.body.isFunc then
-        Program.check Θ Δ_spec Γfn (S.erase n) ds
+        Program.check reg Θ Δ_spec Γfn (S.erase n) ds
       else
-        ValDecl.checkExpr Θ Δ_spec S d
-        Program.check Θ Δ_spec Γfn (S.erase n) ds
+        ValDecl.checkExpr reg Θ Δ_spec S d
+        Program.check reg Θ Δ_spec Γfn (S.erase n) ds
     | _, _ =>
-      let spec ← ValDecl.check Θ Δ_spec Γfn S d
+      let spec ← ValDecl.check reg Θ Δ_spec Γfn S d
       let S' := match d.name.name with
         | some name => S.insert name spec
         | none => S
-      Program.check Θ Δ_spec Γfn S' ds
+      Program.check reg Θ Δ_spec Γfn S' ds
 
 /-- Empty relation signature used before global relation assembly. -/
 def Δ_spec : Signature := Signature.empty
@@ -404,11 +427,12 @@ def Δ_spec : Signature := Signature.empty
     Proper relation support must populate this with relation interpretations. -/
 def ρ_spec : VerifM.Env := VerifM.Env.empty
 
-def Program.verify (prog : Untyped.Program (Spec.Body Untyped.Expr)) : Smt.Strategy Smt.Strategy.Outcome :=
+def Program.verify (reg : Verifier.Registry) (prog : Untyped.Program (Spec.Body Untyped.Expr)) : Smt.Strategy Smt.Strategy.Outcome :=
   VerifM.strategy do
     let (Θ, typed) ← Program.prepare prog
+    Verifier.Registry.introduceRegistry reg
     let relations ← RelationSpec.assemble typed
-    Program.check Θ relations.delta relations.functionMap ∅ typed
+    Program.check reg Θ relations.delta relations.functionMap ∅ typed
 
 /-! ## Correctness -/
 
@@ -428,21 +452,24 @@ theorem Program.prepare_correct (prog : Untyped.Program (Spec.Body Untyped.Expr)
     simp [helab] at heval
     exact VerifM.eval_ret heval
 
-theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
     (st : TransState) (ρ : VerifM.Env)
     (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
+    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
     {Q : Unit → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.checkExpr Θ Δ_spec S d) st ρ Q) :
-    (□ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ Φ) →
-    □ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (d.body.runtime.subst γ) (fun _ => Φ) := by
+    (heval : VerifM.eval (ValDecl.checkExpr reg Θ Δ_spec S d) st ρ Q) :
+    (□ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ Φ) →
+    □ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ wp (reg.wpCtx) (d.body.runtime.subst γ) (fun _ => Φ) := by
   intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind _ _ _ _ hinner
   have hcomp :=
-    compile_correct d.body Θ iprop(□ st.sl Θ ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ Δ_spec ρ_spec
+    compile_correct reg hSound d.body Θ iprop(□ st.sl Θ ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ Δ_spec ρ_spec
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => Φ)
     hcompile
@@ -451,6 +478,8 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (�
     hSwf hΔwf hΔvars
     hΔspec
     hρspec
+    hΔreg
+    hρreg
     (fun _ _ _ _ _ _ _ => by
       istart
       iintro ⟨_, _, Hctx⟩
@@ -472,16 +501,19 @@ theorem ValDecl.checkExpr_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (�
           · iexact Hsl
           · iexact Hspec
 
-theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
+theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
     (ρ_spec : VerifM.Env)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
     (st : TransState) (ρ : VerifM.Env)
     (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
+    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
     {Q : Spec → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.check Θ Δ_spec Γfn S d) st ρ Q) :
+    (heval : VerifM.eval (ValDecl.check reg Θ Δ_spec Γfn S d) st ρ Q) :
     ∃ spec, spec.wfIn Δ_spec ∧
-            (□ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ wp (d.body.runtime.subst γ) (fun v => spec.isPrecondFor Θ Δ_spec ρ_spec v)) ∧
+            (□ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ wp (reg.wpCtx) (d.body.runtime.subst γ) (fun v => spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec v)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.declMeta.spec with
@@ -491,7 +523,7 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
   | some specExpr =>
     simp only [hspec] at heval
     have h1 := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
-    cases hparse : parseSpec Γfn specExpr with
+    cases hparse : parseSpec reg Γfn specExpr with
     | error msg =>
       simp only [hparse] at h1
       exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ h1)).elim
@@ -517,8 +549,8 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
           exact ⟨spec, hswf,
             by
               have hcheck :=
-                checkSpec_correct Θ S d.body spec γ Δ_spec ρ_spec
-                  hswf hSwf hΔwf hΔvars st ρ hΔspec hρspec hcheckSpec
+                checkSpec_correct reg hSound Θ S d.body spec γ Δ_spec ρ_spec
+                  hswf hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hcheckSpec
               refine BIBase.Entails.trans ?_ hcheck
               istart
               iintro ⟨□Hsl, □Hspec⟩
@@ -527,14 +559,17 @@ theorem ValDecl.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
               · iexact Hspec,
                  VerifM.eval_ret hpure⟩
 
-theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
+theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
+    (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
     (ρ_spec : VerifM.Env)
     (S : SpecMap) (prog : Typed.Program (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
     (st : TransState) (ρ : VerifM.Env)
-    (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ) :
-    VerifM.eval (Program.check Θ Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
-    □ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ pwp ((Typed.Program.runtime prog).subst γ) := by
+    (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
+    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env) :
+    VerifM.eval (Program.check reg Θ Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
+    □ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ pwp (reg.wpCtx) ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ st ρ with
   | nil =>
     intro _
@@ -544,9 +579,9 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
     iemp_intro
   | cons d ds ih =>
     intro heval
-    have hpwp_unfold : pwp ((Typed.Program.runtime (d :: ds)).subst γ) ⊣⊢
-        wp (d.body.runtime.subst γ) (fun v =>
-          pwp ((Typed.Program.runtime ds).subst (Runtime.Subst.updateBinder d.name.runtime v γ))) := by
+    have hpwp_unfold : pwp (reg.wpCtx) ((Typed.Program.runtime (d :: ds)).subst γ) ⊣⊢
+        wp (reg.wpCtx) (d.body.runtime.subst γ) (fun v =>
+          pwp (reg.wpCtx) ((Typed.Program.runtime ds).subst (Runtime.Subst.updateBinder d.name.runtime v γ))) := by
       simp [Typed.Program.runtime, Typed.ValDecl.runtime,
         Runtime.Program.subst, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
     refine BIBase.Entails.trans ?_ hpwp_unfold.2
@@ -563,14 +598,14 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
         have hbind := VerifM.eval_bind _ _ _ _ heval
         have ⟨_, hcont⟩ := VerifM.eval_seq hbind
         have hih := ih S γ hSwf st ρ hΔspec hρspec (VerifM.eval_ret hcont)
-        have hwp := ValDecl.checkExpr_correct Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hbind hih
+        have hwp := ValDecl.checkExpr_correct reg hSound Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hbind hih
         refine hwp.trans (wp.mono ?_)
         intro v; rw [hupd v]; exact .rfl
       | some _ =>
         -- unnamed, with spec
         simp only [hname, hspec] at heval
         obtain ⟨spec, _, hwp, hcont⟩ :=
-          ValDecl.check_correct Θ Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec (VerifM.eval_bind _ _ _ _ heval)
+          ValDecl.check_correct reg hSound Θ Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg (VerifM.eval_bind _ _ _ _ heval)
         have hih := ih S γ hSwf st ρ hΔspec hρspec hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
@@ -602,7 +637,7 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
               (args.map (·.runtime))))
           apply SpatialContext.wp_func
           rw [hupd fval]
-          have heval' : VerifM.eval (Program.check Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) := by
+          have heval' : VerifM.eval (Program.check reg Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) := by
             convert heval
           have hih := ih (S.erase n) (γ.update n fval)
             (SpecMap.wfIn_erase hSwf) st ρ hΔspec hρspec heval'
@@ -616,9 +651,9 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
         · -- named, no spec, not a function
           have hbind := VerifM.eval_bind _ _ _ _ heval
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          have hcont' : VerifM.eval (Program.check Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) :=
+          have hcont' : VerifM.eval (Program.check reg Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) :=
             VerifM.eval_ret hcont
-          have hwp := ValDecl.checkExpr_correct Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hbind
+          have hwp := ValDecl.checkExpr_correct reg hSound Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hbind
             (Φ := iprop(emp)) (by istart; iintro _; iemp_intro)
           refine SpatialContext.wp_strengthen_persistent hwp ?_
           intro v
@@ -635,16 +670,16 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
       | some _ =>
         simp only [hname, hspec] at heval
         obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          ValDecl.check_correct Θ Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec (VerifM.eval_bind _ _ _ _ heval)
-        have hcont' : VerifM.eval (Program.check Θ Δ_spec Γfn (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
+          ValDecl.check_correct reg hSound Θ Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg (VerifM.eval_bind _ _ _ _ heval)
+        have hcont' : VerifM.eval (Program.check reg Θ Δ_spec Γfn (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
           convert hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
         have hih := ih (S.insert n spec) (γ.update n v)
           (SpecMap.wfIn_insert hSwf hswf) st ρ hΔspec hρspec hcont'
-        have hstep : (□ st.sl Θ ρ ∗ S.satisfiedBy Θ Δ_spec ρ_spec γ) ∗ spec.isPrecondFor Θ Δ_spec ρ_spec v ⊢
-            pwp ((Typed.Program.runtime ds).subst (γ.update n v)) := by
+        have hstep : (□ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ) ∗ spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec v ⊢
+            pwp (reg.wpCtx) ((Typed.Program.runtime ds).subst (γ.update n v)) := by
           refine BIBase.Entails.trans ?_ hih
           istart
           iintro ⟨Hctx, Hpre⟩
@@ -658,8 +693,9 @@ theorem Program.check_correct (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn 
         exact wand_intro hstep
 
 
-theorem Program.verify_correct (p : Untyped.Program (Spec.Body Untyped.Expr)) :
-  Smt.Strategy.checks (Program.verify p) (⊢ pwp (Untyped.Program.runtime p)) := by
+theorem Program.verify_correct (reg : Verifier.Registry)
+    (hSound : Verifier.Registry.Sound reg) (p : Untyped.Program (Spec.Body Untyped.Expr)) :
+  Smt.Strategy.checks (Program.verify reg p) (⊢ pwp (reg.wpCtx) (Untyped.Program.runtime p)) := by
   simp only [Smt.Strategy.checks, Program.verify, VerifM.strategy]
   intro st' heval
   have h1 := ScopedM.strategy_eval_initial_implies_ScopedM_eval heval
@@ -677,26 +713,44 @@ theorem Program.verify_correct (p : Untyped.Program (Spec.Body Untyped.Expr)) :
     have hverifM := VerifM.eval_of_translate
                       (do
                         let (Θ, typed) ← Program.prepare p
+                        Verifier.Registry.introduceRegistry reg
                         let relations ← RelationSpec.assemble typed
-                        Program.check Θ relations.delta relations.functionMap ∅ typed)
+                        Program.check reg Θ relations.delta relations.functionMap ∅ typed)
                       TransState.empty VerifM.Env.empty ctx_mid hverif hholdsFor hwf
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
     obtain ⟨Θ, typed, hrt, hrest⟩ := Program.prepare_correct p TransState.empty VerifM.Env.empty hbind
-    have hassemble := VerifM.eval_bind _ _ _ _ hrest
-    obtain ⟨spec0, stRel, ρRel, hvars, howns, hcheck⟩ :=
-      RelationSpec.assemble_correct typed hassemble
-    have hcorrect := Program.check_correct Θ stRel.decls spec0.functionMap ρRel
+    -- Peel the registry setup from the continuation generically.
+    have hsetup_bind := VerifM.eval_bind _ _ _ _ hrest
+    obtain ⟨st_setup, ρ_setup, _hΔsub, hdep_setup, hvars_setup_eq, howns_setup,
+      _hasserts, hstable_setup, _hρagree, hcheck_eval⟩ :=
+      Verifier.Registry.eval_introduceRegistry reg hSound hsetup_bind
+    have hassemble := VerifM.eval_bind _ _ _ _ hcheck_eval
+    have hvars_setup : st_setup.decls.vars = [] := by
+      rw [hvars_setup_eq]
+      rfl
+    obtain ⟨spec0, stRel, ρRel, hvars, howns, hsub_setup_rel, hag_setup_rel, hcheck_eval⟩ :=
+      RelationSpec.assemble_correct typed hvars_setup howns_setup hcheck_eval.1.namesDisjoint hassemble
+    have hΔreg : Verifier.Registry.symSubset reg stRel.decls := by
+      intro i hi
+      exact (Verifier.Registry.extendWithSym_subset_sigOf_of_mem hi).trans
+        (hdep_setup.trans hsub_setup_rel)
+    have hρreg : Verifier.Registry.symAgree reg ρRel.env := by
+      intro i hi
+      exact hstable_setup ρRel hag_setup_rel i hi
+    have hcorrect := Program.check_correct reg hSound Θ stRel.decls spec0.functionMap ρRel
                        ∅ typed Runtime.Subst.id
                        (SpecMap.empty_wfIn _)
-                       hcheck.1.namesDisjoint
+                       hcheck_eval.1.namesDisjoint
                        hvars
                        stRel ρRel
                        (Signature.Subset.refl _)
                        VerifM.Env.agreeOn_refl
-                       hcheck
+                       hΔreg
+                       hρreg
+                       hcheck_eval
     rw [Runtime.Program.subst_id] at hcorrect
     have hctx0 : (⊢ □ stRel.sl Θ ρRel ∗
-        SpecMap.satisfiedBy Θ stRel.decls ρRel (∅ : SpecMap) Runtime.Subst.id) := by
+        SpecMap.satisfiedBy (reg.wpCtx) Θ stRel.decls ρRel (∅ : SpecMap) Runtime.Subst.id) := by
       istart
       isplitl []
       · simp [TransState.sl, howns]

--- a/Mica/Verifier/RelationalEncoding.lean
+++ b/Mica/Verifier/RelationalEncoding.lean
@@ -1,4 +1,5 @@
 -- SUMMARY: Bundle for RelationalEncoding/, the two-stage encoding of recursive functions into FOL axioms.
+import Mica.Verifier.RelationalEncoding.Prim
 import Mica.Verifier.RelationalEncoding.Monad
 import Mica.Verifier.RelationalEncoding.Variables
 import Mica.Verifier.RelationalEncoding.Relation

--- a/Mica/Verifier/RelationalEncoding/Axioms.lean
+++ b/Mica/Verifier/RelationalEncoding/Axioms.lean
@@ -366,8 +366,8 @@ theorem bundle_wfIn
     simpa [Δext, bodySig] using bodySig_wf_of_headFresh hΔ hheadFresh
   have hbody_x : bv.wfIn (Δext.declVar ⟨x, .value⟩) := by
     show bv.wfIn (bodySig Δ fn x)
-    exact encode_wfIn (Γ := Relation.ctx Γ f fn)
-      (Δ := bodySig Δ fn x) e
+    exact encode_wfIn_of_gate e
+      (subset_bodySig_of_headFresh hheadFresh)
       (bodySig_wf_of_headFresh hΔ hheadFresh)
       (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
       (encodeBody_def_bodySig henc)

--- a/Mica/Verifier/RelationalEncoding/Monad.lean
+++ b/Mica/Verifier/RelationalEncoding/Monad.lean
@@ -4,6 +4,7 @@ import Mica.FOL.Fixpoint
 import Mica.TinyML.Typed
 import Mica.Base.Fresh
 import Mica.Verifier.RelationalEncoding.Variables
+import Mica.Verifier.RelationalEncoding.Prim
 
 /-!
 # Generic monadic skeleton for TinyML-to-FOL encoders
@@ -130,45 +131,51 @@ mutual
 continuation-passing style, parametric in the encoder operations. The only
 place that pattern-matches on `Typed.Expr`. Errors are reported via
 `ops.error`; the traversal itself is total in `M`. -/
-def encodeWith {M : Type} (ops : EncoderOps M)
+def encodeWith {M : Type} (ops : EncoderOps M) (Δ : Signature)
     (Γ : FunCtx) (δ : VarEnv) : Typed.Expr → (Term .value → M) → M
   | .const c, k => k (encodeConst c)
   | .var x _, k =>
     match δ.lookup x with
     | some v => k v
     | none => ops.error s!"unbound variable: {x}"
+  | .prim n _, _ => ops.error s!"relational encoding: standalone primitive `{n}` is not supported"
   | .unop op e _, k =>
-    encodeWith ops Γ δ e fun v =>
+    encodeWith ops Δ Γ δ e fun v =>
       match encodeUnOp op v with
       | .ok v'    => k v'
       | .error msg => ops.error msg
   | .binop op e1 e2 _, k =>
-    encodeWith ops Γ δ e1 fun v1 =>
-      encodeWith ops Γ δ e2 fun v2 =>
+    encodeWith ops Δ Γ δ e1 fun v1 =>
+      encodeWith ops Δ Γ δ e2 fun v2 =>
         match encodeBinOp op v1 v2 with
         | .ok v     => k v
         | .error msg => ops.error msg
   | .ifThenElse c t e _, k =>
-    encodeWith ops Γ δ c fun b =>
-      ops.ite (.unop .toBool b) (encodeWith ops Γ δ t k) (encodeWith ops Γ δ e k)
+    encodeWith ops Δ Γ δ c fun b =>
+      ops.ite (.unop .toBool b) (encodeWith ops Δ Γ δ t k) (encodeWith ops Δ Γ δ e k)
   | .tuple es, k =>
-    encodeListWith ops Γ δ es fun vs =>
+    encodeListWith ops Δ Γ δ es fun vs =>
       k (.unop .ofValList (Terms.toValList vs))
   | .app (.var f _) [arg] _, k =>
     match FunCtx.lookup Γ f with
     | none     => ops.error s!"unknown function: {f}"
     | some rel =>
-      encodeWith ops Γ δ arg fun v => ops.call rel v k
-  | .cast e _, k  => encodeWith ops Γ δ e k
+      encodeWith ops Δ Γ δ arg fun v => ops.call rel v k
+  | .app (.prim n _) args _, k =>
+    encodeListWith ops Δ Γ δ args fun vs =>
+      match encodePrim Δ n vs with
+      | .ok v      => k v
+      | .error msg => ops.error msg
+  | .cast e _, k  => encodeWith ops Δ Γ δ e k
   | .letIn b bound body, k =>
-    encodeWith ops Γ δ bound fun v =>
-      encodeWith ops Γ (VarEnv.bindBinder δ b v) body k
+    encodeWith ops Δ Γ δ bound fun v =>
+      encodeWith ops Δ Γ (VarEnv.bindBinder δ b v) body k
   | .inj tag arity payload, k =>
-    encodeWith ops Γ δ payload fun v =>
+    encodeWith ops Δ Γ δ payload fun v =>
       k (.unop (.mkInj tag arity) v)
   | .match_ scrut branches _, k =>
-    encodeWith ops Γ δ scrut fun v =>
-      encodeMatchWith ops Γ δ v branches 0 k
+    encodeWith ops Δ Γ δ scrut fun v =>
+      encodeMatchWith ops Δ Γ δ v branches 0 k
   | .app _ _ _, _ => ops.error "relational encoding: only unary calls to named top-level functions are supported"
   | .fix .., _    => ops.error "relational encoding: nested `fix` is not supported"
   | .ref .., _    => ops.error "relational encoding: heap allocation (`ref`) is not supported"
@@ -179,12 +186,12 @@ def encodeWith {M : Type} (ops : EncoderOps M)
 /-- Encode a list of expressions left-to-right, collecting their value terms.
 This is the list companion to `encodeWith`, needed by tuple syntax and later
 other n-ary constructs. -/
-def encodeListWith {M : Type} (ops : EncoderOps M)
+def encodeListWith {M : Type} (ops : EncoderOps M) (Δ : Signature)
     (Γ : FunCtx) (δ : VarEnv) : List Typed.Expr → (List (Term .value) → M) → M
   | [], k => k []
   | e :: es, k =>
-    encodeWith ops Γ δ e fun v =>
-      encodeListWith ops Γ δ es fun vs => k (v :: vs)
+    encodeWith ops Δ Γ δ e fun v =>
+      encodeListWith ops Δ Γ δ es fun vs => k (v :: vs)
 
 /-- Encode a `match_` as an if-let chain. For each non-final branch
 `(b, body)` at index `i`, the carrier tests whether the scrutinee
@@ -194,19 +201,19 @@ remaining branches are tried. The final branch is dispatched
 unconditionally — the elaborator guarantees an exhaustive list, so the
 trailing case must hold. An empty list (which the elaborator never
 produces) is conservatively encoded as `ops.error`. -/
-def encodeMatchWith {M : Type} (ops : EncoderOps M)
+def encodeMatchWith {M : Type} (ops : EncoderOps M) (Δ : Signature)
     (Γ : FunCtx) (δ : VarEnv) (scrut : Term .value) :
     List (Typed.Binder × Typed.Expr) → Nat → (Term .value → M) → M
   | [], _, _ => ops.error "match: non-exhaustive"
   | (b, body) :: rest, i, k =>
     let δ' := VarEnv.bindBinder δ b (.unop .payloadOf scrut)
     match rest with
-    | [] => encodeWith ops Γ δ' body k
+    | [] => encodeWith ops Δ Γ δ' body k
     | _ :: _ =>
       ops.ite
         (.binop .eq (.unop .tagOf scrut) (.const (.i (i : Int))))
-        (encodeWith ops Γ δ' body k)
-        (encodeMatchWith ops Γ δ scrut rest (i + 1) k)
+        (encodeWith ops Δ Γ δ' body k)
+        (encodeMatchWith ops Δ Γ δ scrut rest (i + 1) k)
 end
 
 /-! ## Semantic interpretation of carriers
@@ -243,43 +250,43 @@ structure EncoderOpsInd {M : Type} (ops : EncoderOps M) (P : M → Prop) where
 
 /-- Per-expression statement of `encodeWith_ind`. -/
 def EncodeWithInd (e : Typed.Expr) : Prop :=
-  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop}
+  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop} {Δ : Signature}
     {Γ : FunCtx} {δ : VarEnv} {k : Term .value → M},
     EncoderOpsInd ops P → (∀ v, P (k v)) →
-    P (encodeWith ops Γ δ e k)
+    P (encodeWith ops Δ Γ δ e k)
 
 /-- Per-list statement of `encodeWith_ind`. -/
 def EncodeListWithInd (es : List Typed.Expr) : Prop :=
-  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop}
+  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop} {Δ : Signature}
     {Γ : FunCtx} {δ : VarEnv} {k : List (Term .value) → M},
     EncoderOpsInd ops P → (∀ vs, P (k vs)) →
-    P (encodeListWith ops Γ δ es k)
+    P (encodeListWith ops Δ Γ δ es k)
 
 /-- Per-branch-list statement of `encodeWith_ind`, mirroring `EncodeWithInd`
 but parametric in the scrutinee value and the index offset. -/
 def EncodeMatchWithInd (branches : List (Typed.Binder × Typed.Expr)) : Prop :=
-  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop}
+  ∀ {M : Type} {ops : EncoderOps M} {P : M → Prop} {Δ : Signature}
     {Γ : FunCtx} {δ : VarEnv} {scrut : Term .value} {i : Nat}
     {k : Term .value → M},
     EncoderOpsInd ops P → (∀ v, P (k v)) →
-    P (encodeMatchWith ops Γ δ scrut branches i k)
+    P (encodeMatchWith ops Δ Γ δ scrut branches i k)
 
 /-! ## Per-case helpers for `encodeWith_ind` -/
 
 namespace Ind
 
 theorem const (c : TinyML.Const) : EncodeWithInd (.const c) := by
-  intro _ _ _ _ _ _ _ hk; simp only [encodeWith]; exact hk _
+  intro _ _ _ _ _ _ _ _ hk; simp only [encodeWith]; exact hk _
 
 theorem var (x : String) (ty : TinyML.Typ) : EncodeWithInd (.var x ty) := by
-  intro _ _ _ _ δ _ hops hk
+  intro _ _ _ _ _ δ _ hops hk
   cases hlookup : δ.lookup x with
   | none => simp only [encodeWith, hlookup]; exact hops.error_ind
   | some v => simp only [encodeWith, hlookup]; exact hk v
 
 theorem unop (op : TinyML.UnOp) (e : Typed.Expr) (ty : TinyML.Typ)
     (ih : EncodeWithInd e) : EncodeWithInd (.unop op e ty) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   refine ih hops ?_
   intro v
@@ -290,7 +297,7 @@ theorem unop (op : TinyML.UnOp) (e : Typed.Expr) (ty : TinyML.Typ)
 theorem binop (op : TinyML.BinOp) (e1 e2 : Typed.Expr) (ty : TinyML.Typ)
     (ih1 : EncodeWithInd e1) (ih2 : EncodeWithInd e2) :
     EncodeWithInd (.binop op e1 e2 ty) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   refine ih1 hops ?_
   intro v1
@@ -303,15 +310,16 @@ theorem binop (op : TinyML.BinOp) (e1 e2 : Typed.Expr) (ty : TinyML.Typ)
 theorem ifThenElse (c t e : Typed.Expr) (ty : TinyML.Typ)
     (ihc : EncodeWithInd c) (iht : EncodeWithInd t) (ihe : EncodeWithInd e) :
     EncodeWithInd (.ifThenElse c t e ty) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   refine ihc hops ?_
   intro _
   exact hops.ite_ind (iht hops hk) (ihe hops hk)
 
 theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
-    (ihArgs : ∀ a ∈ args, EncodeWithInd a) : EncodeWithInd (.app fn args ty) := by
-  intro _ _ _ Γ _ _ hops hk
+    (ihArgs : ∀ a ∈ args, EncodeWithInd a) (ihArgsList : EncodeListWithInd args) :
+    EncodeWithInd (.app fn args ty) := by
+  intro _ _ _ _ Γ _ _ hops hk
   match fn, args with
   | .var f _, [arg] =>
       simp only [encodeWith]
@@ -322,6 +330,13 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
           refine ihArgs arg (List.mem_singleton.mpr rfl) hops ?_
           intro _
           exact hops.call_ind hk
+  | .prim n _, args =>
+      simp only [encodeWith]
+      refine ihArgsList hops ?_
+      intro vs
+      cases encodePrim _ n vs with
+      | error _ => simp; exact hops.error_ind
+      | ok _    => simp; exact hk _
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
   | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
@@ -330,17 +345,20 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
 
 theorem cast (e : Typed.Expr) (ty : TinyML.Typ) (ih : EncodeWithInd e) :
     EncodeWithInd (.cast e ty) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]; exact ih hops hk
 
 theorem fix (self : Typed.Binder) (args : List Typed.Binder) (retTy : TinyML.Typ)
     (body : Typed.Expr) : EncodeWithInd (.fix self args retTy body) :=
   fun hops _ => hops.error_ind
 
+theorem prim (name : String) (ty : TinyML.Typ) : EncodeWithInd (.prim name ty) :=
+  fun hops _ => hops.error_ind
+
 theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
     (ihBound : EncodeWithInd bound) (ihBody : EncodeWithInd body) :
     EncodeWithInd (.letIn name bound body) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   exact ihBound hops fun _ => ihBody hops hk
 
@@ -358,13 +376,13 @@ theorem assert (e : Typed.Expr) : EncodeWithInd (.assert e) :=
 
 theorem tuple (es : List Typed.Expr) (ih : EncodeListWithInd es) :
     EncodeWithInd (.tuple es) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   exact ih hops (fun vs => hk (.unop .ofValList (Terms.toValList vs)))
 
 theorem inj (tag arity : Nat) (payload : Typed.Expr)
     (ih : EncodeWithInd payload) : EncodeWithInd (.inj tag arity payload) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   refine ih hops ?_
   intro v; exact hk _
@@ -373,19 +391,19 @@ theorem match_ (scrut : Typed.Expr) (branches : List (Typed.Binder × Typed.Expr
     (ty : TinyML.Typ) (ihScrut : EncodeWithInd scrut)
     (ihBranches : EncodeMatchWithInd branches) :
     EncodeWithInd (.match_ scrut branches ty) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   refine ihScrut hops ?_
   intro _; exact ihBranches hops hk
 
 theorem match_nil : EncodeMatchWithInd [] := by
-  intro _ _ _ _ _ _ _ _ hops _; simp only [encodeMatchWith]; exact hops.error_ind
+  intro _ _ _ _ _ _ _ _ _ hops _; simp only [encodeMatchWith]; exact hops.error_ind
 
 theorem match_cons (b : Typed.Binder) (body : Typed.Expr)
     (rest : List (Typed.Binder × Typed.Expr))
     (ihBody : EncodeWithInd body) (ihRest : EncodeMatchWithInd rest) :
     EncodeMatchWithInd ((b, body) :: rest) := by
-  intro _ _ _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ _ _ hops hk
   simp only [encodeMatchWith]
   cases rest with
   | nil =>
@@ -396,12 +414,12 @@ theorem match_cons (b : Typed.Binder) (body : Typed.Expr)
     · exact ihRest hops hk
 
 theorem list_nil : EncodeListWithInd [] := by
-  intro _ _ _ _ _ _ _ hk; simp only [encodeListWith]; exact hk []
+  intro _ _ _ _ _ _ _ _ hk; simp only [encodeListWith]; exact hk []
 
 theorem list_cons (e : Typed.Expr) (es : List Typed.Expr)
     (ih : EncodeWithInd e) (ihs : EncodeListWithInd es) :
     EncodeListWithInd (e :: es) := by
-  intro _ _ _ _ _ _ hops hk
+  intro _ _ _ _ _ _ _ hops hk
   simp only [encodeListWith]
   refine ih hops ?_
   intro v
@@ -418,6 +436,7 @@ the predicate. -/
 theorem encodeWith_ind_def : ∀ (e : Typed.Expr), EncodeWithInd e
   | .const c => Ind.const c
   | .var x ty => Ind.var x ty
+  | .prim n ty => Ind.prim n ty
   | .unop op e ty => Ind.unop op e ty (encodeWith_ind_def e)
   | .binop op e1 e2 ty =>
       Ind.binop op e1 e2 ty (encodeWith_ind_def e1) (encodeWith_ind_def e2)
@@ -425,7 +444,7 @@ theorem encodeWith_ind_def : ∀ (e : Typed.Expr), EncodeWithInd e
       Ind.ifThenElse c t e ty (encodeWith_ind_def c)
         (encodeWith_ind_def t) (encodeWith_ind_def e)
   | .app fn args ty =>
-      Ind.app fn args ty (fun a _ => encodeWith_ind_def a)
+      Ind.app fn args ty (fun a _ => encodeWith_ind_def a) (encodeListWith_ind_def args)
   | .cast e ty => Ind.cast e ty (encodeWith_ind_def e)
   | .fix self args retTy body => Ind.fix self args retTy body
   | .letIn name bound body =>
@@ -455,10 +474,10 @@ end
 /-- Compatibility wrapper preserving the original signature. -/
 theorem encodeWith_ind {M : Type} {ops : EncoderOps M} {P : M → Prop}
     (hops : EncoderOpsInd ops P)
-    {Γ : FunCtx} {δ : VarEnv} (e : Typed.Expr)
+    {Δ : Signature} {Γ : FunCtx} {δ : VarEnv} (e : Typed.Expr)
     {k : Term .value → M}
     (hk : ∀ v, P (k v)) :
-    P (encodeWith ops Γ δ e k) :=
+    P (encodeWith ops Δ Γ δ e k) :=
   encodeWith_ind_def e hops hk
 
 /-! ## Signature-indexed induction
@@ -508,7 +527,7 @@ def EncodeWithIndSig (e : Typed.Expr) : Prop :=
     EncoderOpsSig ops P Pctx →
     Δ.Subset Δ' → Δ'.wf → Pctx Γ Δ' → δ.wfIn Δ' →
     SigCont P Δ' k →
-    P Δ' (encodeWith ops Γ δ e k)
+    P Δ' (encodeWith ops Δ Γ δ e k)
 
 /-- Per-list statement of `encodeWith_indWithSig`. -/
 def EncodeListWithIndSig (es : List Typed.Expr) : Prop :=
@@ -519,7 +538,7 @@ def EncodeListWithIndSig (es : List Typed.Expr) : Prop :=
     Δ.Subset Δ' → Δ'.wf → Pctx Γ Δ' → δ.wfIn Δ' →
     (∀ {Δ''}, Δ'.Subset Δ'' → Δ''.wf →
       ∀ vs, (∀ v ∈ vs, v.wfIn Δ'') → P Δ'' (k vs)) →
-    P Δ' (encodeListWith ops Γ δ es k)
+    P Δ' (encodeListWith ops Δ Γ δ es k)
 
 /-- Per-branch-list statement of `encodeWith_indWithSig`, parametric in the
 scrutinee value and starting index. The scrutinee must be well-formed at the
@@ -533,7 +552,7 @@ def EncodeMatchWithIndSig (branches : List (Typed.Binder × Typed.Expr)) : Prop 
     Δ.Subset Δ' → Δ'.wf → Pctx Γ Δ' → δ.wfIn Δ' →
     scrut.wfIn Δ' →
     SigCont P Δ' k →
-    P Δ' (encodeMatchWith ops Γ δ scrut branches i k)
+    P Δ' (encodeMatchWith ops Δ Γ δ scrut branches i k)
 
 /-! ## Per-case helpers for `encodeWith_indWithSig` -/
 
@@ -600,8 +619,9 @@ theorem ifThenElse (c t e : Typed.Expr) (ty : TinyML.Typ)
   exact hops.ite_ind hΔ'' hbWf hmtP hmeP
 
 theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
-    (ihArgs : ∀ a ∈ args, EncodeWithIndSig a) : EncodeWithIndSig (.app fn args ty) := by
-  intro _ _ _ _ Γ _ _ δ _ hops hsub hΔ' hΓ hδ hk
+    (ihArgs : ∀ a ∈ args, EncodeWithIndSig a) (ihArgsList : EncodeListWithIndSig args) :
+    EncodeWithIndSig (.app fn args ty) := by
+  intro _ _ _ _ Γ Δ _ δ _ hops hsub hΔ' hΓ hδ hk
   match fn, args with
   | .var f _, [arg] =>
       simp only [encodeWith]
@@ -615,6 +635,15 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
           refine hops.call_ind hΔ'' (hops.ctx_mono hΓ hsub'') hmem hv ?_
           intro Δ''' hsub''' hΔ''' v' hv'
           exact hk (hsub''.trans hsub''') hΔ''' v' hv'
+  | .prim n _, args =>
+      simp only [encodeWith]
+      refine ihArgsList hops hsub hΔ' hΓ hδ ?_
+      intro Δ'' hsub'' hΔ'' vs hvs
+      cases hraw : encodePrim Δ n vs with
+      | error _ => simp; exact hops.error_ind
+      | ok v =>
+          simp
+          exact hk hsub'' hΔ'' v (encodePrim_wfIn hraw (hsub.trans hsub'') hΔ'' hvs)
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
   | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
@@ -628,6 +657,9 @@ theorem cast (e : Typed.Expr) (ty : TinyML.Typ) (ih : EncodeWithIndSig e) :
 
 theorem fix (self : Typed.Binder) (args : List Typed.Binder) (retTy : TinyML.Typ)
     (body : Typed.Expr) : EncodeWithIndSig (.fix self args retTy body) :=
+  fun hops _ _ _ _ _ => hops.error_ind
+
+theorem prim (name : String) (ty : TinyML.Typ) : EncodeWithIndSig (.prim name ty) :=
   fun hops _ _ _ _ _ => hops.error_ind
 
 theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
@@ -741,6 +773,7 @@ expression yields a carrier satisfying `P`. -/
 theorem encodeWith_indWithSig_def : ∀ (e : Typed.Expr), EncodeWithIndSig e
   | .const c => IndSig.const c
   | .var x ty => IndSig.var x ty
+  | .prim n ty => IndSig.prim n ty
   | .unop op e ty => IndSig.unop op e ty (encodeWith_indWithSig_def e)
   | .binop op e1 e2 ty =>
       IndSig.binop op e1 e2 ty (encodeWith_indWithSig_def e1) (encodeWith_indWithSig_def e2)
@@ -749,6 +782,7 @@ theorem encodeWith_indWithSig_def : ∀ (e : Typed.Expr), EncodeWithIndSig e
         (encodeWith_indWithSig_def t) (encodeWith_indWithSig_def e)
   | .app fn args ty =>
       IndSig.app fn args ty (fun a _ => encodeWith_indWithSig_def a)
+        (encodeListWith_indWithSig_def args)
   | .cast e ty => IndSig.cast e ty (encodeWith_indWithSig_def e)
   | .fix self args retTy body => IndSig.fix self args retTy body
   | .letIn name bound body =>
@@ -789,7 +823,7 @@ theorem encodeWith_indWithSig {M : Type} {ops : EncoderOps M}
     (hsub : Δ.Subset Δ') (hΔ' : Δ'.wf) (hΓ : Pctx Γ Δ')
     (hδ : δ.wfIn Δ')
     (hk : SigCont P Δ' k) :
-    P Δ' (encodeWith ops Γ δ e k) :=
+    P Δ' (encodeWith ops Δ Γ δ e k) :=
   encodeWith_indWithSig_def e hops hsub hΔ' hΓ hδ hk
 
 /-! ## Generic paired-encoding binary
@@ -879,56 +913,64 @@ abbrev EncoderListContSpec {M₁ M₂ : Type}
         vs₂.map (fun v => Term.eval ρ₂' v) →
       B Δ₁' Δ₂' ρ₁' ρ₂' (k₁ vs₁) (k₂ vs₂)
 
-/-- Per-expression statement of `encodeWith_bind_binary`. -/
+/-- Per-expression statement of `encodeWith_bind_binary`. The two encoders
+share a single base signature `Δ` — which doubles as the intrinsic gate — and
+the two environments are required to agree on it (`Env.agreeOn Δ ρ₁' ρ₂'`), so
+that intrinsic (uninterpreted) symbols are interpreted identically on both
+sides. This is what lets the prim case discharge cross-environment evaluation
+equality, just as `call` relies on the witness it freshly introduces. -/
 def EncodeWithBindBinary (e : Typed.Expr) : Prop :=
-  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ₁ Δ₂ : Signature} {δ₁ δ₂ : VarEnv}
+  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ : Signature} {δ₁ δ₂ : VarEnv}
     {ops₁ : EncoderOps M₁} {ops₂ : EncoderOps M₂}
     {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop},
     EncoderOpsBinary Γ ops₁ ops₂ B →
     ∀ {k₁ : Term .value → M₁}
       {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env} {k₂ : Term .value → M₂},
-      Δ₁.Subset Δ₁' → Δ₂.Subset Δ₂' →
+      Δ.Subset Δ₁' → Δ.Subset Δ₂' →
       Δ₁'.wf → Δ₂'.wf →
+      Env.agreeOn Δ ρ₁' ρ₂' →
       VarEnv.Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂ →
       EncoderContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂ →
       B Δ₁' Δ₂' ρ₁' ρ₂'
-        (encodeWith ops₁ Γ δ₁ e k₁) (encodeWith ops₂ Γ δ₂ e k₂)
+        (encodeWith ops₁ Δ Γ δ₁ e k₁) (encodeWith ops₂ Δ Γ δ₂ e k₂)
 
 /-- Per-list statement of `encodeWith_bind_binary`. -/
 def EncodeListWithBindBinary (es : List Typed.Expr) : Prop :=
-  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ₁ Δ₂ : Signature} {δ₁ δ₂ : VarEnv}
+  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ : Signature} {δ₁ δ₂ : VarEnv}
     {ops₁ : EncoderOps M₁} {ops₂ : EncoderOps M₂}
     {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop},
     EncoderOpsBinary Γ ops₁ ops₂ B →
     ∀ {k₁ : List (Term .value) → M₁}
       {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env} {k₂ : List (Term .value) → M₂},
-      Δ₁.Subset Δ₁' → Δ₂.Subset Δ₂' →
+      Δ.Subset Δ₁' → Δ.Subset Δ₂' →
       Δ₁'.wf → Δ₂'.wf →
+      Env.agreeOn Δ ρ₁' ρ₂' →
       VarEnv.Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂ →
       EncoderListContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂ →
       B Δ₁' Δ₂' ρ₁' ρ₂'
-        (encodeListWith ops₁ Γ δ₁ es k₁) (encodeListWith ops₂ Γ δ₂ es k₂)
+        (encodeListWith ops₁ Δ Γ δ₁ es k₁) (encodeListWith ops₂ Δ Γ δ₂ es k₂)
 
 /-- Per-branch-list statement of `encodeWith_bind_binary`, parametric in two
 scrutinee values whose evaluations agree, the starting index, and the
 continuations. -/
 def EncodeMatchWithBindBinary (branches : List (Typed.Binder × Typed.Expr)) : Prop :=
-  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ₁ Δ₂ : Signature} {δ₁ δ₂ : VarEnv}
+  ∀ {M₁ M₂ : Type} {Γ : FunCtx} {Δ : Signature} {δ₁ δ₂ : VarEnv}
     {ops₁ : EncoderOps M₁} {ops₂ : EncoderOps M₂}
     {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop},
     EncoderOpsBinary Γ ops₁ ops₂ B →
     ∀ {k₁ : Term .value → M₁}
       {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env} {k₂ : Term .value → M₂}
       {scrut₁ scrut₂ : Term .value} {i : Nat},
-      Δ₁.Subset Δ₁' → Δ₂.Subset Δ₂' →
+      Δ.Subset Δ₁' → Δ.Subset Δ₂' →
       Δ₁'.wf → Δ₂'.wf →
+      Env.agreeOn Δ ρ₁' ρ₂' →
       VarEnv.Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂ →
       scrut₁.wfIn Δ₁' → scrut₂.wfIn Δ₂' →
       Term.eval ρ₁' scrut₁ = Term.eval ρ₂' scrut₂ →
       EncoderContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂ →
       B Δ₁' Δ₂' ρ₁' ρ₂'
-        (encodeMatchWith ops₁ Γ δ₁ scrut₁ branches i k₁)
-        (encodeMatchWith ops₂ Γ δ₂ scrut₂ branches i k₂)
+        (encodeMatchWith ops₁ Δ Γ δ₁ scrut₁ branches i k₁)
+        (encodeMatchWith ops₂ Δ Γ δ₂ scrut₂ branches i k₂)
 
 
 /-! ### Eval helpers for the paired-encoding binary -/
@@ -1014,14 +1056,14 @@ private theorem encodeBinOp_ok_irrel {op : TinyML.BinOp} {a b a' b' c : Term .va
 namespace BindBinary
 
 theorem const (c : TinyML.Const) : EncodeWithBindBinary (.const c) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ _ hk
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ _ _ hk
   simp only [encodeWith]
   exact hk (Signature.Subset.refl _) (Signature.Subset.refl _) hwf₁ hwf₂
     Env.agreeOn_refl Env.agreeOn_refl (encodeConst c) (encodeConst c)
     (encodeConst_wfIn c _) (encodeConst_wfIn c _) (encodeConst_eval c _ _)
 
 theorem var (x : String) (ty : TinyML.Typ) : EncodeWithBindBinary (.var x ty) := by
-  intro _ _ _ _ _ δ₁ δ₂ _ _ _ hops _ _ _ ρ₁' ρ₂' _ _ _ hwf₁ hwf₂ henv hk
+  intro _ _ _ _ δ₁ δ₂ _ _ _ hops _ _ _ ρ₁' ρ₂' _ _ _ hwf₁ hwf₂ _ henv hk
   cases h₁ : δ₁.lookup x with
   | none =>
       have h₂ : δ₂.lookup x = none := by
@@ -1043,9 +1085,9 @@ theorem var (x : String) (ty : TinyML.Typ) : EncodeWithBindBinary (.var x ty) :=
 
 theorem unop (op : TinyML.UnOp) (e : Typed.Expr) (ty : TinyML.Typ)
     (ih : EncodeWithBindBinary e) : EncodeWithBindBinary (.unop op e ty) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeWith]
-  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
   cases hraw₁ : encodeUnOp op v₁ with
   | error msg =>
@@ -1062,12 +1104,13 @@ theorem unop (op : TinyML.UnOp) (e : Typed.Expr) (ty : TinyML.Typ)
 theorem binop (op : TinyML.BinOp) (e1 e2 : Typed.Expr) (ty : TinyML.Typ)
     (ih1 : EncodeWithBindBinary e1) (ih2 : EncodeWithBindBinary e2) :
     EncodeWithBindBinary (.binop op e1 e2 ty) := by
-  intro _ _ _ Δ₁ Δ₂ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ Δ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeWith]
-  refine ih1 hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  refine ih1 hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v1₁ v1₂ hv1₁ hv1₂ heval1
   refine ih2 hops
     (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
+    (Env.agreeOn_of_extensions hsub₁ hsub₂ hagree haa₁ haa₂)
     (VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv) ?_
   intro Δb₁ Δb₂ ρb₁ ρb₂ hsb₁ hsb₂ hwb₁ hwb₂ hab₁ hab₂ v2₁ v2₂ hv2₁ hv2₂ heval2
   have hev1 : Term.eval ρb₁ v1₁ = Term.eval ρb₂ v1₂ := by
@@ -1093,24 +1136,26 @@ theorem ifThenElse (c t e : Typed.Expr) (ty : TinyML.Typ)
     (ihc : EncodeWithBindBinary c) (iht : EncodeWithBindBinary t)
     (ihe : EncodeWithBindBinary e) :
     EncodeWithBindBinary (.ifThenElse c t e ty) := by
-  intro _ _ _ Δ₁ Δ₂ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ Δ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeWith]
-  refine ihc hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  refine ihc hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ b₁ b₂ hb₁ hb₂ hevalb
-  have hsub₁a : Δ₁.Subset Δa₁ := hsub₁.trans hsa₁
-  have hsub₂a : Δ₂.Subset Δa₂ := hsub₂.trans hsa₂
+  have hsub₁a : Δ.Subset Δa₁ := hsub₁.trans hsa₁
+  have hsub₂a : Δ.Subset Δa₂ := hsub₂.trans hsa₂
+  have hagree_a : Env.agreeOn Δ ρa₁ ρa₂ :=
+    Env.agreeOn_of_extensions hsub₁ hsub₂ hagree haa₁ haa₂
   have henv_a := VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv
   have hka : EncoderContSpec _ Δa₁ Δa₂ ρa₁ ρa₂ _ _ :=
     EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk
   refine hops.ite_binary ?_
-    (iht hops hsub₁a hsub₂a hwa₁ hwa₂ henv_a hka)
-    (ihe hops hsub₁a hsub₂a hwa₁ hwa₂ henv_a hka)
+    (iht hops hsub₁a hsub₂a hwa₁ hwa₂ hagree_a henv_a hka)
+    (ihe hops hsub₁a hsub₂a hwa₁ hwa₂ hagree_a henv_a hka)
   simp only [Term.eval, UnOp.eval]; rw [hevalb]
 
 theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
-    (ihArgs : ∀ a ∈ args, EncodeWithBindBinary a) :
+    (ihArgs : ∀ a ∈ args, EncodeWithBindBinary a) (ihArgsList : EncodeListWithBindBinary args) :
     EncodeWithBindBinary (.app fn args ty) := by
-  intro _ _ Γ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ Γ Δ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   match fn, args with
   | .var f _, [arg] =>
       simp only [encodeWith]
@@ -1118,10 +1163,32 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
       | none => exact hops.error_binary
       | some _ =>
           simp only
-          refine ihArgs arg (List.mem_singleton.mpr rfl) hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+          refine ihArgs arg (List.mem_singleton.mpr rfl) hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
           intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ _ _ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
           exact hops.call_binary (FunCtx.mem_of_lookup hlk) hv₁ hv₂ hevalv
             (EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk)
+  | .prim n _, args =>
+      simp only [encodeWith]
+      refine ihArgsList hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
+      intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ vs₁ vs₂ hvs₁ hvs₂ hevals
+      have hagree_a : Env.agreeOn Δ ρa₁ ρa₂ :=
+        Env.agreeOn_of_extensions hsub₁ hsub₂ hagree haa₁ haa₂
+      cases hraw₁ : encodePrim Δ n vs₁ with
+      | error msg =>
+          have hlen : vs₂.length = vs₁.length := by
+            simpa only [List.length_map] using (congrArg List.length hevals).symm
+          have hraw₂ := encodePrim_error_irrel (vs' := vs₂) hraw₁ hlen
+          simp only [hraw₁, hraw₂]
+          exact hops.error_binary
+      | ok v₁ =>
+          have hlen : vs₂.length = vs₁.length := by
+            simpa only [List.length_map] using (congrArg List.length hevals).symm
+          obtain ⟨v₂, hraw₂⟩ := encodePrim_ok_irrel (vs' := vs₂) hraw₁ hlen
+          simp only [hraw₁, hraw₂]
+          exact hk hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂
+            (encodePrim_wfIn hraw₁ (hsub₁.trans hsa₁) hwa₁ hvs₁)
+            (encodePrim_wfIn hraw₂ (hsub₂.trans hsa₂) hwa₂ hvs₂)
+            (encodePrim_eval hraw₁ hraw₂ hagree_a hevals)
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
   | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
@@ -1130,43 +1197,48 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
 
 theorem cast (e : Typed.Expr) (ty : TinyML.Typ) (ih : EncodeWithBindBinary e) :
     EncodeWithBindBinary (.cast e ty) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
-  simpa only [encodeWith] using ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
+  simpa only [encodeWith] using ih hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
 
 theorem fix (self : Typed.Binder) (args : List Typed.Binder) (retTy : TinyML.Typ)
     (body : Typed.Expr) : EncodeWithBindBinary (.fix self args retTy body) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+
+theorem prim (name : String) (ty : TinyML.Typ) : EncodeWithBindBinary (.prim name ty) := by
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
 
 theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
     (ihBound : EncodeWithBindBinary bound) (ihBody : EncodeWithBindBinary body) :
     EncodeWithBindBinary (.letIn name bound body) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ Δ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeWith]
-  refine ihBound hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  refine ihBound hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
   have henv_a := VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv
+  have hagree_a : Env.agreeOn Δ ρa₁ ρa₂ :=
+    Env.agreeOn_of_extensions hsub₁ hsub₂ hagree haa₁ haa₂
   have hka : EncoderContSpec _ Δa₁ Δa₂ ρa₁ ρa₂ _ _ :=
     EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk
   exact ihBody hops (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
-    (VarEnv.Agree.bindBinder henv_a hv₁ hv₂ hevalv) hka
+    hagree_a (VarEnv.Agree.bindBinder henv_a hv₁ hv₂ hevalv) hka
 
 theorem ref (owned : Bool) (e : Typed.Expr) : EncodeWithBindBinary (.ref owned e) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
 
 theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithBindBinary (.deref e ty) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
 
 theorem store (loc val : Typed.Expr) : EncodeWithBindBinary (.store loc val) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
 
 theorem assert (e : Typed.Expr) : EncodeWithBindBinary (.assert e) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
 
 theorem tuple (es : List Typed.Expr) (ih : EncodeListWithBindBinary es) :
     EncodeWithBindBinary (.tuple es) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeWith]
-  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ vs₁ vs₂ hvs₁ hvs₂ hevals
   exact hk hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂
     (.unop .ofValList (Terms.toValList vs₁)) (.unop .ofValList (Terms.toValList vs₂))
@@ -1177,9 +1249,9 @@ theorem tuple (es : List Typed.Expr) (ih : EncodeListWithBindBinary es) :
 theorem inj (tag arity : Nat) (payload : Typed.Expr)
     (ih : EncodeWithBindBinary payload) :
     EncodeWithBindBinary (.inj tag arity payload) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeWith]
-  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
   exact hk hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂
     (.unop (.mkInj tag arity) v₁) (.unop (.mkInj tag arity) v₂)
@@ -1190,19 +1262,21 @@ theorem match_ (scrut : Typed.Expr) (branches : List (Typed.Binder × Typed.Expr
     (ty : TinyML.Typ) (ihScrut : EncodeWithBindBinary scrut)
     (ihBranches : EncodeMatchWithBindBinary branches) :
     EncodeWithBindBinary (.match_ scrut branches ty) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ Δ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeWith]
-  refine ihScrut hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  refine ihScrut hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
   have henv_a := VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv
+  have hagree_a : Env.agreeOn Δ ρa₁ ρa₂ :=
+    Env.agreeOn_of_extensions hsub₁ hsub₂ hagree haa₁ haa₂
   have hka : EncoderContSpec _ Δa₁ Δa₂ ρa₁ ρa₂ _ _ :=
     EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk
   exact ihBranches hops (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
-    henv_a hv₁ hv₂ hevalv hka
+    hagree_a henv_a hv₁ hv₂ hevalv hka
 
 /-- Empty match branch lists encode as the shared match error. -/
 theorem match_nil : EncodeMatchWithBindBinary [] := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+  intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
   simp only [encodeMatchWith]; exact hops.error_binary
 
 /-- Binary preservation for a non-empty match branch list. -/
@@ -1211,8 +1285,8 @@ theorem match_cons (b : Typed.Binder) (body : Typed.Expr)
     (ihBody : EncodeWithBindBinary body)
     (ihRest : EncodeMatchWithBindBinary rest) :
     EncodeMatchWithBindBinary ((b, body) :: rest) := by
-  intro _ _ _ _ _ _ _ _ _ _ hops _ Δ₁' Δ₂' ρ₁' ρ₂' _ scrut₁ scrut₂ _
-        hsub₁ hsub₂ hwf₁ hwf₂ henv hscrut₁ hscrut₂ hevalScrut hk
+  intro _ _ _ Δ _ _ _ _ _ hops _ Δ₁' Δ₂' ρ₁' ρ₂' _ scrut₁ scrut₂ _
+        hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hscrut₁ hscrut₂ hevalScrut hk
   simp only [encodeMatchWith]
   have hpay₁ : (Term.unop UnOp.payloadOf scrut₁).wfIn Δ₁' := ⟨trivial, hscrut₁⟩
   have hpay₂ : (Term.unop UnOp.payloadOf scrut₂).wfIn Δ₂' := ⟨trivial, hscrut₂⟩
@@ -1222,18 +1296,18 @@ theorem match_cons (b : Typed.Binder) (body : Typed.Expr)
   cases rest with
   | nil =>
     exact ihBody hops hsub₁ hsub₂ hwf₁ hwf₂
-      (VarEnv.Agree.bindBinder henv hpay₁ hpay₂ hpayEval) hk
+      hagree (VarEnv.Agree.bindBinder henv hpay₁ hpay₂ hpayEval) hk
   | cons _ _ =>
     refine hops.ite_binary ?_
       (ihBody hops hsub₁ hsub₂ hwf₁ hwf₂
-        (VarEnv.Agree.bindBinder henv hpay₁ hpay₂ hpayEval) hk)
-      (ihRest hops hsub₁ hsub₂ hwf₁ hwf₂ henv hscrut₁ hscrut₂ hevalScrut hk)
+        hagree (VarEnv.Agree.bindBinder henv hpay₁ hpay₂ hpayEval) hk)
+      (ihRest hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hscrut₁ hscrut₂ hevalScrut hk)
     simp [Term.eval, UnOp.eval, BinOp.eval, hevalScrut]
 
 /-- Empty expression lists feed matching empty value lists to their
 continuations. -/
 theorem list_nil : EncodeListWithBindBinary [] := by
-  intro _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ _ hk
+  intro _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ _ _ hk
   simp only [encodeListWith]
   exact hk (Signature.Subset.refl _) (Signature.Subset.refl _) hwf₁ hwf₂
     Env.agreeOn_refl Env.agreeOn_refl [] [] (by simp) (by simp) (by simp)
@@ -1243,12 +1317,13 @@ tail list continuation. -/
 theorem list_cons (e : Typed.Expr) (es : List Typed.Expr)
     (ih : EncodeWithBindBinary e) (ihs : EncodeListWithBindBinary es) :
     EncodeListWithBindBinary (e :: es) := by
-  intro _ _ _ Δ₁ Δ₂ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+  intro _ _ _ Δ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeListWith]
-  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ henv ?_
+  refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
   refine ihs hops
     (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
+    (Env.agreeOn_of_extensions hsub₁ hsub₂ hagree haa₁ haa₂)
     (VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv) ?_
   intro Δb₁ Δb₂ ρb₁ ρb₂ hsb₁ hsb₂ hwb₁ hwb₂ hab₁ hab₂ vs₁ vs₂ hvs₁ hvs₂ hevals
   have hevHead : Term.eval ρb₁ v₁ = Term.eval ρb₂ v₂ := by
@@ -1280,6 +1355,7 @@ mutual
 theorem encodeWith_bind_binary_def : ∀ (e : Typed.Expr), EncodeWithBindBinary e
   | .const c => BindBinary.const c
   | .var x ty => BindBinary.var x ty
+  | .prim n ty => BindBinary.prim n ty
   | .unop op e ty => BindBinary.unop op e ty (encodeWith_bind_binary_def e)
   | .binop op e1 e2 ty =>
       BindBinary.binop op e1 e2 ty (encodeWith_bind_binary_def e1)
@@ -1289,6 +1365,7 @@ theorem encodeWith_bind_binary_def : ∀ (e : Typed.Expr), EncodeWithBindBinary 
         (encodeWith_bind_binary_def t) (encodeWith_bind_binary_def e)
   | .app fn args ty =>
       BindBinary.app fn args ty (fun a _ => encodeWith_bind_binary_def a)
+        (encodeListWith_bind_binary_def args)
   | .cast e ty => BindBinary.cast e ty (encodeWith_bind_binary_def e)
   | .fix self args retTy body => BindBinary.fix self args retTy body
   | .letIn name bound body =>
@@ -1328,19 +1405,21 @@ same syntax `e` but with independent local environments related by
 `(Δ₁', ρ₁')`, `(Δ₂', ρ₂')` extending the initial signatures, so the induction
 can chain inner continuation contracts off the future state reached by the
 outer one. -/
-theorem encodeWith_bind_binary {M₁ M₂ : Type} {Γ : FunCtx} {Δ₁ Δ₂ : Signature}
+theorem encodeWith_bind_binary {M₁ M₂ : Type} {Γ : FunCtx} {Δ : Signature}
     {δ₁ δ₂ : VarEnv}
     {ops₁ : EncoderOps M₁} {ops₂ : EncoderOps M₂}
     {B : Signature → Signature → Env → Env → M₁ → M₂ → Prop}
     (hops : EncoderOpsBinary Γ ops₁ ops₂ B)
     (e : Typed.Expr) {k₁ : Term .value → M₁}
     {Δ₁' Δ₂' : Signature} {ρ₁' ρ₂' : Env} {k₂ : Term .value → M₂}
-    (hsub₁ : Δ₁.Subset Δ₁') (hsub₂ : Δ₂.Subset Δ₂')
+    (hsub₁ : Δ.Subset Δ₁') (hsub₂ : Δ.Subset Δ₂')
     (hwf₁ : Δ₁'.wf) (hwf₂ : Δ₂'.wf)
+    (hagree : Env.agreeOn Δ ρ₁' ρ₂')
     (henv : VarEnv.Agree Δ₁' Δ₂' ρ₁' ρ₂' δ₁ δ₂)
     (hk : EncoderContSpec B Δ₁' Δ₂' ρ₁' ρ₂' k₁ k₂) :
-    B Δ₁' Δ₂' ρ₁' ρ₂' (encodeWith ops₁ Γ δ₁ e k₁) (encodeWith ops₂ Γ δ₂ e k₂) :=
-  encodeWith_bind_binary_def e hops hsub₁ hsub₂ hwf₁ hwf₂ henv hk
+    B Δ₁' Δ₂' ρ₁' ρ₂' (encodeWith ops₁ Δ Γ δ₁ e k₁)
+      (encodeWith ops₂ Δ Γ δ₂ e k₂) :=
+  encodeWith_bind_binary_def e hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
 
 
 end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/OUTLINE.md
+++ b/Mica/Verifier/RelationalEncoding/OUTLINE.md
@@ -2,6 +2,7 @@
 
 - `Axioms.lean` — Solver-facing axioms and validity theorems for skolemized relational encoding.
 - `Monad.lean` — Generic monadic skeleton for TinyML-to-FOL encoders.
+- `Prim.lean` — Encoding of saturated intrinsic applications into FOL terms, with well-formedness, arity-irrelevance, and evaluation lemmas.
 - `Relation.lean` — Stage 1 — encode a recursive TinyML body as a binary FOL relation defined by least fixpoint.
 - `SkolemizeCommon.lean` — Shared split encoding and semantic infrastructure for Skolemization.
 - `SkolemizeCompleteness.lean` — Completeness of Skolemization: relational encoding implies split definedness/value.

--- a/Mica/Verifier/RelationalEncoding/Prim.lean
+++ b/Mica/Verifier/RelationalEncoding/Prim.lean
@@ -5,11 +5,10 @@ namespace Verifier.RelationalEncoding
 
 /-! ## Intrinsic application encoder -/
 
-/-- Encode a saturated intrinsic application `n vs` into a value-sorted FOL
+/-- Encode an intrinsic application `n vs` into a value-sorted FOL
 term over the intrinsic's uninterpreted symbol. The symbol must already be
 declared in the encoding signature `Δ` at the arity implied by the argument
-count; the membership gate rejects unknown or mis-arited names, mirroring the
-`FunCtx.lookup` gate for ordinary calls. All intrinsics live at the value sort. -/
+count. -/
 def encodePrim (Δ : Signature) (n : String) :
     List (Term .value) → Except String (Term .value)
   | [] =>
@@ -27,8 +26,8 @@ def encodePrim (Δ : Signature) (n : String) :
   | _ => .error s!"relational encoding: intrinsic `{n}` applied at unsupported arity"
 
 /-- A successful intrinsic encoding is well-formed in any extension of the
-gating signature. The intrinsic symbol's membership is established at the base
-signature `Δ` (where the gate is checked) and lifted to `Δ'`; the freshness and
+signature. The intrinsic symbol's membership is established at the base
+signature `Δ` and lifted to `Δ'`; the freshness and
 uniqueness side conditions of `wfIn` follow from `Δ'.wf`. -/
 theorem encodePrim_wfIn {Δ Δ' : Signature} {n : String} {vs : List (Term .value)}
     {v : Term .value} (h : encodePrim Δ n vs = .ok v)
@@ -172,7 +171,7 @@ theorem encodePrim_error_irrel {Δ : Signature} {n : String}
                           exact h
 
 /-- `encodePrim` is a pure uninterpreted-symbol application: when the two
-environments agree on the gate signature `Δ` (hence on the intrinsic symbol)
+environments agree on the signature `Δ` (hence on the intrinsic symbol)
 and the argument evaluations agree pointwise, the results evaluate equally. -/
 theorem encodePrim_eval {Δ : Signature} {n : String}
     {vs₁ vs₂ : List (Term .value)} {v₁ v₂ : Term .value} {ρ₁ ρ₂ : Env}

--- a/Mica/Verifier/RelationalEncoding/Prim.lean
+++ b/Mica/Verifier/RelationalEncoding/Prim.lean
@@ -1,0 +1,225 @@
+-- SUMMARY: Encoding of saturated intrinsic applications into FOL terms, with well-formedness, arity-irrelevance, and evaluation lemmas.
+import Mica.FOL.Formulas
+
+namespace Verifier.RelationalEncoding
+
+/-! ## Intrinsic application encoder -/
+
+/-- Encode a saturated intrinsic application `n vs` into a value-sorted FOL
+term over the intrinsic's uninterpreted symbol. The symbol must already be
+declared in the encoding signature `Δ` at the arity implied by the argument
+count; the membership gate rejects unknown or mis-arited names, mirroring the
+`FunCtx.lookup` gate for ordinary calls. All intrinsics live at the value sort. -/
+def encodePrim (Δ : Signature) (n : String) :
+    List (Term .value) → Except String (Term .value)
+  | [] =>
+    if (⟨n, .value⟩ : FOL.Const) ∈ Δ.consts then
+      .ok (.const (.uninterpreted n .value))
+    else .error s!"relational encoding: unknown nullary intrinsic `{n}`"
+  | [a] =>
+    if (⟨n, .value, .value⟩ : FOL.Unary) ∈ Δ.unary then
+      .ok (.unop (.uninterpreted n .value .value) a)
+    else .error s!"relational encoding: unknown unary intrinsic `{n}`"
+  | [a, b] =>
+    if (⟨n, .value, .value, .value⟩ : FOL.Binary) ∈ Δ.binary then
+      .ok (.binop (.uninterpreted n .value .value .value) a b)
+    else .error s!"relational encoding: unknown binary intrinsic `{n}`"
+  | _ => .error s!"relational encoding: intrinsic `{n}` applied at unsupported arity"
+
+/-- A successful intrinsic encoding is well-formed in any extension of the
+gating signature. The intrinsic symbol's membership is established at the base
+signature `Δ` (where the gate is checked) and lifted to `Δ'`; the freshness and
+uniqueness side conditions of `wfIn` follow from `Δ'.wf`. -/
+theorem encodePrim_wfIn {Δ Δ' : Signature} {n : String} {vs : List (Term .value)}
+    {v : Term .value} (h : encodePrim Δ n vs = .ok v)
+    (hsub : Δ.Subset Δ') (hΔ' : Δ'.wf)
+    (hvs : ∀ w ∈ vs, w.wfIn Δ') : v.wfIn Δ' := by
+  cases vs with
+  | nil =>
+    simp only [encodePrim] at h
+    split at h
+    · rename_i hmem
+      simp only [Except.ok.injEq] at h; subst h
+      have hmem' : (⟨n, .value⟩ : FOL.Const) ∈ Δ'.consts := hsub.consts _ hmem
+      exact ⟨hmem', fun τ' hv => Signature.wf_no_var_of_const hΔ' hmem' hv,
+        fun τ' hc => Signature.wf_unique_const hΔ' hmem' hc⟩
+    · simp at h
+  | cons a tl =>
+    cases tl with
+    | nil =>
+      simp only [encodePrim] at h
+      split at h
+      · rename_i hmem
+        simp only [Except.ok.injEq] at h; subst h
+        have hmem' : (⟨n, .value, .value⟩ : FOL.Unary) ∈ Δ'.unary := hsub.unary _ hmem
+        exact ⟨⟨hmem', fun τ' hrel => Signature.wf_no_unaryRel_of_unary hΔ' hmem' hrel,
+            fun τ₁' τ₂' hu => Signature.wf_unique_unary hΔ' hmem' hu⟩,
+          hvs a (by simp)⟩
+      · simp at h
+    | cons b tl2 =>
+      cases tl2 with
+      | nil =>
+        simp only [encodePrim] at h
+        split at h
+        · rename_i hmem
+          simp only [Except.ok.injEq] at h; subst h
+          have hmem' : (⟨n, .value, .value, .value⟩ : FOL.Binary) ∈ Δ'.binary :=
+            hsub.binary _ hmem
+          exact ⟨⟨hmem', fun τ₁' τ₂' hrel => Signature.wf_no_binaryRel_of_binary hΔ' hmem' hrel,
+              fun τ₁' τ₂' τ₃' hb => Signature.wf_unique_binary hΔ' hmem' hb⟩,
+            hvs a (by simp), hvs b (by simp)⟩
+        · simp at h
+      | cons c tl3 =>
+        simp [encodePrim] at h
+
+/-- The success of `encodePrim` depends only on the name, signature, and
+argument count, not the argument terms: equal-length argument lists succeed
+together. -/
+theorem encodePrim_ok_irrel {Δ : Signature} {n : String}
+    {vs vs' : List (Term .value)} {v : Term .value}
+    (h : encodePrim Δ n vs = .ok v) (hlen : vs'.length = vs.length) :
+    ∃ v', encodePrim Δ n vs' = .ok v' := by
+  cases vs with
+  | nil =>
+      cases vs' with
+      | nil => exact ⟨v, h⟩
+      | cons a' tl' =>
+          cases tl' with
+          | nil => simp at hlen
+          | cons b' tl2' =>
+              cases tl2' <;> simp at hlen
+  | cons a tl =>
+      cases tl with
+      | nil =>
+          cases vs' with
+          | nil => simp at hlen
+          | cons a' tl' =>
+              cases tl' with
+              | nil =>
+                  simp only [encodePrim] at h ⊢
+                  split at h <;> simp_all
+              | cons b' tl2' =>
+                  cases tl2' <;> simp at hlen
+      | cons b tl2 =>
+          cases tl2 with
+          | nil =>
+              cases vs' with
+              | nil => simp at hlen
+              | cons a' tl' =>
+                  cases tl' with
+                  | nil => simp at hlen
+                  | cons b' tl2' =>
+                      cases tl2' with
+                      | nil =>
+                          simp only [encodePrim] at h ⊢
+                          split at h <;> simp_all
+                      | cons c' rest => simp at hlen
+          | cons c rest =>
+              simp [encodePrim] at h
+
+/-- The failure of `encodePrim` likewise depends only on the name, signature,
+and argument count: equal-length argument lists fail with the same message. -/
+theorem encodePrim_error_irrel {Δ : Signature} {n : String}
+    {vs vs' : List (Term .value)} {msg : String}
+    (h : encodePrim Δ n vs = .error msg) (hlen : vs'.length = vs.length) :
+    encodePrim Δ n vs' = .error msg := by
+  cases vs with
+  | nil =>
+      cases vs' with
+      | nil => exact h
+      | cons a' tl' =>
+          cases tl' with
+          | nil => simp at hlen
+          | cons b' tl2' =>
+              cases tl2' <;> simp at hlen
+  | cons a tl =>
+      cases tl with
+      | nil =>
+          cases vs' with
+          | nil => simp at hlen
+          | cons a' tl' =>
+              cases tl' with
+              | nil =>
+                  simp only [encodePrim] at h ⊢
+                  split at h <;> simp_all
+              | cons b' tl2' =>
+                  cases tl2' <;> simp at hlen
+      | cons b tl2 =>
+          cases tl2 with
+          | nil =>
+              cases vs' with
+              | nil => simp at hlen
+              | cons a' tl' =>
+                  cases tl' with
+                  | nil => simp at hlen
+                  | cons b' tl2' =>
+                      cases tl2' with
+                      | nil =>
+                          simp only [encodePrim] at h ⊢
+                          split at h <;> simp_all
+                      | cons c' rest => simp at hlen
+          | cons c rest =>
+              cases vs' with
+              | nil => simp at hlen
+              | cons a' tl' =>
+                  cases tl' with
+                  | nil => simp at hlen
+                  | cons b' tl2' =>
+                      cases tl2' with
+                      | nil => simp at hlen
+                      | cons c' rest' =>
+                          simp [encodePrim] at h ⊢
+                          exact h
+
+/-- `encodePrim` is a pure uninterpreted-symbol application: when the two
+environments agree on the gate signature `Δ` (hence on the intrinsic symbol)
+and the argument evaluations agree pointwise, the results evaluate equally. -/
+theorem encodePrim_eval {Δ : Signature} {n : String}
+    {vs₁ vs₂ : List (Term .value)} {v₁ v₂ : Term .value} {ρ₁ ρ₂ : Env}
+    (h₁ : encodePrim Δ n vs₁ = .ok v₁) (h₂ : encodePrim Δ n vs₂ = .ok v₂)
+    (hagree : Env.agreeOn Δ ρ₁ ρ₂)
+    (hvals : vs₁.map (fun t => Term.eval ρ₁ t) = vs₂.map (fun t => Term.eval ρ₂ t)) :
+    Term.eval ρ₁ v₁ = Term.eval ρ₂ v₂ := by
+  rcases vs₁ with _ | ⟨a₁, _ | ⟨b₁, r₁⟩⟩
+  · -- vs₁ = []  (nullary constant)
+    rcases vs₂ with _ | ⟨a₂, t₂⟩
+    · simp only [encodePrim] at h₁ h₂
+      split at h₁
+      · rename_i hmem
+        rw [if_pos hmem] at h₂
+        simp only [Except.ok.injEq] at h₁ h₂; subst h₁; subst h₂
+        simpa [Term.eval, Const.denote] using hagree.2.1 ⟨n, .value⟩ hmem
+      · simp at h₁
+    · simp at hvals
+  · -- vs₁ = [a₁]  (unary)
+    rcases vs₂ with _ | ⟨a₂, _ | ⟨b₂, t₂⟩⟩
+    · simp at hvals
+    · simp only [List.map_cons, List.map_nil, List.cons.injEq] at hvals
+      obtain ⟨ha, _⟩ := hvals
+      simp only [encodePrim] at h₁ h₂
+      split at h₁
+      · rename_i hmem
+        rw [if_pos hmem] at h₂
+        simp only [Except.ok.injEq] at h₁ h₂; subst h₁; subst h₂
+        simp only [Term.eval, UnOp.eval]
+        rw [hagree.2.2.1 ⟨n, .value, .value⟩ hmem, ha]
+      · simp at h₁
+    · simp at hvals
+  · -- vs₁ = b₁ :: r₁
+    rcases r₁ with _ | ⟨c₁, s₁⟩
+    · -- vs₁ = [a₁, b₁]  (binary)
+      rcases vs₂ with _ | ⟨a₂, _ | ⟨b₂, _ | _⟩⟩ <;> try (exfalso; simp at hvals; done)
+      simp only [List.map_cons, List.map_nil, List.cons.injEq] at hvals
+      obtain ⟨ha, hb, _⟩ := hvals
+      simp only [encodePrim] at h₁ h₂
+      split at h₁
+      · rename_i hmem
+        rw [if_pos hmem] at h₂
+        simp only [Except.ok.injEq] at h₁ h₂; subst h₁; subst h₂
+        simp only [Term.eval, BinOp.eval]
+        rw [hagree.2.2.2.1 ⟨n, .value, .value, .value⟩ hmem, ha, hb]
+      · simp at h₁
+    · -- vs₁ length ≥ 3: encodePrim errors
+      simp [encodePrim] at h₁
+
+end Verifier.RelationalEncoding

--- a/Mica/Verifier/RelationalEncoding/Relation.lean
+++ b/Mica/Verifier/RelationalEncoding/Relation.lean
@@ -250,7 +250,7 @@ pinned at result variable `res`. -/
 def relEncodeBody (Γ : FunCtx) (Δ : Signature)
     (f : TinyML.Var) (fn : SpecFn) (x res : TinyML.Var) (e : Typed.Expr) :
     Except String Formula :=
-  encodeWith encoderOps (ctx Γ f fn) (VarEnv.ofSignature (bodySig Δ fn x)) e (kEq res)
+  encodeWith encoderOps Δ (ctx Γ f fn) (VarEnv.ofSignature (bodySig Δ fn x)) e (kEq res)
     (relBodySupply Δ fn x res)
 
 /-- Least-fixpoint relational interpretation of `rec f x := e`. -/
@@ -425,7 +425,7 @@ theorem encodeWith_det {Γ : FunCtx} {Δenc : Signature} {res : String}
     (hδ : δ.wfIn Δview)
     (hk : ∀ {Δ : Signature} {v : Term .value},
         Δview.Subset Δ → Δ.wf → v.wfIn Δ → Rel.Det Γ res Δ (k v)) :
-    Rel.Det Γ res Δview (encodeWith encoderOps Γ δ e k) :=
+    Rel.Det Γ res Δview (encodeWith encoderOps Δenc Γ δ e k) :=
   encodeWith_indWithSig (encoderOps_det Γ res) e hsubView hΔview rfl
     hδ
     (fun hsub hΔ' _ hv => hk hsub hΔ' hv)
@@ -438,6 +438,7 @@ theorem semrel_functional
     (henc : relEncodeBody Γ Δ f fn x res e = .ok body)
     (hΓ : Γ.relWfIn Δ)
     (hrelFresh : fn.relName ∉ Δ.allNames)
+    (hsubBody : Δ.Subset (bodySig Δ fn x))
     (hΔbody : (bodySig Δ fn x).wf)
     (hresFresh : res ∉ (bodySig Δ fn x).allNames)
     (hρdet : BinaryRelDet Γ ρ ρ)
@@ -448,7 +449,7 @@ theorem semrel_functional
   let F : ValRel → ValRel := semanticBody Formula.sem ρ fn x res body
   let R : ValRel := semrel Γ Δ ρ f fn x res e
   set δ := VarEnv.ofSignature (bodySig Δ fn x) with hδ_def
-  set m := encodeWith encoderOps (ctx Γ f fn) δ e (kEq res) with hm_def
+  set m := encodeWith encoderOps Δ (ctx Γ f fn) δ e (kEq res) with hm_def
   have hrun : m (relBodySupply Δ fn x res) = .ok body := by
     simpa [relEncodeBody, hm_def] using henc
   have hR : R = Fix.lfp F := by simp [R, F, semrel, semanticFixpoint, henc]
@@ -463,9 +464,9 @@ theorem semrel_functional
   have hdetM : Rel.Det (ctx Γ f fn) res (bodySig Δ fn x) m :=
     by
       simpa [hm_def] using
-        encodeWith_det (Γ := ctx Γ f fn) (Δenc := bodySig Δ fn x)
+        encodeWith_det (Γ := ctx Γ f fn) (Δenc := Δ)
           (res := res) (e := e) (Δview := bodySig Δ fn x) (δ := δ)
-          (Signature.Subset.refl _) hΔbody
+          hsubBody hΔbody
           (by simpa [hδ_def] using VarEnv.ofSignature_wfIn hΔbody)
           (fun _ _ hv => kEq_det hv)
   have hxres : x ≠ res := by

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
@@ -49,7 +49,7 @@ predicates, so this encoding introduces no existential witnesses. Implemented
 as the shared traversal `encodeWith` instantiated at `encoderOps`. -/
 def encode (Γ : FunCtx) (Δ : Signature) (e : Typed.Expr) :
     Except String DefVal :=
-  encodeWith encoderOps Γ (VarEnv.ofSignature Δ) e (fun v => .ok (DefVal.pure v))
+  encodeWith encoderOps Δ Γ (VarEnv.ofSignature Δ) e (fun v => .ok (DefVal.pure v))
 
 /-! ## Well-formedness of `encode` -/
 
@@ -272,19 +272,30 @@ def encoderOps_wf : EncoderOpsSig encoderOps wfInE FunCtx.splitWfIn where
   ite_ind := encoderOps_ite_wfInE
   error_ind := True.intro
 
-/-- Well-formedness of the solver-facing defined/value encoding. -/
-theorem encode_wfIn {Γ : FunCtx} {Δ : Signature} (e : Typed.Expr)
-    {m : DefVal} (hΔ : Δ.wf) (hΓ : Γ.splitWfIn Δ)
-    (henc : encode Γ Δ e = .ok m) : m.wfIn Δ := by
-  have hcarrier : wfInE Δ
-      (encodeWith encoderOps Γ (VarEnv.ofSignature Δ) e (fun v => .ok (DefVal.pure v))) := by
-    refine encodeWith_indWithSig encoderOps_wf e (Signature.Subset.refl Δ) hΔ hΓ
+/-- Well-formedness of a solver-facing defined/value encoding whose `encodeWith`
+gate signature `Δgate` may differ from the `VarEnv` signature `Δenc` (the two
+coincide for `encode`, but the body encodings gate on the outer signature while
+encoding into a body signature). -/
+theorem encode_wfIn_of_gate {Γ : FunCtx} {Δgate Δenc : Signature} (e : Typed.Expr)
+    {m : DefVal} (hsub : Δgate.Subset Δenc) (hΔ : Δenc.wf) (hΓ : Γ.splitWfIn Δenc)
+    (henc : encodeWith encoderOps Δgate Γ (VarEnv.ofSignature Δenc) e
+        (fun v => .ok (DefVal.pure v)) = .ok m) :
+    m.wfIn Δenc := by
+  have hcarrier : wfInE Δenc
+      (encodeWith encoderOps Δgate Γ (VarEnv.ofSignature Δenc) e
+        (fun v => .ok (DefVal.pure v))) := by
+    refine encodeWith_indWithSig encoderOps_wf e hsub hΔ hΓ
       (VarEnv.ofSignature_wfIn hΔ) ?_
     intro Δ' _ _ v hv
     exact DefVal.pure_wfIn hv
-  unfold encode at henc
   rw [henc] at hcarrier
   exact hcarrier
+
+/-- Well-formedness of the solver-facing defined/value encoding. -/
+theorem encode_wfIn {Γ : FunCtx} {Δ : Signature} (e : Typed.Expr)
+    {m : DefVal} (hΔ : Δ.wf) (hΓ : Γ.splitWfIn Δ)
+    (henc : encode Γ Δ e = .ok m) : m.wfIn Δ :=
+  encode_wfIn_of_gate e (Signature.Subset.refl Δ) hΔ hΓ (by simpa [encode] using henc)
 
 /-! ## Monotonicity of `encode` definedness -/
 
@@ -374,7 +385,8 @@ def encodeBody (Γ : FunCtx) (Δ : Signature)
     Except String DefVal :=
   let Γ' := Relation.ctx Γ f fn
   let Δ' := defvalBodySig Δ fn x
-  encode Γ' Δ' e
+  encodeWith encoderOps Δ Γ' (VarEnv.ofSignature Δ') e
+    (fun v => .ok (DefVal.pure v))
 
 /-- Proof-only binary relation: whenever the split `DefVal` carrier succeeds,
 the paired relational carrier succeeds under any name supply covering the
@@ -560,7 +572,8 @@ theorem semdef_unfold_of_encode
         (semdef Γ Δ ρ f fn x res e body) vin := by
   unfold semdef
   have hcarrier : MonoE
-      (encodeWith encoderOps (Relation.ctx Γ f fn) (VarEnv.ofSignature (defvalBodySig Δ fn x)) e
+      (encodeWith encoderOps Δ (Relation.ctx Γ f fn)
+        (VarEnv.ofSignature (defvalBodySig Δ fn x)) e
         (fun v => .ok (DefVal.pure v))) :=
     encodeWith_ind encoderOps_preservesMono e
       (by
@@ -568,9 +581,12 @@ theorem semdef_unfold_of_encode
         show MonoE (.ok (DefVal.pure v))
         intro ρ ρ' _ _
         simp [DefVal.pure, Formula.eval])
-  have hdef : encode (Relation.ctx Γ f fn) (defvalBodySig Δ fn x) e = .ok body := henc
-  unfold encode at hdef
-  rw [hdef] at hcarrier
+  have henc' :
+      encodeWith encoderOps Δ (Relation.ctx Γ f fn)
+        (VarEnv.ofSignature (defvalBodySig Δ fn x)) e
+        (fun v => .ok (DefVal.pure v)) = .ok body := by
+    simpa [encodeBody] using henc
+  rw [henc'] at hcarrier
   have hbodyMono : DefVal.Mono body := hcarrier
   exact UnaryFix.lfp_unfold (defBody_mono (ρ := ρ) (fn := fn) (x := x)
     (body := body) hbodyMono) vin
@@ -694,8 +710,10 @@ theorem splitSound_cons_relSplitEnv
 theorem encodeBody_def_bodySig {Γ : FunCtx} {Δ : Signature}
     {f : TinyML.Var} {fn : SpecFn} {x res : TinyML.Var} {e : Typed.Expr}
     {body : DefVal} (henc : encodeBody Γ Δ f fn x res e = .ok body) :
-    encode (Relation.ctx Γ f fn) (bodySig Δ fn x) e = .ok body := by
-  unfold encode
+    encodeWith encoderOps Δ (Relation.ctx Γ f fn)
+      (VarEnv.ofSignature (bodySig Δ fn x)) e
+      (fun v => .ok (DefVal.pure v)) = .ok body := by
+  unfold encodeBody at henc
   have hvars :
       VarEnv.ofSignature (bodySig Δ fn x) =
         VarEnv.ofSignature (defvalBodySig Δ fn x) := by
@@ -703,7 +721,7 @@ theorem encodeBody_def_bodySig {Γ : FunCtx} {Δ : Signature}
       Signature.addBinaryRel, Signature.addUnary, Signature.addUnaryRel,
       Signature.remove, Signature.addVar]
   rw [hvars]
-  exact henc
+  simpa [encodeBody] using henc
 
 /-! ### Freshness and signature infrastructure -/
 
@@ -997,29 +1015,55 @@ theorem encodeBody_relEncodeBody {Γ : FunCtx} {Δ : Signature}
     (henc : encodeBody Γ Δ f fn x res e = .ok body) :
     ∃ φ, relEncodeBody Γ Δ f fn x res e = .ok φ := by
   have hΔbody : (bodySig Δ fn x).wf := bodySig_wf_of_headFresh hΔ hheadFresh
+  have hΔrelBody : (Relation.bodySig Δ fn x).wf :=
+    relBodySig_wf_of_headFresh hΔ hheadFresh
   have hΓbody : (Relation.ctx Γ f fn).splitWfIn (bodySig Δ fn x) :=
     ctx_splitWfIn_bodySig_of_headFresh hΓdef hheadFresh
   have hbinary :
-      RelSucceedsWhenDef (Relation.ctx Γ f fn) (bodySig Δ fn x) (bodySig Δ fn x)
+      RelSucceedsWhenDef (Relation.ctx Γ f fn) (Relation.bodySig Δ fn x) (bodySig Δ fn x)
         default default
-        (encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
+        (encodeWith Relation.encoderOps Δ (Relation.ctx Γ f fn)
           (VarEnv.ofSignature (bodySig Δ fn x)) e (Relation.kEq res))
-        (encode (Relation.ctx Γ f fn) (bodySig Δ fn x) e) := by
+        (encodeWith encoderOps Δ (Relation.ctx Γ f fn)
+          (VarEnv.ofSignature (bodySig Δ fn x)) e
+          (fun v => .ok (DefVal.pure v))) := by
+    have hvars :
+        VarEnv.ofSignature (bodySig Δ fn x) =
+          VarEnv.ofSignature (Relation.bodySig Δ fn x) := by
+      simp [VarEnv.ofSignature, bodySig, Relation.bodySig, Signature.declVar,
+        Signature.addBinaryRel, Signature.addUnary, Signature.addUnaryRel,
+        Signature.remove, Signature.addVar]
+    have henv :
+        VarEnv.Agree (Relation.bodySig Δ fn x) (bodySig Δ fn x) default default
+          (VarEnv.ofSignature (bodySig Δ fn x))
+          (VarEnv.ofSignature (bodySig Δ fn x)) := by
+      have hself := varEnv_ofSignature_agree_self (ρ := default) hΔrelBody
+      have hmono := VarEnv.Agree.mono (Signature.Subset.refl _)
+        (relBodySig_subset_bodySig (Δ := Δ) (fn := fn) (x := x))
+        hΔrelBody hΔbody Env.agreeOn_refl Env.agreeOn_refl hself
+      simpa [hvars] using hmono
     refine encodeWith_bind_binary (δ₁ := VarEnv.ofSignature (bodySig Δ fn x))
       (δ₂ := VarEnv.ofSignature (bodySig Δ fn x))
       (relSucceedsWhenDef_ops (Relation.ctx Γ f fn)) e
-      (Signature.Subset.refl _) (Signature.Subset.refl _) hΔbody hΔbody ?_ ?_
-    · exact varEnv_ofSignature_agree_self hΔbody
+      (subset_relBodySig_of_headFresh hheadFresh) (subset_bodySig_of_headFresh hheadFresh)
+      hΔrelBody hΔbody Env.agreeOn_refl henv ?_
     · intro Δrel' Δdef' ρrel' ρdef' _ _ _ _ _ _ vrel vdef _ _ _ _ _ _ s _ body' hbody'
       exact ⟨.eq .value vrel (.var .value res), by simp [Relation.kEq]⟩
-  have hdefBody : encode (Relation.ctx Γ f fn) (bodySig Δ fn x) e = .ok body :=
+  have hdefBody :
+      encodeWith encoderOps Δ (Relation.ctx Γ f fn)
+        (VarEnv.ofSignature (bodySig Δ fn x)) e
+        (fun v => .ok (DefVal.pure v)) = .ok body :=
     encodeBody_def_bodySig henc
   have hcov : (relBodySupply Δ fn x res).Covers (bodySig Δ fn x) := by
     intro n hn
     exact relBodySupply_covers_sig Δ fn x res n
       (Signature.allNames_subset (bodySig_subset_sig_of_headFresh hheadFresh) n hn)
-  obtain ⟨φ, hφ⟩ := hbinary hΔbody hΔbody hΓbody
-    (relBodySupply Δ fn x res) hcov body hdefBody
+  have hcovRel : (relBodySupply Δ fn x res).Covers (Relation.bodySig Δ fn x) := by
+    intro n hn
+    exact hcov n (Signature.allNames_subset
+      (relBodySig_subset_bodySig (Δ := Δ) (fn := fn) (x := x)) n hn)
+  obtain ⟨φ, hφ⟩ := hbinary hΔrelBody hΔbody hΓbody
+    (relBodySupply Δ fn x res) hcovRel body hdefBody
   have hvars :
       VarEnv.ofSignature (bodySig Δ fn x) =
         VarEnv.ofSignature (Relation.bodySig Δ fn x) := by
@@ -1039,9 +1083,11 @@ theorem encodeBody_wfIn_defvalBodySig
     (hheadFresh : HeadFresh Δ fn x res)
     (henc : encodeBody Γ Δ f fn x res e = .ok body) :
     body.wfIn (defvalBodySig Δ fn x) :=
-  encode_wfIn e (defvalBodySig_wf_of_headFresh hΔ hheadFresh)
+  encode_wfIn_of_gate e
+    (subset_defvalBodySig_of_headFresh hheadFresh)
+    (defvalBodySig_wf_of_headFresh hΔ hheadFresh)
     (ctx_splitWfIn_defvalBodySig_of_headFresh hΓdef hheadFresh)
-    henc
+    (by simpa [encodeBody] using henc)
 
 theorem relEnv_relSplitEnv_agreeOn_relSig
     {Δ : Signature} {ρ : Env} {fn : SpecFn} {x res : String}
@@ -1091,7 +1137,7 @@ theorem relEncodeBody_wfIn_relSig
     (hΓfn : Γ.relWfIn Δ) (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hrelEnc : relEncodeBody Γ Δ f fn x res e = .ok φ) :
     φ.wfIn (Relation.sig Δ fn x res) := by
-  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
+  set m := encodeWith Relation.encoderOps Δ (Relation.ctx Γ f fn)
       (VarEnv.ofSignature (Relation.bodySig Δ fn x)) e (Relation.kEq res) with hm_def
   have hrun : m (relBodySupply Δ fn x res) = .ok φ := by
     simpa [Relation.relEncodeBody, hm_def] using hrelEnc
@@ -1103,7 +1149,8 @@ theorem relEncodeBody_wfIn_relSig
     exact Signature.var_mem_declVar (Relation.bodySig Δ fn x) ⟨res, .value⟩
   have hmWf : Relation.Rel.wfIn (Relation.sig Δ fn x res) m :=
     encodeWith_indWithSig Relation.encoderOps_wf e
-      (relBodySig_subset_relSig_of_headFresh hheadFresh)
+      ((subset_relBodySig_of_headFresh hheadFresh).trans
+        (relBodySig_subset_relSig_of_headFresh hheadFresh))
       hsigWf
       (ctx_relWfIn_relSig_of_headFresh hΓfn hheadFresh)
       (fun y v hlookup =>

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCompleteness.lean
@@ -171,13 +171,16 @@ def completeBinary_ops (Γ : FunCtx) (P : Env → Srt.value.denote → Prop) (re
 /-- Pinned-result completeness, obtained directly from a successful paired
 encoding of the same expression: the relational formula implies the split
 body's definedness and value. -/
-theorem encodeWith_kEq_complete {Γ : FunCtx} {Δenc Δrun : Signature}
+theorem encodeWith_kEq_complete {Γ : FunCtx} {Δsym Δenc Δrun : Signature}
     {srun : NameSupply} {ρ : Env}
     {e : Typed.Expr} {body : DefVal}
     {res : String} {φ : Formula}
-    (hrun : encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res) srun = .ok φ)
-    (hdef : encode Γ Δenc e = .ok body)
+    (hrun : encodeWith Relation.encoderOps Δsym Γ (VarEnv.ofSignature Δenc) e
+      (Relation.kEq res) srun = .ok φ)
+    (hdef : encodeWith encoderOps Δsym Γ (VarEnv.ofSignature Δenc) e
+      (fun v => .ok (DefVal.pure v)) = .ok body)
     (hΓ : Γ.splitComplete ρ) (hΓdef : Γ.splitWfIn Δenc)
+    (hsym : Δsym.Subset Δenc)
     (hΔenc : Δenc.wf) (hΔrun : Δrun.wf) (hcov : srun.Covers Δrun)
     (hsub : Δenc.Subset Δrun)
     (hbody : body.wfIn Δenc)
@@ -187,13 +190,13 @@ theorem encodeWith_kEq_complete {Γ : FunCtx} {Δenc Δrun : Signature}
   intro hφ
   have hbinary :
       CompleteBinary Γ (fun ρ v => v = (Term.var .value res).eval ρ) res Δenc Δenc ρ ρ
-        (encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res))
-        (encodeWith encoderOps Γ (VarEnv.ofSignature Δenc) e (fun v => .ok (DefVal.pure v))) := by
+        (encodeWith Relation.encoderOps Δsym Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res))
+        (encodeWith encoderOps Δsym Γ (VarEnv.ofSignature Δenc) e
+          (fun v => .ok (DefVal.pure v))) := by
     refine encodeWith_bind_binary (δ₁ := VarEnv.ofSignature Δenc)
       (δ₂ := VarEnv.ofSignature Δenc) (completeBinary_ops Γ _ res) e
-      (Signature.Subset.refl _) (Signature.Subset.refl _) hΔenc hΔenc
-      ?_ ?_
-    · exact varEnv_ofSignature_agree_self hΔenc
+      hsym hsym hΔenc hΔenc Env.agreeOn_refl
+      (varEnv_ofSignature_agree_self hΔenc) ?_
     -- EncoderContSpec for the `(kEq res, pure)` continuation pair
     intro Δ₁' Δ₂' ρ₁' ρ₂' _hs₁ _hs₂ _hw₁ _hw₂ _ha₁ _ha₂ v₁ v₂ _hv₁ _hv₂ heval Δ s φ' body'
       _ _ _ _ _ _ _ hrun' hd' _ _ _ hres_eq' hφ'
@@ -250,7 +253,7 @@ theorem semrel_complete
       vout := by
   intro hrel
   obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓwf.split hheadFresh henc
-  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
+  set m := encodeWith Relation.encoderOps Δ (Relation.ctx Γ f fn)
       (VarEnv.ofSignature (bodySig Δ fn x)) e (Relation.kEq res) with hm_def
   have hrun : m (relBodySupply Δ fn x res) = .ok φ := by
     have hvars :
@@ -262,8 +265,11 @@ theorem semrel_complete
     rw [hm_def, hvars]
     simpa [Relation.relEncodeBody] using hrelEnc
   have hbodyWf_body : body.wfIn (bodySig Δ fn x) :=
-    encode_wfIn e (bodySig_wf_of_headFresh hΔ hheadFresh)
-      (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh) (encodeBody_def_bodySig henc)
+    encode_wfIn_of_gate e
+      (subset_bodySig_of_headFresh hheadFresh)
+      (bodySig_wf_of_headFresh hΔ hheadFresh)
+      (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
+      (encodeBody_def_bodySig henc)
   have hres_mem : (⟨res, .value⟩ : Var) ∈ (sig Δ fn x res).vars := by
     unfold sig
     exact Signature.var_mem_declVar _ ⟨res, .value⟩
@@ -310,6 +316,7 @@ theorem semrel_complete
     have hproof :=
       encodeWith_kEq_complete (Γ := Relation.ctx Γ f fn)
         (Δenc := bodySig Δ fn x) (Δrun := sig Δ fn x res)
+        (Δsym := Δ)
         (srun := relBodySupply Δ fn x res)
         (ρ := (ρS.updateConst .value x vin).updateConst .value res vout)
         (e := e) (body := body) (res := res) (φ := φ)
@@ -317,6 +324,7 @@ theorem semrel_complete
         (FunCtx.splitComplete_updateConst
           (FunCtx.splitComplete_updateConst hΓS .value x vin) .value res vout)
         (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
+        (subset_bodySig_of_headFresh hheadFresh)
         (bodySig_wf_of_headFresh hΔ hheadFresh)
         (sig_wf_of_headFresh hΔ hheadFresh)
         (relBodySupply_covers_sig Δ fn x res)

--- a/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeSoundness.lean
@@ -184,13 +184,16 @@ def soundBinary_ops (Γ : FunCtx) (P : Env → Srt.value.denote → Prop) (res :
 /-- Pinned-result soundness, obtained directly from a successful paired
 encoding of the same expression: the split body's definedness and value
 imply the relational formula. -/
-theorem encodeWith_kEq_sound {Γ : FunCtx} {Δenc Δrun : Signature}
+theorem encodeWith_kEq_sound {Γ : FunCtx} {Δsym Δenc Δrun : Signature}
     {srun : NameSupply} {ρ : Env}
     {e : Typed.Expr} {body : DefVal}
     {res : String} {φ : Formula}
-    (hrun : encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res) srun = .ok φ)
-    (hdef : encode Γ Δenc e = .ok body)
+    (hrun : encodeWith Relation.encoderOps Δsym Γ (VarEnv.ofSignature Δenc) e
+      (Relation.kEq res) srun = .ok φ)
+    (hdef : encodeWith encoderOps Δsym Γ (VarEnv.ofSignature Δenc) e
+      (fun v => .ok (DefVal.pure v)) = .ok body)
     (hΓ : Γ.splitSound ρ) (hΓdef : Γ.splitWfIn Δenc)
+    (hsym : Δsym.Subset Δenc)
     (hΔenc : Δenc.wf) (hΔrun : Δrun.wf) (hcov : srun.Covers Δrun)
     (hsub : Δenc.Subset Δrun)
     (hbody : body.wfIn Δenc)
@@ -200,13 +203,13 @@ theorem encodeWith_kEq_sound {Γ : FunCtx} {Δenc Δrun : Signature}
   intro hsplit
   have hbinary :
       SoundBinary Γ (fun ρ v => v = (Term.var .value res).eval ρ) res Δenc Δenc ρ ρ
-        (encodeWith Relation.encoderOps Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res))
-        (encodeWith encoderOps Γ (VarEnv.ofSignature Δenc) e (fun v => .ok (DefVal.pure v))) := by
+        (encodeWith Relation.encoderOps Δsym Γ (VarEnv.ofSignature Δenc) e (Relation.kEq res))
+        (encodeWith encoderOps Δsym Γ (VarEnv.ofSignature Δenc) e
+          (fun v => .ok (DefVal.pure v))) := by
     refine encodeWith_bind_binary (δ₁ := VarEnv.ofSignature Δenc)
       (δ₂ := VarEnv.ofSignature Δenc) (soundBinary_ops Γ _ res) e
-      (Signature.Subset.refl _) (Signature.Subset.refl _) hΔenc hΔenc
-      ?_ ?_
-    · exact varEnv_ofSignature_agree_self hΔenc
+      hsym hsym hΔenc hΔenc Env.agreeOn_refl
+      (varEnv_ofSignature_agree_self hΔenc) ?_
     -- EncoderContSpec for the `(kEq res, pure)` continuation pair
     intro Δ₁' Δ₂' ρ₁' ρ₂' _hs₁ _hs₂ _hw₁ _hw₂ _ha₁ _ha₂ v₁ v₂ _hv₁ _hv₂ heval Δ s φ' body'
       _ _ _ _ _ _ _ hrun' hd' _ _ _ hres_eq' _ hP'
@@ -262,7 +265,7 @@ theorem semrel_sound
       semrel Γ Δ ρ f fn x res e vin vout := by
   intro hsem hval
   obtain ⟨φ, hrelEnc⟩ := encodeBody_relEncodeBody hΔ hΓwf.split hheadFresh henc
-  set m := encodeWith Relation.encoderOps (Relation.ctx Γ f fn)
+  set m := encodeWith Relation.encoderOps Δ (Relation.ctx Γ f fn)
       (VarEnv.ofSignature (bodySig Δ fn x)) e (Relation.kEq res) with hm_def
   have hrun : m (relBodySupply Δ fn x res) = .ok φ := by
     have hvars :
@@ -290,8 +293,11 @@ theorem semrel_sound
     rw [hrel_eq]
     exact Fix.lfp_prefixed (Relation.semanticBody_mono_of_semanticMono hmonoφ)
   have hbodyWf_body : body.wfIn (bodySig Δ fn x) :=
-    encode_wfIn e (bodySig_wf_of_headFresh hΔ hheadFresh)
-      (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh) (encodeBody_def_bodySig henc)
+    encode_wfIn_of_gate e
+      (subset_bodySig_of_headFresh hheadFresh)
+      (bodySig_wf_of_headFresh hΔ hheadFresh)
+      (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
+      (encodeBody_def_bodySig henc)
   have hres_mem : (⟨res, .value⟩ : Var) ∈ (sig Δ fn x res).vars := by
     unfold sig
     exact Signature.var_mem_declVar _ ⟨res, .value⟩
@@ -305,6 +311,7 @@ theorem semrel_sound
       φ.eval ((ρsplit.updateConst .value x vin').updateConst .value res vout') :=
     encodeWith_kEq_sound (Γ := Relation.ctx Γ f fn)
       (Δenc := bodySig Δ fn x) (Δrun := sig Δ fn x res)
+      (Δsym := Δ)
       (srun := relBodySupply Δ fn x res)
       (ρ := (ρsplit.updateConst .value x vin').updateConst .value res vout')
       (e := e) (body := body) (res := res) (φ := φ)
@@ -312,6 +319,7 @@ theorem semrel_sound
       (FunCtx.splitSound_updateConst
         (FunCtx.splitSound_updateConst hΓsplit .value x vin') .value res vout')
       (ctx_splitWfIn_bodySig_of_headFresh hΓwf.split hheadFresh)
+      (subset_bodySig_of_headFresh hheadFresh)
       (bodySig_wf_of_headFresh hΔ hheadFresh)
       (sig_wf_of_headFresh hΔ hheadFresh) (relBodySupply_covers_sig Δ fn x res)
       (bodySig_subset_sig_of_headFresh hheadFresh)
@@ -391,6 +399,7 @@ theorem relation_semrel_functional_of_encodeBody
     exact hheadFresh.resFresh (Signature.allNames_subset
       (relBodySig_subset_bodySig (Δ := Δ) (fn := fn) (x := x)) _ hres)
   exact Relation.semrel_functional hrelEnc hΓwf.rel hheadFresh.relFresh
+    (subset_relBodySig_of_headFresh hheadFresh)
     (relBodySig_wf_of_headFresh hΔ hheadFresh)
     hresFreshR hρdet vin y₁ y₂
 

--- a/Mica/Verifier/SpecMaps.lean
+++ b/Mica/Verifier/SpecMaps.lean
@@ -17,23 +17,23 @@ open Iris Iris.BI
 
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
-def SpecMap.satisfiedBy (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+def SpecMap.satisfiedBy (wctx : WpCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (γ : Runtime.Subst) : iProp :=
   iprop(□ (∀ x s, ⌜S.lookup x = some s⌝ -∗
-    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor Θ Δ_spec ρ_spec f))
+    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor wctx Θ Δ_spec ρ_spec f))
 
-instance : Iris.BI.Persistent (SpecMap.satisfiedBy Θ Δ_spec ρ_spec S γ) := by
+instance : Iris.BI.Persistent (SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec S γ) := by
   unfold SpecMap.satisfiedBy; infer_instance
 
 theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp)
     (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (S : SpecMap) (γ : Runtime.Subst) :
-  (P ⊢ S.satisfiedBy Θ Δ_spec ρ_spec γ) →
+  (P ⊢ S.satisfiedBy wctx Θ Δ_spec ρ_spec γ) →
   S.lookup x = some s →
-  (∀ fval, γ x = some fval → s.isPrecondFor Θ Δ_spec ρ_spec fval ∗ P ⊢ Q) →
+  (∀ fval, γ x = some fval → s.isPrecondFor wctx Θ Δ_spec ρ_spec fval ∗ P ⊢ Q) →
   (P ⊢ Q) := by
   intro hsat hlook hcont
   simp only [SpecMap.satisfiedBy] at hsat
-  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor Θ Δ_spec ρ_spec fval) ∗ P := by
+  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor wctx Θ Δ_spec ρ_spec fval) ∗ P := by
     refine (persistent_entails_r hsat).trans ?_
     istart
     iintro ⟨□Hall, HP⟩
@@ -129,7 +129,7 @@ theorem SpecMap.satisfiedBy_preserved {Θ : TinyML.TypeEnv} {Δ_spec : Signature
     {S S' : SpecMap} {γ γ' : Runtime.Subst}
     (h : ∀ y s, S'.lookup y = some s →
       S.lookup y = some s ∧ (∀ f, γ y = some f → γ' y = some f)) :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ S'.satisfiedBy Θ Δ_spec ρ_spec γ' := by
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢ S'.satisfiedBy wctx Θ Δ_spec ρ_spec γ' := by
   simp only [SpecMap.satisfiedBy]
   iintro □HS
   imodintro
@@ -147,8 +147,8 @@ theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {Δ_spec :
     {γ γ' : Runtime.Subst} {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
     (hγ' : γ' x = some fval)
     (hγ : ∀ y f, y ≠ x → γ y = some f → γ' y = some f) :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ' := by
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ' := by
   simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
   iintro ⟨□HS, □Hf⟩
   imodintro
@@ -171,14 +171,14 @@ theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {Δ_spec :
 
 theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ :=
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ :=
   SpecMap.satisfiedBy_insert_of_preserved hγ (fun _ _ _ hf => hf)
 
 theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec v ⊢
-      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.insert x spec S) (γ.update x v) :=
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec v ⊢
+      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) (γ.update x v) :=
   SpecMap.satisfiedBy_insert_of_preserved
     (by simp [Runtime.Subst.update])
     (fun y f hyx hf => by simp [Runtime.Subst.update, beq_false_of_ne hyx, hf])
@@ -193,8 +193,8 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
 theorem SpecMap.satisfiedBy_insertBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
     (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval) :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (S.insertBinder b spec) γ := by
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (S.insertBinder b spec) γ := by
   rcases hb : b.name with _ | x
   · rw [SpecMap.insertBinder_none hb]; iintro ⟨HS, _⟩; iexact HS
   · obtain ⟨_, ty⟩ := b; cases hb
@@ -202,8 +202,8 @@ theorem SpecMap.satisfiedBy_insertBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signat
 
 theorem SpecMap.satisfiedBy_insertBinder_updateBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor Θ Δ_spec ρ_spec v ⊢
-      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec v ⊢
+      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.insertBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]; iintro ⟨HS, _⟩; iexact HS
@@ -225,8 +225,8 @@ theorem SpecMap.wfIn_eraseBinder {S : SpecMap} {b : Typed.Binder} {Δ : Signatur
 theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
     {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
     {vs : List Runtime.Val} (hlen : keys.length = vs.length) :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢
-      (SpecMap.eraseAll keys S).satisfiedBy Θ Δ_spec ρ_spec (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢
+      (SpecMap.eraseAll keys S).satisfiedBy wctx Θ Δ_spec ρ_spec (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hy_notin : y ∉ keys := by
@@ -241,7 +241,7 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {Δ_s
   exact hf
 
 theorem SpecMap.empty_satisfiedBy (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (γ : Runtime.Subst) :
-    ⊢ SpecMap.satisfiedBy Θ Δ_spec ρ_spec (∅ : SpecMap) γ := by
+    ⊢ SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (∅ : SpecMap) γ := by
   simp only [SpecMap.satisfiedBy]
   imodintro
   iintro %x %s %h
@@ -253,8 +253,8 @@ theorem SpecMap.empty_wfIn (Δ : Signature) :
 
 theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
     {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢
-      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢
+      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by
@@ -264,8 +264,8 @@ theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {�
 
 theorem SpecMap.satisfiedBy_eraseBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢
-      SpecMap.satisfiedBy Θ Δ_spec ρ_spec (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢
+      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.eraseBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]
@@ -274,7 +274,7 @@ theorem SpecMap.satisfiedBy_eraseBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signatu
 
 theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} (hx : S.lookup x = none) :
-    S.satisfiedBy Θ Δ_spec ρ_spec γ ⊢ S.satisfiedBy Θ Δ_spec ρ_spec (γ.update x v) := by
+    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢ S.satisfiedBy wctx Θ Δ_spec ρ_spec (γ.update x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)

--- a/Mica/Verifier/SpecTranslation.lean
+++ b/Mica/Verifier/SpecTranslation.lean
@@ -22,12 +22,14 @@ open Verifier.RelationalEncoding
 private abbrev M := Except String
 
 /-- Encode a spec expression into a `DefVal`. -/
-def encodeExpr (Γfn : FunCtx) (δ : VarEnv) (e : Typed.Expr) : M Skolemize.DefVal :=
-  encodeWith Skolemize.encoderOps Γfn δ e (fun v => .ok (Skolemize.DefVal.pure v))
+def encodeExpr (Δ : Signature) (Γfn : FunCtx) (δ : VarEnv) (e : Typed.Expr) :
+    M Skolemize.DefVal :=
+  encodeWith Skolemize.encoderOps Δ Γfn δ e (fun v => .ok (Skolemize.DefVal.pure v))
 
 /-- Encode a boolean spec expression into its definedness and truth formulas. -/
-def encodeBool (Γfn : FunCtx) (δ : VarEnv) (e : Typed.Expr) : M (Formula × Formula) := do
-  let dv ← encodeExpr Γfn δ e
+def encodeBool (Δ : Signature) (Γfn : FunCtx) (δ : VarEnv) (e : Typed.Expr) :
+    M (Formula × Formula) := do
+  let dv ← encodeExpr Δ Γfn δ e
   .ok (dv.defined, .eq .bool (.unop .toBool dv.value) (.const (.b true)))
 
 /-- Look up a spec-level variable's encoded value. -/
@@ -46,35 +48,37 @@ def translatePred (δ : VarEnv) (ty : TinyML.Typ) : Spec.Pred → M (Atom .value
   | .own loc => do .ok (.own (← lookupVar δ loc) ty)
 
 /-- Translate a spec assertion, asserting each leaf's definedness before its value. -/
-def translateAssert (Γfn : FunCtx) (inner : VarEnv → α → M β) :
+def translateAssert (Δ : Signature) (Γfn : FunCtx) (inner : VarEnv → α → M β) :
     VarEnv → Spec.Assert Typed.Expr α → M (Assertion β)
   | δ, .ret a => do .ok (.ret (← inner δ a))
   | δ, .assert cond rest => do
-    let (defd, φ) ← encodeBool Γfn δ cond
-    .ok (.assert defd (.assert φ (← translateAssert Γfn inner δ rest)))
+    let (defd, φ) ← encodeBool Δ Γfn δ cond
+    .ok (.assert defd (.assert φ (← translateAssert Δ Γfn inner δ rest)))
   | δ, .let_ x e rest => do
-    let dv ← encodeExpr Γfn δ e
+    let dv ← encodeExpr Δ Γfn δ e
     let v : Var := ⟨x, .value⟩
     .ok (.assert dv.defined (.let_ v dv.value
       (assertAll (TinyML.typeConstraints e.ty (.var .value x))
-        (← translateAssert Γfn inner (δ.bind x (.var .value x)) rest))))
+        (← translateAssert Δ Γfn inner (δ.bind x (.var .value x)) rest))))
   | δ, .bind pred x ty rest => do
     let atom ← translatePred δ ty pred
     let v : Var := ⟨x, .value⟩
     .ok (.pred v atom
       (assertAll (TinyML.typeConstraints ty (.var .value x))
-        (← translateAssert Γfn inner (δ.bind x (.var .value x)) rest)))
+        (← translateAssert Δ Γfn inner (δ.bind x (.var .value x)) rest)))
   | δ, .ite cond thn els => do
-    let (defd, φ) ← encodeBool Γfn δ cond
-    .ok (.assert defd (.ite φ (← translateAssert Γfn inner δ thn)
-      (← translateAssert Γfn inner δ els)))
+    let (defd, φ) ← encodeBool Δ Γfn δ cond
+    .ok (.assert defd (.ite φ (← translateAssert Δ Γfn inner δ thn)
+      (← translateAssert Δ Γfn inner δ els)))
 
-def translatePost (Γfn : FunCtx) (δ : VarEnv) : Spec.Post Typed.Expr → M (Assertion Unit) :=
-  translateAssert Γfn (fun _ () => .ok ()) δ
+def translatePost (Δ : Signature) (Γfn : FunCtx) (δ : VarEnv) :
+    Spec.Post Typed.Expr → M (Assertion Unit) :=
+  translateAssert Δ Γfn (fun _ () => .ok ()) δ
 
-def translatePre (Γfn : FunCtx) (δ : VarEnv) : Spec.Pre Typed.Expr → M PredTrans :=
-  translateAssert Γfn (fun δ (name, post) => do
-    let post' ← translatePost Γfn (δ.bind name (.var .value name)) post
+def translatePre (Δ : Signature) (Γfn : FunCtx) (δ : VarEnv) :
+    Spec.Pre Typed.Expr → M PredTrans :=
+  translateAssert Δ Γfn (fun δ (name, post) => do
+    let post' ← translatePost Δ Γfn (δ.bind name (.var .value name)) post
     .ok (name, post')) δ
 
 /-- Build the initial encoder environment from the spec's argument names. -/
@@ -82,10 +86,10 @@ private def argEnv (names : List String) : VarEnv :=
   names.map (fun n => (n, .var .value n))
 
 /-- Translate a typechecked spec body into a spec predicate. -/
-def translate (Γfn : FunCtx) (body : (Spec.Body Typed.Expr)) : M SpecPredicate :=
+def translate (Δ : Signature) (Γfn : FunCtx) (body : (Spec.Body Typed.Expr)) : M SpecPredicate :=
   let (names, pre) := body
   do
-    let pt ← translatePre Γfn (argEnv names) pre
+    let pt ← translatePre Δ Γfn (argEnv names) pre
     .ok (names, pt)
 
 end SpecTranslation

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -43,14 +43,14 @@ def argsEnv (ρ : VerifM.Env) : List (String × TinyML.Typ) → List Runtime.Val
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
 
-def isPrecondFor (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+def isPrecondFor (wctx : WpCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (f : Runtime.Val) (s : Spec) : iProp :=
   iprop(□ ∀ (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
       TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
         PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
           (argsEnv ρ s.args vs) -∗
-        wp (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
+        wp wctx (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
     context extended with all argument variables. -/
@@ -105,20 +105,20 @@ def implement (Δ_base : Signature) (s : Spec) (body : List FOL.Const → VerifM
 /-! ## Precondition Proofs -/
 section Precondition
 
-instance : Iris.BI.Persistent (isPrecondFor Θ Δ_spec ρ_spec f s) := by
+instance : Iris.BI.Persistent (isPrecondFor wctx Θ Δ_spec ρ_spec f s) := by
   unfold isPrecondFor
   infer_instance
 
 /-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
-theorem isPrecondFor_intro (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (s : Spec)
+theorem isPrecondFor_intro (wctx : WpCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (s : Spec)
     (f : Runtime.Val) :
     iprop(□ ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
       (⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
         TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
         PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
           (argsEnv ρ s.args vs)) -∗
-        wp (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor Θ Δ_spec ρ_spec f := by
+        wp wctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor wctx Θ Δ_spec ρ_spec f := by
   unfold isPrecondFor
   iintro □H
   imodintro
@@ -134,18 +134,18 @@ theorem isPrecondFor_intro (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec 
 /-- Löb-style rule for spec preconditions on `fix`: to prove
     `s.isPrecondFor Θ (.fix f args e)`, assume it as the recursive hypothesis and
     prove the `wp` of the body (after the usual fix-substitution). -/
-theorem isPrecondFor_fix {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {s : Spec}
+theorem isPrecondFor_fix {wctx : WpCtx} {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {s : Spec}
     {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {R : iProp}
-    (h : R ⊢ □ (s.isPrecondFor Θ Δ_spec ρ_spec (.fix f args e) -∗
+    (h : R ⊢ □ (s.isPrecondFor wctx Θ Δ_spec ρ_spec (.fix f args e) -∗
         ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
           TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
           PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
               (argsEnv ρ s.args vs) -∗
-          wp (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
-    R ⊢ s.isPrecondFor Θ Δ_spec ρ_spec (.fix f args e) := by
-  refine (SpatialContext.wp_fix' (f := f) (args := args) (e := e) (Φ := fun P vs =>
+          wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
+    R ⊢ s.isPrecondFor wctx Θ Δ_spec ρ_spec (.fix f args e) := by
+  refine (SpatialContext.wp_fix' (wctx := wctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
       iprop(∃ ρ : VerifM.Env,
         ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
           TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
@@ -382,7 +382,7 @@ theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (Δ_base : Signature)
       iintuitionistic Hty
       ihave Hpure := (TinyML.typeConstraints_hold (ty := s.retTy) (t := t) (ρ := ρ''.env) (Θ := Θ) (v := v) hteval) $$ Hty
       ipure Hpure
-      obtain ⟨st₃, hst₃_decls, hst₃_owns, hret⟩ :=
+      obtain ⟨st₃, hst₃_decls, hst₃_owns, _, hret⟩ :=
         VerifM.eval_assumeAll (VerifM.eval_bind _ _ _ _ hΨ'')
           (fun φ hφ => TinyML.typeConstraints_wfIn htwf φ hφ)
           (fun φ hφ => Hpure φ hφ)
@@ -484,7 +484,7 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
       ihave %htyped_formulas := TinyML.typeConstraints_hold (ty := ty)
           (t := .const (.uninterpreted argVar.name .value))
           (ρ := ρ₁.env) (Θ := Θ) (v := v) hvar_eval $$ Hv
-      obtain ⟨st₂, hst₂_decls, hst₂_owns, hdecl₂⟩ :=
+      obtain ⟨st₂, hst₂_decls, hst₂_owns, _, hdecl₂⟩ :=
         VerifM.eval_assumeAll (VerifM.eval_bind _ _ _ _ hdecl)
           (fun φ hφ => TinyML.typeConstraints_wfIn hvar_wf φ hφ)
           (fun φ hφ => htyped_formulas φ hφ)


### PR DESCRIPTION
This PR adds support for intrinsics. Intrinsics enable one to extend the builtin functions that Mica can use such that, for example, `Int.min` and `Int.max` become automatically available both in specs and in code. Every intrinsic provides:

- a rule in the operational semantics
- an interpretation for its weakest precondition rule
- a specification that is proven sound against the weakest precondition rule
- an optional first-order symbol to use it in specs
- axioms about the first-order symbol

Intrinsics will make it easier to extend Mica with additional functionality (e.g., strings and floats) in subsequent PRs.