### PR TITLE
String support

### DIFF
--- a/Examples/strings.ml
+++ b/Examples/strings.ml
@@ -1,0 +1,18 @@
+(* String lane acceptance tests. *)
+
+let wrap (s : string) : string =
+  let x = ref ("[." ^ s ^ ".]") [@owned] in 
+  ! x
+[@@spec fun s ->
+  ret (fun v ->
+    assert (String.starts_with "[" v);
+    assert (String.length v = String.length s + 4);
+    assert (String.ends_with "]" v))];;
+
+let greet (name : string) : string =
+  "hello " ^ name
+[@@spec fun name ->
+  ret (fun v ->
+    assert (String.starts_with "hello " v);
+    assert (not (String.starts_with "hi" v));
+    assert (String.ends_with name v))];;

--- a/Mica/Engine/Driver.lean
+++ b/Mica/Engine/Driver.lean
@@ -39,6 +39,7 @@ def preamble : String := s!"
 (declare-datatypes ((Value 0) (ValueList 0)) (
   ((of_int (to_int Int))
    (of_bool (to_bool Bool))
+   (of_string (to_string (Seq (_ BitVec 8))))
    (of_loc (to_loc Loc))
    (of_other (to_other Other))
    (of_tuple (to_tuple ValueList))

--- a/Mica/FOL/Formulas.lean
+++ b/Mica/FOL/Formulas.lean
@@ -5,6 +5,7 @@ import Mica.Base.Except
 inductive UnPred : Srt → Type where
   | isInt   : UnPred .value
   | isBool  : UnPred .value
+  | isStr   : UnPred .value
   | isLoc   : UnPred .value
   | isTuple : UnPred .value
   | isInj (tag : Nat) (arity : Nat) : UnPred .value
@@ -245,6 +246,7 @@ theorem Context.wfIn_mono (Γ : Context) (h : Γ.wfIn Δ) (hsub : Δ.Subset Δ')
 @[simp] def UnPred.eval : Env → UnPred τ → τ.denote → Prop
   | _, .isInt,   v => match v with | .int _ => True | _ => False
   | _, .isBool,  v => match v with | .bool _ => True | _ => False
+  | _, .isStr,   v => match v with | .str _ => True | _ => False
   | _, .isLoc,   v => match v with | .loc _ => True | _ => False
   | _, .isTuple, v => match v with | .tuple _ => True | _ => False
   | _, .isInj tag arity, v => match v with | .inj t a _ => t = tag ∧ a = arity | _ => False

--- a/Mica/FOL/Printing.lean
+++ b/Mica/FOL/Printing.lean
@@ -87,7 +87,7 @@ private def byteToSMTLIB (b : UInt8) : String :=
 
 private def stringConstToSMTLIB : List UInt8 → String
   | [] => "(as seq.empty (Seq (_ BitVec 8)))"
-  | b :: bs => bs.foldl (fun acc c => s!"(seq.++ {acc} {byteToSMTLIB c})") (byteToSMTLIB b)
+  | s => s!"(seq.++ {" ".intercalate (s.map byteToSMTLIB)})"
 
 private def byteToHum (b : UInt8) : String :=
   let n := b.toNat

--- a/Mica/FOL/Printing.lean
+++ b/Mica/FOL/Printing.lean
@@ -16,14 +16,18 @@ Two serialization targets:
 def Srt.toSMTLIB : Srt → String
   | .int     => "Int"
   | .bool    => "Bool"
+  | .string  => "(Seq (_ BitVec 8))"
   | .value   => "Value"
   | .vallist => "ValueList"
 
 def UnOp.toSMTLIB : UnOp τ₁ τ₂ → String
   | .ofInt   => "of_int"
   | .ofBool  => "of_bool"
+  | .ofString => "of_string"
   | .toInt   => "to_int"
   | .toBool  => "to_bool"
+  | .toString => "to_string"
+  | .seqLen => "seq.len"
   | .neg     => "-"
   | .not     => "not"
   | .ofValList => "of_tuple"
@@ -47,12 +51,16 @@ def BinOp.toSMTLIB : BinOp τ₁ τ₂ τ₃ → String
   | .gt    => ">"
   | .ge    => ">="
   | .eq    => "="
+  | .seqConcat => "seq.++"
+  | .seqPrefixOf => "seq.prefixof"
+  | .seqSuffixOf => "seq.suffixof"
   | .vcons => "vcons"
   | .uninterpreted name _ _ _ => name
 
 def UnPred.toSMTLIB : UnPred τ → String
   | .isInt   => "is-of_int"
   | .isBool  => "is-of_bool"
+  | .isStr   => "is-of_string"
   | .isLoc   => "is-of_loc"
   | .isTuple => "is-of_tuple"
   | .isInj _ _ => ""  -- handled specially in Formula.toSMTLIB
@@ -63,10 +71,40 @@ def BinPred.toSMTLIB : BinPred τ₁ τ₂ → String
   | .le => "<="
   | .uninterpreted name _ _ => name
 
+private def hexDigit (n : Nat) : Char :=
+  match n with
+  | 0 => '0' | 1 => '1' | 2 => '2' | 3 => '3'
+  | 4 => '4' | 5 => '5' | 6 => '6' | 7 => '7'
+  | 8 => '8' | 9 => '9' | 10 => 'A' | 11 => 'B'
+  | 12 => 'C' | 13 => 'D' | 14 => 'E' | _ => 'F'
+
+private def byteHex (b : UInt8) : String :=
+  let n := b.toNat
+  String.ofList [hexDigit (n / 16), hexDigit (n % 16)]
+
+private def byteToSMTLIB (b : UInt8) : String :=
+  s!"(seq.unit #x{byteHex b})"
+
+private def stringConstToSMTLIB : List UInt8 → String
+  | [] => "(as seq.empty (Seq (_ BitVec 8)))"
+  | b :: bs => bs.foldl (fun acc c => s!"(seq.++ {acc} {byteToSMTLIB c})") (byteToSMTLIB b)
+
+private def byteToHum (b : UInt8) : String :=
+  let n := b.toNat
+  if n == 10 then "\\n"
+  else if n == 9 then "\\t"
+  else if n == 13 then "\\r"
+  else if n == 34 then "\\\""
+  else if n == 92 then "\\\\"
+  else if 32 ≤ n && n < 127 then
+    String.singleton (Char.ofNat n)
+  else s!"\\x{byteHex b}"
+
 def Term.toSMTLIB : Term τ → String
   | .var _ name   => name
   | .const (.i n)   => if n ≥ 0 then s!"{n}" else s!"(- {-n})"
   | .const (.b b)   => if b then "true" else "false"
+  | .const (.str s) => stringConstToSMTLIB s
   | .const .unit    => "(of_other unit_val)"
   | .const .vnil    => "vnil"
   | .const (.uninterpreted name _) => name
@@ -116,14 +154,18 @@ private def termStr (p : Prec) : {τ : Srt} → Term τ → String
   | _, .var _ x        => x
   | _, .const (.i n)   => if n < 0 then s!"({n})" else s!"{n}"
   | _, .const (.b b)   => if b then "true" else "false"
+  | _, .const (.str s) => s!"\"{s.map byteToHum |>.foldl (· ++ ·) ""}\""
   | _, .const .unit    => "()"
   | _, .const .vnil    => "[]"
   | _, .const (.uninterpreted name _) => name
   | _, .unop op a  => match op with
     | .ofInt   => termStr p a     -- transparent coercion
     | .ofBool  => termStr p a     -- transparent coercion
+    | .ofString => termStr p a    -- transparent coercion
     | .toInt   => s!"toInt({termStr .bottom a})"
     | .toBool  => s!"toBool({termStr .bottom a})"
+    | .toString => s!"toString({termStr .bottom a})"
+    | .seqLen => s!"len({termStr .bottom a})"
     | .neg     => parens (Prec.lt .mul p) s!"-{termStr .top a}"
     | .not     => parens (Prec.lt .not_ p) s!"!{termStr .top a}"
     | .ofValList => s!"tuple({termStr .bottom a})"
@@ -146,6 +188,9 @@ private def termStr (p : Prec) : {τ : Srt} → Term τ → String
     | .gt    => parens (Prec.lt .cmp p) s!"{termStr .add a} > {termStr .add b}"
     | .ge    => parens (Prec.lt .cmp p) s!"{termStr .add a} >= {termStr .add b}"
     | .eq    => parens (Prec.lt .cmp p) s!"{termStr .add a} = {termStr .add b}"
+    | .seqConcat => parens (Prec.lt .add p) s!"{termStr .add a} ++ {termStr .mul b}"
+    | .seqPrefixOf => s!"prefixOf({termStr .bottom a}, {termStr .bottom b})"
+    | .seqSuffixOf => s!"suffixOf({termStr .bottom a}, {termStr .bottom b})"
     | .vcons => parens (Prec.lt .top p) s!"{termStr .top a} :: {termStr .top b}"
     | .uninterpreted name _ _ _ => s!"{name}({termStr .bottom a}, {termStr .bottom b})"
   | _, .ite c t e  => parens (Prec.lt .bottom p) s!"if {termStr .bottom c} then {termStr .bottom t} else {termStr .bottom e}"
@@ -158,6 +203,7 @@ private def formulaStr (p : Prec) : Formula → String
   | .unpred pred v   => match pred with
     | .isInt   => s!"isInt({termStr .bottom v})"
     | .isBool  => s!"isBool({termStr .bottom v})"
+    | .isStr   => s!"isStr({termStr .bottom v})"
     | .isLoc   => s!"isLoc({termStr .bottom v})"
     | .isTuple => s!"isTuple({termStr .bottom v})"
     | .isInj tag arity => s!"isInj({tag}/{arity}, {termStr .bottom v})"

--- a/Mica/FOL/Terms.lean
+++ b/Mica/FOL/Terms.lean
@@ -6,8 +6,11 @@ import Batteries.Data.List.Basic
 inductive UnOp : Srt → Srt → Type where
   | ofInt      : UnOp .int     .value
   | ofBool     : UnOp .bool    .value
+  | ofString   : UnOp .string  .value
   | toInt      : UnOp .value   .int
   | toBool     : UnOp .value   .bool
+  | toString   : UnOp .value   .string
+  | seqLen     : UnOp .string  .int
   | neg        : UnOp .int     .int
   | not        : UnOp .bool    .bool
   | ofValList  : UnOp .vallist .value
@@ -32,6 +35,9 @@ inductive BinOp : Srt → Srt → Srt → Type where
   | gt   : BinOp .int   .int     .bool
   | ge   : BinOp .int   .int     .bool
   | eq   : BinOp τ      τ        .bool
+  | seqConcat : BinOp .string .string .string
+  | seqPrefixOf : BinOp .string .string .bool
+  | seqSuffixOf : BinOp .string .string .bool
   | vcons : BinOp .value .vallist .vallist
   | uninterpreted : String → (τ₁ τ₂ τ₃ : Srt) → BinOp τ₁ τ₂ τ₃
   deriving DecidableEq, Repr
@@ -39,6 +45,7 @@ inductive BinOp : Srt → Srt → Srt → Type where
 inductive Const : Srt → Type where
   | i    : Int  → Const .int
   | b    : Bool → Const .bool
+  | str  : List UInt8 → Const .string
   | unit : Const .value
   | vnil : Const .vallist
   | uninterpreted : String → (τ : Srt) → Const τ
@@ -47,6 +54,7 @@ inductive Const : Srt → Type where
 @[simp] def Const.denote : Env → Const τ → τ.denote
   | _, .i n  => n
   | _, .b v  => v
+  | _, .str s => s
   | _, .unit => Runtime.Val.unit
   | _, .vnil => []
   | ρ, .uninterpreted name _ => ρ.consts τ name
@@ -325,8 +333,11 @@ theorem Term.wfIn_mono (t : Term τ) (h : t.wfIn Δ) (hsub : Δ.Subset Δ') (hwf
 @[simp] def UnOp.eval : Env → UnOp τ₁ τ₂ → τ₁.denote → τ₂.denote
   | _, .ofInt,   n  => Runtime.Val.int n
   | _, .ofBool,  b  => Runtime.Val.bool b
+  | _, .ofString, s => Runtime.Val.str s
   | _, .toInt,   v  => match v with | .int n => n | _ => 0
   | _, .toBool,  v  => match v with | .bool b => b | _ => false
+  | _, .toString, v => match v with | .str s => s | _ => []
+  | _, .seqLen, s => (s.length : Int)
   | _, .neg,     n  => -n
   | _, .not,     b  => !b
   | _, .ofValList, vs => Runtime.Val.tuple vs
@@ -350,6 +361,9 @@ theorem Term.wfIn_mono (t : Term τ) (h : t.wfIn Δ) (hsub : Δ.Subset Δ') (hwf
   | _, .gt,    a, b  => decide (a > b)
   | _, .ge,    a, b  => decide (a ≥ b)
   | _, .eq,    a, b  => decide (a = b)
+  | _, .seqConcat, a, b => a ++ b
+  | _, .seqPrefixOf, a, b => a.isPrefixOf b
+  | _, .seqSuffixOf, a, b => a.isSuffixOf b
   | _, .vcons, v, vs => v :: vs
   | ρ, .uninterpreted name _ _ _, x, y => ρ.binary τ₁ τ₂ τ₃ name x y
 

--- a/Mica/FOL/Variables.lean
+++ b/Mica/FOL/Variables.lean
@@ -8,6 +8,7 @@ import Mica.TinyML.RuntimeExpr
 inductive Srt where
   | int
   | bool
+  | string
   | value
   | vallist
   deriving DecidableEq, Repr
@@ -15,6 +16,7 @@ inductive Srt where
 @[reducible] def Srt.denote : Srt → Type
   | .int => Int
   | .bool => Bool
+  | .string => List UInt8
   | .value => Runtime.Val
   | .vallist => List Runtime.Val
 

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -60,6 +60,7 @@ structure Location where
 inductive Const where
   | int (n : Int)
   | bool (b : Bool)
+  | string (s : List UInt8)
   | char (c : Char)
   | unit
   deriving Repr
@@ -74,7 +75,7 @@ inductive BinOp where
   | add | sub | mul | div | mod
   | eq | neq | lt | le | gt | ge
   | and | or
-  | semi | pipeRight | atAt | assign
+  | semi | pipeRight | atAt | assign | concat
   deriving Repr, BEq
 
 -- Types

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -117,6 +117,7 @@ def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyM
     | "int"  => if args'.isEmpty then .ok .int  else err loc (.arityMismatch 0 args'.length)
     | "bool" => if args'.isEmpty then .ok .bool else err loc (.arityMismatch 0 args'.length)
     | "unit" => if args'.isEmpty then .ok .unit else err loc (.arityMismatch 0 args'.length)
+    | "string" => if args'.isEmpty then .ok .string else err loc (.arityMismatch 0 args'.length)
     | "ref" =>
       match args' with
       | [arg] => .ok (.ref arg)
@@ -224,7 +225,7 @@ private def elaborateBinOp (loc : Location) : BinOp → ElabM TinyML.BinOp
   | .div => .ok .div | .mod => .ok .mod
   | .eq => .ok .eq | .lt => .ok .lt | .le => .ok .le | .gt => .ok .gt | .ge => .ok .ge
   | .and => .ok .and | .or => .ok .or
-  | .neq | .semi | .pipeRight | .atAt | .assign =>
+  | .neq | .semi | .pipeRight | .atAt | .assign | .concat =>
     err loc (.internalError "desugared operator reached elaborateBinOp")
 
 -- Helper to elaborate a constructor lookup (not recursive)
@@ -256,6 +257,7 @@ def Expr.elaborate (env : ElabEnv) : Expr → ElabM Untyped.Expr
 def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Untyped.Expr
   | .const (.int n)  => .ok (.const (.int n))
   | .const (.bool b) => .ok (.const (.bool b))
+  | .const (.string s) => .ok (.const (.string s))
   | .const .unit     => .ok (.const .unit)
   | .const (.char _) => err loc .unsupportedChar
 
@@ -337,6 +339,10 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     let l' ← Expr.elaborate env l
     let r' ← Expr.elaborate env r
     .ok (.unop .not (.binop .eq l' r'))
+  | .binop .concat l r => do
+    let l' ← Expr.elaborate env l
+    let r' ← Expr.elaborate env r
+    .ok (.app (.prim "string_cat" (.arrow .string (.arrow .string .string))) [l', r'])
   | .binop op l r => do
     let op' ← elaborateBinOp loc op
     let l' ← Expr.elaborate env l

--- a/Mica/Frontend/Lexer.lean
+++ b/Mica/Frontend/Lexer.lean
@@ -19,6 +19,8 @@ inductive LexErrorKind where
   | invalidIntLiteral (text : String)
   | invalidCharEscape (c : Char)
   | unterminatedCharLiteral
+  | invalidStringEscape (text : String)
+  | unterminatedStringLiteral
   deriving Repr
 
 structure LexError where
@@ -35,6 +37,8 @@ def LexError.toString (e : LexError) : String :=
   | .invalidIntLiteral t => s!"{loc}: invalid integer literal '{t}'"
   | .invalidCharEscape c => s!"{loc}: invalid character escape '\\{c}'"
   | .unterminatedCharLiteral => s!"{loc}: unterminated character literal"
+  | .invalidStringEscape text => s!"{loc}: invalid string escape '\\{text}'"
+  | .unterminatedStringLiteral => s!"{loc}: unterminated string literal"
 
 instance : ToString LexError := ⟨LexError.toString⟩
 
@@ -44,6 +48,7 @@ instance : ToString LexError := ⟨LexError.toString⟩
 inductive Token where
   | intLit  (n : Int)
   | charLit (c : Char)
+  | stringLit (s : List UInt8)
   | ident   (name : String)   -- identifier (lowercase, uppercase, or starting with ')
   -- keywords
   | kw_let | kw_rec | kw_in | kw_fun
@@ -55,6 +60,7 @@ inductive Token where
   | kw_mod | kw_and
   -- punctuation and operators
   | plus | minus | star | slash
+  | caret
   | eq | neq | lt | le | gt | ge   -- = <> < <= > >=
   | ampamp | pipepipe               -- && ||
   | pipeGt                          -- |>
@@ -73,6 +79,7 @@ inductive Token where
 def Token.toString : Token → String
   | .intLit n  => s!"INT({n})"
   | .charLit c => s!"CHAR({c})"
+  | .stringLit _ => "STRING"
   | .ident s   => s!"IDENT({s})"
   | .kw_let   => "let"   | .kw_rec  => "rec"   | .kw_in   => "in"
   | .kw_fun   => "fun"   | .kw_if   => "if"    | .kw_then => "then"
@@ -82,6 +89,7 @@ def Token.toString : Token → String
   | .kw_true  => "true"  | .kw_false => "false"
   | .kw_mod   => "mod"   | .kw_and  => "and"
   | .plus     => "+"     | .minus   => "-"    | .star  => "*"  | .slash => "/"
+  | .caret    => "^"
   | .eq       => "="     | .neq     => "<>"   | .lt    => "<"
   | .le       => "<="    | .gt      => ">"    | .ge    => ">="
   | .ampamp   => "&&"    | .pipepipe => "||"
@@ -125,6 +133,23 @@ private def LexState.peek2 (st : LexState) : Option Char :=
 -- Helpers
 
 private def isDigit (c : Char) : Bool := '0' ≤ c && c ≤ '9'
+private def isHexDigit (c : Char) : Bool :=
+  isDigit c || ('a' ≤ c && c ≤ 'f') || ('A' ≤ c && c ≤ 'F')
+
+private def hexVal (c : Char) : Nat :=
+  if '0' ≤ c && c ≤ '9' then c.toNat - '0'.toNat
+  else if 'a' ≤ c && c ≤ 'f' then 10 + c.toNat - 'a'.toNat
+  else if 'A' ≤ c && c ≤ 'F' then 10 + c.toNat - 'A'.toNat
+  else 0
+
+private def decVal (c : Char) : Nat := c.toNat - '0'.toNat
+
+private def isOctDigit (c : Char) : Bool := '0' ≤ c && c ≤ '7'
+private def octVal (c : Char) : Nat := c.toNat - '0'.toNat
+
+/-- UTF-8 encoding of a Unicode scalar value, as a byte list. -/
+private def utf8Bytes (n : Nat) : List UInt8 := (Char.ofNat n).toString.toUTF8.data.toList
+
 private def isUpper (c : Char) : Bool := 'A' ≤ c && c ≤ 'Z'
 private def isLower (c : Char) : Bool := 'a' ≤ c && c ≤ 'z'
 private def isAlpha (c : Char) : Bool := isUpper c || isLower c || c == '_'
@@ -209,12 +234,15 @@ where
         -- apostrophe handling: 'c' char literal, 'a type var / identifier, x' continuation
         | '\'', _ =>
           lexApostrophe st acc
+        | '"', _ =>
+          lexString st acc
         | _, _ =>
           -- single-char tokens
           let single : Option Token :=
             match c with
             | '+' => some .plus     | '-' => some .minus   | '*' => some .star
             | '/' => some .slash    | '=' => some .eq      | '<' => some .lt
+            | '^' => some .caret
             | '>' => some .gt       | ':' => some .colon   | ';' => some .semi
             | '.' => some .dot      | ',' => some .comma   | '!' => some .bang
             | '|' => some .pipe     | '@' => some .at
@@ -280,6 +308,103 @@ where
     let name := String.ofList chars
     let tok := keyword name
     lex st' (acc.push ({ start := p, stop := st'.pos }, tok))
+
+  lexString (st : LexState) (acc : Array (Location × Token))
+      : Except LexError (Array (Location × Token)) :=
+    let p := st.pos
+    let st1 := st.advance '"'
+    match stringBytes st1 [] with
+    | .ok (bytes, st') =>
+      let st'' := st'.advance '"'
+      lex st'' (acc.push ({ start := p, stop := st''.pos }, .stringLit bytes))
+    | .error e => .error e
+
+  stringBytes (st : LexState) (acc : List UInt8)
+      : Except LexError (List UInt8 × LexState) :=
+    match st.source with
+    | [] => .error { pos := st.pos, kind := .unterminatedStringLiteral }
+    | '"' :: _ => .ok (acc.reverse, st)
+    | '\n' :: _ => .error { pos := st.pos, kind := .unterminatedStringLiteral }
+    | '\\' :: esc :: _ =>
+      -- `st1` is positioned at the escape character (just past the backslash).
+      let st1 := st.advance '\\'
+      let simple : Option UInt8 :=
+        match esc with
+        | 'n' => some 10  | 't' => some 9   | 'r' => some 13  | 'b' => some 8
+        | '\\' => some 92 | '"' => some 34  | '\'' => some 39 | ' ' => some 32
+        | _ => none
+      match simple with
+      | some b => stringBytes (st1.advance esc) (b :: acc)
+      | none =>
+        match esc with
+        -- Line continuation: `\` newline spaces-or-tabs is ignored.
+        | '\n' => stringLineCont (st1.advance '\n') acc
+        | '\r' =>
+          let st2 := st1.advance '\r'
+          match st2.source with
+          | '\n' :: _ => stringLineCont (st2.advance '\n') acc
+          | _ => stringLineCont st2 acc
+        -- `\xHH`: two hexadecimal digits.
+        | 'x' =>
+          let st2 := st1.advance 'x'
+          match st2.source with
+          | h1 :: h2 :: _ =>
+            if isHexDigit h1 && isHexDigit h2 then
+              stringBytes ((st2.advance h1).advance h2) (UInt8.ofNat (hexVal h1 * 16 + hexVal h2) :: acc)
+            else .error { pos := st.pos, kind := .invalidStringEscape "x" }
+          | _ => .error { pos := st.pos, kind := .invalidStringEscape "x" }
+        -- `\oOOO`: three octal digits.
+        | 'o' =>
+          let st2 := st1.advance 'o'
+          match st2.source with
+          | a :: b :: c :: _ =>
+            if isOctDigit a && isOctDigit b && isOctDigit c then
+              let n := octVal a * 64 + octVal b * 8 + octVal c
+              if n ≤ 255 then
+                stringBytes (((st2.advance a).advance b).advance c) (UInt8.ofNat n :: acc)
+              else .error { pos := st.pos, kind := .invalidStringEscape (String.ofList ['o', a, b, c]) }
+            else .error { pos := st.pos, kind := .invalidStringEscape "o" }
+          | _ => .error { pos := st.pos, kind := .invalidStringEscape "o" }
+        -- `\u{X…}`: Unicode scalar value, substituted by its UTF-8 encoding.
+        | 'u' =>
+          let st2 := st1.advance 'u'
+          match st2.source with
+          | '{' :: _ =>
+            let (hexes, st3) := collectWhile isHexDigit (st2.advance '{')
+            match st3.source with
+            | '}' :: _ =>
+              if hexes.isEmpty then .error { pos := st.pos, kind := .invalidStringEscape "u" }
+              else
+                let n := hexes.foldl (fun a c => a * 16 + hexVal c) 0
+                if n ≤ 0xD7FF || (0xE000 ≤ n && n ≤ 0x10FFFF) then
+                  stringBytes (st3.advance '}') ((utf8Bytes n).reverse ++ acc)
+                else .error { pos := st.pos, kind := .invalidStringEscape "u" }
+            | _ => .error { pos := st.pos, kind := .invalidStringEscape "u" }
+          | _ => .error { pos := st.pos, kind := .invalidStringEscape "u" }
+        -- `\DDD`: three decimal digits.
+        | d1 =>
+          if isDigit d1 then
+            match st1.source with
+            | a :: b :: c :: _ =>
+              if isDigit a && isDigit b && isDigit c then
+                let n := decVal a * 100 + decVal b * 10 + decVal c
+                if n ≤ 255 then
+                  stringBytes (((st1.advance a).advance b).advance c) (UInt8.ofNat n :: acc)
+                else .error { pos := st.pos, kind := .invalidStringEscape (String.ofList [a, b, c]) }
+              else .error { pos := st.pos, kind := .invalidStringEscape (String.singleton d1) }
+            | _ => .error { pos := st.pos, kind := .invalidStringEscape (String.singleton d1) }
+          else .error { pos := st.pos, kind := .invalidStringEscape (String.singleton esc) }
+    | c :: _ =>
+      stringBytes (st.advance c) (c.toString.toUTF8.data.toList.reverse ++ acc)
+
+  /-- Skip the spaces and tabs following an escaped newline, then resume. -/
+  stringLineCont (st : LexState) (acc : List UInt8)
+      : Except LexError (List UInt8 × LexState) :=
+    match st.source with
+    | c :: _ =>
+      if c == ' ' || c == '\t' then stringLineCont (st.advance c) acc
+      else stringBytes st acc
+    | [] => stringBytes st acc
 
   lexComment (st : LexState) (acc : Array (Location × Token)) (depth : Nat)
       : Except LexError (Array (Location × Token)) :=

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -481,7 +481,17 @@ where
 
   -- comparison (left-assoc)
   parseCmp : Parser Expr :=
-    parseLAssoc [(.eq, .eq), (.neq, .neq), (.lt, .lt), (.le, .le), (.gt, .gt), (.ge, .ge)] parseAdd
+    parseLAssoc [(.eq, .eq), (.neq, .neq), (.lt, .lt), (.le, .le), (.gt, .gt), (.ge, .ge)] parseConcat
+
+  -- `^` right-assoc, just below `+`/`-` (matches OCaml: looser than `+`/`-`)
+  parseConcat : Parser Expr := fun st => do
+    let (lhs, st) ← parseAdd st
+    match peekTok st with
+    | .caret => do
+      let (rhs, st) ← parseConcat (advance st)
+      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
+      .ok ({ loc, kind := .binop .concat lhs rhs }, st)
+    | _ => .ok (lhs, st)
 
   -- `+` `-` left-assoc
   parseAdd : Parser Expr :=
@@ -552,7 +562,7 @@ where
     else .ok ([], st)
 
   isArgStart : Token → Bool
-    | .intLit _ | .charLit _ | .ident _ | .lparen | .lbrace
+    | .intLit _ | .charLit _ | .stringLit _ | .ident _ | .lparen | .lbrace
     | .kw_true | .kw_false => true
     | _ => false
 
@@ -586,6 +596,7 @@ where
     match peekTok st with
     | .intLit n  => .ok (mkExpr p (advance st) (.const (.int n)), advance st)
     | .charLit c => .ok (mkExpr p (advance st) (.const (.char c)), advance st)
+    | .stringLit s => .ok (mkExpr p (advance st) (.const (.string s)), advance st)
     | .kw_true   => .ok (mkExpr p (advance st) (.const (.bool true)), advance st)
     | .kw_false  => .ok (mkExpr p (advance st) (.const (.bool false)), advance st)
     | .ident name => do

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -23,9 +23,27 @@ private def parenIf (cond : Bool) (s : String) : String :=
 -- ---------------------------------------------------------------------------
 -- Const printing
 
+private def hexDigit (n : Nat) : Char :=
+  match n with
+  | 0 => '0' | 1 => '1' | 2 => '2' | 3 => '3'
+  | 4 => '4' | 5 => '5' | 6 => '6' | 7 => '7'
+  | 8 => '8' | 9 => '9' | 10 => 'A' | 11 => 'B'
+  | 12 => 'C' | 13 => 'D' | 14 => 'E' | _ => 'F'
+
+private def byteEsc (b : UInt8) : String :=
+  let n := b.toNat
+  if n == 10 then "\\n"
+  else if n == 9 then "\\t"
+  else if n == 13 then "\\r"
+  else if n == 34 then "\\\""
+  else if n == 92 then "\\\\"
+  else if 32 ≤ n && n < 127 then String.singleton (Char.ofNat n)
+  else "\\x" ++ String.ofList [hexDigit (n / 16), hexDigit (n % 16)]
+
 partial def Const.print : Const → String
   | .int n   => toString n
   | .bool b  => if b then "true" else "false"
+  | .string s => "\"" ++ joinWith "" (s.map byteEsc) ++ "\""
   | .unit    => "()"
   | .char c  =>
     let s := match c with
@@ -53,16 +71,16 @@ partial def BinOp.print : BinOp → String
   | .add => "+" | .sub => "-" | .mul => "*" | .div => "/" | .mod => "mod"
   | .eq => "=" | .neq => "<>" | .lt => "<" | .le => "<=" | .gt => ">" | .ge => ">="
   | .and => "&&" | .or => "||"
-  | .semi => ";" | .pipeRight => "|>" | .atAt => "@@" | .assign => ":="
+  | .semi => ";" | .pipeRight => "|>" | .atAt => "@@" | .assign => ":=" | .concat => "^"
 
 private partial def BinOp.prec : BinOp → Nat
   | .semi => 1 | .assign => 2 | .or => 3 | .and => 4
   | .pipeRight => 5 | .atAt => 6
   | .eq | .neq | .lt | .le | .gt | .ge => 7
-  | .add | .sub => 8 | .mul | .div | .mod => 9
+  | .concat => 8 | .add | .sub => 9 | .mul | .div | .mod => 10
 
 private partial def BinOp.rightAssoc : BinOp → Bool
-  | .semi | .assign | .or | .and | .atAt => true
+  | .semi | .assign | .or | .and | .atAt | .concat => true
   | _ => false
 
 -- ---------------------------------------------------------------------------

--- a/Mica/SeparationLogic/LogicalRelation.lean
+++ b/Mica/SeparationLogic/LogicalRelation.lean
@@ -39,6 +39,7 @@ def PrimitiveType.valRelBody : PrimitiveType → Runtime.Val → iProp
   | .unit, v => iprop(⌜v = .unit⌝)
   | .bool, v => iprop(⌜∃ b, v = .bool b⌝)
   | .int, v => iprop(⌜∃ n, v = .int n⌝)
+  | .string, v => iprop(⌜∃ s, v = .str s⌝)
 
 theorem PrimitiveType.valRelBody_persistent (p : PrimitiveType) (v : Runtime.Val) :
     Persistent (p.valRelBody v) := by
@@ -426,6 +427,11 @@ theorem ValHasType.int (Θ : TypeEnv) (v : Runtime.Val) :
   change ValHasType Θ v (.prim .int) ⊣⊢ iprop(⌜∃ n, v = .int n⌝)
   exact equiv_iff.mp (ValHasType.unfold Θ v Typ.int)
 
+theorem ValHasType.string (Θ : TypeEnv) (v : Runtime.Val) :
+    ValHasType Θ v Typ.string ⊣⊢ iprop(⌜∃ s, v = .str s⌝) := by
+  change ValHasType Θ v (.prim .string) ⊣⊢ iprop(⌜∃ s, v = .str s⌝)
+  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.string)
+
 theorem ValHasType.value (Θ : TypeEnv) (v : Runtime.Val) :
     ValHasType Θ v .value ⊣⊢ iprop(True) := by
   exact equiv_iff.mp (ValHasType.unfold Θ v .value)
@@ -607,6 +613,13 @@ theorem ValHasType.int_intro (Θ : TypeEnv) (n : Int) :
   iapply (ValHasType.int Θ (.int n)).2
   ipure_intro
   exact ⟨n, rfl⟩
+
+/-- The canonical proof that a string literal has type `string`. -/
+theorem ValHasType.string_intro (Θ : TypeEnv) (s : List UInt8) :
+    ⊢ ValHasType Θ (.str s) Typ.string := by
+  iapply (ValHasType.string Θ (.str s)).2
+  ipure_intro
+  exact ⟨s, rfl⟩
 
 mutual
   theorem ValHasType.sub {Θ : TypeEnv} {v : Runtime.Val} {t t' : Typ}
@@ -989,12 +1002,14 @@ def PrimitiveType.typeConstraints (p : PrimitiveType) (t : Term .value) : List F
   match p with
   | .int => [.unpred .isInt t]
   | .bool => [.unpred .isBool t]
+  | .string => [.unpred .isStr t]
   | .unit => []
 
 /-- Primitive type constraints only reference free variables of the constrained term. -/
 theorem PrimitiveType.typeConstraints_wfIn {p : PrimitiveType} {t : Term .value} {Δ : Signature}
     (ht : t.wfIn Δ) : ∀ φ ∈ p.typeConstraints t, φ.wfIn Δ := by
   cases p <;> simp [PrimitiveType.typeConstraints]
+  · simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
   · simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
   · simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
 
@@ -1015,6 +1030,14 @@ theorem PrimitiveType.typeConstraints_hold {p : PrimitiveType} {t : Term .value}
   · refine (TinyML.ValHasType.int Θ v).1.trans ?_
     iintro %h
     rcases h with ⟨n, rfl⟩
+    ipure_intro
+    intro φ hφ
+    simp [PrimitiveType.typeConstraints] at hφ
+    rcases hφ with rfl
+    simp [Formula.eval, ht]
+  · refine (TinyML.ValHasType.string Θ v).1.trans ?_
+    iintro %h
+    rcases h with ⟨s, rfl⟩
     ipure_intro
     intro φ hφ
     simp [PrimitiveType.typeConstraints] at hφ

--- a/Mica/Stdlib.lean
+++ b/Mica/Stdlib.lean
@@ -1,6 +1,7 @@
 -- SUMMARY: The concrete stdlib: the intrinsic registry, its soundness aggregate, and the prelude resolver.
 import Mica.Verifier.Intrinsic
 import Mica.Stdlib.IntStd
+import Mica.Stdlib.StringStd
 import Mica.Frontend.Resolver
 
 open Iris Iris.BI
@@ -9,7 +10,15 @@ namespace Stdlib
 
 open Verifier
 
-def registry : Registry := [Intrinsics.intMax, Intrinsics.intMin]
+def registry : Registry := [
+  Intrinsics.stringEndsWith,
+  Intrinsics.stringStartsWith,
+  Intrinsics.stringEqual,
+  Intrinsics.stringCat,
+  Intrinsics.stringLength,
+  Intrinsics.intMax,
+  Intrinsics.intMin
+]
 
 theorem registry_sound : Registry.Sound registry := by
   simp [registry, Registry.Sound, Registry.SoundIn]
@@ -17,7 +26,7 @@ theorem registry_sound : Registry.Sound registry := by
   -- listed. Do not repeat concrete intrinsic names in this proof: infer each
   -- local dependency fragment, then prove only that it is contained in the
   -- registry.
-  repeat apply And.intro
+  repeat' apply And.intro
   all_goals
     try trivial
     apply IntrinsicSound.mono
@@ -25,10 +34,12 @@ theorem registry_sound : Registry.Sound registry := by
     · simp
 
 theorem registry_wf : Registry.Wf registry := by
-  simp only [registry, Registry.Wf, Registry.WfFrom, Signature.extendWithSym,
-    Signature.empty, Signature.addConst, Signature.addUnary, Signature.addBinary,
+  -- The per-symbol freshness side conditions reduce to literal-name
+  -- disequalities; the `@[simp]` `*_folSym`/`*Sym_name` lemmas expose the
+  -- names, so this stays generic over the registry contents.
+  simp [registry, Registry.Wf, Registry.WfFrom, Signature.extendWithSym,
+    Signature.empty, Signature.addUnary, Signature.addBinary,
     Signature.allNames]
-  simp
 
 private def resolvedType (i : Intrinsic) : TinyML.Typ :=
   i.argTysList.foldr TinyML.Typ.arrow i.resultTy

--- a/Mica/Stdlib/OUTLINE.md
+++ b/Mica/Stdlib/OUTLINE.md
@@ -1,3 +1,4 @@
 **Mica/Stdlib**
 
 - `IntStd.lean` — Integer-arithmetic intrinsics (`Int.min`, `Int.max`) and their soundness instances.
+- `StringStd.lean` — Byte-string intrinsics (`String.length`, `cat`, `equal`, `starts_with`, `ends_with`) and their soundness instances.

--- a/Mica/Stdlib/OUTLINE.md
+++ b/Mica/Stdlib/OUTLINE.md
@@ -1,4 +1,4 @@
 **Mica/Stdlib**
 
 - `IntStd.lean` — Integer-arithmetic intrinsics (`Int.min`, `Int.max`) and their soundness instances.
-- `StringStd.lean` — Byte-string intrinsics (`String.length`, `cat`, `equal`, `starts_with`, `ends_with`) and their soundness instances.
+- `StringStd.lean` — Byte-string intrinsics (`String.length`, `cat`, `equal`, `starts_with`, `ends_with`) and soundness instances.

--- a/Mica/Stdlib/StringStd.lean
+++ b/Mica/Stdlib/StringStd.lean
@@ -1,0 +1,758 @@
+-- SUMMARY: Byte-string intrinsics (`String.length`, `cat`, `equal`, `starts_with`, `ends_with`) and soundness instances.
+import Mica.Stdlib.IntStd
+
+open Iris Iris.BI
+
+namespace Stdlib
+
+open Verifier
+
+namespace Intrinsics
+
+/-- String projection of a runtime value, matching FOL's `toString`. -/
+private def valStr : Runtime.Val → List UInt8
+  | .str s => s
+  | _      => []
+
+@[simp] private theorem valStr_str (s : List UInt8) : valStr (.str s) = s := rfl
+
+@[simp] private theorem toString_eq_valStr (ρ : Env) (v : Runtime.Val) :
+    UnOp.eval ρ .toString v = valStr v := rfl
+
+/-- FOL symbol for `String.length`. -/
+def stringLengthSym : FOL.Symbol .one where
+  name   := "string_length"
+  interp := fun a => .int (valStr a).length
+
+/-- FOL symbol for `String.cat`. -/
+def stringCatSym : FOL.Symbol .two where
+  name   := "string_cat"
+  interp := fun (a, b) => .str (valStr a ++ valStr b)
+
+/-- FOL symbol for `String.equal`. -/
+def stringEqualSym : FOL.Symbol .two where
+  name   := "string_equal"
+  interp := fun (a, b) => .bool (valStr a == valStr b)
+
+/-- FOL symbol for `String.starts_with`. -/
+def stringStartsWithSym : FOL.Symbol .two where
+  name   := "string_starts_with"
+  interp := fun (p, s) => .bool ((valStr p).isPrefixOf (valStr s))
+
+/-- FOL symbol for `String.ends_with`. -/
+def stringEndsWithSym : FOL.Symbol .two where
+  name   := "string_ends_with"
+  interp := fun (q, s) => .bool ((valStr q).isSuffixOf (valStr s))
+
+@[simp] theorem stringLengthSym_name : stringLengthSym.name = "string_length" := rfl
+@[simp] theorem stringCatSym_name : stringCatSym.name = "string_cat" := rfl
+@[simp] theorem stringEqualSym_name : stringEqualSym.name = "string_equal" := rfl
+@[simp] theorem stringStartsWithSym_name : stringStartsWithSym.name = "string_starts_with" := rfl
+@[simp] theorem stringEndsWithSym_name : stringEndsWithSym.name = "string_ends_with" := rfl
+
+private def stringLengthTerm (x : Term .value) : Term .value :=
+  .unop (.uninterpreted stringLengthSym.name .value .value) x
+
+private def stringCatTerm (x y : Term .value) : Term .value :=
+  .binop (.uninterpreted stringCatSym.name .value .value .value) x y
+
+private def stringEqualTerm (x y : Term .value) : Term .value :=
+  .binop (.uninterpreted stringEqualSym.name .value .value .value) x y
+
+private def stringStartsWithTerm (x y : Term .value) : Term .value :=
+  .binop (.uninterpreted stringStartsWithSym.name .value .value .value) x y
+
+private def stringEndsWithTerm (x y : Term .value) : Term .value :=
+  .binop (.uninterpreted stringEndsWithSym.name .value .value .value) x y
+
+/-! Each intrinsic carries two axioms, both quantified over the **value sort**:
+a *defining* axiom tying the symbol to Z3's native sequence theory (through the
+`toString`/`toInt` projections), and a *typing* axiom asserting the result is
+the expected value constructor (`is-of_int`/`is-of_string`/`is-of_bool`).
+
+The typing axiom is what lets a bare value-level equality such as
+`String.length s = 2` discharge: without it Z3 only knows the symbol's `toInt`
+projection, not that the result *is* an integer value. -/
+
+def stringLengthDefAxiom : Formula :=
+  .forall_ "s" .value <|
+    .eq .int
+      (.unop .toInt (stringLengthTerm (.var .value "s")))
+      (.unop .seqLen (.unop .toString (.var .value "s")))
+
+def stringLengthTypeAxiom : Formula :=
+  .forall_ "s" .value <| .unpred .isInt (stringLengthTerm (.var .value "s"))
+
+def stringCatDefAxiom : Formula :=
+  .forall_ "a" .value <| .forall_ "b" .value <|
+    .eq .string
+      (.unop .toString (stringCatTerm (.var .value "a") (.var .value "b")))
+      (.binop .seqConcat (.unop .toString (.var .value "a")) (.unop .toString (.var .value "b")))
+
+def stringCatTypeAxiom : Formula :=
+  .forall_ "a" .value <| .forall_ "b" .value <|
+    .unpred .isStr (stringCatTerm (.var .value "a") (.var .value "b"))
+
+def stringEqualDefAxiom : Formula :=
+  .forall_ "a" .value <| .forall_ "b" .value <|
+    .eq .bool
+      (.unop .toBool (stringEqualTerm (.var .value "a") (.var .value "b")))
+      (.binop (.eq (τ := .string)) (.unop .toString (.var .value "a")) (.unop .toString (.var .value "b")))
+
+def stringEqualTypeAxiom : Formula :=
+  .forall_ "a" .value <| .forall_ "b" .value <|
+    .unpred .isBool (stringEqualTerm (.var .value "a") (.var .value "b"))
+
+def stringStartsWithDefAxiom : Formula :=
+  .forall_ "prefix" .value <| .forall_ "s" .value <|
+    .eq .bool
+      (.unop .toBool (stringStartsWithTerm (.var .value "prefix") (.var .value "s")))
+      (.binop .seqPrefixOf (.unop .toString (.var .value "prefix")) (.unop .toString (.var .value "s")))
+
+def stringStartsWithTypeAxiom : Formula :=
+  .forall_ "prefix" .value <| .forall_ "s" .value <|
+    .unpred .isBool (stringStartsWithTerm (.var .value "prefix") (.var .value "s"))
+
+def stringEndsWithDefAxiom : Formula :=
+  .forall_ "suffix" .value <| .forall_ "s" .value <|
+    .eq .bool
+      (.unop .toBool (stringEndsWithTerm (.var .value "suffix") (.var .value "s")))
+      (.binop .seqSuffixOf (.unop .toString (.var .value "suffix")) (.unop .toString (.var .value "s")))
+
+def stringEndsWithTypeAxiom : Formula :=
+  .forall_ "suffix" .value <| .forall_ "s" .value <|
+    .unpred .isBool (stringEndsWithTerm (.var .value "suffix") (.var .value "s"))
+
+private theorem off_shape_one {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} {ty : TinyML.Typ}
+    (P : iProp) (hlen : vs.length ≠ 1) :
+    TinyML.ValsHaveTypes Θ vs [ty] ⊢ P := by
+  refine TinyML.ValsHaveTypes.length_eq.trans ?_
+  iintro %h
+  simp at h; omega
+
+private theorem off_shape_two_ty {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} {ty₁ ty₂ : TinyML.Typ}
+    (P : iProp) (hlen : vs.length ≠ 2) :
+    TinyML.ValsHaveTypes Θ vs [ty₁, ty₂] ⊢ P := by
+  refine TinyML.ValsHaveTypes.length_eq.trans ?_
+  iintro %h
+  simp at h; omega
+
+private theorem assert_ret_apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
+    (s : String) (ρ : VerifM.Env) (φ : Formula) (v : Runtime.Val)
+    (hφ : φ.eval (ρ.updateConst .value s v).env) :
+    PredTrans.apply Θ Φ (.ret (s, .assert φ (.ret ()))) ρ ⊢ Φ v := by
+  simp only [PredTrans.apply, Assertion.pre, Assertion.post]
+  refine (forall_elim v).trans ?_
+  iintro Hw
+  iapply Hw
+  ipure_intro
+  exact hφ
+
+private theorem respects_updateConstE_one {ρ : Env} {s : FOL.Symbol .one}
+    {τ : Srt} {x : String} {v : τ.denote} (h : ρ.respects (some s)) :
+    (ρ.updateConst τ x v).respects (some s) := by
+  show (ρ.updateConst τ x v).unary .value .value s.name = _
+  rw [Env.updateConst_unary]; exact h
+
+private theorem respects_updateConstE_two {ρ : Env} {s : FOL.Symbol .two}
+    {τ : Srt} {x : String} {v : τ.denote} (h : ρ.respects (some s)) :
+    (ρ.updateConst τ x v).respects (some s) := by
+  show (ρ.updateConst τ x v).binary .value .value .value s.name = _
+  rw [Env.updateConst_binary]; exact h
+
+private theorem respects_argsEnv_one {s : FOL.Symbol .one} :
+    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
+      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
+  | [], _, _, h => h
+  | _ :: _, [], _, h => h
+  | (name, _) :: rest, v :: vs, ρ, h => by
+      simp only [Spec.argsEnv]
+      refine respects_argsEnv_one rest vs ?_
+      rw [VerifM.Env.updateConst_env]; exact respects_updateConstE_one h
+
+private theorem respects_argsEnv_two {s : FOL.Symbol .two} :
+    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
+      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
+  | [], _, _, h => h
+  | _ :: _, [], _, h => h
+  | (name, _) :: rest, v :: vs, ρ, h => by
+      simp only [Spec.argsEnv]
+      refine respects_argsEnv_two rest vs ?_
+      rw [VerifM.Env.updateConst_env]; exact respects_updateConstE_two h
+
+/-- `String.length`: byte length. -/
+def stringLength : Intrinsic where
+  arity    := .one
+  name     := "string_length"
+  path     := some ("String", ["length"])
+  reduce   := fun a v => ∃ s : List UInt8, a = .str s ∧ v = .int s.length
+  wp       := fun a Q => iprop(∃ s : List UInt8, ⌜a = .str s⌝ ∗ Q (.int s.length))
+  spec     :=
+    { args  := [("s", .string)]
+      retTy := .int
+      pred  := .ret ("ret",
+        .assert (.eq .value (.var .value "ret") (stringLengthTerm (.var .value "s")))
+          (.ret ())) }
+  folSym   := some stringLengthSym
+  axioms   := [stringLengthDefAxiom, stringLengthTypeAxiom]
+
+@[simp] theorem stringLength_arity : stringLength.arity = .one := rfl
+@[simp] theorem stringLength_folSym : stringLength.folSym = some stringLengthSym := rfl
+@[simp] theorem stringLength_toWp (a : Runtime.Val) (Q : Runtime.Val → iProp) :
+    stringLength.toWp [a] Q =
+      iprop(∃ s : List UInt8, ⌜a = .str s⌝ ∗ Q (.int s.length)) :=
+  Intrinsic.toWp_one_of_arity _ _ _ _ _ _ _ _ Q
+
+private theorem stringLength_base_wf :
+    PredTrans.wfIn
+      ((Intrinsic.sigOf [stringLength]).declVars (Spec.argVars stringLength.specArgs)) stringLength.spec.pred := by
+  apply PredTrans.checkWf_ok
+  rfl
+
+private theorem stringLength_assert_eval (ρ : VerifM.Env) (s : List UInt8)
+    (hρ : ρ.env.respects (some stringLengthSym)) :
+    (Formula.eq .value (.var .value "ret") (stringLengthTerm (.var .value "s"))).eval
+      ((Spec.argsEnv ρ stringLength.specArgs [.str s]).updateConst .value "ret" (.int s.length)).env := by
+  have hargs := respects_argsEnv_one stringLength.specArgs [.str s] hρ
+  have hun : (Spec.argsEnv ρ stringLength.specArgs [.str s]).env.unary
+      .value .value "string_length" = stringLengthSym.interp := by
+    simpa [Env.respects, stringLengthSym] using hargs
+  show Runtime.Val.int s.length =
+    (Spec.argsEnv ρ stringLength.specArgs [.str s]).env.unary .value .value "string_length" (.str s)
+  simp [hun, stringLengthSym]
+
+instance : IntrinsicSound [stringLength] stringLength where
+  axiomWf := by
+    intro Δ hsub hwf φ hφ
+    simp only [stringLength, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    rcases hφ with rfl | rfl
+    · have hbase : stringLengthDefAxiom.wfIn (Intrinsic.sigOf [stringLength]) := by
+        simp [stringLengthDefAxiom, stringLengthTerm, Intrinsic.sigOf, Intrinsic.foldSig,
+          stringLength, stringLengthSym, Formula.wfIn, Term.wfIn, UnOp.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addUnary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+    · have hbase : stringLengthTypeAxiom.wfIn (Intrinsic.sigOf [stringLength]) := by
+        simp [stringLengthTypeAxiom, stringLengthTerm, Intrinsic.sigOf, Intrinsic.foldSig,
+          stringLength, stringLengthSym, Formula.wfIn, Term.wfIn, UnOp.wfIn, UnPred.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addUnary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+  proof := by
+    intro ρ hdeps φ hφ
+    simp only [stringLength, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    have hlen : ρ.respects (some stringLengthSym) := hdeps stringLength (by simp)
+    simp only [Env.respects] at hlen
+    have hu : ∀ s : Runtime.Val,
+        (ρ.updateConst .value "s" s).unary .value .value "string_length" = stringLengthSym.interp := by
+      intro s; rw [Env.updateConst_unary]; simpa [stringLengthSym] using hlen
+    rcases hφ with rfl | rfl
+    · simp only [stringLengthDefAxiom, Formula.eval]
+      intro s
+      simp [stringLengthTerm, Term.eval, Env.lookupConst_updateConst_same, hu s,
+        stringLengthSym, valStr]
+      rfl
+    · simp only [stringLengthTypeAxiom, Formula.eval]
+      intro s
+      simp [stringLengthTerm, Term.eval, Env.lookupConst_updateConst_same, hu s,
+        stringLengthSym, valStr]
+  specWf := by
+    intro Δ hsub hwf
+    exact PredTrans.wfIn_mono stringLength_base_wf
+      (Signature.Subset.declVars hsub (Spec.argVars stringLength.specArgs))
+      (Signature.wf_declVars hwf)
+  bridge := by
+    intro Θ vs ρ Φ hρ
+    simp only [stringLength_folSym, Env.respects] at hρ
+    show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string] ∗ _ ⊢ _
+    match vs with
+    | [] => exact (sep_mono_l (off_shape_one _ (by simp))).trans sep_elim_l
+    | _ :: _ :: _ => exact (sep_mono_l (off_shape_one _ (by simp))).trans sep_elim_l
+    | [v] =>
+      iintro ⟨Hvs, Hpred⟩
+      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v [] _ _).1 $$ Hvs
+      icases Hcons with ⟨Hv, _⟩
+      ihave Hveq := (TinyML.ValHasType.string Θ v).1 $$ Hv
+      ipure Hveq
+      obtain ⟨s, rfl⟩ := Hveq
+      rw [stringLength_toWp]
+      iexists s
+      isplitr [Hpred]
+      · ipure_intro; rfl
+      · refine (assert_ret_apply Θ _ "ret" _ _ (.int s.length) ?_).trans ?_
+        · exact stringLength_assert_eval ρ s hρ
+        · iintro Hwand
+          iapply Hwand
+          exact TinyML.ValHasType.int_intro Θ s.length
+
+/-- `String.cat`: byte-string concatenation. -/
+def stringCat : Intrinsic where
+  arity    := .two
+  name     := "string_cat"
+  path     := some ("String", ["cat"])
+  reduce   := fun (a, b) v => ∃ x y : List UInt8, a = .str x ∧ b = .str y ∧ v = .str (x ++ y)
+  wp       := fun (a, b) Q => iprop(∃ x y : List UInt8, ⌜a = .str x ∧ b = .str y⌝ ∗ Q (.str (x ++ y)))
+  spec     :=
+    { args  := [("a", .string), ("b", .string)]
+      retTy := .string
+      pred  := .ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (stringCatTerm (.var .value "a") (.var .value "b")))
+          (.ret ())) }
+  folSym   := some stringCatSym
+  axioms   := [stringCatDefAxiom, stringCatTypeAxiom]
+
+@[simp] theorem stringCat_arity : stringCat.arity = .two := rfl
+@[simp] theorem stringCat_folSym : stringCat.folSym = some stringCatSym := rfl
+@[simp] theorem stringCat_toWp (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
+    stringCat.toWp [a, b] Q =
+      iprop(∃ x y : List UInt8, ⌜a = .str x ∧ b = .str y⌝ ∗ Q (.str (x ++ y))) :=
+  Intrinsic.toWp_two_of_arity _ _ _ _ _ _ _ _ _ Q
+
+private theorem stringCat_base_wf :
+    PredTrans.wfIn
+      ((Intrinsic.sigOf [stringCat]).declVars (Spec.argVars stringCat.specArgs)) stringCat.spec.pred := by
+  apply PredTrans.checkWf_ok
+  rfl
+
+private theorem stringCat_assert_eval (ρ : VerifM.Env) (x y : List UInt8)
+    (hρ : ρ.env.respects (some stringCatSym)) :
+    (Formula.eq .value (.var .value "ret")
+      (stringCatTerm (.var .value "a") (.var .value "b"))).eval
+      ((Spec.argsEnv ρ stringCat.specArgs [.str x, .str y]).updateConst
+        .value "ret" (.str (x ++ y))).env := by
+  have hargs := respects_argsEnv_two stringCat.specArgs [.str x, .str y] hρ
+  have hbin : (Spec.argsEnv ρ stringCat.specArgs [.str x, .str y]).env.binary
+      .value .value .value "string_cat" = fun a b => stringCatSym.interp (a, b) := by
+    simpa [Env.respects, stringCatSym] using hargs
+  show Runtime.Val.str (x ++ y) =
+    (Spec.argsEnv ρ stringCat.specArgs [.str x, .str y]).env.binary
+      .value .value .value "string_cat" (.str x) (.str y)
+  simp [hbin, stringCatSym]
+
+instance : IntrinsicSound [stringCat] stringCat where
+  axiomWf := by
+    intro Δ hsub hwf φ hφ
+    simp only [stringCat, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    rcases hφ with rfl | rfl
+    · have hbase : stringCatDefAxiom.wfIn (Intrinsic.sigOf [stringCat]) := by
+        simp [stringCatDefAxiom, stringCatTerm, Intrinsic.sigOf, Intrinsic.foldSig, stringCat,
+          stringCatSym, Formula.wfIn, Term.wfIn, BinOp.wfIn, UnOp.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addBinary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+    · have hbase : stringCatTypeAxiom.wfIn (Intrinsic.sigOf [stringCat]) := by
+        simp [stringCatTypeAxiom, stringCatTerm, Intrinsic.sigOf, Intrinsic.foldSig, stringCat,
+          stringCatSym, Formula.wfIn, Term.wfIn, BinOp.wfIn, UnPred.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addBinary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+  proof := by
+    intro ρ hdeps φ hφ
+    simp only [stringCat, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    have hcat : ρ.respects (some stringCatSym) := hdeps stringCat (by simp)
+    simp only [Env.respects] at hcat
+    have hb : ∀ x y : Runtime.Val,
+        ((ρ.updateConst .value "a" x).updateConst .value "b" y).binary
+          .value .value .value "string_cat" = fun a b => stringCatSym.interp (a, b) := by
+      intro x y; rw [Env.updateConst_binary, Env.updateConst_binary]; simpa [stringCatSym] using hcat
+    rcases hφ with rfl | rfl
+    · simp only [stringCatDefAxiom, Formula.eval]
+      intro x y
+      simp [stringCatTerm, Term.eval, Env.lookupConst_updateConst_same,
+        Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), hb x y, stringCatSym, valStr]
+      rfl
+    · simp only [stringCatTypeAxiom, Formula.eval]
+      intro x y
+      simp [stringCatTerm, Term.eval, Env.lookupConst_updateConst_same,
+        Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), hb x y, stringCatSym, valStr]
+  specWf := by
+    intro Δ hsub hwf
+    exact PredTrans.wfIn_mono stringCat_base_wf
+      (Signature.Subset.declVars hsub (Spec.argVars stringCat.specArgs))
+      (Signature.wf_declVars hwf)
+  bridge := by
+    intro Θ vs ρ Φ hρ
+    simp only [stringCat_folSym, Env.respects] at hρ
+    show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string, TinyML.Typ.string] ∗ _ ⊢ _
+    match vs with
+    | [] => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | [_] => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | _ :: _ :: _ :: _ => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | [v1, v2] =>
+      iintro ⟨Hvs, Hpred⟩
+      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v1 [v2] _ _).1 $$ Hvs
+      icases Hcons with ⟨Hv1, Hvs2⟩
+      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
+      icases Hcons2 with ⟨Hv2, _⟩
+      ihave Hv1eq := (TinyML.ValHasType.string Θ v1).1 $$ Hv1
+      ipure Hv1eq
+      ihave Hv2eq := (TinyML.ValHasType.string Θ v2).1 $$ Hv2
+      ipure Hv2eq
+      obtain ⟨x, rfl⟩ := Hv1eq
+      obtain ⟨y, rfl⟩ := Hv2eq
+      rw [stringCat_toWp]
+      iexists x
+      iexists y
+      isplitr [Hpred]
+      · ipure_intro; exact ⟨rfl, rfl⟩
+      · refine (assert_ret_apply Θ _ "ret" _ _ (.str (x ++ y)) ?_).trans ?_
+        · exact stringCat_assert_eval ρ x y hρ
+        · iintro Hwand
+          iapply Hwand
+          exact TinyML.ValHasType.string_intro Θ (x ++ y)
+
+/-- `String.equal`: byte-string equality. -/
+def stringEqual : Intrinsic where
+  arity    := .two
+  name     := "string_equal"
+  path     := some ("String", ["equal"])
+  reduce   := fun (a, b) v => ∃ x y : List UInt8, a = .str x ∧ b = .str y ∧ v = .bool (x == y)
+  wp       := fun (a, b) Q => iprop(∃ x y : List UInt8, ⌜a = .str x ∧ b = .str y⌝ ∗ Q (.bool (x == y)))
+  spec     :=
+    { args  := [("a", .string), ("b", .string)]
+      retTy := .bool
+      pred  := .ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (stringEqualTerm (.var .value "a") (.var .value "b")))
+          (.ret ())) }
+  folSym   := some stringEqualSym
+  axioms   := [stringEqualDefAxiom, stringEqualTypeAxiom]
+
+@[simp] theorem stringEqual_arity : stringEqual.arity = .two := rfl
+@[simp] theorem stringEqual_folSym : stringEqual.folSym = some stringEqualSym := rfl
+@[simp] theorem stringEqual_toWp (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
+    stringEqual.toWp [a, b] Q =
+      iprop(∃ x y : List UInt8, ⌜a = .str x ∧ b = .str y⌝ ∗ Q (.bool (x == y))) :=
+  Intrinsic.toWp_two_of_arity _ _ _ _ _ _ _ _ _ Q
+
+private theorem stringEqual_base_wf :
+    PredTrans.wfIn
+      ((Intrinsic.sigOf [stringEqual]).declVars (Spec.argVars stringEqual.specArgs)) stringEqual.spec.pred := by
+  apply PredTrans.checkWf_ok
+  rfl
+
+private theorem stringEqual_assert_eval (ρ : VerifM.Env) (x y : List UInt8)
+    (hρ : ρ.env.respects (some stringEqualSym)) :
+    (Formula.eq .value (.var .value "ret")
+      (stringEqualTerm (.var .value "a") (.var .value "b"))).eval
+      ((Spec.argsEnv ρ stringEqual.specArgs [.str x, .str y]).updateConst
+        .value "ret" (.bool (x == y))).env := by
+  have hargs := respects_argsEnv_two stringEqual.specArgs [.str x, .str y] hρ
+  have hbin : (Spec.argsEnv ρ stringEqual.specArgs [.str x, .str y]).env.binary
+      .value .value .value "string_equal" = fun a b => stringEqualSym.interp (a, b) := by
+    simpa [Env.respects, stringEqualSym] using hargs
+  show Runtime.Val.bool (x == y) =
+    (Spec.argsEnv ρ stringEqual.specArgs [.str x, .str y]).env.binary
+      .value .value .value "string_equal" (.str x) (.str y)
+  simp [hbin, stringEqualSym]
+
+instance : IntrinsicSound [stringEqual] stringEqual where
+  axiomWf := by
+    intro Δ hsub hwf φ hφ
+    simp only [stringEqual, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    rcases hφ with rfl | rfl
+    · have hbase : stringEqualDefAxiom.wfIn (Intrinsic.sigOf [stringEqual]) := by
+        simp [stringEqualDefAxiom, stringEqualTerm, Intrinsic.sigOf, Intrinsic.foldSig,
+          stringEqual, stringEqualSym, Formula.wfIn, Term.wfIn, BinOp.wfIn, UnOp.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addBinary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+    · have hbase : stringEqualTypeAxiom.wfIn (Intrinsic.sigOf [stringEqual]) := by
+        simp [stringEqualTypeAxiom, stringEqualTerm, Intrinsic.sigOf, Intrinsic.foldSig,
+          stringEqual, stringEqualSym, Formula.wfIn, Term.wfIn, BinOp.wfIn, UnPred.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addBinary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+  proof := by
+    intro ρ hdeps φ hφ
+    simp only [stringEqual, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    have heq : ρ.respects (some stringEqualSym) := hdeps stringEqual (by simp)
+    simp only [Env.respects] at heq
+    have hb : ∀ x y : Runtime.Val,
+        ((ρ.updateConst .value "a" x).updateConst .value "b" y).binary
+          .value .value .value "string_equal" = fun a b => stringEqualSym.interp (a, b) := by
+      intro x y; rw [Env.updateConst_binary, Env.updateConst_binary]; simpa [stringEqualSym] using heq
+    rcases hφ with rfl | rfl
+    · simp only [stringEqualDefAxiom, Formula.eval]
+      intro x y
+      simp [stringEqualTerm, Term.eval, Env.lookupConst_updateConst_same,
+        Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), hb x y, stringEqualSym, valStr,
+        Bool.beq_eq_decide_eq]
+      rfl
+    · simp only [stringEqualTypeAxiom, Formula.eval]
+      intro x y
+      simp [stringEqualTerm, Term.eval, Env.lookupConst_updateConst_same,
+        Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), hb x y, stringEqualSym, valStr]
+  specWf := by
+    intro Δ hsub hwf
+    exact PredTrans.wfIn_mono stringEqual_base_wf
+      (Signature.Subset.declVars hsub (Spec.argVars stringEqual.specArgs))
+      (Signature.wf_declVars hwf)
+  bridge := by
+    intro Θ vs ρ Φ hρ
+    simp only [stringEqual_folSym, Env.respects] at hρ
+    show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string, TinyML.Typ.string] ∗ _ ⊢ _
+    match vs with
+    | [] => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | [_] => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | _ :: _ :: _ :: _ => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | [v1, v2] =>
+      iintro ⟨Hvs, Hpred⟩
+      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v1 [v2] _ _).1 $$ Hvs
+      icases Hcons with ⟨Hv1, Hvs2⟩
+      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
+      icases Hcons2 with ⟨Hv2, _⟩
+      ihave Hv1eq := (TinyML.ValHasType.string Θ v1).1 $$ Hv1
+      ipure Hv1eq
+      ihave Hv2eq := (TinyML.ValHasType.string Θ v2).1 $$ Hv2
+      ipure Hv2eq
+      obtain ⟨x, rfl⟩ := Hv1eq
+      obtain ⟨y, rfl⟩ := Hv2eq
+      rw [stringEqual_toWp]
+      iexists x
+      iexists y
+      isplitr [Hpred]
+      · ipure_intro; exact ⟨rfl, rfl⟩
+      · refine (assert_ret_apply Θ _ "ret" _ _ (.bool (x == y)) ?_).trans ?_
+        · exact stringEqual_assert_eval ρ x y hρ
+        · iintro Hwand
+          iapply Hwand
+          exact TinyML.ValHasType.bool_intro Θ (x == y)
+
+/-- `String.starts_with`: byte-string prefix test. -/
+def stringStartsWith : Intrinsic where
+  arity    := .two
+  name     := "string_starts_with"
+  path     := some ("String", ["starts_with"])
+  reduce   := fun (p, s) v => ∃ x y : List UInt8, p = .str x ∧ s = .str y ∧ v = .bool (x.isPrefixOf y)
+  wp       := fun (p, s) Q => iprop(∃ x y : List UInt8, ⌜p = .str x ∧ s = .str y⌝ ∗ Q (.bool (x.isPrefixOf y)))
+  spec     :=
+    { args  := [("prefix", .string), ("s", .string)]
+      retTy := .bool
+      pred  := .ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (stringStartsWithTerm (.var .value "prefix") (.var .value "s")))
+          (.ret ())) }
+  folSym   := some stringStartsWithSym
+  axioms   := [stringStartsWithDefAxiom, stringStartsWithTypeAxiom]
+
+@[simp] theorem stringStartsWith_arity : stringStartsWith.arity = .two := rfl
+@[simp] theorem stringStartsWith_folSym : stringStartsWith.folSym = some stringStartsWithSym := rfl
+@[simp] theorem stringStartsWith_toWp (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
+    stringStartsWith.toWp [a, b] Q =
+      iprop(∃ x y : List UInt8, ⌜a = .str x ∧ b = .str y⌝ ∗ Q (.bool (x.isPrefixOf y))) :=
+  Intrinsic.toWp_two_of_arity _ _ _ _ _ _ _ _ _ Q
+
+private theorem stringStartsWith_base_wf :
+    PredTrans.wfIn
+      ((Intrinsic.sigOf [stringStartsWith]).declVars (Spec.argVars stringStartsWith.specArgs)) stringStartsWith.spec.pred := by
+  apply PredTrans.checkWf_ok
+  rfl
+
+private theorem stringStartsWith_assert_eval (ρ : VerifM.Env) (x y : List UInt8)
+    (hρ : ρ.env.respects (some stringStartsWithSym)) :
+    (Formula.eq .value (.var .value "ret")
+      (stringStartsWithTerm (.var .value "prefix") (.var .value "s"))).eval
+      ((Spec.argsEnv ρ stringStartsWith.specArgs [.str x, .str y]).updateConst
+        .value "ret" (.bool (x.isPrefixOf y))).env := by
+  have hargs := respects_argsEnv_two stringStartsWith.specArgs [.str x, .str y] hρ
+  have hbin : (Spec.argsEnv ρ stringStartsWith.specArgs [.str x, .str y]).env.binary
+      .value .value .value "string_starts_with" = fun a b => stringStartsWithSym.interp (a, b) := by
+    simpa [Env.respects, stringStartsWithSym] using hargs
+  show Runtime.Val.bool (x.isPrefixOf y) =
+    (Spec.argsEnv ρ stringStartsWith.specArgs [.str x, .str y]).env.binary
+      .value .value .value "string_starts_with" (.str x) (.str y)
+  simp [hbin, stringStartsWithSym]
+
+instance : IntrinsicSound [stringStartsWith] stringStartsWith where
+  axiomWf := by
+    intro Δ hsub hwf φ hφ
+    simp only [stringStartsWith, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    rcases hφ with rfl | rfl
+    · have hbase : stringStartsWithDefAxiom.wfIn (Intrinsic.sigOf [stringStartsWith]) := by
+        simp [stringStartsWithDefAxiom, stringStartsWithTerm, Intrinsic.sigOf, Intrinsic.foldSig,
+          stringStartsWith, stringStartsWithSym, Formula.wfIn, Term.wfIn, BinOp.wfIn, UnOp.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addBinary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+    · have hbase : stringStartsWithTypeAxiom.wfIn (Intrinsic.sigOf [stringStartsWith]) := by
+        simp [stringStartsWithTypeAxiom, stringStartsWithTerm, Intrinsic.sigOf, Intrinsic.foldSig,
+          stringStartsWith, stringStartsWithSym, Formula.wfIn, Term.wfIn, BinOp.wfIn, UnPred.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addBinary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+  proof := by
+    intro ρ hdeps φ hφ
+    simp only [stringStartsWith, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    have hp : ρ.respects (some stringStartsWithSym) := hdeps stringStartsWith (by simp)
+    simp only [Env.respects] at hp
+    have hb : ∀ x y : Runtime.Val,
+        ((ρ.updateConst .value "prefix" x).updateConst .value "s" y).binary
+          .value .value .value "string_starts_with" = fun a b => stringStartsWithSym.interp (a, b) := by
+      intro x y; rw [Env.updateConst_binary, Env.updateConst_binary]; simpa [stringStartsWithSym] using hp
+    rcases hφ with rfl | rfl
+    · simp only [stringStartsWithDefAxiom, Formula.eval]
+      intro x y
+      simp [stringStartsWithTerm, Term.eval, Env.lookupConst_updateConst_same,
+        Env.lookupConst_updateConst_ne (show "prefix" ≠ "s" by decide), hb x y, stringStartsWithSym, valStr]
+      rfl
+    · simp only [stringStartsWithTypeAxiom, Formula.eval]
+      intro x y
+      simp [stringStartsWithTerm, Term.eval, Env.lookupConst_updateConst_same,
+        Env.lookupConst_updateConst_ne (show "prefix" ≠ "s" by decide), hb x y, stringStartsWithSym, valStr]
+  specWf := by
+    intro Δ hsub hwf
+    exact PredTrans.wfIn_mono stringStartsWith_base_wf
+      (Signature.Subset.declVars hsub (Spec.argVars stringStartsWith.specArgs))
+      (Signature.wf_declVars hwf)
+  bridge := by
+    intro Θ vs ρ Φ hρ
+    simp only [stringStartsWith_folSym, Env.respects] at hρ
+    show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string, TinyML.Typ.string] ∗ _ ⊢ _
+    match vs with
+    | [] => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | [_] => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | _ :: _ :: _ :: _ => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | [v1, v2] =>
+      iintro ⟨Hvs, Hpred⟩
+      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v1 [v2] _ _).1 $$ Hvs
+      icases Hcons with ⟨Hv1, Hvs2⟩
+      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
+      icases Hcons2 with ⟨Hv2, _⟩
+      ihave Hv1eq := (TinyML.ValHasType.string Θ v1).1 $$ Hv1
+      ipure Hv1eq
+      ihave Hv2eq := (TinyML.ValHasType.string Θ v2).1 $$ Hv2
+      ipure Hv2eq
+      obtain ⟨x, rfl⟩ := Hv1eq
+      obtain ⟨y, rfl⟩ := Hv2eq
+      rw [stringStartsWith_toWp]
+      iexists x
+      iexists y
+      isplitr [Hpred]
+      · ipure_intro; exact ⟨rfl, rfl⟩
+      · refine (assert_ret_apply Θ _ "ret" _ _ (.bool (x.isPrefixOf y)) ?_).trans ?_
+        · exact stringStartsWith_assert_eval ρ x y hρ
+        · iintro Hwand
+          iapply Hwand
+          exact TinyML.ValHasType.bool_intro Θ (x.isPrefixOf y)
+
+/-- `String.ends_with`: byte-string suffix test. -/
+def stringEndsWith : Intrinsic where
+  arity    := .two
+  name     := "string_ends_with"
+  path     := some ("String", ["ends_with"])
+  reduce   := fun (q, s) v => ∃ x y : List UInt8, q = .str x ∧ s = .str y ∧ v = .bool (x.isSuffixOf y)
+  wp       := fun (q, s) Q => iprop(∃ x y : List UInt8, ⌜q = .str x ∧ s = .str y⌝ ∗ Q (.bool (x.isSuffixOf y)))
+  spec     :=
+    { args  := [("suffix", .string), ("s", .string)]
+      retTy := .bool
+      pred  := .ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (stringEndsWithTerm (.var .value "suffix") (.var .value "s")))
+          (.ret ())) }
+  folSym   := some stringEndsWithSym
+  axioms   := [stringEndsWithDefAxiom, stringEndsWithTypeAxiom]
+
+@[simp] theorem stringEndsWith_arity : stringEndsWith.arity = .two := rfl
+@[simp] theorem stringEndsWith_folSym : stringEndsWith.folSym = some stringEndsWithSym := rfl
+@[simp] theorem stringEndsWith_toWp (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
+    stringEndsWith.toWp [a, b] Q =
+      iprop(∃ x y : List UInt8, ⌜a = .str x ∧ b = .str y⌝ ∗ Q (.bool (x.isSuffixOf y))) :=
+  Intrinsic.toWp_two_of_arity _ _ _ _ _ _ _ _ _ Q
+
+private theorem stringEndsWith_base_wf :
+    PredTrans.wfIn
+      ((Intrinsic.sigOf [stringEndsWith]).declVars (Spec.argVars stringEndsWith.specArgs)) stringEndsWith.spec.pred := by
+  apply PredTrans.checkWf_ok
+  rfl
+
+private theorem stringEndsWith_assert_eval (ρ : VerifM.Env) (x y : List UInt8)
+    (hρ : ρ.env.respects (some stringEndsWithSym)) :
+    (Formula.eq .value (.var .value "ret")
+      (stringEndsWithTerm (.var .value "suffix") (.var .value "s"))).eval
+      ((Spec.argsEnv ρ stringEndsWith.specArgs [.str x, .str y]).updateConst
+        .value "ret" (.bool (x.isSuffixOf y))).env := by
+  have hargs := respects_argsEnv_two stringEndsWith.specArgs [.str x, .str y] hρ
+  have hbin : (Spec.argsEnv ρ stringEndsWith.specArgs [.str x, .str y]).env.binary
+      .value .value .value "string_ends_with" = fun a b => stringEndsWithSym.interp (a, b) := by
+    simpa [Env.respects, stringEndsWithSym] using hargs
+  show Runtime.Val.bool (x.isSuffixOf y) =
+    (Spec.argsEnv ρ stringEndsWith.specArgs [.str x, .str y]).env.binary
+      .value .value .value "string_ends_with" (.str x) (.str y)
+  simp [hbin, stringEndsWithSym]
+
+instance : IntrinsicSound [stringEndsWith] stringEndsWith where
+  axiomWf := by
+    intro Δ hsub hwf φ hφ
+    simp only [stringEndsWith, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    rcases hφ with rfl | rfl
+    · have hbase : stringEndsWithDefAxiom.wfIn (Intrinsic.sigOf [stringEndsWith]) := by
+        simp [stringEndsWithDefAxiom, stringEndsWithTerm, Intrinsic.sigOf, Intrinsic.foldSig,
+          stringEndsWith, stringEndsWithSym, Formula.wfIn, Term.wfIn, BinOp.wfIn, UnOp.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addBinary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+    · have hbase : stringEndsWithTypeAxiom.wfIn (Intrinsic.sigOf [stringEndsWith]) := by
+        simp [stringEndsWithTypeAxiom, stringEndsWithTerm, Intrinsic.sigOf, Intrinsic.foldSig,
+          stringEndsWith, stringEndsWithSym, Formula.wfIn, Term.wfIn, BinOp.wfIn, UnPred.wfIn,
+          Signature.extendWithSym, Signature.empty, Signature.addBinary,
+          Signature.declVar, Signature.addVar, Signature.remove]
+      exact Formula.wfIn_mono _ hbase hsub hwf
+  proof := by
+    intro ρ hdeps φ hφ
+    simp only [stringEndsWith, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    have hp : ρ.respects (some stringEndsWithSym) := hdeps stringEndsWith (by simp)
+    simp only [Env.respects] at hp
+    have hb : ∀ x y : Runtime.Val,
+        ((ρ.updateConst .value "suffix" x).updateConst .value "s" y).binary
+          .value .value .value "string_ends_with" = fun a b => stringEndsWithSym.interp (a, b) := by
+      intro x y; rw [Env.updateConst_binary, Env.updateConst_binary]; simpa [stringEndsWithSym] using hp
+    rcases hφ with rfl | rfl
+    · simp only [stringEndsWithDefAxiom, Formula.eval]
+      intro x y
+      simp [stringEndsWithTerm, Term.eval, Env.lookupConst_updateConst_same,
+        Env.lookupConst_updateConst_ne (show "suffix" ≠ "s" by decide), hb x y, stringEndsWithSym, valStr]
+      rfl
+    · simp only [stringEndsWithTypeAxiom, Formula.eval]
+      intro x y
+      simp [stringEndsWithTerm, Term.eval, Env.lookupConst_updateConst_same,
+        Env.lookupConst_updateConst_ne (show "suffix" ≠ "s" by decide), hb x y, stringEndsWithSym, valStr]
+  specWf := by
+    intro Δ hsub hwf
+    exact PredTrans.wfIn_mono stringEndsWith_base_wf
+      (Signature.Subset.declVars hsub (Spec.argVars stringEndsWith.specArgs))
+      (Signature.wf_declVars hwf)
+  bridge := by
+    intro Θ vs ρ Φ hρ
+    simp only [stringEndsWith_folSym, Env.respects] at hρ
+    show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string, TinyML.Typ.string] ∗ _ ⊢ _
+    match vs with
+    | [] => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | [_] => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | _ :: _ :: _ :: _ => exact (sep_mono_l (off_shape_two_ty _ (by simp))).trans sep_elim_l
+    | [v1, v2] =>
+      iintro ⟨Hvs, Hpred⟩
+      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v1 [v2] _ _).1 $$ Hvs
+      icases Hcons with ⟨Hv1, Hvs2⟩
+      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
+      icases Hcons2 with ⟨Hv2, _⟩
+      ihave Hv1eq := (TinyML.ValHasType.string Θ v1).1 $$ Hv1
+      ipure Hv1eq
+      ihave Hv2eq := (TinyML.ValHasType.string Θ v2).1 $$ Hv2
+      ipure Hv2eq
+      obtain ⟨x, rfl⟩ := Hv1eq
+      obtain ⟨y, rfl⟩ := Hv2eq
+      rw [stringEndsWith_toWp]
+      iexists x
+      iexists y
+      isplitr [Hpred]
+      · ipure_intro; exact ⟨rfl, rfl⟩
+      · refine (assert_ret_apply Θ _ "ret" _ _ (.bool (x.isSuffixOf y)) ?_).trans ?_
+        · exact stringEndsWith_assert_eval ρ x y hρ
+        · iintro Hwand
+          iapply Hwand
+          exact TinyML.ValHasType.bool_intro Θ (x.isSuffixOf y)
+
+end Intrinsics
+end Stdlib

--- a/Mica/TinyML/Common.lean
+++ b/Mica/TinyML/Common.lean
@@ -27,6 +27,7 @@ inductive UnOp where
 inductive Const where
   | int  (n : Int)
   | bool (b : Bool)
+  | string (s : List UInt8)
   | unit
   deriving Repr, BEq, DecidableEq
 

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -146,6 +146,7 @@ private partial def printAtom : Untyped.Expr → String
 partial def printConst : TinyML.Const → String
   | .int n => if n < 0 then s!"({n})" else s!"{n}"
   | .bool b => if b then "true" else "false"
+  | .string _ => "\"...\""
   | .unit => "()"
 
 partial def printFix (self : Untyped.Binder) (args : List Untyped.Binder) (body : Untyped.Expr) : String :=

--- a/Mica/TinyML/RuntimeExpr.lean
+++ b/Mica/TinyML/RuntimeExpr.lean
@@ -22,6 +22,7 @@ mutual
   inductive Val where
     | int (n : Int)
     | bool (b : Bool)
+    | str (s : List UInt8)
     | unit
     | inj (tag : Nat) (arity : Nat) (payload : Val)
     | loc (l : Location)
@@ -72,6 +73,7 @@ theorem Expr.isFunc_elim {e : Expr} (h : e.isFunc = true) :
 def Val.ofConst : TinyML.Const → Val
   | .int n  => .int n
   | .bool b => .bool b
+  | .string s => .str s
   | .unit   => .unit
 
 
@@ -86,6 +88,9 @@ mutual
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case bool.bool a b => exact match decEq a b with
+      | isTrue h => isTrue (by subst h; rfl)
+      | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case str.str a b => exact match decEq a b with
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case unit.unit => exact isTrue rfl

--- a/Mica/TinyML/Typed.lean
+++ b/Mica/TinyML/Typed.lean
@@ -203,6 +203,7 @@ abbrev Binders := List Binder
 def Const.ty : Const → Typ
   | .int _ => .int
   | .bool _ => .bool
+  | .string _ => .string
   | .unit => .unit
 
 def arrowOfArgs : List Binder → Typ → Typ

--- a/Mica/TinyML/Types.lean
+++ b/Mica/TinyML/Types.lean
@@ -11,6 +11,7 @@ inductive PrimitiveType where
   | unit
   | bool
   | int
+  | string
   deriving Repr, DecidableEq
 
 /-- Decidable equality for primitive types. -/
@@ -22,6 +23,7 @@ def PrimitiveType.print : PrimitiveType → String
   | .unit => "unit"
   | .bool => "bool"
   | .int => "int"
+  | .string => "string"
 
 /-- Type primitive binary operators before lifting the result to `Typ`. -/
 def PrimitiveType.binOpTypeOf : BinOp → PrimitiveType → PrimitiveType → Option PrimitiveType
@@ -119,6 +121,8 @@ inductive Typ where
 @[simp] def Typ.bool : Typ := .prim .bool
 /-- Compatibility name for the integer primitive type. -/
 @[simp] def Typ.int : Typ := .prim .int
+/-- Compatibility name for the string primitive type. -/
+@[simp] def Typ.string : Typ := .prim .string
 
 def Typ.primDecEq (p q : PrimitiveType) : Decidable (Typ.prim p = Typ.prim q) :=
   match PrimitiveType.decEq p q with

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -109,6 +109,7 @@ mutual
   def compile (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
     | .const (.int n)  => pure (.unop .ofInt  (.const (.i n)))
     | .const (.bool b) => pure (.unop .ofBool (.const (.b b)))
+    | .const (.string s) => pure (.unop .ofString (.const (.str s)))
     | .const .unit     => pure (Term.const .unit)
     | .var x vty => do
         let x' ← VerifM.expectSome s!"undefined variable: {x}" (B.lookup x)
@@ -530,6 +531,22 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
     · iexact Howns
     · isplitl []
       · exact TinyML.ValHasType.bool_intro Θ b
+      · iexact HR
+  | string s =>
+    simp only [compile] at heval
+    simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
+    obtain heval := VerifM.eval_ret heval
+    simp only [Expr.ty, Const.ty] at hpost
+    refine SpatialContext.wp_val ?_
+    istart
+    iintro ⟨Howns, _HS, _Hts, HR⟩
+    iapply (hpost (.str s) ρ st _ heval
+      (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
+      (by simp [Term.eval, UnOp.eval, Const.denote]))
+    isplitl [Howns]
+    · iexact Howns
+    · isplitl []
+      · exact TinyML.ValHasType.string_intro Θ s
       · iexact HR
   | unit =>
     simp only [compile] at heval

--- a/Mica/Verifier/RelationalEncoding/Monad.lean
+++ b/Mica/Verifier/RelationalEncoding/Monad.lean
@@ -37,6 +37,7 @@ namespace Verifier.RelationalEncoding
 def encodeConst : TinyML.Const → Term .value
   | .int  n => .unop .ofInt  (.const (.i n))
   | .bool b => .unop .ofBool (.const (.b b))
+  | .string s => .unop .ofString (.const (.str s))
   | .unit   => .const .unit
 
 /-- Encode a TinyML unary op acting on a value-sorted argument. -/


### PR DESCRIPTION
This PR adds string support to Mica. It adds several intrinsics and a new SMT sort. Strings are represented as byte lists to avoid issues between the Lean encoding of strings and OCaml's notion of strings.