### PR TITLE
Concrete Iris ghost-state signature for Mica

### DIFF
--- a/Mica/SeparationLogic/Axioms.lean
+++ b/Mica/SeparationLogic/Axioms.lean
@@ -1,5 +1,6 @@
 -- SUMMARY: Axiomatized Iris connectives and weakest-precondition rules for TinyML programs and heap operations.
 import Iris.Examples.IProp
+import Mica.SeparationLogic.GhostState
 import Mica.TinyML.RuntimeExpr
 import Mica.TinyML.OpSem
 
@@ -24,9 +25,9 @@ macro_rules
   | `($P -∗ $Q) => ``(BIBase.wand $P $Q)
   | `(⌜$φ⌝)     => ``(BIBase.pure $φ)
 
--- Placeholder signature for now; eventually we will provide the resources
--- needed by the rules below (heap, invariants).
-def Sig : BundledGFunctors.{0} := .default
+-- The concrete signature from `GhostState`: invariants, later credits, and
+-- heap resources over TinyML heaps. The rules below are still axiomatized
+-- against it.
 abbrev iProp := IProp.{0} Sig
 
 -- Points-to axiomatized for now.

--- a/Mica/SeparationLogic/GhostState.lean
+++ b/Mica/SeparationLogic/GhostState.lean
@@ -1,0 +1,106 @@
+-- SUMMARY: Concrete Iris ghost-state signature for Mica: invariants, later credits, and heap resources over TinyML heaps.
+import Iris.BI.Lib.GenHeap
+import Iris.ProgramLogic.WeakestPre
+import Iris.ProofMode
+import Mica.TinyML.Language
+
+/-!
+The concrete Iris signature for Mica: a `MicaGpreS`/`MicaGS` pair of ghost-state
+classes for the generic heap over TinyML locations and values, and the bundled
+functor signature `Sig` they are instantiated at.
+-/
+
+open Iris ProgramLogic Std
+
+/-- Ghost-state prerequisites: the signature supports invariants, later
+    credits, and a generic heap over TinyML locations and values. -/
+class MicaGpreS (hlc : outParam HasLC) (GF : BundledGFunctors) extends InvGpreS GF where
+  heap_pre : genHeapPreS PNat Runtime.Location Runtime.Val GF TinyML.HeapF
+
+attribute [reducible, instance] MicaGpreS.heap_pre
+
+/-- Allocated ghost state: invariant machinery plus a heap instance (ghost
+    names for the heap and meta maps). Mica's `iProp` definitions are stated
+    parametrically in this class so that adequacy can allocate the names. -/
+class MicaGS (hlc : outParam HasLC) (GF : BundledGFunctors) extends InvGS_gen hlc GF where
+  heap : genHeapGS PNat Runtime.Location Runtime.Val GF TinyML.HeapF
+
+attribute [reducible, instance] MicaGS.heap
+
+/-- The concrete bundled functor signature for Mica: invariants (0–2), later
+    credits (3), the heap and meta ghost maps (4–6). -/
+def Sig : BundledGFunctors
+  | 0 => ⟨InvMapF, by infer_instance⟩
+  | 1 => ⟨constOF (DisjointLeibnizSet CoPset), by infer_instance⟩
+  | 2 => ⟨constOF (DisjointLeibnizSet PosSet), by infer_instance⟩
+  | 3 => ⟨Auth.AuthURF (F := PNat) (constOF Credit), by infer_instance⟩
+  | 4 => ⟨constOF (HeapView PNat Runtime.Location (Agree (LeibnizO Runtime.Val)) TinyML.HeapF),
+          by infer_instance⟩
+  | 5 => ⟨constOF (HeapView PNat Runtime.Location (Agree (LeibnizO GName)) TinyML.HeapF),
+          by infer_instance⟩
+  | 6 => ⟨constOF MetaUR, by infer_instance⟩
+  | _ => ⟨constOF Unit, by infer_instance⟩
+
+instance instMicaGpreS_Sig : MicaGpreS HasLC.hasLC Sig where
+  toWsatGpreS := by
+    constructor
+    · exists 0
+    · exists 1
+    · exists 2
+  toLcGpreS := by
+    constructor
+    · exists 3
+  heap_pre := by
+    constructor
+    · constructor
+      exists 4
+    · constructor
+      exists 5
+    · exists 6
+
+/-- The gen-heap `insert` (alter-based) agrees with `Heap.update`. -/
+theorem TinyML.Heap.insert_eq_update (μ : TinyML.Heap) (l : Runtime.Location)
+    (v : Runtime.Val) : Iris.Std.insert μ l v = μ.update l v := by
+  refine Std.ExtTreeMap.ext_getElem? fun k => ?_
+  show (μ.alter l fun _ => some v)[k]? = (μ.insert l v)[k]?
+  simp [Std.ExtTreeMap.getElem?_alter, Std.ExtTreeMap.getElem?_insert]
+
+/-- `genHeap_alloc` restated against `Heap.update`. -/
+theorem genHeap_alloc' {hlc} {GF : BundledGFunctors} [MicaGS hlc GF] {σ : TinyML.Heap}
+    {l : Runtime.Location} {v : Runtime.Val} (h : σ.lookup l = none) :
+    genHeapInterp (F := PNat) (GF := GF) (H := TinyML.HeapF) σ ⊢
+      |==> (genHeapInterp (F := PNat) (GF := GF) (H := TinyML.HeapF) (σ.update l v) ∗
+        pointsTo l (DFrac.own 1) v ∗ metaToken l ⊤) := by
+  have := genHeap_alloc (GF := GF) (H := TinyML.HeapF) (v := v)
+    (show Iris.Std.get? σ l = none from h)
+  rwa [TinyML.Heap.insert_eq_update] at this
+
+/-- `genHeap_update` restated against `Heap.update`. -/
+theorem genHeap_update' {hlc} {GF : BundledGFunctors} [MicaGS hlc GF] {σ : TinyML.Heap}
+    {l : Runtime.Location} {v₁ v₂ : Runtime.Val} :
+    genHeapInterp (F := PNat) (GF := GF) (H := TinyML.HeapF) σ ∗ pointsTo l (DFrac.own 1) v₁ ==∗
+      genHeapInterp (F := PNat) (GF := GF) (H := TinyML.HeapF) (σ.update l v₂) ∗
+        pointsTo l (DFrac.own 1) v₂ := by
+  have := genHeap_update (GF := GF) (H := TinyML.HeapF) (σ := σ) (l := l)
+    (v₁ := v₁) (v₂ := v₂)
+  rwa [TinyML.Heap.insert_eq_update] at this
+
+/-- Ownership of the physical TinyML heap — Mica's state interpretation.
+    The heap assertion that the generic primitive-call rule (`wp.prim`)
+    interfaces with. -/
+abbrev heapInterp {hlc} {GF : BundledGFunctors} [MicaGS hlc GF] (σ : TinyML.Heap) :
+    IProp GF :=
+  genHeapInterp (F := PNat) (GF := GF) (H := TinyML.HeapF) σ
+
+/-- State interpretation: ownership of the physical TinyML heap. -/
+instance instStateInterp {hlc} {GF : BundledGFunctors} [MicaGS hlc GF] :
+    StateInterp TinyML.Heap Empty GF where
+  stateInterp σ _ _ _ := genHeapInterp (F := PNat) (GF := GF) (H := TinyML.HeapF) σ
+
+/-- The Iris ghost-state interface for the TinyML language: no observations,
+    no forked threads, no extra laters per step. -/
+instance instIrisGS {hlc} {GF : BundledGFunctors} (ctx : TinyML.PrimCtx) [MicaGS hlc GF] :
+    IrisGS_gen hlc (TinyML.LExpr ctx) GF where
+  numLatersPerStep _ := 0
+  forkPost _ := iprop(True)
+  stateInterp_mono σ ns obs nt := by iintro $

--- a/Mica/SeparationLogic/OUTLINE.md
+++ b/Mica/SeparationLogic/OUTLINE.md
@@ -1,6 +1,7 @@
 **Mica/SeparationLogic**
 
 - `Axioms.lean` — Axiomatized Iris connectives and weakest-precondition rules for TinyML programs and heap operations.
+- `GhostState.lean` — Concrete Iris ghost-state signature for Mica: invariants, later credits, and heap resources over TinyML heaps.
 - `Interpretations.lean` — Iris interpretations of spatial atoms and contexts, with lemmas relating syntax to separation-logic assertions.
 - `LogicalRelation.lean` — Iris logical relations for TinyML values and types, together with formula generation for type constraints.
 - `PrimitiveLaws.lean` — Spatially lifted weakest-precondition laws for TinyML primitive operations.


### PR DESCRIPTION
This PR adds a ghost state instance for Mica's TinyML language.