### PR TITLE
Instantiate the weakest precondition; de-axiomatize the separation logic

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -42,9 +42,10 @@ open Iris Iris.BI in
     precondition holds under the registry-derived `wp` context. Instantiates the
     generic `Program.verify_correct` at the concrete stdlib registry, discharging
     its obligations from `Stdlib.registry_sound`. -/
-theorem verify_sound (p : Untyped.Program (Spec.Body Untyped.Expr)) :
+theorem verify_sound [MicaGS HasLC.hasLC Sig]
+    (p : Untyped.Program (Spec.Body Untyped.Expr)) :
     Smt.Strategy.checks (Program.verify Stdlib.registry p)
-      (⊢ pwp (Stdlib.registry.wpCtx) (Untyped.Program.runtime p)) :=
+      (⊢ pwp Stdlib.registry.primCtx (Untyped.Program.runtime p)) :=
   Program.verify_correct Stdlib.registry Stdlib.registry_sound p
 
 def main (args : List String) : IO Unit := do

--- a/Mica/SeparationLogic/Axioms.lean
+++ b/Mica/SeparationLogic/Axioms.lean
@@ -1,236 +1,642 @@
--- SUMMARY: Axiomatized Iris connectives and weakest-precondition rules for TinyML programs and heap operations.
-import Iris.Examples.IProp
+-- SUMMARY: The Iris weakest precondition for TinyML and its derived proof rules, including invariant-based heap rules and primitive-call lifting.
+import Mathlib.Data.List.Induction
+import Iris.ProgramLogic.Lifting
+import Iris.Instances.Lib.Invariants
 import Mica.SeparationLogic.GhostState
 import Mica.TinyML.RuntimeExpr
 import Mica.TinyML.OpSem
 
-open Iris Iris.BI Iris.OFE
+open Iris Iris.BI Iris.OFE Iris.ProgramLogic Iris.ProgramLogic.EctxLanguage
 
 /-!
-This module is the axiomatization boundary between TinyML and Iris. It fixes a
-global Iris signature and exposes the core BI interface (`iProp`, `∗`, `-∗`,
-`⌜_⌝`), weakest preconditions (`wp`/`wps`/`pwp`), and heap predicates
-(`pointsTo`, `locinv`) used by the verifier.
-
-Heap reasoning is provided in two parallel styles: explicit ownership rules
-(`wp.ref`/`wp.deref`/`wp.store` over `l ↦ v`) and invariant-based rules
-(`wp.ref_inv`/`wp.deref_inv`/`wp.store_inv` over `locinv`). Later files prove
-derived proof rules against this common axiomatic interface.
+This module defines Mica's weakest precondition as the Iris weakest
+precondition of the TinyML language instance (`Mica.TinyML.Language`,
+`Mica.SeparationLogic.GhostState`) and derives the proof rules used by the
+verifier. Heap predicates come from iris-lean's generic heap (`l ↦ v` is
+`Iris.pointsTo`); location invariants (`locinv`) are Iris invariants
+(`Iris.inv`); primitive calls are lifted from the primitive operational
+semantics (`wp.prim`, consumed at the registry level by
+`Verifier.Registry.wp_prim`).
 -/
 
--- Top-level elaboration for Iris connectives (the Iris library only provides
--- these inside `iprop(...)` blocks).
+-- Top-level elaboration for Iris connectives: the Iris library provides these
+-- only inside `iprop(...)` blocks, and the candidates in scope at top level
+-- do not elaborate at `iProp` (removing these rules yields "overloaded"
+-- elaboration errors at every top-level `∗`/`⌜⌝` use).
 macro_rules
   | `($P ∗ $Q)  => ``(BIBase.sep $P $Q)
   | `($P -∗ $Q) => ``(BIBase.wand $P $Q)
   | `(⌜$φ⌝)     => ``(BIBase.pure $φ)
 
 -- The concrete signature from `GhostState`: invariants, later credits, and
--- heap resources over TinyML heaps. The rules below are still axiomatized
--- against it.
+-- heap resources over TinyML heaps.
 abbrev iProp := IProp.{0} Sig
 
--- Points-to axiomatized for now.
-axiom pointsTo : Runtime.Location → Runtime.Val → iProp
-notation:50 l " ↦ " v:51 => pointsTo l v
+variable [MicaGS HasLC.hasLC Sig]
 
 abbrev WpCtx := String → List Runtime.Val → (Runtime.Val → iProp) → iProp
 
-axiom wp : WpCtx → Runtime.Expr → (Runtime.Val → iProp) → iProp
+/-- Weakest precondition for TinyML expressions: the Iris weakest
+    precondition of the TinyML language instance at primitive context `ctx`,
+    with stuckness `NotStuck` and the full mask. -/
+def wp (ctx : TinyML.PrimCtx) (e : Runtime.Expr) (Φ : Runtime.Val → iProp) : iProp :=
+  Wp.wp Stuckness.NotStuck ⊤ (show TinyML.LExpr ctx from e) Φ
 
-axiom locinv : Runtime.Location → (Runtime.Val → iProp) → iProp
-/- We don't have invariants yet, but the idea is the encoding of locinv is
-        locinv l I := inv N (∃ v, l ↦ v * I v)
-We don't give out access to the points-to direcly in the rules below and,
-instead, the invariant on the value I has to be persistent. -/
-axiom locinv_persistent l I : Persistent (locinv l I)
+/-- The namespace housing the location invariants (`locinv`). A single fixed
+    namespace suffices: every rule below opens at most one invariant around
+    one atomic step. -/
+def micaN : Namespace := nroot.@"mica_locinv"
 
-attribute [instance] locinv_persistent
+/-- Location invariant: an Iris invariant owning the location and constraining
+    its contents by `I`. The rules below never give out the points-to itself;
+    where the payload `I` is handed out (`wp.deref_inv`), it must be
+    persistent. -/
+def locinv (l : Runtime.Location) (I : Runtime.Val → iProp) : iProp :=
+  inv micaN iprop(∃ v, l ↦ v ∗ I v)
 
-/- In Iris, invariants are contractive in their body. `locinv` is currently
-axiomatized in Mica, so this experiment records the corresponding local axiom. -/
-axiom locinv_contractive (l : Runtime.Location) :
-  Contractive (fun I : Runtime.Val → iProp => locinv l I)
+instance locinv_persistent (l : Runtime.Location) (I : Runtime.Val → iProp) :
+    Persistent (locinv l I) :=
+  inv_persistent micaN _
 
-attribute [instance] locinv_contractive
+instance locinv_contractive (l : Runtime.Location) :
+    Contractive (fun I : Runtime.Val → iProp => locinv l I) where
+  distLater_dist H :=
+    Contractive.distLater_dist (f := inv micaN)
+      (fun m hm => exists_ne fun v => sep_ne.ne .rfl (H m hm v))
 
 /-- Weakest precondition for a list of expressions, evaluated right-to-left.
-    `wps wctx [e1, e2, e3] Q` first evaluates `e3`, then `e2`, then `e1`,
+    `wps ctx [e1, e2, e3] Q` first evaluates `e3`, then `e2`, then `e1`,
     and passes `[v1, v2, v3]` (in original order) to `Q`. -/
-noncomputable def wps (wctx : WpCtx) : Runtime.Exprs → (Runtime.Vals → iProp) → iProp
+def wps (ctx : TinyML.PrimCtx) : Runtime.Exprs → (Runtime.Vals → iProp) → iProp
   | [], Q => Q []
-  | e :: es, Q => wps wctx es (fun vs => wp wctx e (fun v => Q (v :: vs)))
+  | e :: es, Q => wps ctx es (fun vs => wp ctx e (fun v => Q (v :: vs)))
 
-/-! ## Core axioms -/
+/-! ## Core rules -/
 
-axiom pointsTo.exclusive (l : Runtime.Location) (v1 v2 : Runtime.Val) :
-    l ↦ v1 ∗ l ↦ v2 ⊢ (False : iProp)
+theorem pointsTo.exclusive (l : Runtime.Location) (v1 v2 : Runtime.Val) :
+    l ↦ v1 ∗ l ↦ v2 ⊢ (False : iProp) := by
+  istart
+  iintro ⟨H1, H2⟩
+  icases pointsTo_ne $$ H1 H2 with %Hne
+  exact absurd rfl Hne
 
-axiom wp.val {wctx : WpCtx} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
-    Q v ⊢ wp wctx (.val v) Q
+theorem wp.val {ctx : TinyML.PrimCtx} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
+    Q v ⊢ wp ctx (.val v) Q :=
+  wp_value' (Val := Runtime.Val)
 
-axiom wp.bind {wctx : WpCtx} {k : TinyML.K} {e : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    wp wctx e (fun v => wp wctx (k.fill (.val v)) Q) ⊢ wp wctx (k.fill e) Q
+theorem wp.bind {ctx : TinyML.PrimCtx} {k : TinyML.K} {e : Runtime.Expr} {Q : Runtime.Val → iProp} :
+    wp ctx e (fun v => wp ctx (k.fill (.val v)) Q) ⊢ wp ctx (k.fill e) Q :=
+  wp_bind (fun e : TinyML.LExpr ctx => k.fill e)
 
-axiom wp.wand {wctx : WpCtx} {e : Runtime.Expr} {P Q : Runtime.Val → iProp} :
-    (∀ v, P v -∗ Q v) ∗ wp wctx e P ⊢ wp wctx e Q
+theorem wp.wand {ctx : TinyML.PrimCtx} {e : Runtime.Expr} {P Q : Runtime.Val → iProp} :
+    (∀ v, P v -∗ Q v) ∗ wp ctx e P ⊢ wp ctx e Q :=
+  sep_symm.trans (wand_elim (wp_wand (Val := Runtime.Val)))
 
-axiom wp.app {wctx : WpCtx} {fn : Runtime.Expr} {args : Runtime.Exprs} {P : Runtime.Val → iProp} :
-    wps wctx args (fun vs => wp wctx fn (fun fv =>
-      wp wctx (.app (.val fv) (vs.map Runtime.Expr.val)) P)) ⊢
-    wp wctx (.app fn args) P
+-- Derived monotonicity as an entailment
+theorem wp.mono {ctx : TinyML.PrimCtx} {e : Runtime.Expr} {P Q : Runtime.Val → iProp}
+    (h : ∀ v, P v ⊢ Q v) : wp ctx e P ⊢ wp ctx e Q :=
+  emp_sep.2.trans (sep_mono_left (forall_intro fun v => wand_intro (emp_sep.1.trans (h v))))
+    |>.trans (wp.wand (ctx := ctx) (e := e))
 
-axiom wp.func {wctx : WpCtx} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
-    (P : Runtime.Val → iProp) :
-    P (.fix f args e) ⊢ wp wctx (.fix f args e) P
+/-- Lift a deterministic, heap-preserving head step to a `wp` rule that strips
+    a later. The `EctxLifting` wrappers are not public in iris-lean, so this
+    routes through the public `wp_lift_pure_det_step_no_fork` and the public
+    baseStep/primStep conversion lemmas of `EctxLanguage`. -/
+private theorem wp.pure_step' {ctx : TinyML.PrimCtx} {e₁ e₂ : Runtime.Expr}
+    (hstep : ∀ μ, TinyML.Head ctx e₁ μ e₂ μ)
+    (hdet : ∀ μ e' μ', TinyML.Head ctx e₁ μ e' μ' → e' = e₂ ∧ μ' = μ)
+    {Q : Runtime.Val → iProp} :
+    ▷ wp ctx e₂ Q ⊢ wp ctx e₁ Q := by
+  have hred : ∀ μ : TinyML.Heap,
+      BaseStep.Reducible (show TinyML.LExpr ctx from e₁, μ) :=
+    fun μ => ⟨[], e₂, μ, [], hstep μ, rfl, rfl⟩
+  have hsafe : ∀ μ : TinyML.Heap,
+      PrimStep.Reducible (show TinyML.LExpr ctx from e₁, μ) :=
+    fun μ => primStep_reducible_of_baseStep_reducible (hred μ)
+  refine ((later_mono (wand_intro sep_elim_left)).trans
+      (step_fupd_intro Std.LawfulSet.subset_refl)).trans
+    (wp_lift_pure_det_step_no_fork (e₂ := show TinyML.LExpr ctx from e₂) ⊤ hsafe ?_)
+  rintro μ obs e' μ' eₜ hps
+  obtain ⟨h, rfl, rfl⟩ := baseStep_of_primStep_of_baseStep_reducible (hred μ) hps
+  obtain ⟨he, hμ⟩ := hdet _ _ _ h
+  exact ⟨rfl, hμ, he, rfl⟩
 
-axiom wp.fix {wctx : WpCtx} {vs : List Runtime.Val} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
-    {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp} :
-      wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P
-    ⊢ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P
+/-- Later-free version of `wp.pure_step'`. -/
+private theorem wp.pure_step {ctx : TinyML.PrimCtx} {e₁ e₂ : Runtime.Expr}
+    (hstep : ∀ μ, TinyML.Head ctx e₁ μ e₂ μ)
+    (hdet : ∀ μ e' μ', TinyML.Head ctx e₁ μ e' μ' → e' = e₂ ∧ μ' = μ)
+    {Q : Runtime.Val → iProp} :
+    wp ctx e₂ Q ⊢ wp ctx e₁ Q :=
+  later_intro.trans (wp.pure_step' hstep hdet)
 
-axiom wp.fix' {wctx : WpCtx} {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
-    {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp} :
-    □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-        Φ P vs -∗ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
-      ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-        Φ P vs -∗ wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)
-    ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp), Φ P vs -∗ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P)
+theorem wp.func {ctx : TinyML.PrimCtx} {f : Runtime.Binder} {args : List Runtime.Binder}
+    {e : Runtime.Expr} (P : Runtime.Val → iProp) :
+    P (.fix f args e) ⊢ wp ctx (.fix f args e) P :=
+  wp.val.trans (wp.pure_step (fun _ => .fixIntro)
+    (by rintro μ e' μ' h; cases h; exact ⟨rfl, rfl⟩))
 
-axiom wp.unop {wctx : WpCtx} {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iProp} :
-    TinyML.evalUnOp op v = some res →
-    Q res ⊢ wp wctx (.unop op (.val v)) Q
+theorem wp.fix {ctx : TinyML.PrimCtx} {vs : List Runtime.Val} {f : Runtime.Binder}
+    {args : List Runtime.Binder} {e : Runtime.Expr} {P : Runtime.Val → iProp}
+    (hlen : args.length = vs.length) :
+      wp ctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P
+    ⊢ wp ctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P :=
+  wp.pure_step (fun _ => .beta hlen) (fun _ _ _ h => h.beta_inv)
 
-axiom wp.binop {wctx : WpCtx} {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val → iProp} :
-    TinyML.evalBinOp op vl vr = some res →
-    Q res ⊢ wp wctx (.binop op (.val vl) (.val vr)) Q
+theorem wp.unop {ctx : TinyML.PrimCtx} {op : TinyML.UnOp} {v res : Runtime.Val}
+    {Q : Runtime.Val → iProp} (heval : TinyML.evalUnOp op v = some res) :
+    Q res ⊢ wp ctx (.unop op (.val v)) Q :=
+  wp.val.trans (wp.pure_step (fun _ => .unop heval)
+    (by rintro μ e' μ' h; cases h; simp_all))
 
-axiom wp.if_true {wctx : WpCtx} {thn els : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    wp wctx thn Q ⊢ wp wctx (.ifThenElse (.val (.bool true)) thn els) Q
+theorem wp.binop {ctx : TinyML.PrimCtx} {op : TinyML.BinOp} {vl vr res : Runtime.Val}
+    {Q : Runtime.Val → iProp} (heval : TinyML.evalBinOp op vl vr = some res) :
+    Q res ⊢ wp ctx (.binop op (.val vl) (.val vr)) Q :=
+  wp.val.trans (wp.pure_step (fun _ => .binop heval)
+    (by rintro μ e' μ' h; cases h; simp_all))
 
-axiom wp.if_false {wctx : WpCtx} {thn els : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    wp wctx els Q ⊢ wp wctx (.ifThenElse (.val (.bool false)) thn els) Q
+theorem wp.if_true {ctx : TinyML.PrimCtx} {thn els : Runtime.Expr} {Q : Runtime.Val → iProp} :
+    wp ctx thn Q ⊢ wp ctx (.ifThenElse (.val (.bool true)) thn els) Q :=
+  wp.pure_step (fun _ => .ifTrue) (by rintro μ e' μ' h; cases h; exact ⟨rfl, rfl⟩)
+
+theorem wp.if_false {ctx : TinyML.PrimCtx} {thn els : Runtime.Expr} {Q : Runtime.Val → iProp} :
+    wp ctx els Q ⊢ wp ctx (.ifThenElse (.val (.bool false)) thn els) Q :=
+  wp.pure_step (fun _ => .ifFalse) (by rintro μ e' μ' h; cases h; exact ⟨rfl, rfl⟩)
 
 /-- `assert true` returns unit; `assert false` is stuck. -/
-axiom wp.assert {wctx : WpCtx} {P : Runtime.Val → iProp} :
-    P .unit ⊢ wp wctx (.assert (.val (.bool true))) P
+theorem wp.assert {ctx : TinyML.PrimCtx} {P : Runtime.Val → iProp} :
+    P .unit ⊢ wp ctx (.assert (.val (.bool true))) P :=
+  wp.val.trans (wp.pure_step (fun _ => .assertOk)
+    (by rintro μ e' μ' h; cases h; exact ⟨rfl, rfl⟩))
 
 /-- A tuple expression evaluates each component (right-to-left) and wraps the results. -/
-axiom wp.tuple {wctx : WpCtx} {vs : Runtime.Vals} {Q : Runtime.Val → iProp} :
-    Q (.tuple vs) ⊢ wp wctx (.tuple (vs.map Runtime.Expr.val)) Q
+theorem wp.tuple {ctx : TinyML.PrimCtx} {vs : Runtime.Vals} {Q : Runtime.Val → iProp} :
+    Q (.tuple vs) ⊢ wp ctx (.tuple (vs.map Runtime.Expr.val)) Q :=
+  wp.val.trans (wp.pure_step (fun _ => .tuple) (fun _ _ _ h => h.tuple_inv))
 
 /-- An injection expression evaluates its payload and wraps it with the given tag and arity. -/
-axiom wp.inj {wctx : WpCtx} {tag arity : Nat} {payload : Runtime.Val} {Q : Runtime.Val → iProp} :
-    Q (.inj tag arity payload) ⊢ wp wctx (.inj tag arity (.val payload)) Q
-
-axiom wp.prim {wctx : WpCtx} {n : String} {vs : List Runtime.Val} {Q : Runtime.Val → iProp} :
-    wctx n vs Q ⊢ wp wctx (.app (.val (.prim n)) (vs.map Runtime.Expr.val)) Q
+theorem wp.inj {ctx : TinyML.PrimCtx} {tag arity : Nat} {payload : Runtime.Val}
+    {Q : Runtime.Val → iProp} :
+    Q (.inj tag arity payload) ⊢ wp ctx (.inj tag arity (.val payload)) Q :=
+  wp.val.trans (wp.pure_step (fun _ => .injVal)
+    (by rintro μ e' μ' h; cases h; exact ⟨rfl, rfl⟩))
 
 /-- A match expression evaluates the scrutinee, then dispatches to the appropriate branch. -/
-axiom wp.match_ {wctx : WpCtx} {tag arity : Nat} {payload : Runtime.Val} {branches : Runtime.Exprs}
-    {branch : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    branches[tag]? = some branch →
-    wp wctx (.app branch [.val payload]) Q ⊢
-    wp wctx (.match_ (.val (.inj tag arity payload)) branches) Q
+theorem wp.match_ {ctx : TinyML.PrimCtx} {tag arity : Nat} {payload : Runtime.Val}
+    {branches : Runtime.Exprs} {branch : Runtime.Expr} {Q : Runtime.Val → iProp}
+    (hbranch : branches[tag]? = some branch) (harity : arity = branches.length) :
+    wp ctx (.app branch [.val payload]) Q ⊢
+    wp ctx (.match_ (.val (.inj tag arity payload)) branches) Q := by
+  have hlt : tag < branches.length := List.getElem?_eq_some_iff.mp hbranch |>.1
+  have hget : branches[tag] = branch := by
+    simpa [List.getElem?_eq_getElem hlt] using hbranch
+  subst hget
+  exact wp.pure_step (fun _ => .match_ hlt harity)
+    (by
+      rintro μ e' μ' h
+      cases h
+      exact ⟨rfl, rfl⟩)
 
 /-! ## Heap operations -/
 
 /-- `ref e` allocates a fresh location, stores the value, and returns the location. -/
-axiom wp.ref {wctx : WpCtx} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
+theorem wp.ref {ctx : TinyML.PrimCtx} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
     iprop(∀ (l : Runtime.Location), l ↦ v -∗ Q (.loc l)) ⊢
-    wp wctx (.ref (.val v)) Q
+    wp ctx (.ref (.val v)) Q := by
+  istart
+  iintro HΦ
+  simp only [_root_.wp]
+  iapply wp_lift_atomic_step rfl
+  iintro %σ₁ %ns %obs %obs' %nt Hσ !>
+  obtain ⟨l, hl⟩ := Iris.Std.List.fresh σ₁.keys
+  have hfresh : TinyML.Heap.Fresh l σ₁ := fun hmem => hl (Std.ExtTreeMap.mem_keys.mpr hmem)
+  have hred : BaseStep.Reducible (show TinyML.LExpr ctx from .ref (.val v), σ₁) :=
+    ⟨[], .val (.loc l), σ₁.update l v, [], .ref hfresh, rfl, rfl⟩
+  isplitr
+  · ipureintro
+    exact primStep_reducible_of_baseStep_reducible hred
+  iintro !> %e₂ %σ₂ %eₜ %Hps Hcr
+  obtain ⟨hh, rfl, rfl⟩ := baseStep_of_primStep_of_baseStep_reducible hred Hps
+  cases hh
+  rename_i l' hfresh'
+  imod genHeap_alloc' (σ₁.lookup_fresh l' hfresh') $$ Hσ with ⟨Hσ, Hpt, _Hmt⟩
+  imodintro
+  simp only [stateInterp, Algebra.BigOpL.bigOpL_nil]
+  iframe Hσ
+  isplit <;> try itrivial
+  iexists (Runtime.Val.loc l')
+  isplit
+  · ipureintro; rfl
+  · iapply HΦ $$ %l' Hpt
 
 /-- `deref e` reads the value stored at the location. Reading preserves ownership. -/
-axiom wp.deref {wctx : WpCtx} {l : Runtime.Location} {v : Runtime.Val} {Q : Runtime.Val → iProp} :
-    l ↦ v ∗ (l ↦ v -∗ Q v) ⊢ wp wctx (.deref (.val (.loc l))) Q
+theorem wp.deref {ctx : TinyML.PrimCtx} {l : Runtime.Location} {v : Runtime.Val}
+    {Q : Runtime.Val → iProp} :
+    l ↦ v ∗ (l ↦ v -∗ Q v) ⊢ wp ctx (.deref (.val (.loc l))) Q := by
+  istart
+  iintro ⟨Hpt, HΦ⟩
+  simp only [_root_.wp]
+  iapply wp_lift_atomic_step rfl
+  iintro %σ₁ %ns %obs %obs' %nt Hσ !>
+  ihave %Hlook : (⌜Iris.Std.get? σ₁ l = some v⌝ : iProp) $$ [Hσ Hpt]
+  · ihave >%h := genHeap_valid $$ [$Hσ $Hpt]
+    itrivial
+  have hlk : TinyML.Heap.lookup l σ₁ = some v := Hlook
+  have hred : BaseStep.Reducible (show TinyML.LExpr ctx from .deref (.val (.loc l)), σ₁) :=
+    ⟨[], .val v, σ₁, [], .deref hlk, rfl, rfl⟩
+  isplitr
+  · ipureintro
+    exact primStep_reducible_of_baseStep_reducible hred
+  iintro !> %e₂ %σ₂ %eₜ %Hps Hcr
+  obtain ⟨hh, rfl, rfl⟩ := baseStep_of_primStep_of_baseStep_reducible hred Hps
+  cases hh
+  rename_i v' hlk'
+  obtain rfl : v = v' := Option.some.inj (hlk.symm.trans hlk')
+  imodintro
+  simp only [List.length_nil, Nat.add_zero, Algebra.BigOpL.bigOpL_nil]
+  iframe Hσ
+  isplit <;> try itrivial
+  iexists v
+  isplit
+  · ipureintro; rfl
+  · iapply HΦ $$ Hpt
 
 /-- `store loc val` updates the value at the location. -/
-axiom wp.store {wctx : WpCtx} {l : Runtime.Location} {old v : Runtime.Val} {Q : Runtime.Val → iProp} :
-    l ↦ old ∗ (l ↦ v -∗ Q .unit) ⊢ wp wctx (.store (.val (.loc l)) (.val v)) Q
+theorem wp.store {ctx : TinyML.PrimCtx} {l : Runtime.Location} {old v : Runtime.Val}
+    {Q : Runtime.Val → iProp} :
+    l ↦ old ∗ (l ↦ v -∗ Q .unit) ⊢ wp ctx (.store (.val (.loc l)) (.val v)) Q := by
+  istart
+  iintro ⟨Hpt, HΦ⟩
+  simp only [_root_.wp]
+  iapply wp_lift_atomic_step rfl
+  iintro %σ₁ %ns %obs %obs' %nt Hσ !>
+  ihave %Hlook : (⌜Iris.Std.get? σ₁ l = some old⌝ : iProp) $$ [Hσ Hpt]
+  · ihave >%h := genHeap_valid $$ [$Hσ $Hpt]
+    itrivial
+  have hlk : TinyML.Heap.lookup l σ₁ = some old := Hlook
+  have hred : BaseStep.Reducible (show TinyML.LExpr ctx from .store (.val (.loc l)) (.val v), σ₁) :=
+    ⟨[], .val .unit, σ₁.update l v, [], .store hlk, rfl, rfl⟩
+  isplitr
+  · ipureintro
+    exact primStep_reducible_of_baseStep_reducible hred
+  iintro !> %e₂ %σ₂ %eₜ %Hps Hcr
+  obtain ⟨hh, rfl, rfl⟩ := baseStep_of_primStep_of_baseStep_reducible hred Hps
+  cases hh
+  rename_i w hlk'
+  imod genHeap_update' (v₂ := v) $$ [$Hσ $Hpt] with ⟨Hσ, Hpt⟩
+  imodintro
+  simp only [stateInterp, Algebra.BigOpL.bigOpL_nil]
+  iframe Hσ
+  isplit <;> try itrivial
+  iexists Runtime.Val.unit
+  isplit
+  · ipureintro; rfl
+  · iapply HΦ $$ Hpt
 
+/-! ## Invariant-based heap rules -/
 
-/-- `ref e` allocates a fresh location, stores the value, and returns the location. -/
-axiom wp.ref_inv {wctx : WpCtx} {v : Runtime.Val} {I: Runtime.Val → iProp} {Q : Runtime.Val → iProp} :
+/-- `ref e` under a location invariant: allocate the location, then mint
+    `locinv l I` from the fresh points-to and the persistent payload. -/
+theorem wp.ref_inv {ctx : TinyML.PrimCtx} {v : Runtime.Val}
+    {I : Runtime.Val → iProp} {Q : Runtime.Val → iProp} :
     iprop((□ I v) ∗ ∀ (l : Runtime.Location), locinv l I -∗ Q (.loc l)) ⊢
-    wp wctx (.ref (.val v)) Q
+    wp ctx (.ref (.val v)) Q := by
+  simp only [locinv]
+  refine .trans ?_ ((wp.ref (Q := fun w => iprop(|={⊤}=> Q w))).trans
+    (wp_fupd Stuckness.NotStuck ⊤ (show TinyML.LExpr ctx from .ref (.val v)) Q))
+  istart
+  iintro ⟨#HI, HΦ⟩ %l Hpt
+  imod inv_alloc micaN ⊤ iprop(∃ w, l ↦ w ∗ I w) $$ [Hpt] with Hinv
+  · inext
+    iexists v
+    isplitl [Hpt]
+    · iexact Hpt
+    · iexact HI
+  imodintro
+  iapply HΦ $$ %l Hinv
 
-/-- `deref e` reads the value stored at the location. Reading preserves ownership. -/
-axiom wp.deref_inv {wctx : WpCtx} {l : Runtime.Location} {I: Runtime.Val → iProp} {Q : Runtime.Val → iProp} :
-    locinv l I ∗ (∀ v, I v -∗ Q v) ⊢ wp wctx (.deref (.val (.loc l))) Q
+/-- `deref e` under a location invariant: open the invariant around the read.
+    The payload is handed to the continuation *and* restored into the
+    invariant, so `I` must be persistent. -/
+theorem wp.deref_inv {ctx : TinyML.PrimCtx} {l : Runtime.Location}
+    {I : Runtime.Val → iProp} [∀ v, Persistent (I v)] {Q : Runtime.Val → iProp} :
+    locinv l I ∗ (∀ v, I v -∗ Q v) ⊢ wp ctx (.deref (.val (.loc l))) Q := by
+  simp only [locinv]
+  istart
+  iintro ⟨#Hinv, HΦ⟩
+  simp only [_root_.wp]
+  iapply wp_lift_step_fupd rfl
+  iintro %σ₁ %ns %obs %obs' %nt Hσ
+  imod inv_acc _ _ _ CoPset.subseteq_top $$ Hinv with ⟨HP, Hcl⟩
+  icases HP with ⟨%w, Hpt, HI⟩
+  imod Hpt with Hpt
+  ihave %Hlook : (⌜Iris.Std.get? σ₁ l = some w⌝ : iProp) $$ [Hσ Hpt]
+  · ihave >%h := genHeap_valid $$ [$Hσ $Hpt]
+    itrivial
+  have hlk : TinyML.Heap.lookup l σ₁ = some w := Hlook
+  have hred : BaseStep.Reducible (show TinyML.LExpr ctx from .deref (.val (.loc l)), σ₁) :=
+    ⟨[], .val w, σ₁, [], .deref hlk, rfl, rfl⟩
+  iapply fupd_mask_intro Std.LawfulSet.empty_subset
+  iintro Hclose
+  isplitr
+  · ipureintro
+    exact primStep_reducible_of_baseStep_reducible hred
+  iintro %e₂ %σ₂ %eₜ %Hps -
+  obtain ⟨hh, rfl, rfl⟩ := baseStep_of_primStep_of_baseStep_reducible hred Hps
+  cases hh
+  rename_i w' hlk'
+  obtain rfl : w = w' := Option.some.inj (hlk.symm.trans hlk')
+  imodintro
+  inext
+  iintuitionistic HI
+  imod Hclose with -
+  imod Hcl $$ [Hpt] with -
+  · inext
+    iexists w
+    isplitl [Hpt]
+    · iexact Hpt
+    · iexact HI
+  imodintro
+  simp only [stateInterp, Algebra.BigOpL.bigOpL_nil]
+  iframe Hσ
+  isplitl [HΦ]
+  · iapply wp_value ⟨rfl⟩
+    iapply HΦ $$ HI
+  · itrivial
 
-/-- `store loc val` updates the value at the location. -/
-axiom wp.store_inv {wctx : WpCtx} {l : Runtime.Location} {v: Runtime.Val} {Q : Runtime.Val → iProp} :
-    locinv l I ∗ (□ I v) ∗ Q .unit ⊢ wp wctx (.store (.val (.loc l)) (.val v)) Q
+/-- `store loc val` under a location invariant: open the invariant around the
+    write and restore it with the new (persistent) payload. -/
+theorem wp.store_inv {ctx : TinyML.PrimCtx} {l : Runtime.Location}
+    {v : Runtime.Val} {I : Runtime.Val → iProp} {Q : Runtime.Val → iProp} :
+    locinv l I ∗ (□ I v) ∗ Q .unit ⊢ wp ctx (.store (.val (.loc l)) (.val v)) Q := by
+  simp only [locinv]
+  istart
+  iintro ⟨#Hinv, #HIv, HΦ⟩
+  simp only [_root_.wp]
+  iapply wp_lift_step_fupd rfl
+  iintro %σ₁ %ns %obs %obs' %nt Hσ
+  imod inv_acc _ _ _ CoPset.subseteq_top $$ Hinv with ⟨HP, Hcl⟩
+  icases HP with ⟨%w, Hpt, HI⟩
+  imod Hpt with Hpt
+  iclear HI
+  ihave %Hlook : (⌜Iris.Std.get? σ₁ l = some w⌝ : iProp) $$ [Hσ Hpt]
+  · ihave >%h := genHeap_valid $$ [$Hσ $Hpt]
+    itrivial
+  have hlk : TinyML.Heap.lookup l σ₁ = some w := Hlook
+  have hred : BaseStep.Reducible
+      (show TinyML.LExpr ctx from .store (.val (.loc l)) (.val v), σ₁) :=
+    ⟨[], .val .unit, σ₁.update l v, [], .store hlk, rfl, rfl⟩
+  iapply fupd_mask_intro Std.LawfulSet.empty_subset
+  iintro Hclose
+  isplitr
+  · ipureintro
+    exact primStep_reducible_of_baseStep_reducible hred
+  iintro %e₂ %σ₂ %eₜ %Hps -
+  obtain ⟨hh, rfl, rfl⟩ := baseStep_of_primStep_of_baseStep_reducible hred Hps
+  cases hh
+  imodintro
+  inext
+  imod genHeap_update' (v₂ := v) $$ [$Hσ $Hpt] with ⟨Hσ, Hpt⟩
+  imod Hclose with -
+  imod Hcl $$ [Hpt] with -
+  · inext
+    iexists v
+    isplitl [Hpt]
+    · iexact Hpt
+    · iexact HIv
+  imodintro
+  simp only [stateInterp, Algebra.BigOpL.bigOpL_nil]
+  iframe Hσ
+  isplitl [HΦ]
+  · iapply wp_value ⟨rfl⟩
+    iexact HΦ
+  · itrivial
 
+/-! ## Primitive calls -/
+
+/-- Generic lifting rule for primitive calls — the relationship between the
+    primitive operational semantics and the weakest precondition. A primitive
+    call takes one atomic step by `Head.primStep`; the premise asks, for the
+    current heap, that the call is reducible under `ctx` and that every result
+    the context relates re-establishes the heap interpretation and the
+    postcondition. -/
+theorem wp.prim {ctx : TinyML.PrimCtx} {n : String} {vs : List Runtime.Val}
+    {Q : Runtime.Val → iProp} :
+    iprop(∀ μ, heapInterp μ ={⊤}=∗
+        ⌜∃ v μ', ctx n vs μ v μ'⌝ ∗
+        ▷ ∀ v μ', ⌜ctx n vs μ v μ'⌝ ={⊤}=∗ heapInterp μ' ∗ Q v) ⊢
+      wp ctx (.app (.val (.prim n)) (vs.map Runtime.Expr.val)) Q := by
+  istart
+  iintro H
+  simp only [_root_.wp]
+  iapply wp_lift_atomic_step rfl
+  iintro %σ₁ %ns %obs %obs' %nt Hσ
+  imod H $$ %σ₁ Hσ with ⟨%hex, H⟩
+  obtain ⟨v, μ', hstep⟩ := hex
+  have hred : BaseStep.Reducible
+      (show TinyML.LExpr ctx from .app (.val (.prim n)) (vs.map Runtime.Expr.val), σ₁) :=
+    ⟨[], .val v, μ', [], .primStep hstep, rfl, rfl⟩
+  imodintro
+  isplitr
+  · ipureintro
+    exact primStep_reducible_of_baseStep_reducible hred
+  iintro !> %e₂ %σ₂ %eₜ %Hps Hcr
+  obtain ⟨hh, rfl, rfl⟩ := baseStep_of_primStep_of_baseStep_reducible hred Hps
+  obtain ⟨w, hw, rfl⟩ := TinyML.Head.prim_inv hh
+  imod H $$ %w %σ₂ %hw with ⟨Hσ, HQ⟩
+  imodintro
+  simp only [stateInterp, Algebra.BigOpL.bigOpL_nil]
+  iframe Hσ
+  isplit <;> try itrivial
+  iexists w
+  isplit
+  · ipureintro; rfl
+  · iexact HQ
+
+/-- Primitive-call rule for pure contexts: at `n`/`vs`, `ctx` is
+    heap-independent and heap-preserving, with at least one result. Covers
+    every current stdlib intrinsic (`Verifier.Reduce.pure`). -/
+theorem wp.prim_pure {ctx : TinyML.PrimCtx} {n : String} {vs : List Runtime.Val}
+    {rel : Runtime.Val → Prop} {Q : Runtime.Val → iProp}
+    (hctx : ∀ μ v μ', ctx n vs μ v μ' ↔ rel v ∧ μ' = μ) (hne : ∃ v, rel v) :
+    iprop(∀ v, ⌜rel v⌝ -∗ Q v) ⊢
+      wp ctx (.app (.val (.prim n)) (vs.map Runtime.Expr.val)) Q := by
+  refine .trans ?_ wp.prim
+  istart
+  iintro H %μ Hσ
+  imodintro
+  isplitr
+  · ipureintro
+    obtain ⟨v, hv⟩ := hne
+    exact ⟨v, μ, (hctx μ v μ).mpr ⟨hv, rfl⟩⟩
+  iintro !> %v %μ' %hstep
+  obtain ⟨hv, rfl⟩ := (hctx μ v μ').mp hstep
+  imodintro
+  iframe Hσ
+  iapply H $$ %v %hv
+
+/-! ## Recursion -/
+
+theorem wp.fix' {ctx : TinyML.PrimCtx} {f : Runtime.Binder} {args : List Runtime.Binder}
+    {e : Runtime.Expr} {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp}
+    (hlen : ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      Φ P vs ⊢ (⌜args.length = vs.length⌝ : iProp)) :
+    □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+        Φ P vs -∗ wp ctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
+      ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+        Φ P vs -∗ wp ctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)
+    ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp), Φ P vs -∗ wp ctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) := by
+  istart
+  iintro #H
+  iapply loeb_wand_intuitionistically
+  imodintro
+  iintro #HG
+  imodintro
+  iintro %vs %P HΦ
+  ihave %hl : (⌜args.length = vs.length⌝ : iProp) $$ [HΦ]
+  · iapply hlen vs P
+    iexact HΦ
+  iapply wp.pure_step' (fun _ => .beta hl) (fun _ _ _ h => h.beta_inv)
+  inext
+  ispecialize H $$ HG
+  iapply H $$ %vs %P HΦ
+
+/-- Definitional unfolding of `wp` into the Iris weakest precondition; stated
+    here so it remains usable once `wp` is marked irreducible (adequacy needs
+    it). -/
+theorem wp_def {ctx : TinyML.PrimCtx} {e : Runtime.Expr} {Φ : Runtime.Val → iProp} :
+    wp ctx e Φ = Wp.wp Stuckness.NotStuck ⊤ (show TinyML.LExpr ctx from e) Φ := rfl
+
+/- All rules below treat `wp` as opaque; keep unification from unfolding the
+   Iris fixpoint. -/
+attribute [irreducible] _root_.wp
+
+/-! ## Application -/
+
+@[simp] theorem wps_nil {ctx : TinyML.PrimCtx} {Q : Runtime.Vals → iProp} :
+    wps ctx [] Q = Q [] := rfl
+@[simp] theorem wps_cons {ctx : TinyML.PrimCtx} {e : Runtime.Expr} {es : Runtime.Exprs}
+    {Q : Runtime.Vals → iProp} :
+    wps ctx (e :: es) Q = wps ctx es (fun vs => wp ctx e (fun v => Q (v :: vs))) := rfl
+
+theorem wps_snoc {ctx : TinyML.PrimCtx} {es : Runtime.Exprs} {e : Runtime.Expr}
+    {Q : Runtime.Vals → iProp} :
+    wps ctx (es ++ [e]) Q = wp ctx e (fun v => wps ctx es (fun vs => Q (vs ++ [v]))) := by
+  induction es generalizing Q with
+  | nil => rfl
+  | cons a es ih => simp [wps_cons, ih]
+
+/-- Evaluate the focused argument of an application (frame `appArgs`). -/
+private theorem wp.bind_appArgs {ctx : TinyML.PrimCtx} {fn e : Runtime.Expr}
+    {left : Runtime.Exprs} {right : Runtime.Vals} {Q : Runtime.Val → iProp} :
+    wp ctx e (fun v => wp ctx (.app fn (left ++ [.val v] ++ right.map .val)) Q) ⊢
+    wp ctx (.app fn (left ++ [e] ++ right.map .val)) Q :=
+  wp.bind (k := .appArgs fn left .hole right)
+
+/-- Evaluate the function position once all arguments are values (frame `appFn`). -/
+private theorem wp.bind_appFn {ctx : TinyML.PrimCtx} {fn : Runtime.Expr} {vs : Runtime.Vals}
+    {Q : Runtime.Val → iProp} :
+    wp ctx fn (fun fv => wp ctx (.app (.val fv) (vs.map .val)) Q) ⊢
+    wp ctx (.app fn (vs.map .val)) Q :=
+  wp.bind (k := .appFn .hole vs)
+
+theorem wp.app {ctx : TinyML.PrimCtx} {fn : Runtime.Expr} {args : Runtime.Exprs}
+    {P : Runtime.Val → iProp} :
+    wps ctx args (fun vs => wp ctx fn (fun fv =>
+      wp ctx (.app (.val fv) (vs.map Runtime.Expr.val)) P)) ⊢
+    wp ctx (.app fn args) P := by
+  suffices h : ∀ (es : Runtime.Exprs) (right : Runtime.Vals),
+      wps ctx es (fun vs => wp ctx fn (fun fv =>
+        wp ctx (.app (.val fv) ((vs ++ right).map Runtime.Expr.val)) P)) ⊢
+      wp ctx (.app fn (es ++ right.map Runtime.Expr.val)) P by
+    simpa using h args []
+  intro es
+  induction es using List.reverseRecOn with
+  | nil =>
+    intro right
+    simpa using wp.bind_appFn (vs := right)
+  | append_singleton es e ih =>
+    intro right
+    rw [wps_snoc]
+    have eq1 : ∀ v : Runtime.Val,
+        wps ctx es (fun vs => wp ctx fn (fun fv =>
+          wp ctx (.app (.val fv) ((vs ++ [v] ++ right).map Runtime.Expr.val)) P)) =
+        wps ctx es (fun vs => wp ctx fn (fun fv =>
+          wp ctx (.app (.val fv) ((vs ++ v :: right).map Runtime.Expr.val)) P)) := by
+      intro v; simp [List.append_assoc]
+    have eq2 : ∀ v : Runtime.Val,
+        wp ctx (.app fn (es ++ (v :: right).map Runtime.Expr.val)) P =
+        wp ctx (.app fn (es ++ [.val v] ++ right.map Runtime.Expr.val)) P := by
+      intro v; simp [List.append_assoc]
+    refine BIBase.Entails.trans
+      (wp.mono (Q := fun v => wp ctx (.app fn (es ++ [.val v] ++ right.map .val)) P) ?_)
+      wp.bind_appArgs
+    intro v
+    exact (BIBase.Entails.of_eq (eq1 v)).trans ((ih (v :: right)).trans
+      (BIBase.Entails.of_eq (eq2 v)))
 
 /-! ## Derived lemmas -/
 
-@[simp] theorem wps_nil {wctx : WpCtx} {Q : Runtime.Vals → iProp} : wps wctx [] Q = Q [] := rfl
-@[simp] theorem wps_cons {wctx : WpCtx} {e : Runtime.Expr} {es : Runtime.Exprs} {Q : Runtime.Vals → iProp} :
-    wps wctx (e :: es) Q = wps wctx es (fun vs => wp wctx e (fun v => Q (v :: vs))) := rfl
-
--- Derived monotonicity as an entailment
-theorem wp.mono {wctx : WpCtx} {e : Runtime.Expr} {P Q : Runtime.Val → iProp}
-    (h : ∀ v, P v ⊢ Q v) : wp wctx e P ⊢ wp wctx e Q :=
-  emp_sep.2.trans (sep_mono_left (forall_intro fun v => wand_intro (emp_sep.1.trans (h v)))) |>.trans wp.wand
-
-theorem wps.mono {wctx : WpCtx} {es : Runtime.Exprs} {P Q : Runtime.Vals → iProp}
-    (h : ∀ vs, P vs ⊢ Q vs) : wps wctx es P ⊢ wps wctx es Q := by
+theorem wps.mono {ctx : TinyML.PrimCtx} {es : Runtime.Exprs} {P Q : Runtime.Vals → iProp}
+    (h : ∀ vs, P vs ⊢ Q vs) : wps ctx es P ⊢ wps ctx es Q := by
   induction es generalizing P Q with
   | nil => exact h []
   | cons e es ih =>
     simp only [wps_cons]
     exact ih (fun vs => wp.mono (fun v => h (v :: vs)))
 
-/-- Program-level weakest precondition: every declaration evaluates safely,
-    and each result is substituted into the remaining program. -/
-noncomputable def pwp (wctx : WpCtx) : Runtime.Program → iProp
-  | [] => emp
-  | ⟨b, e⟩ :: rest =>
-    wp wctx e (fun v => pwp wctx (Runtime.Program.subst rest (Runtime.Subst.updateBinder b v .id)))
-termination_by prog => prog.length
-decreasing_by
-  simp [Runtime.Program.subst_length]
-
-@[simp] theorem pwp_nil {wctx : WpCtx} : pwp wctx [] = (emp : iProp) := by
-  simp [pwp]
-
-@[simp] theorem pwp_cons {wctx : WpCtx} {b : Runtime.Binder} {e : Runtime.Expr} {rest : Runtime.Program} :
-    pwp wctx ({ name := b, body := e } :: rest) =
-      wp wctx e (fun v => pwp wctx (Runtime.Program.subst rest (Runtime.Subst.updateBinder b v .id))) := by
-  simp [pwp]
-
 /-- Derived wp rule for let-bindings (desugared to immediately-applied fix). -/
-theorem wp.letIn {wctx : WpCtx} {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.Val → iProp} :
-    wp wctx bound (fun v => wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q) ⊢
-    wp wctx (Runtime.Expr.letIn b bound body) Q := by
+theorem wp.letIn {ctx : TinyML.PrimCtx} {b : Runtime.Binder} {bound body : Runtime.Expr}
+    {Q : Runtime.Val → iProp} :
+    wp ctx bound (fun v => wp ctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q) ⊢
+    wp ctx (Runtime.Expr.letIn b bound body) Q := by
   simp only [Runtime.Expr.letIn]
   istart
   iintro Hbound
   iapply wp.app
   simp only [wps_cons, wps_nil]
-  iapply (wp.wand (P := fun v => wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q))
+  iapply (wp.wand (P := fun v => wp ctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q))
   isplitl []
   · iintro %v Hv
     iapply wp.func
-    iapply (wp.fix (Φ := fun _ => emp) (vs := [v]))
+    iapply (wp.fix (vs := [v]) rfl)
     simp only [Runtime.Subst.updateBinder, Runtime.Subst.updateAllBinder_cons,
                Runtime.Subst.updateAllBinder_nil_left]
-    iexact Hv
-  · iexact Hbound
+    iassumption
+  · iassumption
+
+/-- Program-level weakest precondition: the program, desugared to its nested
+    `let`-bindings (`Runtime.Program.expr`), runs safely to completion. -/
+def pwp (ctx : TinyML.PrimCtx) (prog : Runtime.Program) : iProp :=
+  wp ctx prog.expr (fun _ => emp)
+
+/-- The empty program imposes no obligation. -/
+theorem pwp_nil {ctx : TinyML.PrimCtx} : (emp : iProp) ⊢ pwp ctx [] := by
+  simp only [pwp, Runtime.Program.expr]
+  exact wp.val (v := .unit) (Q := fun _ => emp)
+
+/-- A leading declaration: prove its body via `wp`, then the rest under the
+    extended substitution. -/
+theorem pwp_cons {ctx : TinyML.PrimCtx} {b : Runtime.Binder} {e : Runtime.Expr}
+    {rest : Runtime.Program} :
+    wp ctx e (fun v => pwp ctx (Runtime.Program.subst rest (Runtime.Subst.updateBinder b v .id))) ⊢
+      pwp ctx ({ name := b, body := e } :: rest) := by
+  simp only [pwp, Runtime.Program.expr]
+  refine .trans (wp.mono fun v => ?_) wp.letIn
+  rw [Runtime.Program.expr_subst]
+  exact .rfl
 
 /-- Applying a single-argument lambda `(fun b -> body)` to a value reduces to substituting. -/
-theorem wp.app_lambda_single {wctx : WpCtx} {b : Runtime.Binder} {body : Runtime.Expr} {v : Runtime.Val}
-    {Φ : Runtime.Val → iProp} :
-    wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Φ ⊢
-    wp wctx (.app (.fix .none [b] body) [.val v]) Φ := by
+theorem wp.app_lambda_single {ctx : TinyML.PrimCtx} {b : Runtime.Binder} {body : Runtime.Expr}
+    {v : Runtime.Val} {Φ : Runtime.Val → iProp} :
+    wp ctx (body.subst (Runtime.Subst.id.updateBinder b v)) Φ ⊢
+    wp ctx (.app (.fix .none [b] body) [.val v]) Φ := by
   istart
   iintro Hwp
   iapply wp.app
   simp only [wps_cons, wps_nil]
   iapply wp.val
   iapply wp.func
-  iapply (wp.fix (Φ := fun _ => emp) (vs := [v]))
+  iapply (wp.fix (vs := [v]) rfl)
   simp only [Runtime.Subst.updateBinder, Runtime.Subst.updateAllBinder_cons,
              Runtime.Subst.updateAllBinder_nil_left]
-  iexact Hwp
+  iassumption

--- a/Mica/SeparationLogic/Interpretations.lean
+++ b/Mica/SeparationLogic/Interpretations.lean
@@ -5,6 +5,8 @@ import Mica.TinyML.Types
 
 open Iris Iris.BI
 
+variable [MicaGS HasLC.hasLC Sig]
+
 /-! # Spatial Atoms and Contexts — Iris Interpretation
 
 The syntactic definitions (`SpatialAtom`, `SpatialContext`, `wfIn`, `find`,
@@ -57,7 +59,7 @@ end SpatialAtom
 namespace SpatialContext
 
 /-- Iris interpretation of a spatial context: the separating conjunction of all items. -/
-noncomputable def interp (Θ : TinyML.TypeEnv) (ρ : Env) : SpatialContext → iProp
+def interp (Θ : TinyML.TypeEnv) (ρ : Env) : SpatialContext → iProp
   | []     => emp
   | a :: Γ => a.interp Θ ρ ∗ interp Θ ρ Γ
 
@@ -83,6 +85,7 @@ theorem interp_env_agree (Θ : TinyML.TypeEnv) {ctx : SpatialContext} {Δ : Sign
 @[simp] theorem interp_insert (Θ : TinyML.TypeEnv) (ρ : Env) (a : SpatialAtom) (ctx : SpatialContext) :
     interp Θ ρ (insert a ctx) = (a.interp Θ ρ ∗ interp Θ ρ ctx) := rfl
 
+omit [MicaGS HasLC.hasLC Sig] in
 private theorem sep_comm3 {A B C : iProp} : A ∗ (B ∗ C) ⊣⊢ B ∗ (A ∗ C) :=
   ⟨sep_assoc.2 |>.trans (sep_mono_left sep_comm.1) |>.trans sep_assoc.1,
    sep_assoc.2 |>.trans (sep_mono_left sep_comm.2) |>.trans sep_assoc.1⟩

--- a/Mica/SeparationLogic/LogicalRelation.lean
+++ b/Mica/SeparationLogic/LogicalRelation.lean
@@ -9,6 +9,8 @@ import Iris.BI.Lib.Fixpoint
 
 open Iris Iris.BI Iris.OFE
 
+variable [MicaGS HasLC.hasLC Sig]
+
 namespace TinyML
 
 /-!
@@ -28,19 +30,20 @@ abbrev RecCont := Runtime.Val → TypeName → List Typ → iProp
 abbrev RecIdx := LeibnizO (Runtime.Val × TypeName × List Typ)
 
 /-- Reinterpret a predicate over `RecIdx` as a curried continuation. -/
-@[reducible] noncomputable def RecCont.ofPred (Φ : RecIdx → iProp) : RecCont :=
+@[reducible] def RecCont.ofPred (Φ : RecIdx → iProp) : RecCont :=
   fun v T args => Φ ⟨(v, T, args)⟩
 
 /-- The outer approximation ranges over closed value relations. -/
 abbrev ValShape := Runtime.Val → Typ → iProp
 
 /-- Interpret one primitive type as an Iris assertion over a runtime value. -/
-noncomputable def PrimitiveType.valRelBody : PrimitiveType → Runtime.Val → iProp
+def PrimitiveType.valRelBody : PrimitiveType → Runtime.Val → iProp
   | .unit, v => iprop(⌜v = .unit⌝)
   | .bool, v => iprop(⌜∃ b, v = .bool b⌝)
   | .int, v => iprop(⌜∃ n, v = .int n⌝)
   | .string, v => iprop(⌜∃ s, v = .str s⌝)
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem PrimitiveType.valRelBody_persistent (p : PrimitiveType) (v : Runtime.Val) :
     Persistent (p.valRelBody v) := by
   unfold PrimitiveType.valRelBody
@@ -53,7 +56,7 @@ continuation `k`. Tuples and sums are structural and mutually recursive with
 the list/sum helpers below.
 -/
 mutual
-  noncomputable def ValRelBody (R : ValShape) (v : Runtime.Val) (t : Typ) (k : RecCont) : iProp :=
+  def ValRelBody (R : ValShape) (v : Runtime.Val) (t : Typ) (k : RecCont) : iProp :=
     match t with
     | .prim p     => p.valRelBody v
     | .value      => iprop(True)
@@ -68,12 +71,12 @@ mutual
         iprop(∃ tag payload, ⌜v = .inj tag ts.length payload⌝ ∗
           ValSumRelBody R tag payload ts k)
 
-  noncomputable def ValsRelBody : ValShape → List Runtime.Val → List Typ → RecCont → iProp
+  def ValsRelBody : ValShape → List Runtime.Val → List Typ → RecCont → iProp
     | _, [], [], _ => iprop(emp)
     | R, v :: vs, t :: ts, k => iprop(ValRelBody R v t k ∗ ValsRelBody R vs ts k)
     | _, _, _, _ => iprop(False)
 
-  noncomputable def ValSumRelBody : ValShape → Nat → Runtime.Val → List Typ → RecCont → iProp
+  def ValSumRelBody : ValShape → Nat → Runtime.Val → List Typ → RecCont → iProp
     | _, _, _, [], _ => iprop(False)
     | R, 0, payload, t :: _, k => ValRelBody R payload t k
     | R, n + 1, payload, _ :: ts, k => ValSumRelBody R n payload ts k
@@ -222,7 +225,7 @@ private instance ValRelBody.contractive (k : RecCont) (v : Runtime.Val) (t : Typ
   distLater_dist hR := ValRelBody.dist hR Dist.rfl t v
 
 /-- One unfolding of the inner recursive type interpretation. -/
-private noncomputable def ValRelIndF (Θ : TypeEnv) (R : ValShape) (Φ : RecIdx → iProp) (x : RecIdx) : iProp :=
+private def ValRelIndF (Θ : TypeEnv) (R : ValShape) (Φ : RecIdx → iProp) (x : RecIdx) : iProp :=
   match x with
   | ⟨(v, T, args)⟩ =>
       iprop(∃ ty, ⌜TypeName.unfold Θ T args = some ty⌝ ∗
@@ -270,7 +273,7 @@ private instance (Θ : TypeEnv) (R : ValShape) : BIMonoPred (ValRelIndF Θ R) wh
     exact Dist.of_eq rfl
 
 /-- The inner least fixpoint for named types, with the outer approximation fixed. -/
-private noncomputable def ValRelInd (Θ : TypeEnv) (R : ValShape) : RecCont :=
+private def ValRelInd (Θ : TypeEnv) (R : ValShape) : RecCont :=
   fun v T args => Iris.bi_least_fixpoint (ValRelIndF Θ R) ⟨(v, T, args)⟩
 
 private theorem ValRelInd.unfold {Θ : TypeEnv} {R : ValShape}
@@ -294,7 +297,7 @@ private instance ValRelInd.contractive (Θ : TypeEnv) :
     exact (ValRelIndF.contractive Θ (fun x => Φ x) x).distLater_dist hR
 
 /-- The outer functional. It closes the named-type continuation using `ValRelInd`. -/
-private noncomputable def ValRelF (Θ : TypeEnv) (R : ValShape) : ValShape :=
+private def ValRelF (Θ : TypeEnv) (R : ValShape) : ValShape :=
   fun v t => ValRelBody R v t (ValRelInd Θ R)
 
 private instance ValRelF.contractive (Θ : TypeEnv) : Contractive (ValRelF Θ) where
@@ -305,15 +308,15 @@ private instance ValRelF.contractive (Θ : TypeEnv) : Contractive (ValRelF Θ) w
     exact ValRelBody.dist hR hk t v
 
 /-- The mixed recursive value relation. -/
-noncomputable def ValHasType (Θ : TypeEnv) : ValShape :=
+def ValHasType (Θ : TypeEnv) : ValShape :=
   fixpoint (ValRelF Θ)
 
 /-- Final tuple/list relation induced by the mixed recursive value relation. -/
-noncomputable def ValsHaveTypes (Θ : TypeEnv) (vs : List Runtime.Val) (ts : List Typ) : iProp :=
+def ValsHaveTypes (Θ : TypeEnv) (vs : List Runtime.Val) (ts : List Typ) : iProp :=
   ValsRelBody (ValHasType Θ) vs ts (ValRelInd Θ (ValHasType Θ))
 
 /-- Final sum-payload relation induced by the mixed recursive value relation. -/
-noncomputable def ValSumRel (Θ : TypeEnv) (tag : Nat) (payload : Runtime.Val)
+def ValSumRel (Θ : TypeEnv) (tag : Nat) (payload : Runtime.Val)
     (ts : List Typ) : iProp :=
   ValSumRelBody (ValHasType Θ) tag payload ts (ValRelInd Θ (ValHasType Θ))
 
@@ -1005,6 +1008,7 @@ def PrimitiveType.typeConstraints (p : PrimitiveType) (t : Term .value) : List F
   | .string => [.unpred .isStr t]
   | .unit => []
 
+omit [MicaGS HasLC.hasLC Sig] in
 /-- Primitive type constraints only reference free variables of the constrained term. -/
 theorem PrimitiveType.typeConstraints_wfIn {p : PrimitiveType} {t : Term .value} {Δ : Signature}
     (ht : t.wfIn Δ) : ∀ φ ∈ p.typeConstraints t, φ.wfIn Δ := by
@@ -1066,6 +1070,7 @@ def typeConstraintsList (ts : List TinyML.Typ) (tl : Term .vallist) : List Formu
 end
 
 
+omit [MicaGS HasLC.hasLC Sig] in
 mutual
   /-- All formulas in `typeConstraints ty t` only reference free variables of `t`. -/
   theorem typeConstraints_wfIn {ty : TinyML.Typ} {t : Term .value} {Δ : Signature}

--- a/Mica/SeparationLogic/OUTLINE.md
+++ b/Mica/SeparationLogic/OUTLINE.md
@@ -1,6 +1,6 @@
 **Mica/SeparationLogic**
 
-- `Axioms.lean` — Axiomatized Iris connectives and weakest-precondition rules for TinyML programs and heap operations.
+- `Axioms.lean` — The Iris weakest precondition for TinyML and its derived proof rules, including invariant-based heap rules and primitive-call lifting.
 - `GhostState.lean` — Concrete Iris ghost-state signature for Mica: invariants, later credits, and heap resources over TinyML heaps.
 - `Interpretations.lean` — Iris interpretations of spatial atoms and contexts, with lemmas relating syntax to separation-logic assertions.
 - `LogicalRelation.lean` — Iris logical relations for TinyML values and types, together with formula generation for type constraints.

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -3,38 +3,40 @@ import Mica.SeparationLogic.Interpretations
 
 open Iris Iris.BI
 
+variable [MicaGS HasLC.hasLC Sig]
+
 /-! # Primitive Laws with Spatial Contexts
 
 Lifted versions of the wp axioms from `Axioms.lean`, stated in terms of
-spatial contexts. Each rule has the form `ctx.interp ρ ⊢ wp wctx e Q` given
+spatial contexts. Each rule has the form `ctx.interp ρ ⊢ wp pctx e Q` given
 appropriate premises, where the context may change between premise and
 conclusion for stateful operations. -/
 
 namespace SpatialContext
 
-variable {wctx : WpCtx}
+variable {pctx : TinyML.PrimCtx}
 
 private theorem wp_bind_tuple_aux {left : Runtime.Exprs} {es : Runtime.Exprs} {right : Runtime.Vals}
     {Q : Runtime.Val → iProp} :
-    wps wctx es (fun vs => wp wctx (.tuple (left ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) ⊢
-    wp wctx (.tuple (left ++ es ++ right.map Runtime.Expr.val)) Q := by
+    wps pctx es (fun vs => wp pctx (.tuple (left ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) ⊢
+    wp pctx (.tuple (left ++ es ++ right.map Runtime.Expr.val)) Q := by
   induction es generalizing left with
   | nil =>
       simp
   | cons e es ih =>
       simp only [wps_cons]
       have hmono :
-          wps wctx es (fun vs =>
-            wp wctx e (fun v =>
-              wp wctx (.tuple (left ++ (v :: vs).map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q)) ⊢
-          wps wctx es (fun vs =>
-            wp wctx (.tuple ((left ++ [e]) ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) := by
+          wps pctx es (fun vs =>
+            wp pctx e (fun v =>
+              wp pctx (.tuple (left ++ (v :: vs).map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q)) ⊢
+          wps pctx es (fun vs =>
+            wp pctx (.tuple ((left ++ [e]) ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) := by
         apply wps.mono
         intro vs
         have hbind :
-            wp wctx e (fun v =>
-              wp wctx (.tuple (left ++ (v :: vs).map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) ⊢
-            wp wctx (.tuple ((left ++ [e]) ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q := by
+            wp pctx e (fun v =>
+              wp pctx (.tuple (left ++ (v :: vs).map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q) ⊢
+            wp pctx (.tuple ((left ++ [e]) ++ vs.map Runtime.Expr.val ++ right.map Runtime.Expr.val)) Q := by
           simpa [TinyML.K.fill, List.map_cons, List.append_assoc] using
             (wp.bind (k := TinyML.K.tupleK left .hole (vs ++ right)))
         exact hbind
@@ -44,15 +46,15 @@ private theorem wp_bind_tuple_aux {left : Runtime.Exprs} {es : Runtime.Exprs} {r
 theorem wp_val {v : Runtime.Val} {Q : Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢ Q v) :
-    R ⊢ wp wctx (.val v) Q :=
+    R ⊢ wp pctx (.val v) Q :=
   h.trans wp.val
 
 /-- Unary operation under evaluation: first evaluate the operand, then take the
     head unary-operation step. -/
 theorem wp_bind_unop {op : TinyML.UnOp} {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx e (fun v => wp wctx (.unop op (.val v)) Q)) :
-    R ⊢ wp wctx (.unop op e) Q :=
+    (h : R ⊢ wp pctx e (fun v => wp pctx (.unop op (.val v)) Q)) :
+    R ⊢ wp pctx (.unop op e) Q :=
   h.trans (wp.bind (k := TinyML.K.unop op .hole))
 
 /-- Unary operation at values: context unchanged. -/
@@ -60,7 +62,7 @@ theorem wp_unop {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iP
     {R : iProp}
     (h : R ⊢ Q res) :
     TinyML.evalUnOp op v = some res →
-    R ⊢ wp wctx (.unop op (.val v)) Q := by
+    R ⊢ wp pctx (.unop op (.val v)) Q := by
   intro heval
   exact h.trans (wp.unop heval)
 
@@ -68,12 +70,12 @@ theorem wp_unop {op : TinyML.UnOp} {v res : Runtime.Val} {Q : Runtime.Val → iP
     left operand, then take the head binary-operation step. -/
 theorem wp_bind_binop {op : TinyML.BinOp} {l r : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx r (fun vr => wp wctx l (fun vl =>
-      wp wctx (.binop op (.val vl) (.val vr)) Q))) :
-    R ⊢ wp wctx (.binop op l r) Q := by
+    (h : R ⊢ wp pctx r (fun vr => wp pctx l (fun vl =>
+      wp pctx (.binop op (.val vl) (.val vr)) Q))) :
+    R ⊢ wp pctx (.binop op l r) Q := by
   have hr :
-      wp wctx r (fun vr => wp wctx l (fun vl => wp wctx (.binop op (.val vl) (.val vr)) Q)) ⊢
-      wp wctx r (fun vr => wp wctx (.binop op l (.val vr)) Q) := by
+      wp pctx r (fun vr => wp pctx l (fun vl => wp pctx (.binop op (.val vl) (.val vr)) Q)) ⊢
+      wp pctx r (fun vr => wp pctx (.binop op l (.val vr)) Q) := by
     apply wp.mono
     intro vr
     exact wp.bind (k := TinyML.K.binopL op .hole vr)
@@ -84,7 +86,7 @@ theorem wp_binop {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val 
     {R : iProp}
     (h : R ⊢ Q res) :
     TinyML.evalBinOp op vl vr = some res →
-    R ⊢ wp wctx (.binop op (.val vl) (.val vr)) Q := by
+    R ⊢ wp pctx (.binop op (.val vl) (.val vr)) Q := by
   intro heval
   apply h.trans
   iapply (wp.binop heval)
@@ -93,30 +95,30 @@ theorem wp_binop {op : TinyML.BinOp} {vl vr res : Runtime.Val} {Q : Runtime.Val 
     appropriate branch head step. -/
 theorem wp_bind_if {cond thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx cond (fun v => wp wctx (.ifThenElse (.val v) thn els) Q)) :
-    R ⊢ wp wctx (.ifThenElse cond thn els) Q :=
+    (h : R ⊢ wp pctx cond (fun v => wp pctx (.ifThenElse (.val v) thn els) Q)) :
+    R ⊢ wp pctx (.ifThenElse cond thn els) Q :=
   h.trans (wp.bind (k := TinyML.K.ifCond .hole thn els))
 
 /-- Conditional on `true`: context unchanged. -/
 theorem wp_if_true {thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx thn Q) :
-    R ⊢ wp wctx (.ifThenElse (.val (.bool true)) thn els) Q :=
+    (h : R ⊢ wp pctx thn Q) :
+    R ⊢ wp pctx (.ifThenElse (.val (.bool true)) thn els) Q :=
   h.trans wp.if_true
 
 /-- Conditional on `false`: context unchanged. -/
 theorem wp_if_false {thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx els Q) :
-    R ⊢ wp wctx (.ifThenElse (.val (.bool false)) thn els) Q :=
+    (h : R ⊢ wp pctx els Q) :
+    R ⊢ wp pctx (.ifThenElse (.val (.bool false)) thn els) Q :=
   h.trans wp.if_false
 
 /-- Reference allocation under evaluation: first evaluate the payload, then
     allocate. -/
 theorem wp_bind_ref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx e (fun v => wp wctx (.ref (.val v)) Q)) :
-    R ⊢ wp wctx (.ref e) Q :=
+    (h : R ⊢ wp pctx e (fun v => wp pctx (.ref (.val v)) Q)) :
+    R ⊢ wp pctx (.ref e) Q :=
   h.trans (wp.bind (k := TinyML.K.ref .hole))
 
 /-- Reference allocation at values. The continuation receives fresh ownership in
@@ -132,7 +134,7 @@ theorem wp_ref (Θ : TinyML.TypeEnv) {v : Runtime.Val} {Q : Runtime.Val → iPro
     (h : ∀ loc,
       newctx.interp Θ (ρ.updateConst .value name (.loc loc)) ∗ R ⊢
       Q (.loc loc)) :
-    ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R  ⊢ wp wctx (.ref (.val v)) Q := by
+    ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R  ⊢ wp pctx (.ref (.val v)) Q := by
   have hforall : ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R ⊢
       BIBase.forall fun (loc : Runtime.Location) => loc ↦ v -∗ Q (.loc loc) := by
     apply forall_intro
@@ -178,8 +180,8 @@ theorem wp_ref (Θ : TinyML.TypeEnv) {v : Runtime.Val} {Q : Runtime.Val → iPro
     the resulting value. -/
 theorem wp_bind_deref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx e (fun v => wp wctx (.deref (.val v)) Q)) :
-    R ⊢ wp wctx (.deref e) Q :=
+    (h : R ⊢ wp pctx e (fun v => wp pctx (.deref (.val v)) Q)) :
+    R ⊢ wp pctx (.deref e) Q :=
   h.trans (wp.bind (k := TinyML.K.deref .hole))
 
 /-- Dereference at values: the context must contain a matching points-to.
@@ -198,7 +200,7 @@ theorem wp_deref (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     remove ctx n = some (.pointsTo lt vt ty, rest) →
     Term.eval ρ lt = v →
     v = .loc loc →
-    ctx.interp Θ ρ ∗ R ⊢ wp wctx (.deref (.val v)) Q := by
+    ctx.interp Θ ρ ∗ R ⊢ wp pctx (.deref (.val v)) Q := by
   intro hrem hlt hv
   subst hv
   -- Split the context and rewrite the selected atom to a raw points-to fact.
@@ -235,12 +237,12 @@ theorem wp_deref (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     location expression, then take the head store step. -/
 theorem wp_bind_store {loc val : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx val (fun vv => wp wctx loc (fun vl =>
-      wp wctx (.store (.val vl) (.val vv)) Q))) :
-    R ⊢ wp wctx (.store loc val) Q := by
+    (h : R ⊢ wp pctx val (fun vv => wp pctx loc (fun vl =>
+      wp pctx (.store (.val vl) (.val vv)) Q))) :
+    R ⊢ wp pctx (.store loc val) Q := by
   have hloc :
-      wp wctx val (fun vv => wp wctx loc (fun vl => wp wctx (.store (.val vl) (.val vv)) Q)) ⊢
-      wp wctx val (fun vv => wp wctx (.store loc (.val vv)) Q) := by
+      wp pctx val (fun vv => wp pctx loc (fun vl => wp pctx (.store (.val vl) (.val vv)) Q)) ⊢
+      wp pctx val (fun vv => wp pctx (.store loc (.val vv)) Q) := by
     apply wp.mono
     intro vv
     exact wp.bind (k := TinyML.K.storeL .hole vv)
@@ -257,7 +259,7 @@ theorem wp_store (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     vloc = .loc loc →
     Term.eval ρ vt_new = vnew →
     ctx.interp Θ ρ ∗ TinyML.ValHasType Θ vnew ty ∗ R ⊢
-      wp wctx (.store (.val vloc) (.val vnew)) Q := by
+      wp pctx (.store (.val vloc) (.val vnew)) Q := by
   intro hrem hlt hvloc hvnew
   subst hvloc
   have hsplit : ctx.interp Θ ρ ⊢
@@ -293,38 +295,38 @@ theorem wp_store (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     the head assert step. -/
 theorem wp_bind_assert {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx e (fun v => wp wctx (.assert (.val v)) Q)) :
-    R ⊢ wp wctx (.assert e) Q :=
+    (h : R ⊢ wp pctx e (fun v => wp pctx (.assert (.val v)) Q)) :
+    R ⊢ wp pctx (.assert e) Q :=
   h.trans (wp.bind (k := TinyML.K.assert .hole))
 
 /-- Assert on `true`: context unchanged. -/
 theorem wp_assert {Q : Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢ Q .unit) :
-    R ⊢ wp wctx (.assert (.val (.bool true))) Q :=
+    R ⊢ wp pctx (.assert (.val (.bool true))) Q :=
   h.trans wp.assert
 
 /-- Injection under evaluation: first evaluate the payload, then take the head
     injection step. -/
 theorem wp_bind_inj {tag arity : Nat} {payload : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx payload (fun v => wp wctx (.inj tag arity (.val v)) Q)) :
-    R ⊢ wp wctx (.inj tag arity payload) Q :=
+    (h : R ⊢ wp pctx payload (fun v => wp pctx (.inj tag arity (.val v)) Q)) :
+    R ⊢ wp pctx (.inj tag arity payload) Q :=
   h.trans (wp.bind (k := TinyML.K.injK tag arity .hole))
 
 /-- Injection at values: context unchanged. -/
 theorem wp_inj {tag arity : Nat} {payload : Runtime.Val} {Q : Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢ Q (.inj tag arity payload)) :
-    R ⊢ wp wctx (.inj tag arity (.val payload)) Q :=
+    R ⊢ wp pctx (.inj tag arity (.val payload)) Q :=
   h.trans wp.inj
 
 /-- Tuple under evaluation: evaluate the components right-to-left, then take
     the head tuple step on the resulting values. -/
 theorem wp_bind_tuple {es : Runtime.Exprs} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wps wctx es (fun vs => wp wctx (.tuple (vs.map Runtime.Expr.val)) Q)) :
-    R ⊢ wp wctx (.tuple es) Q := by
+    (h : R ⊢ wps pctx es (fun vs => wp pctx (.tuple (vs.map Runtime.Expr.val)) Q)) :
+    R ⊢ wp pctx (.tuple es) Q := by
   apply h.trans
   simpa using (wp_bind_tuple_aux (left := []) (es := es) (right := []) (Q := Q))
 
@@ -332,95 +334,93 @@ theorem wp_bind_tuple {es : Runtime.Exprs} {Q : Runtime.Val → iProp}
 theorem wp_tuple {vs : Runtime.Vals} {Q : Runtime.Val → iProp}
     {R : iProp}
     (h : R ⊢ Q (.tuple vs)) :
-    R ⊢ wp wctx (.tuple (vs.map Runtime.Expr.val)) Q :=
+    R ⊢ wp pctx (.tuple (vs.map Runtime.Expr.val)) Q :=
   h.trans wp.tuple
 
 /-- Match under evaluation: first evaluate the scrutinee, then dispatch on the
     resulting injected value. -/
 theorem wp_bind_match {scrut : Runtime.Expr} {branches : Runtime.Exprs} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx scrut (fun v => wp wctx (.match_ (.val v) branches) Q)) :
-    R ⊢ wp wctx (.match_ scrut branches) Q :=
+    (h : R ⊢ wp pctx scrut (fun v => wp pctx (.match_ (.val v) branches) Q)) :
+    R ⊢ wp pctx (.match_ scrut branches) Q :=
   h.trans (wp.bind (k := TinyML.K.matchK branches .hole))
 
 /-- Match on an injected value: context unchanged. -/
 theorem wp_match {tag arity : Nat} {payload : Runtime.Val} {branches : Runtime.Exprs}
     {branch : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx (.app branch [.val payload]) Q) :
+    (h : R ⊢ wp pctx (.app branch [.val payload]) Q) :
     branches[tag]? = some branch →
-    R ⊢ wp wctx (.match_ (.val (.inj tag arity payload)) branches) Q := by
-  intro hbranch
-  exact h.trans (wp.match_ hbranch)
+    arity = branches.length →
+    R ⊢ wp pctx (.match_ (.val (.inj tag arity payload)) branches) Q := by
+  intro hbranch harity
+  exact h.trans (wp.match_ hbranch harity)
 
 /-- Function values: context unchanged. -/
 theorem wp_func {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Q : Runtime.Val → iProp} {R : iProp}
     (h : R ⊢ Q (.fix f args e)) :
-    R ⊢ wp wctx (.fix f args e) Q :=
+    R ⊢ wp pctx (.fix f args e) Q :=
   h.trans (wp.func Q)
 
 /-- Application under evaluation: first evaluate the arguments right-to-left,
     then the function, then take the head application step. -/
 theorem wp_bind_app {fn : Runtime.Expr} {args : Runtime.Exprs} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wps wctx args (fun vs => wp wctx fn (fun fv =>
-      wp wctx (.app (.val fv) (vs.map Runtime.Expr.val)) Q))) :
-    R ⊢ wp wctx (.app fn args) Q :=
+    (h : R ⊢ wps pctx args (fun vs => wp pctx fn (fun fv =>
+      wp pctx (.app (.val fv) (vs.map Runtime.Expr.val)) Q))) :
+    R ⊢ wp pctx (.app fn args) Q :=
   h.trans wp.app
 
 /-- Fixpoint unfolding: spatially lifted version of `wp.fix`. -/
 theorem wp_fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
-    {P : Runtime.Val → iProp} {Φ : List Runtime.Val → iProp}
+    {P : Runtime.Val → iProp}
     R
+    (hlen : args.length = vs.length)
     (h : R ⊢
-      (wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
+      (wp pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
     R ⊢
-      (wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
-  h.trans (wp.fix (Φ := Φ))
+      (wp pctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
+  h.trans (wp.fix hlen)
 
 /-- Fixpoint unfolding with a continuation-indexed invariant. -/
 theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp}
     {R : iProp}
+    (hlen : ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      Φ P vs ⊢ (⌜args.length = vs.length⌝ : iProp))
     (h : R ⊢
       □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
+          Φ P vs -∗ wp pctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
         ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
+          Φ P vs -∗ wp pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
     R ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp wctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
-  h.trans (wp.fix' (Φ := Φ))
+          Φ P vs -∗ wp pctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
+  h.trans (wp.fix' (Φ := Φ) hlen)
 
 /-- Let-bindings: evaluate the bound expression, then continue in the body with
     the resulting value substituted. -/
 theorem wp_letIn {b : Runtime.Binder} {bound body : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
-    (h : R ⊢ wp wctx bound (fun v => wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q)) :
-    R ⊢ wp wctx (Runtime.Expr.letIn b bound body) Q :=
+    (h : R ⊢ wp pctx bound (fun v => wp pctx (body.subst (Runtime.Subst.id.updateBinder b v)) Q)) :
+    R ⊢ wp pctx (Runtime.Expr.letIn b bound body) Q :=
   h.trans wp.letIn
-
-theorem wp_prim {n : String} {vs : List Runtime.Val} {Q : Runtime.Val → iProp}
-    {R : iProp}
-    (h : R ⊢ wctx n vs Q) :
-    R ⊢ wp wctx (.app (.val (.prim n)) (vs.map Runtime.Expr.val)) Q :=
-  h.trans wp.prim
 
 theorem wp_app_lambda_single {b : Runtime.Binder} {body : Runtime.Expr} {v : Runtime.Val}
     {Φ : Runtime.Val → iProp} {R : iProp}
-    (h : R ⊢ wp wctx (body.subst (Runtime.Subst.id.updateBinder b v)) Φ) :
-    R ⊢ wp wctx (.app (.fix .none [b] body) [.val v]) Φ :=
+    (h : R ⊢ wp pctx (body.subst (Runtime.Subst.id.updateBinder b v)) Φ) :
+    R ⊢ wp pctx (.app (.fix .none [b] body) [.val v]) Φ :=
   h.trans wp.app_lambda_single
 
 
 /-- Strengthen the postcondition of a `wp` using a persistent resource:
-    if `R` (persistent) entails `wp wctx e P`, and `R` together with `P v` entails `Q v`,
-    then `R` entails `wp wctx e Q`. -/
+    if `R` (persistent) entails `wp pctx e P`, and `R` together with `P v` entails `Q v`,
+    then `R` entails `wp pctx e Q`. -/
 theorem wp_strengthen_persistent
     {R : iProp} [Iris.BI.Persistent R] {e : Runtime.Expr}
     {P Q : Runtime.Val → iProp}
-    (hwp : R ⊢ wp wctx e P) (hpost : ∀ v, R ⊢ P v -∗ Q v) :
-    R ⊢ wp wctx e Q := by
+    (hwp : R ⊢ wp pctx e P) (hpost : ∀ v, R ⊢ P v -∗ Q v) :
+    R ⊢ wp pctx e Q := by
   iintro #HR
   iapply wp.wand
   isplitr

--- a/Mica/SeparationLogic/ProofModePatterns.lean
+++ b/Mica/SeparationLogic/ProofModePatterns.lean
@@ -203,7 +203,7 @@ example (P Q : iProp) : P ∗ (P -∗ Q) ⊢ Q := by
   iexact HP
 
 /-- Apply an external lemma. The lemma must conclude with an entailment. -/
-example (wctx : WpCtx) (v : Runtime.Val) (Q : Runtime.Val → iProp) : Q v ⊢ wp wctx (.val v) Q := by
+example (pctx : TinyML.PrimCtx) (v : Runtime.Val) (Q : Runtime.Val → iProp) : Q v ⊢ wp pctx (.val v) Q := by
   istart
   iintro HQ
   iapply wp.val
@@ -223,7 +223,7 @@ example (P : Nat → iProp) : (∀ n, P n) ⊢ P 42 := by
 
 /-- Introduce a persistent assertion, cross a persistency modality, and use it twice. -/
 example (R Q : iProp): R ∗ □ Q ⊢ □ (Q ∗ Q) := by
-  iintro ⟨HR, #HQ⟩
+  iintro ⟨HR, □HQ⟩
   imodintro
   isplitl
   . iexact HQ

--- a/Mica/SeparationLogic/SpatialAtom.lean
+++ b/Mica/SeparationLogic/SpatialAtom.lean
@@ -36,13 +36,15 @@ theorem wfIn_mono {a : SpatialAtom} {Δ Δ' : Signature}
   | pointsTo l v _ => exact ⟨Term.wfIn_mono l h.1 hsub hwf, Term.wfIn_mono v h.2 hsub hwf⟩
 
 /-- Iris interpretation of a single spatial atom. -/
-noncomputable def interp (Θ : TinyML.TypeEnv) (ρ : Env) : SpatialAtom → iProp
+def interp [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (ρ : Env) :
+    SpatialAtom → iProp
   | .pointsTo l v ty => ∃ (loc : Runtime.Location),
       ⌜Term.eval ρ l = .loc loc⌝ ∗ loc ↦ Term.eval ρ v ∗
         TinyML.ValHasType Θ (Term.eval ρ v) ty
 
 /-- Congruence for points-to interpretation under equal location and value evaluation. -/
-theorem pointsTo_congr (Θ : TinyML.TypeEnv) {ρ : Env} {l l' v v' : Term .value} {ty : TinyML.Typ}
+theorem pointsTo_congr [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) {ρ : Env}
+    {l l' v v' : Term .value} {ty : TinyML.Typ}
     (hl : Term.eval ρ l = Term.eval ρ l')
     (hv : Term.eval ρ v = Term.eval ρ v') :
     interp Θ ρ (.pointsTo l v ty) ⊣⊢ interp Θ ρ (.pointsTo l' v' ty) := by

--- a/Mica/Stdlib/IntStd.lean
+++ b/Mica/Stdlib/IntStd.lean
@@ -99,7 +99,7 @@ private theorem respects_argsEnv {s : FOL.Symbol .two} :
 
 /-- Apply a `.ret (s, .assert φ ...)` spec at a value, discharging the asserted
     `φ` as a pure side condition. -/
-private theorem assert_ret_apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
+private theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
     (s : String) (ρ : VerifM.Env) (φ : Formula) (v : Runtime.Val)
     (hφ : φ.eval (ρ.updateConst .value s v).env) :
     PredTrans.apply Θ Φ (.ret (s, .assert φ (.ret ()))) ρ ⊢ Φ v := by
@@ -112,7 +112,7 @@ private theorem assert_ret_apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iPr
 
 /-- Shape lemma: every length-mismatched two-int argument list makes the
     typing premise inconsistent. -/
-private theorem off_shape_two {Θ : TinyML.TypeEnv} {vs : List Runtime.Val}
+private theorem off_shape_two [MicaGS HasLC.hasLC Sig] {Θ : TinyML.TypeEnv} {vs : List Runtime.Val}
     (P : iProp) (hlen : vs.length ≠ 2) :
     TinyML.ValsHaveTypes Θ vs [TinyML.Typ.int, TinyML.Typ.int] ⊢ P := by
   refine TinyML.ValsHaveTypes.length_eq.trans ?_
@@ -203,6 +203,27 @@ private theorem intMin_assert_eval (ρ : VerifM.Env) (x y : Int)
   simp [hbin, intMinSym]
 
 instance : IntrinsicSound [intMin] intMin where
+  wp_sound := by
+    intro _ ctx hctx vs Φ
+    match vs with
+    | [] => exact false_elim
+    | [_] => exact false_elim
+    | _ :: _ :: _ :: _ => exact false_elim
+    | [a, b] =>
+      rw [intMin_toWp]
+      istart
+      iintro ⟨%x, %y, %hab, HΦ⟩
+      obtain ⟨rfl, rfl⟩ := hab
+      have hrel : ∀ μ v μ',
+          ctx intMin.name [Runtime.Val.int x, Runtime.Val.int y] μ v μ' ↔
+            v = .int (min x y) ∧ μ' = μ := by
+        intro μ v μ'
+        rw [hctx]
+        simp [intMin, Intrinsic.toReduce_two_of_arity, Reduce.pure]
+      iapply (wp.prim_pure hrel ⟨_, rfl⟩)
+      iintro %v %hv
+      subst hv
+      iexact HΦ
   axiomWf := by
     intro Δ hsub hwf φ hφ
     simp only [intMin, List.mem_singleton] at hφ
@@ -234,7 +255,7 @@ instance : IntrinsicSound [intMin] intMin where
       (Signature.Subset.declVars hsub (Spec.argVars intMin.specArgs))
       (Signature.wf_declVars hwf)
   bridge := by
-    intro Θ vs ρ Φ hρ
+    intro _ Θ vs ρ Φ hρ
     simp only [intMin_folSym, Env.respects] at hρ
     show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.int, TinyML.Typ.int] ∗ _ ⊢ _
     match vs with
@@ -316,6 +337,27 @@ private theorem intMax_assert_eval (ρ : VerifM.Env) (x y : Int)
   simp [hbin, intMaxSym]
 
 instance : IntrinsicSound [intMax] intMax where
+  wp_sound := by
+    intro _ ctx hctx vs Φ
+    match vs with
+    | [] => exact false_elim
+    | [_] => exact false_elim
+    | _ :: _ :: _ :: _ => exact false_elim
+    | [a, b] =>
+      rw [intMax_toWp]
+      istart
+      iintro ⟨%x, %y, %hab, HΦ⟩
+      obtain ⟨rfl, rfl⟩ := hab
+      have hrel : ∀ μ v μ',
+          ctx intMax.name [Runtime.Val.int x, Runtime.Val.int y] μ v μ' ↔
+            v = .int (max x y) ∧ μ' = μ := by
+        intro μ v μ'
+        rw [hctx]
+        simp [intMax, Intrinsic.toReduce_two_of_arity, Reduce.pure]
+      iapply (wp.prim_pure hrel ⟨_, rfl⟩)
+      iintro %v %hv
+      subst hv
+      iexact HΦ
   axiomWf := by
     intro Δ hsub hwf φ hφ
     simp only [intMax, List.mem_singleton] at hφ
@@ -347,7 +389,7 @@ instance : IntrinsicSound [intMax] intMax where
       (Signature.Subset.declVars hsub (Spec.argVars intMax.specArgs))
       (Signature.wf_declVars hwf)
   bridge := by
-    intro Θ vs ρ Φ hρ
+    intro _ Θ vs ρ Φ hρ
     simp only [intMax_folSym, Env.respects] at hρ
     show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.int, TinyML.Typ.int] ∗ _ ⊢ _
     match vs with

--- a/Mica/Stdlib/StringStd.lean
+++ b/Mica/Stdlib/StringStd.lean
@@ -132,21 +132,21 @@ def stringEndsWithTypeAxiom : Formula :=
     [.term (stringEndsWithTerm (.var .value "suffix") (.var .value "s"))] <|
     .unpred .isBool (stringEndsWithTerm (.var .value "suffix") (.var .value "s"))
 
-private theorem off_shape_one {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} {ty : TinyML.Typ}
+private theorem off_shape_one [MicaGS HasLC.hasLC Sig] {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} {ty : TinyML.Typ}
     (P : iProp) (hlen : vs.length ≠ 1) :
     TinyML.ValsHaveTypes Θ vs [ty] ⊢ P := by
   refine TinyML.ValsHaveTypes.length_eq.trans ?_
   iintro %h
   simp at h; omega
 
-private theorem off_shape_two_ty {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} {ty₁ ty₂ : TinyML.Typ}
+private theorem off_shape_two_ty [MicaGS HasLC.hasLC Sig] {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} {ty₁ ty₂ : TinyML.Typ}
     (P : iProp) (hlen : vs.length ≠ 2) :
     TinyML.ValsHaveTypes Θ vs [ty₁, ty₂] ⊢ P := by
   refine TinyML.ValsHaveTypes.length_eq.trans ?_
   iintro %h
   simp at h; omega
 
-private theorem assert_ret_apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
+private theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
     (s : String) (ρ : VerifM.Env) (φ : Formula) (v : Runtime.Val)
     (hφ : φ.eval (ρ.updateConst .value s v).env) :
     PredTrans.apply Θ Φ (.ret (s, .assert φ (.ret ()))) ρ ⊢ Φ v := by
@@ -231,6 +231,26 @@ private theorem stringLength_assert_eval (ρ : VerifM.Env) (s : List UInt8)
   simp [hun, stringLengthSym]
 
 instance : IntrinsicSound [stringLength] stringLength where
+  wp_sound := by
+    intro _ ctx hctx vs Φ
+    match vs with
+    | [] => exact false_elim
+    | _ :: _ :: _ => exact false_elim
+    | [a] =>
+      rw [stringLength_toWp]
+      istart
+      iintro ⟨%s, %ha, HΦ⟩
+      obtain rfl := ha
+      have hrel : ∀ μ v μ',
+          ctx stringLength.name [Runtime.Val.str s] μ v μ' ↔
+            v = .int s.length ∧ μ' = μ := by
+        intro μ v μ'
+        rw [hctx]
+        simp [stringLength, Intrinsic.toReduce_one_of_arity, Reduce.pure]
+      iapply (wp.prim_pure hrel ⟨_, rfl⟩)
+      iintro %v %hv
+      subst hv
+      iexact HΦ
   axiomWf := by
     intro Δ hsub hwf φ hφ
     simp only [stringLength, List.mem_cons, List.not_mem_nil, or_false] at hφ
@@ -271,7 +291,7 @@ instance : IntrinsicSound [stringLength] stringLength where
       (Signature.Subset.declVars hsub (Spec.argVars stringLength.specArgs))
       (Signature.wf_declVars hwf)
   bridge := by
-    intro Θ vs ρ Φ hρ
+    intro _ Θ vs ρ Φ hρ
     simp only [stringLength_folSym, Env.respects] at hρ
     show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string] ∗ _ ⊢ _
     match vs with
@@ -340,6 +360,27 @@ private theorem stringCat_assert_eval (ρ : VerifM.Env) (x y : List UInt8)
   simp [hbin, stringCatSym]
 
 instance : IntrinsicSound [stringCat] stringCat where
+  wp_sound := by
+    intro _ ctx hctx vs Φ
+    match vs with
+    | [] => exact false_elim
+    | [_] => exact false_elim
+    | _ :: _ :: _ :: _ => exact false_elim
+    | [a, b] =>
+      rw [stringCat_toWp]
+      istart
+      iintro ⟨%x, %y, %hab, HΦ⟩
+      obtain ⟨rfl, rfl⟩ := hab
+      have hrel : ∀ μ v μ',
+          ctx stringCat.name [Runtime.Val.str x, Runtime.Val.str y] μ v μ' ↔
+            v = .str (x ++ y) ∧ μ' = μ := by
+        intro μ v μ'
+        rw [hctx]
+        simp [stringCat, Intrinsic.toReduce_two_of_arity, Reduce.pure]
+      iapply (wp.prim_pure hrel ⟨_, rfl⟩)
+      iintro %v %hv
+      subst hv
+      iexact HΦ
   axiomWf := by
     intro Δ hsub hwf φ hφ
     simp only [stringCat, List.mem_cons, List.not_mem_nil, or_false] at hφ
@@ -381,7 +422,7 @@ instance : IntrinsicSound [stringCat] stringCat where
       (Signature.Subset.declVars hsub (Spec.argVars stringCat.specArgs))
       (Signature.wf_declVars hwf)
   bridge := by
-    intro Θ vs ρ Φ hρ
+    intro _ Θ vs ρ Φ hρ
     simp only [stringCat_folSym, Env.respects] at hρ
     show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string, TinyML.Typ.string] ∗ _ ⊢ _
     match vs with
@@ -457,6 +498,27 @@ private theorem stringEqual_assert_eval (ρ : VerifM.Env) (x y : List UInt8)
   simp [hbin, stringEqualSym]
 
 instance : IntrinsicSound [stringEqual] stringEqual where
+  wp_sound := by
+    intro _ ctx hctx vs Φ
+    match vs with
+    | [] => exact false_elim
+    | [_] => exact false_elim
+    | _ :: _ :: _ :: _ => exact false_elim
+    | [a, b] =>
+      rw [stringEqual_toWp]
+      istart
+      iintro ⟨%x, %y, %hab, HΦ⟩
+      obtain ⟨rfl, rfl⟩ := hab
+      have hrel : ∀ μ v μ',
+          ctx stringEqual.name [Runtime.Val.str x, Runtime.Val.str y] μ v μ' ↔
+            v = .bool (x == y) ∧ μ' = μ := by
+        intro μ v μ'
+        rw [hctx]
+        simp [stringEqual, Intrinsic.toReduce_two_of_arity, Reduce.pure]
+      iapply (wp.prim_pure hrel ⟨_, rfl⟩)
+      iintro %v %hv
+      subst hv
+      iexact HΦ
   axiomWf := by
     intro Δ hsub hwf φ hφ
     simp only [stringEqual, List.mem_cons, List.not_mem_nil, or_false] at hφ
@@ -499,7 +561,7 @@ instance : IntrinsicSound [stringEqual] stringEqual where
       (Signature.Subset.declVars hsub (Spec.argVars stringEqual.specArgs))
       (Signature.wf_declVars hwf)
   bridge := by
-    intro Θ vs ρ Φ hρ
+    intro _ Θ vs ρ Φ hρ
     simp only [stringEqual_folSym, Env.respects] at hρ
     show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string, TinyML.Typ.string] ∗ _ ⊢ _
     match vs with
@@ -575,6 +637,27 @@ private theorem stringStartsWith_assert_eval (ρ : VerifM.Env) (x y : List UInt8
   simp [hbin, stringStartsWithSym]
 
 instance : IntrinsicSound [stringStartsWith] stringStartsWith where
+  wp_sound := by
+    intro _ ctx hctx vs Φ
+    match vs with
+    | [] => exact false_elim
+    | [_] => exact false_elim
+    | _ :: _ :: _ :: _ => exact false_elim
+    | [a, b] =>
+      rw [stringStartsWith_toWp]
+      istart
+      iintro ⟨%x, %y, %hab, HΦ⟩
+      obtain ⟨rfl, rfl⟩ := hab
+      have hrel : ∀ μ v μ',
+          ctx stringStartsWith.name [Runtime.Val.str x, Runtime.Val.str y] μ v μ' ↔
+            v = .bool (x.isPrefixOf y) ∧ μ' = μ := by
+        intro μ v μ'
+        rw [hctx]
+        simp [stringStartsWith, Intrinsic.toReduce_two_of_arity, Reduce.pure]
+      iapply (wp.prim_pure hrel ⟨_, rfl⟩)
+      iintro %v %hv
+      subst hv
+      iexact HΦ
   axiomWf := by
     intro Δ hsub hwf φ hφ
     simp only [stringStartsWith, List.mem_cons, List.not_mem_nil, or_false] at hφ
@@ -616,7 +699,7 @@ instance : IntrinsicSound [stringStartsWith] stringStartsWith where
       (Signature.Subset.declVars hsub (Spec.argVars stringStartsWith.specArgs))
       (Signature.wf_declVars hwf)
   bridge := by
-    intro Θ vs ρ Φ hρ
+    intro _ Θ vs ρ Φ hρ
     simp only [stringStartsWith_folSym, Env.respects] at hρ
     show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string, TinyML.Typ.string] ∗ _ ⊢ _
     match vs with
@@ -692,6 +775,27 @@ private theorem stringEndsWith_assert_eval (ρ : VerifM.Env) (x y : List UInt8)
   simp [hbin, stringEndsWithSym]
 
 instance : IntrinsicSound [stringEndsWith] stringEndsWith where
+  wp_sound := by
+    intro _ ctx hctx vs Φ
+    match vs with
+    | [] => exact false_elim
+    | [_] => exact false_elim
+    | _ :: _ :: _ :: _ => exact false_elim
+    | [a, b] =>
+      rw [stringEndsWith_toWp]
+      istart
+      iintro ⟨%x, %y, %hab, HΦ⟩
+      obtain ⟨rfl, rfl⟩ := hab
+      have hrel : ∀ μ v μ',
+          ctx stringEndsWith.name [Runtime.Val.str x, Runtime.Val.str y] μ v μ' ↔
+            v = .bool (x.isSuffixOf y) ∧ μ' = μ := by
+        intro μ v μ'
+        rw [hctx]
+        simp [stringEndsWith, Intrinsic.toReduce_two_of_arity, Reduce.pure]
+      iapply (wp.prim_pure hrel ⟨_, rfl⟩)
+      iintro %v %hv
+      subst hv
+      iexact HΦ
   axiomWf := by
     intro Δ hsub hwf φ hφ
     simp only [stringEndsWith, List.mem_cons, List.not_mem_nil, or_false] at hφ
@@ -733,7 +837,7 @@ instance : IntrinsicSound [stringEndsWith] stringEndsWith where
       (Signature.Subset.declVars hsub (Spec.argVars stringEndsWith.specArgs))
       (Signature.wf_declVars hwf)
   bridge := by
-    intro Θ vs ρ Φ hρ
+    intro _ Θ vs ρ Φ hρ
     simp only [stringEndsWith_folSym, Env.respects] at hρ
     show TinyML.ValsHaveTypes Θ vs [TinyML.Typ.string, TinyML.Typ.string] ∗ _ ⊢ _
     match vs with

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -11,6 +11,8 @@ import Mica.Base.Except
 
 open Iris Iris.BI
 
+variable [MicaGS HasLC.hasLC Sig]
+
 /-!
 # Assertions
 
@@ -48,7 +50,7 @@ def Assertion.toStringHum {α : Type} (showA : α → String) : Assertion α →
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-noncomputable def Assertion.pre (Θ : TinyML.TypeEnv) (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
+def Assertion.pre (Θ : TinyML.TypeEnv) (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   (match m with
   | .ret a        => Φ a ρ
   | .assert φ k   => ⌜φ.eval ρ.env⌝ ∗ Assertion.pre Θ Φ k ρ
@@ -58,7 +60,7 @@ noncomputable def Assertion.pre (Θ : TinyML.TypeEnv) (Φ : α → VerifM.Env �
       iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.pre Θ Φ kt ρ) ∧
             (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.pre Θ Φ ke ρ)))
 
-noncomputable def Assertion.post (Θ : TinyML.TypeEnv) {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
+def Assertion.post (Θ : TinyML.TypeEnv) {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
   | .assert φ k   => ⌜φ.eval ρ.env⌝ -∗ Assertion.post Θ Φ k ρ
@@ -94,6 +96,7 @@ def Assertion.checkWf (retCheck : α → Signature → Except String Unit)
   | .pred v p k  => do p.checkWf Δ; k.checkWf retCheck (Δ.declVar v)
   | .ite φ kt ke => do φ.checkWf Δ; kt.checkWf retCheck Δ; ke.checkWf retCheck Δ
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Assertion.checkWf_ok {m : Assertion α} {retCheck : α → Signature → Except String Unit}
     {retWf : α → Signature → Prop} {Δ : Signature}
     (hret : ∀ a Δ', retCheck a Δ' = .ok () → retWf a Δ')
@@ -114,6 +117,7 @@ theorem Assertion.checkWf_ok {m : Assertion α} {retCheck : α → Signature →
     have ⟨_, h2, h3⟩ := Except.bind_ok h23
     exact ⟨Formula.checkWf_ok h1, iht h2, ihe h3⟩
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Prop)
     (hret : ∀ a Δ Δ', Δ.Subset Δ' → Δ'.wf → retWf a Δ → retWf a Δ')
     {Δ Δ' : Signature}

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -6,6 +6,8 @@ import Mica.Verifier.Monad
 import Mica.Verifier.RelationalEncoding.SkolemizeCompleteness
 
 open Iris Iris.BI
+
+variable [MicaGS HasLC.hasLC Sig]
 open Verifier.RelationalEncoding
 
 /-!
@@ -64,7 +66,7 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-noncomputable def Atom.eval (Θ : TinyML.TypeEnv) {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
+def Atom.eval (Θ : TinyML.TypeEnv) {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
   match p with
   | isint t  => λ v => ⌜.int v = t.eval ρ.env⌝
   | isbool t => λ v => ⌜.bool v = t.eval ρ.env⌝
@@ -94,6 +96,7 @@ def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
   | .own _ _ => none
   | .rel _ _ => none
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : Signature}
     (h : φ.matchAtom a = some t) (hφ : φ.wfIn Δ) : t.wfIn Δ := by
   cases a with
@@ -110,6 +113,7 @@ theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : 
   | rel name arg => simp only [Formula.matchAtom] at h; cases h
 
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
     (h : φ.matchAtom a = some t) : a.toItem t = .pure φ := by
   cases a with
@@ -142,6 +146,7 @@ theorem Atom.resolve_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {C : List Formu
   rw [Formula.matchAtom_correct hφ_match]
   simpa [CtxItem.interp, hC _ hφ_mem] using (pure_intro (PROP := iProp) trivial)
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Atom.resolve_wfIn {a : Atom τ} {C : List Formula} {t : Term τ} {Δ : Signature}
     (h : a.resolve C = some t) (hwf : ∀ φ ∈ C, φ.wfIn Δ) :
     t.wfIn Δ := by
@@ -182,6 +187,7 @@ def Atom.checkWf (p : Atom τ) (Δ : Signature) : Except String Unit :=
       (SpecFn.isDefined name t).checkWf Δ
       (SpecFn.call name t).checkWf Δ
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Atom.checkWf_ok {p : Atom τ} {Δ : Signature} (h : p.checkWf Δ = .ok ()) : p.wfIn Δ := by
   cases p with
   | isint t  => exact Term.checkWf_ok h
@@ -192,6 +198,7 @@ theorem Atom.checkWf_ok {p : Atom τ} {Δ : Signature} (h : p.checkWf Δ = .ok (
     have ⟨w, hd, hv⟩ := Except.bind_ok h
     exact ⟨Formula.checkWf_ok hd, Term.checkWf_ok hv⟩
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
     (h : p.wfIn Δ) (hmono : Δ.Subset Δ') (hwf : Δ'.wf) : p.wfIn Δ' := by
   cases p with
@@ -215,6 +222,7 @@ theorem Atom.eval_env_agree (Θ : TinyML.TypeEnv) {p : Atom τ} {ρ ρ' : VerifM
     rw [(Formula.eval_env_agree hwf.1 hagree),
         Term.eval_env_agree hwf.2 hagree]
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     (hp : p.wfIn Δ) (ht : t.wfIn Δ) :
     (p.toItem t).wfIn Δ := by
@@ -295,6 +303,7 @@ theorem Atom.eval_subst (Θ : TinyML.TypeEnv) {p : Atom τ} {σ : Subst} {ρ : V
     rw [Term.eval_subst hp.2.2 hσ hwfΔ']
     simp [Subst.eval]
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn dom Δ') (hdom : Δ.vars ⊆ dom)
     (hsymbols : Δ.SymbolSubset Δ')
@@ -350,6 +359,7 @@ theorem Atom.candidates_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {φ : Formul
   | own l ty => simp [candidates] at hmem
   | rel name arg => simp [candidates] at hmem
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Signature}
     (hmem : (φ, t) ∈ a.candidates) (h : a.wfIn Δ) : φ.wfIn Δ ∧ t.wfIn Δ := by
   cases a with
@@ -445,6 +455,7 @@ def VerifM.findMatch (lq : Term .value) (ty : TinyML.Typ) : VerifM (Option (Term
           let _ ← VerifM.ctx (fun _ => ((), rest))
           pure (some v)
 
+omit [MicaGS HasLC.hasLC Sig] in
 /-- Correctness of `findMatchIn`: on a `some (n, v)` result, `remove ctx n`
     extracts a points-to whose location the solver has proved equal to `lq`. -/
 theorem VerifM.eval_findMatchIn {lq : Term .value} {ty : TinyML.Typ} {ctx : SpatialContext}

--- a/Mica/Verifier/Bindings.lean
+++ b/Mica/Verifier/Bindings.lean
@@ -8,6 +8,8 @@ import Mica.SeparationLogic.LogicalRelation
 
 open Iris Iris.BI
 
+variable [MicaGS HasLC.hasLC Sig]
+
 /-! ### Bindings -/
 
 abbrev Bindings := List (TinyML.Var × FOL.Const)
@@ -22,6 +24,7 @@ def Bindings.agreeOnLinked (B : Bindings) (ρ : Env) (γ : Runtime.Subst) :=
 def Bindings.wfIn (B : Bindings) (decls : Signature) : Prop :=
   ∀ p ∈ B, p.2 ∈ decls.consts
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Bindings.agreeOnLinked_env_agree {B : Bindings} {decls : Signature} {ρ ρ' : Env} {γ : Runtime.Subst}
     (hagr : B.agreeOnLinked ρ γ) (henv : Env.agreeOn decls ρ ρ')
     (hwf : B.wfIn decls) : B.agreeOnLinked ρ' γ := by
@@ -34,6 +37,7 @@ theorem Bindings.agreeOnLinked_env_agree {B : Bindings} {decls : Signature} {ρ 
   rw [hsort] at henv'
   exact ⟨hsort, hγ.trans (congrArg some henv')⟩
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Bindings.wfIn_cons {B : Bindings} {decls : Signature} {x : TinyML.Var} {v : FOL.Const}
     (hbwf : B.wfIn decls) :
     Bindings.wfIn ((x, v) :: B) (decls.addConst v) := by
@@ -44,7 +48,7 @@ theorem Bindings.wfIn_cons {B : Bindings} {decls : Signature} {x : TinyML.Var} {
   · exact List.Mem.tail _ (hbwf p hp)
 
 /-- The substitution `γ` maps every binding to a value well-typed by `Γ`. -/
-noncomputable def Bindings.typedSubst (Θ : TinyML.TypeEnv) (B : Bindings) (Γ : TinyML.TyCtx) (γ : Runtime.Subst) : iProp :=
+def Bindings.typedSubst (Θ : TinyML.TypeEnv) (B : Bindings) (Γ : TinyML.TyCtx) (γ : Runtime.Subst) : iProp :=
   iprop(□ ∀ x x' t, ⌜B.lookup x = some x'⌝ -∗ ⌜Γ x = some t⌝ -∗ ∃ v, ⌜γ x = some v⌝ ∗ TinyML.ValHasType Θ v t)
 
 instance Bindings.typedSubst_persistent {B Γ γ} (Θ : TinyML.TypeEnv) : Persistent (Bindings.typedSubst Θ B Γ γ) :=
@@ -92,6 +96,7 @@ theorem Bindings.typedSubst_cons {B : Bindings} {Γ : TinyML.TyCtx} {γ : Runtim
       simp [Runtime.Subst.update, hyx, hw']
     · iexact Hw'
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Bindings.agreeOnLinked_cons {B : Bindings} {ρ ρ' : Env} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : FOL.Const}
     (hagree : B.agreeOnLinked ρ γ)
@@ -136,6 +141,7 @@ theorem Bindings.typedSubst_of_agreeOnLinked
     · ipureintro; exact hmem
     · ipureintro; exact hΓ
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem findVal_none_of_not_mem
     (ns : List String) (vs : List Runtime.Val) (x : String)
     (hlen : ns.length = vs.length) (hx : x ∉ ns) :
@@ -150,6 +156,7 @@ theorem findVal_none_of_not_mem
       simp only [List.map_cons, Runtime.Binders.findVal_cons, ih vs hlen hx.2]
       simp [BEq.beq, Runtime.instBEqBinder.beq, Ne.symm hx.1]
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem not_mem_of_lookup_zip_reverse_none
     (ns : List String) (avs : List FOL.Const) (x : String)
     (hlen : ns.length = avs.length)
@@ -167,6 +174,7 @@ theorem not_mem_of_lookup_zip_reverse_none
   have := h _ hmem'
   simp [hni] at this
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Bindings.agreeOnLinked_zip_reverse
     (names : List String) (vars : List FOL.Const) (vals : List Runtime.Val)
     (γ : Runtime.Subst) (ρ : Env)
@@ -210,11 +218,13 @@ theorem Bindings.agreeOnLinked_zip_reverse
                 exact findVal_none_of_not_mem ns vs x hlen_nvl hx_notin
             · simp [List.lookup, hxn] at hmem
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Bindings.lookup_reverse_zip_append {keys : List String} {vars : List FOL.Const} {x : String} (B : Bindings) :
     ((keys.zip vars).reverse ++ B).lookup x =
       ((keys.zip vars).reverse.lookup x).or (B.lookup x) := by
   rw [List.lookup_append]
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Bindings.agreeOnLinked_updateAllBinder
     (B : Bindings) (names : List String) (vars : List FOL.Const) (vals : List Runtime.Val)
     (γ : Runtime.Subst) (ρ : Env)

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -15,6 +15,8 @@ import Mathlib.Data.Finmap
 import Mica.Verifier.Intrinsic
 
 open Iris Iris.BI
+
+variable [MicaGS HasLC.hasLC Sig]
 open Typed
 
 /-! ## Expression Compilation
@@ -53,6 +55,7 @@ def compileUnop (op : TinyML.UnOp) (s : Term .value) : Option (Term .value) :=
   | .not => some (Term.unop .ofBool (Term.unop .not (b s)))
   | .proj n => some (.unop .vhead (vtailN (.unop .toValList s) n))
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem compileUnop_wfIn {op : TinyML.UnOp} {s : Term .value} {Δ : Signature}
     (hs : s.wfIn Δ) {t : Term .value} (heq : compileUnop op s = some t) :
     t.wfIn Δ := by
@@ -60,6 +63,7 @@ theorem compileUnop_wfIn {op : TinyML.UnOp} {s : Term .value} {Δ : Signature}
     simp only [Term.wfIn, UnOp.wfIn, true_and]
   all_goals first | exact hs | (have : (Term.unop UnOp.toValList s).wfIn _ := ⟨trivial, hs⟩; exact vtailN_wfIn this _)
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem compileUnop_eval {op : TinyML.UnOp} {s : Term .value} {ρ : VerifM.Env}
     {v w : Runtime.Val} {t : Term .value}
     (hs : s.eval ρ.env = v) (heval : TinyML.evalUnOp op v = some w)
@@ -77,6 +81,7 @@ theorem compileUnop_eval {op : TinyML.UnOp} {s : Term .value} {ρ : VerifM.Env}
     cases h : s.eval ρ.env <;>
     simp_all [TinyML.evalUnOp, Term.eval, UnOp.eval]
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem compileOp_wfIn {op : TinyML.BinOp} {sl sr : Term .value} {Δ : Signature}
     (hl : sl.wfIn Δ) (hr : sr.wfIn Δ) {t : Term .value} (heq : compileOp op sl sr = some t) :
     t.wfIn Δ := by
@@ -84,6 +89,7 @@ theorem compileOp_wfIn {op : TinyML.BinOp} {sl sr : Term .value} {Δ : Signature
     simp only [Term.wfIn] <;>
     tauto
 
+omit [MicaGS HasLC.hasLC Sig] in
 /-- If `evalBinOp op v1 v2 = some w` and the input terms evaluate to `v1`, `v2`,
     then the compiled SMT term evaluates to `w`.
     Pair/store return `none` from `compileOp` so those cases are vacuous via `hcomp`. -/
@@ -288,6 +294,7 @@ end
 
 /-! ### Helper lemmas -/
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem compileBranches_length_get (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (ts : List TinyML.Typ)
     (branches : List (Binder × Expr)) (idx : Nat) :
@@ -315,10 +322,10 @@ namespace Helpers
 theorem ctx_dup (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl Θ ρ ∗
-        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
-          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R)) := by
+        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R)) := by
   iintro ⟨Howns, #HS, #HT, HR⟩
   isplitl [Howns]
   · iexact Howns
@@ -335,10 +342,10 @@ theorem ctx_dup (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signa
 theorem ctx_dup_flip (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl Θ ρ ∗
-        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
-          (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R))) := by
+        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+          (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))) := by
   iintro ⟨Howns, #HS, #HT, HR⟩
   isplitl [Howns]
   · iexact Howns
@@ -356,9 +363,9 @@ theorem ctx_push (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Sign
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
       st.sl Θ ρ ∗
-        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (TinyML.ValHasType Θ v ty ∗ R)) := by
   iintro ⟨Howns, Hv, #HS, #HT, HR⟩
   isplitl [Howns]
@@ -375,9 +382,9 @@ theorem ctx_push_flip (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec :
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
       st.sl Θ ρ ∗
-        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
+        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
           (TinyML.ValHasType Θ v ty ∗ R)) := by
   iintro ⟨Howns, Hv, #HT, #HS, HR⟩
   isplitl [Howns]
@@ -397,6 +404,7 @@ end Helpers
 
 /-! #### Correctness Statements -/
 
+omit [MicaGS HasLC.hasLC Sig] in
 private theorem specInvariants_mono
     {Δ_spec : Signature} {ρ_spec st st' : VerifM.Env} {decls decls' : Signature}
     (hΔspec : Δ_spec.Subset decls)
@@ -423,7 +431,7 @@ def correctExpr (reg : Verifier.Registry) (e : Expr) : Prop :=
     Verifier.Registry.symAgree reg ρ_spec.env →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
       st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢ Φ v) →
-    st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (reg.wpCtx) (e.runtime.subst γ) Φ
+    st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp reg.primCtx (e.runtime.subst γ) Φ
 
 def correctBranch (reg : Verifier.Registry) (branch : Binder × Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -444,9 +452,9 @@ def correctBranch (reg : Verifier.Registry) (branch : Binder × Expr) : Prop :=
     Verifier.Registry.symAgree reg ρ_spec.env →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
-      st.sl Θ ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (reg.wpCtx) (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
+      st.sl Θ ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp reg.primCtx (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
 
 def correctBranches (reg : Verifier.Registry) (branches : List (Binder × Expr)) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -466,11 +474,11 @@ def correctBranches (reg : Verifier.Registry) (branches : List (Binder × Expr))
     Verifier.Registry.symAgree reg ρ_spec.env →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
       VerifM.eval (compileBranch reg Θ Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
-        st.sl Θ ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp (reg.wpCtx) (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
+        st.sl Θ ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp reg.primCtx (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
 
 def correctExprs (reg : Verifier.Registry) (es : List Expr) : Prop :=
   ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
@@ -491,8 +499,8 @@ def correctExprs (reg : Verifier.Registry) (es : List Expr) : Prop :=
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ'.env terms vs →
-       st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
-    st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps (reg.wpCtx) (es.map (fun e => e.runtime.subst γ)) Φ
+       st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
+    st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps reg.primCtx (es.map (fun e => e.runtime.subst γ)) Φ
 
 /-! #### Correctness Compatibility Lemmas -/
 
@@ -761,7 +769,7 @@ theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
   have hwf_addConst : TransState.wf { st₁ with decls := st₁.decls.addConst c } :=
     TransState.freshConst.wf _ hwf_st₁
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (reg.wpCtx) (.ref (.val v_e)) Φ := by
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp reg.primCtx (.ref (.val v_e)) Φ := by
     istart
     iintro ⟨Howns, #Hty, HR⟩
     iapply (wp.ref_inv (I := fun w => TinyML.ValHasType Θ w e.ty))
@@ -830,7 +838,7 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
   have hc_fresh : c.name ∉ st₁.decls.allNames :=
     TransState.freshConst_fresh st₁ none .value
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (reg.wpCtx) (.ref (.val v_e)) Φ := by
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp reg.primCtx (.ref (.val v_e)) Φ := by
     refine SpatialContext.wp_ref Θ
       (ctx := st₁.owns) (ρ := ρ_e.env) (R := R) (Δ := st₁.decls)
       (vt := se) (ty := e.ty) (name := c.name)
@@ -905,7 +913,7 @@ theorem compileDerefShared_correct (reg : Verifier.Registry) (e : Expr) (ty : Ti
         (Term.const_wfIn_addConst_of_fresh (Δ := st₁.decls) (c := c)
           (VerifM.eval.wf hdecl_eval).namesDisjoint hc_fresh)
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp (reg.wpCtx) (.deref (.val v_e)) Φ := by
+      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp reg.primCtx (.deref (.val v_e)) Φ := by
     rw [href]
     istart
     iintro ⟨Howns, Href, HR⟩
@@ -962,7 +970,7 @@ theorem compileDerefOwned_correct (reg : Verifier.Registry) (e : Expr) (ty : Tin
   rw [howned]
   refine VerifM.eval_findMatchForce Θ
     (R := TinyML.ValHasType Θ v_e (.owned ty) ∗ R)
-    (Φ := wp (reg.wpCtx) (.deref (.val v_e)) Φ) hfind_eval hse_wf ?_
+    (Φ := wp reg.primCtx (.deref (.val v_e)) Φ) hfind_eval hse_wf ?_
   intro v st₂ hQ hdecls hv_wf
   have hassume_eval := VerifM.eval_bind _ _ _ _ hQ
   have hatom_wf : (SpatialAtom.pointsTo se v ty).wfIn st₂.decls := by
@@ -975,7 +983,7 @@ theorem compileDerefOwned_correct (reg : Verifier.Registry) (e : Expr) (ty : Tin
     exact hv_wf
   have hwp :
       SpatialAtom.interp Θ ρ_e.env (.pointsTo se v ty) ∗ st₂.sl Θ ρ_e ∗
-        (TinyML.ValHasType Θ v_e (.owned ty) ∗ R) ⊢ wp (reg.wpCtx) (.deref (.val v_e)) Φ := by
+        (TinyML.ValHasType Θ v_e (.owned ty) ∗ R) ⊢ wp reg.primCtx (.deref (.val v_e)) Φ := by
     simp only [SpatialAtom.interp]
     istart
     iintro ⟨Hatom, Howns, _Howned, HR⟩
@@ -1043,13 +1051,13 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_v : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R))) :=
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))) :=
     Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
@@ -1059,8 +1067,8 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
   have heval_l : (compile reg Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
   have hlocStart :
       st₁.sl Θ ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
-        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl Θ ρ_v ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+          st₁.sl Θ ρ_v ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (TinyML.ValHasType Θ v_v val.ty ∗ R)) :=
     Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
   have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
@@ -1076,7 +1084,7 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
     hpost .unit ρ_l st₂ _ hret hunit_wf (by simp [Term.eval])
   have hwp :
       st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ v_l loc.ty ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R)) ⊢
-        wp (reg.wpCtx) (.store (.val v_l) (.val v_v)) Φ := by
+        wp reg.primCtx (.store (.val v_l) (.val v_v)) Φ := by
     rw [href]
     istart
     iintro ⟨Howns, Hloc, #Hval, HR⟩
@@ -1109,13 +1117,13 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_v : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R))) :=
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))) :=
     Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
@@ -1125,8 +1133,8 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
   have heval_l : (compile reg Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind _ _ _ _ hΨ_v
   have hlocStart :
       st₁.sl Θ ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
-        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl Θ ρ_v ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+          st₁.sl Θ ρ_v ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
             (TinyML.ValHasType Θ v_v val.ty ∗ R)) :=
     Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
   have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
@@ -1143,7 +1151,7 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
   rw [howned]
   refine VerifM.eval_findMatchForce Θ
     (R := TinyML.ValHasType Θ v_l (.owned val.ty) ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R))
-    (Φ := wp (reg.wpCtx) (.store (.val v_l) (.val v_v)) Φ) hfind_eval hsl_wf ?_
+    (Φ := wp reg.primCtx (.store (.val v_l) (.val v_v)) Φ) hfind_eval hsl_wf ?_
   intro old st₃ hQ hdecls hold_wf
   have hassume_eval := VerifM.eval_bind _ _ _ _ hQ
   have hatom_wf : (SpatialAtom.pointsTo sl sv val.ty).wfIn st₃.decls := by
@@ -1156,7 +1164,7 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
   have hwp :
       SpatialAtom.interp Θ ρ_l.env (.pointsTo sl old val.ty) ∗ st₃.sl Θ ρ_l ∗
         (TinyML.ValHasType Θ v_l (.owned val.ty) ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R)) ⊢
-          wp (reg.wpCtx) (.store (.val v_l) (.val v_v)) Φ := by
+          wp reg.primCtx (.store (.val v_l) (.val v_v)) Φ := by
     simp only [SpatialAtom.interp]
     istart
     iintro ⟨Hatom, Howns, _Howned, #HnewTy, HR⟩
@@ -1244,7 +1252,7 @@ theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Ex
   have hq : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w :=
     by simpa [hty_eq] using
       (hpost w ρ_e st₁ t hΨ_e (compileUnop_wfIn hse_wf hcompUnop) ht_eval)
-  have hwp : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (reg.wpCtx) (.unop op (.val v_e)) Φ :=
+  have hwp : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp reg.primCtx (.unop op (.val v_e)) Φ :=
     SpatialContext.wp_unop
       (R := st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R)
       (Q := Φ) (op := op) (v := v_e) (res := w) hq heval_op
@@ -1264,13 +1272,13 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
   simp only [compile] at heval
   have heval_r : (compile reg Θ Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
     Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_binop <| hstart.trans <|
-    ihR Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihR Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr
   obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
@@ -1280,9 +1288,9 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
   have heval_l : (compile reg Θ Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind _ _ _ _ hΨ_r
   have hleftStart :
       st₁.sl Θ ρ_r ∗ TinyML.ValHasType Θ vr r.ty ∗
-        (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
           st₁.sl Θ ρ_r ∗
-            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
               (TinyML.ValHasType Θ vr r.ty ∗ R)) :=
     Helpers.ctx_push reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_r γ R vr r.ty
   have hspecInv_r := specInvariants_mono hΔspec hρspec hdecls_r hagreeOn_r
@@ -1327,7 +1335,7 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
       have hwp_int :
           st₂.sl Θ ρ_l ∗
               (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
-            wp (reg.wpCtx) (.binop .div (.val vl) (.val vr)) Φ := by
+            wp reg.primCtx (.binop .div (.val vl) (.val vr)) Φ := by
         istart
         iintro H
         icases H with ⟨Howns, Hvl, Hvr, HR⟩
@@ -1378,7 +1386,7 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
       have hwp_int :
           st₂.sl Θ ρ_l ∗
               (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
-            wp (reg.wpCtx) (.binop .mod (.val vl) (.val vr)) Φ := by
+            wp reg.primCtx (.binop .mod (.val vl) (.val vr)) Φ := by
         istart
         iintro H
         icases H with ⟨Howns, Hvl, Hvr, HR⟩
@@ -1450,7 +1458,7 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
     have hq : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w := by
       simpa [hty_eq] using
         (hpost w ρ_l st₂ t hΨ_ndiv (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval)
-    have hwp : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp (reg.wpCtx) (.binop op (.val vl) (.val vr)) Φ :=
+    have hwp : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp reg.primCtx (.binop op (.val vl) (.val vr)) Φ :=
       SpatialContext.wp_binop
         (R := st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R)
         (Q := Φ) (op := op) (vl := vl) (vr := vr) (res := w) hq heval_op
@@ -1471,12 +1479,12 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
   simp only [Runtime.Expr.letIn_subst]
   have heval_e_outer : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
     Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
-  refine (hstart.trans <| ihE Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+  refine (hstart.trans <| ihE Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
     (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_).trans wp.letIn
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e
   obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -1487,8 +1495,8 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
   | none =>
     simp [hname] at hΨ_e
     have hdrop :
-        st₁.sl Θ ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-          st₁.sl Θ ρ_e ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          st₁.sl Θ ρ_e ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       iintro ⟨Howns, _Hv, #HS, #HT, HR⟩
       isplitl [Howns]
       · iexact Howns
@@ -1505,8 +1513,8 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
         hpost v ρ' st' se hΨ' hs hw)
     have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ Runtime.Binder.none v_e
     have hbody' : st₁.sl Θ ρ_e ∗
-          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-            wp (reg.wpCtx)
+          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+            wp reg.primCtx
               (Runtime.Expr.subst
                 (Runtime.Subst.updateBinder Runtime.Binder.none v_e Runtime.Subst.id)
                 (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
@@ -1529,12 +1537,12 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
     set ρ_body := ρ_e.updateConst .value v.name v_e
     set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
     suffices st₂.sl Θ ρ_body ∗
-        (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-          wp (reg.wpCtx) (body.runtime.subst γ_body) Φ by
+        (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          wp reg.primCtx (body.runtime.subst γ_body) Φ by
       have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ (.named x) v_e
       have hbody' : st₂.sl Θ ρ_body ∗
-            (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-              wp (reg.wpCtx)
+            (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+              wp reg.primCtx
                 (Runtime.Expr.subst
                   (Runtime.Subst.updateBinder (.named x) v_e Runtime.Subst.id)
                   (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
@@ -1588,9 +1596,9 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
       rwa [hρ_body_lookup] at h
     have hres :
         st₂.sl Θ ρ_body ∗
-          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
             st₂.sl Θ ρ_body ∗
-              (SpecMap.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
+              (SpecMap.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
                 Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body ∗ R) := by
       iintro ⟨Howns, Hve, #HS, #HT, HR⟩
       isplitl [Howns]
@@ -1623,13 +1631,13 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
   simp only [compile] at heval
   have heval_cond : (compile reg Θ Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
         st.sl Θ ρ ∗
-          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
     Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_if <| hstart.trans <|
-    ihCond Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihCond Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c
   obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
@@ -1657,9 +1665,9 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
   have hbool_cases_bool :
       st₁.sl Θ ρ_c ∗
           (TinyML.ValHasType Θ v_c .bool ∗
-            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
         st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     iintro ⟨Howns, Hv, #HS, #HT, HR⟩
     ihave Hv_bool := (TinyML.ValHasType.bool Θ v_c).1 $$ Hv
     icases Hv_bool with ⟨%b, %hv⟩
@@ -1673,9 +1681,9 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
           · iexact HT
           · iexact HR
   have hbool_cases :
-      st₁.sl Θ ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+      st₁.sl Θ ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
         st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
     simpa [hcond_bool] using hbool_cases_bool
   refine hbool_cases.trans ?_
   istart
@@ -1688,16 +1696,16 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
         simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_c)
     have hwp :
-        st_els.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          wp (reg.wpCtx) (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
+        st_els.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          wp reg.primCtx (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_false
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
         ihEls Θ R S B Γ st_els ρ_c γ Δ_spec ρ_spec Ψ Φ heval_els hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hels_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_els.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          st_els.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       simp [st_els, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -1716,16 +1724,16 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
         simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_ne)
     have hwp :
-        st_thn.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          wp (reg.wpCtx) (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
+        st_thn.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          wp reg.primCtx (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_true
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
         ihThn Θ R S B Γ st_thn ρ_c γ Δ_spec ρ_spec Ψ Φ heval_thn hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hthn_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_thn.sl Θ ρ_c ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+          st_thn.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
       simp [st_thn, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -1757,7 +1765,7 @@ theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
     exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
   refine SpatialContext.wp_tuple ?_
   have hstep :
-      st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) ⊢
+      st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) ⊢
         st'.sl Θ ρ' ∗ TinyML.ValHasType Θ (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
     iintro ⟨Howns, Hvals, #HS, HR⟩
     isplitl [Howns]
@@ -1786,8 +1794,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     simp only [compile] at heval
     obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
     have heval_args : (compileExprs reg Θ Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
-    refine SpecMap.project (wctx := reg.wpCtx)
-      (P := st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ Δ_spec ρ_spec S γ ?_ hlookup ?_
+    refine SpecMap.project (pctx := reg.primCtx)
+      (P := st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ Δ_spec ρ_spec S γ ?_ hlookup ?_
     · istart
       iintro ⟨_, #HS, _⟩
       iexact HS
@@ -1795,11 +1803,11 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       simp [Expr.runtime, Runtime.Expr.subst, hγf]
       refine SpatialContext.wp_bind_app ?_
       have hctx :
-          spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ∗
-              (st.sl Θ ρ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+          spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ∗
+              (st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
             st.sl Θ ρ ∗
-              (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗
-                Bindings.typedSubst Θ B Γ γ ∗ (spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ∗ R)) := by
+              (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+                Bindings.typedSubst Θ B Γ γ ∗ (spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ∗ R)) := by
         istart
         iintro ⟨#Hspec, Howns, #HS, #HT, HR⟩
         isplitl [Howns]
@@ -1812,7 +1820,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
               · iexact Hspec
               · iexact HR
       refine hctx.trans <|
-        ihArgs Θ (spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+        ihArgs Θ (spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
           (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
       intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
       obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
@@ -1948,9 +1956,9 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
           · iexact HR')
     obtain ⟨hsub_ty, happly⟩ := hcall
     refine SpatialContext.wp_val ?_
-    refine BIBase.Entails.trans ?_ wp.prim
-    show _ ⊢ (reg.wpCtx) n vs Φ
-    have hctx_eq : (reg.wpCtx) n vs Φ = i.toWp vs Φ := by
+    refine BIBase.Entails.trans ?_ (Verifier.Registry.wp_prim reg hSound)
+    show _ ⊢ reg.wpCtx n vs Φ
+    have hctx_eq : reg.wpCtx n vs Φ = i.toWp vs Φ := by
       simp only [Verifier.Registry.wpCtx, hilookup]
     rw [hctx_eq]
     istart
@@ -2015,7 +2023,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
   simp only [compile] at heval
   have heval_scrut : (compile reg Θ Δ_spec S B Γ scrut).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_match <| BIBase.Entails.trans ?_ <|
-    ihScrut Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihScrut Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   · exact Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
   intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se
@@ -2079,8 +2087,8 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
           have hbranch_entail :
               st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-                wp (reg.wpCtx)
+                    (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+                wp reg.primCtx
                   ((Runtime.Expr.subst γ
                         (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime)).app
                     [Runtime.Expr.val v_payload])
@@ -2101,8 +2109,8 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
           have hmatch_entail :
               st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-                wp (reg.wpCtx)
+                    (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
+                wp reg.primCtx
                   ((Runtime.Expr.val (Runtime.Val.inj tag ts.length v_payload)).match_
                     (List.map (Runtime.Expr.subst γ ∘ fun p =>
                       Runtime.Expr.fix Runtime.Binder.none [p.1.runtime] p.2.runtime) branches))
@@ -2110,12 +2118,13 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
             SpatialContext.wp_match
               (R := st_scrut.sl Θ ρ_scrut ∗
                   TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R))
+                    (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R))
               (branch :=
                 Runtime.Expr.subst γ
                   (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime))
               (by simpa [Runtime.Expr.subst_fix] using hbranch_entail)
               (by simp [htag_branches])
+              (by simpa using hlen)
           rw [hval_eq]
           iapply hmatch_entail
           isplitl [Hsl]
@@ -2200,10 +2209,10 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
           st₂.sl Θ ρ₁ ∗
-              (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B (Γ.extendBinder binder ty_i) γ ∗
-                (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-            wp (reg.wpCtx) (body.runtime.subst γ) Φ :=
-        ihBody Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Δ_spec ρ_spec Ψ Φ
+              (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B (Γ.extendBinder binder ty_i) γ ∗
+                (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+            wp reg.primCtx (body.runtime.subst γ) Φ :=
+        ihBody Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Δ_spec ρ_spec Ψ Φ
           heval_body'' hagree₁ hbwf₁ hSwf hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
           hΔreg hρreg
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
@@ -2262,11 +2271,11 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
           st₂.sl Θ ρ₁ ∗
-              (SpecMap.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
+              (SpecMap.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
                 Bindings.typedSubst Θ ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) ∗
-                (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-            wp (reg.wpCtx) (body.runtime.subst (Runtime.Subst.update γ x payload)) Φ :=
-        ihBody Θ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
+                (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
+            wp reg.primCtx (body.runtime.subst (Runtime.Subst.update γ x payload)) Φ :=
+        ihBody Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
           (Runtime.Subst.update γ x payload) Δ_spec ρ_spec Ψ Φ heval_body'' hagree₁ hbwf₂ (SpecMap.wfIn_erase hSwf)
           hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
           hΔreg hρreg
@@ -2331,7 +2340,7 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
   simp only [List.map, wps_cons]
   have heval_rest : (compileExprs reg Θ Δ_spec S B Γ rest).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine BIBase.Entails.trans ?_ <|
-    ihRest Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihRest Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   · iintro ⟨Hsl, #HS, #HT, HR⟩
     isplitl [Hsl]
@@ -2353,7 +2362,7 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
   have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind _ _ _ _ hΨ_vs
   have hspecInv_vs := specInvariants_mono hΔspec hρspec hdecls_vs hagreeOn_vs
   refine BIBase.Entails.trans ?_ <|
-    ihE Θ (TinyML.ValsHaveTypes Θ vs (rest.map Expr.ty) ∗ (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ R))
+    ihE Θ (TinyML.ValsHaveTypes Θ vs (rest.map Expr.ty) ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
     S B Γ st_vs ρ_vs γ Δ_spec ρ_spec _ _
     (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hSwf hΔwf hΔvars hspecInv_vs.1 hspecInv_vs.2 hΔreg hρreg ?_
   · iintro ⟨Hsl, Hvs, #HS, #HT, #HSpare, HR⟩

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -14,6 +14,8 @@ import Mathlib.Data.Finmap
 import Mica.Verifier.Intrinsic
 
 open Iris Iris.BI
+
+variable [MicaGS HasLC.hasLC Sig]
 open Typed
 
 
@@ -72,8 +74,8 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
           st''.sl Θ ρ'' ∗ Q ∗
             ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
     st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗ Q ⊢
-      (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval) -∗
-        wp (reg.wpCtx) (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
+      (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval) -∗
+        wp reg.primCtx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
   simp only [checkBody] at hbody_eval
   obtain ⟨hargNames_len, _, hbs_eq⟩ := extractArgNames_spec hext
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_def ▸ hbs_eq
@@ -132,20 +134,20 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     rw [hsnd]
     iassumption
   have hS'_sat :
-      S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ⊢
-        S'.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ_body := by
+      S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ⊢
+        S'.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ_body := by
     have hinsert :
-        S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval ⊢
-          (S.insertBinder fb s).satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) :=
+        S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ⊢
+          (S.insertBinder fb s).satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) :=
       SpecMap.satisfiedBy_insertBinder_updateBinder
     have herase :
-        (S.insertBinder fb s).satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) ⊢
-          S'.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
+        (S.insertBinder fb s).satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) ⊢
+          S'.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
       SpecMap.satisfiedBy_eraseAll_updateAllBinder hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
-      st'.sl Θ ρ' ∗ (S'.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
-        wp (reg.wpCtx) (body.runtime.subst γ_body) P := by
+      st'.sl Θ ρ' ∗ (S'.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
+        wp reg.primCtx (body.runtime.subst γ_body) P := by
     refine compile_correct reg hSound body Θ Q S' B Γ st' ρ' γ_body Δ_spec ρ_spec _ _
       (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hS'wf hΔwf hΔvars
       hΔspec hρspec hΔreg hρreg ?_
@@ -196,7 +198,7 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg ρ_spec.env) :
     VerifM.eval (checkSpec reg Θ Δ_spec S e s) st ρ (fun _ _ _ => True) →
-    st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ wp (reg.wpCtx) (e.runtime.subst γ) (fun v => s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec v) := by
+    st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ wp reg.primCtx (e.runtime.subst γ) (fun v => s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec v) := by
   intro heval
   -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
   have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
@@ -227,10 +229,10 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       rw [hgoal]
       set fval := Runtime.Val.fix fb.runtime (argBinders.map (·.runtime))
         (body.runtime.subst γ') with hfval_def
-      obtain ⟨_, _, hbs_eq⟩ := extractArgNames_spec hext
+      obtain ⟨_, hargs_len, hbs_eq⟩ := extractArgNames_spec hext
       have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_eq
       apply SpatialContext.wp_func
-      apply Spec.isPrecondFor_fix
+      apply Spec.isPrecondFor_fix (by simpa using hargs_len)
       istart
       iintro H
       icases H with ⟨Hsl, #Hspec⟩
@@ -247,8 +249,8 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       have hbody' : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
           PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
           (Spec.argsEnv ρ_call s.args vs) ⊢
-          SpecMap.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec S γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval -∗
-            wp (reg.wpCtx) (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
+          SpecMap.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec S γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval -∗
+            wp reg.primCtx (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
         iintro H
         icases H with ⟨Htyped', Hpred'⟩
         iintuitionistic Htyped'
@@ -256,8 +258,8 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
           simpa using hΔspec
         ihave Hwand := Spec.implement_correct Θ s _ Δ_spec ρ_spec (TransState.persist st) ρ vs P
           (TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
-            (S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec fval) -∗
-              wp (reg.wpCtx) (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval) -∗
+              wp reg.primCtx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
           hswf hΔspec_persist hρspec hΔwf hΔvars himpl
           (fun argVars st' ρ' Q hst_sub hρ_agree hargVars_mem hargVars_sort hargVars_lookup hbody_eval => by
             have hΔspec' : Δ_spec.Subset st'.decls := hΔspec_persist.trans hst_sub

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -386,7 +386,7 @@ def sigOf (fragment : List Intrinsic) : Signature :=
 
 `compile` routes a `.prim n args` call through `Spec.call` against the
 intrinsic's spec. The resulting `PredTrans.apply` obligation must be bridged
-to the `i.toWp` iProp consumed by the registry-derived `wp.prim` axiom. The
+to the `i.toWp` iProp consumed by the registry-derived `Registry.wp_prim`. The
 bridge is one of the per-intrinsic obligations captured by `IntrinsicSound`
 below. The aggregate over the registry is the def `Registry.Sound`. -/
 
@@ -399,13 +399,13 @@ end Intrinsic
 
 /-- Per-intrinsic soundness obligation, discharged together for each intrinsic
     and aggregated over a registry by `Registry.Sound`. It bundles the two
-    spec→wp bridge facts (`specWf`, `bridge`) with the two axiom facts
-    (`axiomWf`, `proof`).
+    spec→wp bridge facts (`specWf`, `bridge`), the opsem↔wp fact (`wp_sound`),
+    and the two axiom facts (`axiomWf`, `proof`).
 
     `specWf`/`bridge` are independent of `fragment`: from a `PredTrans.apply`
     obligation against `i.spec` (the shape produced by `Spec.call_correct`) and
-    the typing of the arguments, `bridge` derives `i.toWp` — the iProp the
-    `wp.prim` axiom demands of the registry-derived context. Both take the
+    the typing of the arguments, `bridge` derives `i.toWp` — the iProp
+    `Registry.wp_prim` demands of the registry-derived context. Both take the
     symbol's declaration / interpretation as an explicit side condition: `i.spec`
     may mention `i.folSym`, so it is only well-formed in a signature declaring
     that symbol, and the bridge only holds when the environment interprets the
@@ -420,12 +420,17 @@ class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Pr
     ∀ (Δ : Signature), (Signature.empty.extendWithSym i.folSym).Subset Δ → Δ.wf →
       PredTrans.wfIn (Δ.declVars (Spec.argVars i.specArgs)) i.spec.pred
   bridge :
-    ∀ (Θ : TinyML.TypeEnv) (vs : List Runtime.Val) (ρ : VerifM.Env)
+    ∀ [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (vs : List Runtime.Val) (ρ : VerifM.Env)
       (Φ : Runtime.Val → iProp),
     ρ.env.respects i.folSym →
     TinyML.ValsHaveTypes Θ vs i.argTysList ∗
       PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r i.resultTy -∗ Φ r) i.spec.pred
         (Spec.argsEnv ρ i.specArgs vs) ⊢ i.toWp vs Φ
+  wp_sound :
+    ∀ [MicaGS HasLC.hasLC Sig] (ctx : TinyML.PrimCtx),
+      (∀ vs μ v μ', ctx i.name vs μ v μ' ↔ i.toReduce vs μ v μ') →
+      ∀ (vs : List Runtime.Val) (Φ : Runtime.Val → iProp),
+        i.toWp vs Φ ⊢ wp ctx (.app (.val (.prim i.name)) (vs.map Runtime.Expr.val)) Φ
   axiomWf : ∀ {Δ : Signature}, (Intrinsic.sigOf fragment).Subset Δ → Δ.wf →
             ∀ φ ∈ i.axioms, Formula.wfIn φ Δ
   proof : ∀ ρ : Env,
@@ -571,6 +576,23 @@ theorem SoundIn.get {R todo : Registry} (h : SoundIn R todo) :
 theorem Sound.get {R : Registry} (h : Sound R) {i : Intrinsic} (hi : i ∈ R) :
     IntrinsicSound R i := SoundIn.get h i hi
 
+/-- The wp rule for primitive calls: a sound registry's spec context (`wpCtx`)
+    entails the weakest precondition at its operational context (`primCtx`).
+    Dispatches the per-intrinsic `IntrinsicSound.wp_sound` obligation at the
+    looked-up entry; `primCtx` agrees with that entry's `toReduce` at its name
+    by construction. -/
+theorem wp_prim [MicaGS HasLC.hasLC Sig] (R : Registry) (hSound : R.Sound) {n : String}
+    {vs : List Runtime.Val} {Q : Runtime.Val → iProp} :
+    R.wpCtx n vs Q ⊢ wp R.primCtx (.app (.val (.prim n)) (vs.map Runtime.Expr.val)) Q := by
+  unfold wpCtx
+  cases h : R.lookup? n with
+  | none =>
+    exact false_elim
+  | some i =>
+    obtain rfl := lookup?_name h
+    refine (hSound.get (mem_of_lookup? h)).wp_sound R.primCtx (fun vs μ v μ' => ?_) vs Q
+    simp [primCtx, h]
+
 theorem stdEnv_eq_foldEnv (R : Registry) : stdEnv R = foldEnv Env.empty R := rfl
 
 /-- Folding a well-formed registry into an environment preserves agreement
@@ -660,6 +682,7 @@ theorem IntrinsicSound.mono {deps deps' : Registry} {i : Intrinsic}
     IntrinsicSound deps' i where
   specWf := h.specWf
   bridge := h.bridge
+  wp_sound := h.wp_sound
   axiomWf := by
     intro Δ hsig hwf φ hφ
     exact h.axiomWf ((Registry.sigOf_subset_of_subset hsub).trans hsig) hwf φ hφ

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -12,6 +12,7 @@ import Mathlib.Data.Finmap
 
 open Iris Iris.BI
 
+variable [MicaGS HasLC.hasLC Sig]
 
 /-!
 # Predicate Transformers
@@ -43,6 +44,7 @@ def PredTrans.checkWf (Δ : Signature) (pt : PredTrans) : Except String Unit :=
     (fun post Δ' => Assertion.checkWf (fun _ _ => .ok ()) (Δ'.declVar ⟨post.1, .value⟩) post.2)
     Δ pt
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
     (h : pt.checkWf Δ = .ok ()) : pt.wfIn Δ :=
   Assertion.checkWf_ok
@@ -53,7 +55,7 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-noncomputable def PredTrans.apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
+def PredTrans.apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
   Assertion.pre Θ (fun post ρ' =>
     BIBase.forall fun v : Runtime.Val =>
       Assertion.post Θ (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
@@ -89,6 +91,7 @@ def PredTrans.implement (σ : FiniteSubst) (pt : PredTrans) (body : VerifM (Term
 -- Properties
 -- ---------------------------------------------------------------------------
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
     (h : pt.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : pt.wfIn Δ' := by
   unfold PredTrans.wfIn at h ⊢
@@ -311,7 +314,7 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
         { st₂ with
           decls := st₂.decls.addConst resVar
           asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st₂.asserts }
-      have hpre := @Assertion.prove_correct Unit Θ postBody Δ_base σ₂ (fun _ _ => True)
+      have hpre := @Assertion.prove_correct _ Unit Θ postBody Δ_base σ₂ (fun _ _ => True)
         st₃
         (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
         _ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) (Φ (result.eval ρ₂.env) -∗ S)

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -12,6 +12,8 @@ import Mica.Engine.Driver
 import Mica.Verifier.Intrinsic
 
 open Iris Iris.BI
+
+variable [MicaGS HasLC.hasLC Sig]
 open Typed
 open Verifier.RelationalEncoding (FunCtx)
 
@@ -150,6 +152,7 @@ def assemble (prog : Typed.Program (Spec.Body Typed.Expr)) : VerifM RelationSpec
   let Δ ← VerifM.ctx (fun st => (st.decls, st.owns))
   assembleFrom { RelationSpec.empty with delta := Δ } prog
 
+omit [MicaGS HasLC.hasLC Sig] in
 private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr)) :
     ∀ (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
       {Q : RelationSpec → TransState → VerifM.Env → Prop},
@@ -339,6 +342,7 @@ private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr
           VerifM.Env.agreeOn_trans hag_old (VerifM.Env.agreeOn_mono hsub_old hagRel),
           hresD, hQ⟩
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem assemble_correct (typed : Typed.Program (Spec.Body Typed.Expr))
     {st : TransState} {ρ : VerifM.Env}
     {Q : RelationSpec → TransState → VerifM.Env → Prop}
@@ -436,6 +440,7 @@ def Program.verify (reg : Verifier.Registry) (prog : Untyped.Program (Spec.Body 
 
 /-! ## Correctness -/
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem Program.prepare_correct (prog : Untyped.Program (Spec.Body Untyped.Expr))
     (st : TransState) (ρ : VerifM.Env)
     {Q : (TinyML.TypeEnv × Typed.Program (Spec.Body Typed.Expr)) → TransState → VerifM.Env → Prop}
@@ -462,8 +467,8 @@ theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.R
     (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
     {Q : Unit → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (ValDecl.checkExpr reg Θ Δ_spec S d) st ρ Q) :
-    (□ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ Φ) →
-    □ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ wp (reg.wpCtx) (d.body.runtime.subst γ) (fun _ => Φ) := by
+    (□ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ Φ) →
+    □ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ wp reg.primCtx (d.body.runtime.subst γ) (fun _ => Φ) := by
   intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
@@ -513,7 +518,7 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
     {Q : Spec → TransState → VerifM.Env → Prop}
     (heval : VerifM.eval (ValDecl.check reg Θ Δ_spec Γfn S d) st ρ Q) :
     ∃ spec, spec.wfIn Δ_spec ∧
-            (□ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ wp (reg.wpCtx) (d.body.runtime.subst γ) (fun v => spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec v)) ∧
+            (□ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ wp reg.primCtx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec v)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.declMeta.spec with
@@ -569,22 +574,27 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
     (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg ρ_spec.env) :
     VerifM.eval (Program.check reg Θ Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
-    □ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ ⊢ pwp (reg.wpCtx) ((Typed.Program.runtime prog).subst γ) := by
+    □ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ pwp reg.primCtx ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ st ρ with
   | nil =>
     intro _
-    simp only [Typed.Program.runtime, List.map_nil, Runtime.Program.subst, pwp]
+    simp only [Typed.Program.runtime, List.map_nil, Runtime.Program.subst]
+    refine BIBase.Entails.trans ?_ pwp_nil
     istart
     iintro _
     iempintro
   | cons d ds ih =>
     intro heval
-    have hpwp_unfold : pwp (reg.wpCtx) ((Typed.Program.runtime (d :: ds)).subst γ) ⊣⊢
-        wp (reg.wpCtx) (d.body.runtime.subst γ) (fun v =>
-          pwp (reg.wpCtx) ((Typed.Program.runtime ds).subst (Runtime.Subst.updateBinder d.name.runtime v γ))) := by
-      simp [Typed.Program.runtime, Typed.ValDecl.runtime,
-        Runtime.Program.subst, Runtime.Decl.subst, Runtime.Program.subst_remove_update]
-    refine BIBase.Entails.trans ?_ hpwp_unfold.2
+    have hpwp_unfold :
+        wp reg.primCtx (d.body.runtime.subst γ) (fun v =>
+          pwp reg.primCtx ((Typed.Program.runtime ds).subst (Runtime.Subst.updateBinder d.name.runtime v γ)))
+        ⊢ pwp reg.primCtx ((Typed.Program.runtime (d :: ds)).subst γ) := by
+      simp only [Typed.Program.runtime, Typed.ValDecl.runtime,
+        Runtime.Program.subst, Runtime.Decl.subst, List.map_cons]
+      refine BIBase.Entails.trans (wp.mono fun v => ?_) pwp_cons
+      rw [Runtime.Program.subst_remove_update]
+      exact .rfl
+    refine BIBase.Entails.trans ?_ hpwp_unfold
     simp only [Program.check] at heval
     cases hname : d.name.name with
     | none =>
@@ -678,8 +688,8 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         rw [hupd v]
         have hih := ih (S.insert n spec) (γ.update n v)
           (SpecMap.wfIn_insert hSwf hswf) st ρ hΔspec hρspec hcont'
-        have hstep : (□ st.sl Θ ρ ∗ S.satisfiedBy (reg.wpCtx) Θ Δ_spec ρ_spec γ) ∗ spec.isPrecondFor (reg.wpCtx) Θ Δ_spec ρ_spec v ⊢
-            pwp (reg.wpCtx) ((Typed.Program.runtime ds).subst (γ.update n v)) := by
+        have hstep : (□ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ) ∗ spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec v ⊢
+            pwp reg.primCtx ((Typed.Program.runtime ds).subst (γ.update n v)) := by
           refine BIBase.Entails.trans ?_ hih
           istart
           iintro ⟨Hctx, Hpre⟩
@@ -695,7 +705,7 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
 
 theorem Program.verify_correct (reg : Verifier.Registry)
     (hSound : Verifier.Registry.Sound reg) (p : Untyped.Program (Spec.Body Untyped.Expr)) :
-  Smt.Strategy.checks (Program.verify reg p) (⊢ pwp (reg.wpCtx) (Untyped.Program.runtime p)) := by
+  Smt.Strategy.checks (Program.verify reg p) (⊢ pwp reg.primCtx (Untyped.Program.runtime p)) := by
   simp only [Smt.Strategy.checks, Program.verify, VerifM.strategy]
   intro st' heval
   have h1 := ScopedM.strategy_eval_initial_implies_ScopedM_eval heval
@@ -756,7 +766,7 @@ theorem Program.verify_correct (reg : Verifier.Registry)
                        hcheck_eval
     rw [Runtime.Program.subst_id] at hcorrect
     have hctx0 : (⊢ □ stRel.sl Θ ρRel ∗
-        SpecMap.satisfiedBy (reg.wpCtx) Θ stRel.decls ρRel (∅ : SpecMap) Runtime.Subst.id) := by
+        SpecMap.satisfiedBy reg.primCtx Θ stRel.decls ρRel (∅ : SpecMap) Runtime.Subst.id) := by
       istart
       isplitl []
       · simp [TransState.sl, howns]

--- a/Mica/Verifier/SpecMaps.lean
+++ b/Mica/Verifier/SpecMaps.lean
@@ -11,29 +11,31 @@ import Mathlib.Data.Finmap
 
 open Iris Iris.BI
 
+variable [MicaGS HasLC.hasLC Sig]
+
 -- ---------------------------------------------------------------------------
 -- SpecMap
 -- ---------------------------------------------------------------------------
 
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
-noncomputable def SpecMap.satisfiedBy (wctx : WpCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+def SpecMap.satisfiedBy (pctx : TinyML.PrimCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (γ : Runtime.Subst) : iProp :=
   iprop(□ (∀ x s, ⌜S.lookup x = some s⌝ -∗
-    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor wctx Θ Δ_spec ρ_spec f))
+    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor pctx Θ Δ_spec ρ_spec f))
 
-instance : Iris.BI.Persistent (SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec S γ) := by
+instance : Iris.BI.Persistent (SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec S γ) := by
   unfold SpecMap.satisfiedBy; infer_instance
 
 theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp)
     (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (S : SpecMap) (γ : Runtime.Subst) :
-  (P ⊢ S.satisfiedBy wctx Θ Δ_spec ρ_spec γ) →
+  (P ⊢ S.satisfiedBy pctx Θ Δ_spec ρ_spec γ) →
   S.lookup x = some s →
-  (∀ fval, γ x = some fval → s.isPrecondFor wctx Θ Δ_spec ρ_spec fval ∗ P ⊢ Q) →
+  (∀ fval, γ x = some fval → s.isPrecondFor pctx Θ Δ_spec ρ_spec fval ∗ P ⊢ Q) →
   (P ⊢ Q) := by
   intro hsat hlook hcont
   simp only [SpecMap.satisfiedBy] at hsat
-  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor wctx Θ Δ_spec ρ_spec fval) ∗ P := by
+  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor pctx Θ Δ_spec ρ_spec fval) ∗ P := by
     refine (persistent_entails_right hsat).trans ?_
     istart
     iintro ⟨#Hall, HP⟩
@@ -57,11 +59,13 @@ theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp)
 def SpecMap.wfIn (S : SpecMap) (Δ : Signature) : Prop :=
   ∀ f spec, S.lookup f = some spec → spec.wfIn Δ
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.wfIn_mono {S : SpecMap} {Δ Δ' : Signature}
     (h : S.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) :
     S.wfIn Δ' :=
   fun f spec hlookup => Spec.wfIn_mono (h f spec hlookup) hsub hwf
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.wfIn_erase {S : SpecMap} {x : TinyML.Var} {Δ : Signature}
     (h : S.wfIn Δ) : SpecMap.wfIn (Finmap.erase x S) Δ := by
   intro f spec hlookup
@@ -74,12 +78,15 @@ theorem SpecMap.wfIn_erase {S : SpecMap} {x : TinyML.Var} {Δ : Signature}
 def SpecMap.eraseAll (keys : List String) (S : SpecMap) : SpecMap :=
   keys.foldl (fun acc k => Finmap.erase k acc) S
 
+omit [MicaGS HasLC.hasLC Sig] in
 @[simp] theorem SpecMap.eraseAll_nil (S : SpecMap) : SpecMap.eraseAll [] S = S := rfl
 
+omit [MicaGS HasLC.hasLC Sig] in
 @[simp] theorem SpecMap.eraseAll_cons (k : String) (ks : List String) (S : SpecMap) :
     SpecMap.eraseAll (k :: ks) S = SpecMap.eraseAll ks (Finmap.erase k S) := by
   simp [SpecMap.eraseAll, List.foldl_cons]
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.lookup_eraseAll {keys : List String} {S : SpecMap} {y : String} :
     (SpecMap.eraseAll keys S).lookup y = if y ∈ keys then none else S.lookup y := by
   induction keys generalizing S with
@@ -91,6 +98,7 @@ theorem SpecMap.lookup_eraseAll {keys : List String} {S : SpecMap} {y : String} 
     · rw [Finmap.lookup_erase_ne (Ne.symm hky)]
       by_cases hmem : y ∈ ks <;> simp [hmem, Ne.symm hky]
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.wfIn_eraseAll {keys : List String} {S : SpecMap} {Δ : Signature}
     (h : S.wfIn Δ) : (SpecMap.eraseAll keys S).wfIn Δ := by
   induction keys generalizing S with
@@ -102,10 +110,12 @@ def SpecMap.insertBinder (S : SpecMap) (b : Typed.Binder) (spec : Spec) : SpecMa
   | some x => S.insert x spec
   | none => S
 
+omit [MicaGS HasLC.hasLC Sig] in
 @[simp] theorem SpecMap.insertBinder_none {S : SpecMap} {b : Typed.Binder} {spec : Spec}
     (h : b.name = none) : S.insertBinder b spec = S := by
   simp [SpecMap.insertBinder, h]
 
+omit [MicaGS HasLC.hasLC Sig] in
 @[simp] theorem SpecMap.insertBinder_some {S : SpecMap} {b : Typed.Binder} {spec : Spec}
     {x : TinyML.Var} (h : b.name = some x) : S.insertBinder b spec = S.insert x spec := by
   simp [SpecMap.insertBinder, h]
@@ -115,10 +125,12 @@ def SpecMap.eraseBinder (S : SpecMap) (b : Typed.Binder) : SpecMap :=
   | some x => S.erase x
   | none => S
 
+omit [MicaGS HasLC.hasLC Sig] in
 @[simp] theorem SpecMap.eraseBinder_none {S : SpecMap} {b : Typed.Binder}
     (h : b.name = none) : S.eraseBinder b = S := by
   simp [SpecMap.eraseBinder, h]
 
+omit [MicaGS HasLC.hasLC Sig] in
 @[simp] theorem SpecMap.eraseBinder_some {S : SpecMap} {b : Typed.Binder} {x : TinyML.Var}
     (h : b.name = some x) : S.eraseBinder b = S.erase x := by
   simp [SpecMap.eraseBinder, h]
@@ -129,7 +141,7 @@ theorem SpecMap.satisfiedBy_preserved {Θ : TinyML.TypeEnv} {Δ_spec : Signature
     {S S' : SpecMap} {γ γ' : Runtime.Subst}
     (h : ∀ y s, S'.lookup y = some s →
       S.lookup y = some s ∧ (∀ f, γ y = some f → γ' y = some f)) :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢ S'.satisfiedBy wctx Θ Δ_spec ρ_spec γ' := by
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢ S'.satisfiedBy pctx Θ Δ_spec ρ_spec γ' := by
   simp only [SpecMap.satisfiedBy]
   iintro #HS
   imodintro
@@ -147,8 +159,8 @@ theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {Δ_spec :
     {γ γ' : Runtime.Subst} {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
     (hγ' : γ' x = some fval)
     (hγ : ∀ y f, y ≠ x → γ y = some f → γ' y = some f) :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ' := by
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ' := by
   simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
   iintro ⟨#HS, #Hf⟩
   imodintro
@@ -171,18 +183,19 @@ theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {Δ_spec :
 
 theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ :=
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ :=
   SpecMap.satisfiedBy_insert_of_preserved hγ (fun _ _ _ hf => hf)
 
 theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec v ⊢
-      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) (γ.update x v) :=
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec v ⊢
+      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) (γ.update x v) :=
   SpecMap.satisfiedBy_insert_of_preserved
     (by simp [Runtime.Subst.update])
     (fun y f hyx hf => by simp [Runtime.Subst.update, beq_false_of_ne hyx, hf])
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : Signature}
     (hS : S.wfIn Δ) (hs : spec.wfIn Δ) : SpecMap.wfIn (Finmap.insert x spec S) Δ := by
   intro y s' hlookup
@@ -193,8 +206,8 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
 theorem SpecMap.satisfiedBy_insertBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
     (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval) :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (S.insertBinder b spec) γ := by
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (S.insertBinder b spec) γ := by
   rcases hb : b.name with _ | x
   · rw [SpecMap.insertBinder_none hb]; iintro ⟨HS, _⟩; iexact HS
   · obtain ⟨_, ty⟩ := b; cases hb
@@ -202,20 +215,22 @@ theorem SpecMap.satisfiedBy_insertBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signat
 
 theorem SpecMap.satisfiedBy_insertBinder_updateBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor wctx Θ Δ_spec ρ_spec v ⊢
-      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec v ⊢
+      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.insertBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]; iintro ⟨HS, _⟩; iexact HS
   · rw [SpecMap.insertBinder_some hb, Typed.Binder.runtime_of_name_some hb]
     exact SpecMap.satisfiedBy_insert_update
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.wfIn_insertBinder {S : SpecMap} {b : Typed.Binder} {spec : Spec} {Δ : Signature}
     (hS : S.wfIn Δ) (hs : spec.wfIn Δ) : SpecMap.wfIn (S.insertBinder b spec) Δ := by
   rcases hb : b.name with _ | _
   · rwa [SpecMap.insertBinder_none hb]
   · rw [SpecMap.insertBinder_some hb]; exact SpecMap.wfIn_insert hS hs
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.wfIn_eraseBinder {S : SpecMap} {b : Typed.Binder} {Δ : Signature}
     (hS : S.wfIn Δ) : SpecMap.wfIn (S.eraseBinder b) Δ := by
   rcases hb : b.name with _ | _
@@ -225,8 +240,8 @@ theorem SpecMap.wfIn_eraseBinder {S : SpecMap} {b : Typed.Binder} {Δ : Signatur
 theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
     {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
     {vs : List Runtime.Val} (hlen : keys.length = vs.length) :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢
-      (SpecMap.eraseAll keys S).satisfiedBy wctx Θ Δ_spec ρ_spec (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢
+      (SpecMap.eraseAll keys S).satisfiedBy pctx Θ Δ_spec ρ_spec (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hy_notin : y ∉ keys := by
@@ -241,20 +256,21 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {Δ_s
   exact hf
 
 theorem SpecMap.empty_satisfiedBy (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (γ : Runtime.Subst) :
-    ⊢ SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (∅ : SpecMap) γ := by
+    ⊢ SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (∅ : SpecMap) γ := by
   simp only [SpecMap.satisfiedBy]
   imodintro
   iintro %x %s %h
   simp [Finmap.lookup_empty] at h
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.empty_wfIn (Δ : Signature) :
     SpecMap.wfIn (∅ : SpecMap) Δ := by
   intro f spec h; simp [Finmap.lookup_empty] at h
 
 theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
     {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢
-      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢
+      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by
@@ -264,8 +280,8 @@ theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {�
 
 theorem SpecMap.satisfiedBy_eraseBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢
-      SpecMap.satisfiedBy wctx Θ Δ_spec ρ_spec (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢
+      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.eraseBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]
@@ -274,7 +290,7 @@ theorem SpecMap.satisfiedBy_eraseBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signatu
 
 theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} (hx : S.lookup x = none) :
-    S.satisfiedBy wctx Θ Δ_spec ρ_spec γ ⊢ S.satisfiedBy wctx Θ Δ_spec ρ_spec (γ.update x v) := by
+    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢ S.satisfiedBy pctx Θ Δ_spec ρ_spec (γ.update x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -11,6 +11,8 @@ import Mathlib.Data.Finmap
 
 open Iris Iris.BI
 
+variable [MicaGS HasLC.hasLC Sig]
+
 /-!
 # Specifications
 
@@ -43,14 +45,14 @@ def argsEnv (ρ : VerifM.Env) : List (String × TinyML.Typ) → List Runtime.Val
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
 
-noncomputable def isPrecondFor (wctx : WpCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+def isPrecondFor (pctx : TinyML.PrimCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (f : Runtime.Val) (s : Spec) : iProp :=
   iprop(□ ∀ (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
       TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
         PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
           (argsEnv ρ s.args vs) -∗
-        wp wctx (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
+        wp pctx (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
     context extended with all argument variables. -/
@@ -105,20 +107,20 @@ def implement (Δ_base : Signature) (s : Spec) (body : List FOL.Const → VerifM
 /-! ## Precondition Proofs -/
 section Precondition
 
-instance : Iris.BI.Persistent (isPrecondFor wctx Θ Δ_spec ρ_spec f s) := by
+instance : Iris.BI.Persistent (isPrecondFor pctx Θ Δ_spec ρ_spec f s) := by
   unfold isPrecondFor
   infer_instance
 
 /-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
-theorem isPrecondFor_intro (wctx : WpCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (s : Spec)
+theorem isPrecondFor_intro (pctx : TinyML.PrimCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (s : Spec)
     (f : Runtime.Val) :
     iprop(□ ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
       (⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
         TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
         PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
           (argsEnv ρ s.args vs)) -∗
-        wp wctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor wctx Θ Δ_spec ρ_spec f := by
+        wp pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor pctx Θ Δ_spec ρ_spec f := by
   unfold isPrecondFor
   iintro #H
   imodintro
@@ -134,23 +136,31 @@ theorem isPrecondFor_intro (wctx : WpCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signa
 /-- Löb-style rule for spec preconditions on `fix`: to prove
     `s.isPrecondFor Θ (.fix f args e)`, assume it as the recursive hypothesis and
     prove the `wp` of the body (after the usual fix-substitution). -/
-theorem isPrecondFor_fix {wctx : WpCtx} {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {s : Spec}
+theorem isPrecondFor_fix {pctx : TinyML.PrimCtx} {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {s : Spec}
     {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {R : iProp}
-    (h : R ⊢ □ (s.isPrecondFor wctx Θ Δ_spec ρ_spec (.fix f args e) -∗
+    (hargs : args.length = s.args.length)
+    (h : R ⊢ □ (s.isPrecondFor pctx Θ Δ_spec ρ_spec (.fix f args e) -∗
         ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
           TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
           PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
               (argsEnv ρ s.args vs) -∗
-          wp wctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
-    R ⊢ s.isPrecondFor wctx Θ Δ_spec ρ_spec (.fix f args e) := by
-  refine (SpatialContext.wp_fix' (wctx := wctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
+          wp pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
+    R ⊢ s.isPrecondFor pctx Θ Δ_spec ρ_spec (.fix f args e) := by
+  refine (SpatialContext.wp_fix' (pctx := pctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
       iprop(∃ ρ : VerifM.Env,
         ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
           TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
           PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
-            (argsEnv ρ s.args vs))) (h.trans ?_)).trans ?_
+            (argsEnv ρ s.args vs))) ?_ (h.trans ?_)).trans ?_
+  · intro vs P
+    istart
+    iintro ⟨%ρ, %hagr, Htyped, -⟩
+    ihave %Hlen := TinyML.ValsHaveTypes.length_eq $$ Htyped
+    ipureintro
+    simp at Hlen
+    omega
   · istart
     iintro #HR
     imodintro
@@ -191,10 +201,12 @@ end Precondition
 /-! ## Well-Formedness Proofs -/
 section WellFormedness
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem checkWf_ok {spec : Spec} {Δ : Signature}
     (h : spec.checkWf Δ = .ok ()) : spec.wfIn Δ :=
   PredTrans.checkWf_ok h
 
+omit [MicaGS HasLC.hasLC Sig] in
 theorem wfIn_mono {spec : Spec} {Δ Δ' : Signature}
     (h : spec.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) :
     spec.wfIn Δ' :=
@@ -206,6 +218,7 @@ end WellFormedness
 /-! ## Environment Agreement -/
 section EnvironmentAgreement
 
+omit [MicaGS HasLC.hasLC Sig] in
 /-- `argsEnv` preserves `agreeOn`: if two envs agree on `Δ`,
     then after applying the same updates, they agree on `argVars args ++ Δ`. -/
 theorem argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : VerifM.Env}
@@ -232,6 +245,7 @@ end EnvironmentAgreement
 /-! ## Call Protocol Correctness -/
 section CallCorrectness
 
+omit [MicaGS HasLC.hasLC Sig] in
 /-- Correctness of `declareArgs`: after processing all arguments, the resulting
     substitution is well-formed, types match, and the env agrees with `argsEnv`. -/
 theorem declareArgs_correct (Θ : TinyML.TypeEnv) :

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -136,7 +136,8 @@ theorem Env.agreeOn_update_fresh_binaryRel {ρ : Env} {b : FOL.BinaryRel}
 end VerifM
 
 /-- Semantic interpretation of a verifier context item. -/
-noncomputable def CtxItem.interp (Θ : TinyML.TypeEnv) (ρ : VerifM.Env) : CtxItem → iProp
+def CtxItem.interp [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+    (ρ : VerifM.Env) : CtxItem → iProp
   | .pure φ => ⌜φ.eval ρ.env⌝
   | .spatial a => a.interp Θ ρ.env
 
@@ -145,10 +146,12 @@ def CtxItem.purePart (i : CtxItem) (ρ : VerifM.Env) : Prop :=
   | .pure φ => φ.eval ρ.env
   | .spatial _ => True
 
-noncomputable def TransState.sl (Θ : TinyML.TypeEnv) (st : TransState) (ρ : VerifM.Env) : iProp :=
+def TransState.sl [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+    (st : TransState) (ρ : VerifM.Env) : iProp :=
   SpatialContext.interp Θ ρ.env st.owns
 
-@[simp] theorem TransState.sl_eq (Θ : TinyML.TypeEnv) (st : TransState) (ρ : VerifM.Env) :
+@[simp] theorem TransState.sl_eq [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+    (st : TransState) (ρ : VerifM.Env) :
     st.sl Θ ρ = SpatialContext.interp Θ ρ.env st.owns := rfl
 
 /-- Drop the non-persistent spatial part of the verifier state. -/
@@ -161,7 +164,8 @@ def TransState.persist (st : TransState) : TransState :=
 @[simp] theorem TransState.persist_asserts (st : TransState) :
     st.persist.asserts = st.asserts := rfl
 
-theorem TransState.sl_entails_persist (Θ : TinyML.TypeEnv) (st : TransState) (ρ : VerifM.Env) :
+theorem TransState.sl_entails_persist [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+    (st : TransState) (ρ : VerifM.Env) :
     st.sl Θ ρ ⊢ □ st.persist.sl Θ ρ := by
   istart
   iintro _


### PR DESCRIPTION
This PR instantiates the weakest precondition with the new TinyML language instance. It uses the instantiated weakest precondition to implement the axioms (and hence remove the axiomatisation). 