### PR TITLE
Remove ad-hoc inj constructor

### DIFF
--- a/Mica/FOL/Formulas.lean
+++ b/Mica/FOL/Formulas.lean
@@ -8,7 +8,7 @@ inductive UnPred : Srt → Type where
   | isStr   : UnPred .value
   | isLoc   : UnPred .value
   | isTuple : UnPred .value
-  | isInj (tag : Nat) (arity : Nat) : UnPred .value
+  | isOfInj : UnPred .value
   | uninterpreted : String → (τ : Srt) → UnPred τ
   deriving DecidableEq, Repr
 
@@ -340,7 +340,7 @@ theorem Context.wfIn_mono (Γ : Context) (h : Γ.wfIn Δ) (hsub : Δ.Subset Δ')
   | _, .isStr,   v => match v with | .str _ => True | _ => False
   | _, .isLoc,   v => match v with | .loc _ => True | _ => False
   | _, .isTuple, v => match v with | .tuple _ => True | _ => False
-  | _, .isInj tag arity, v => match v with | .inj t a _ => t = tag ∧ a = arity | _ => False
+  | _, .isOfInj, v => match v with | .inj _ _ _ => True | _ => False
   | ρ, .uninterpreted name _, v => ρ.unaryRel τ name v
 
 @[simp] def BinPred.eval : Env → BinPred τ₁ τ₂ → τ₁.denote → τ₂.denote → Prop

--- a/Mica/FOL/Printing.lean
+++ b/Mica/FOL/Printing.lean
@@ -35,7 +35,7 @@ def UnOp.toSMTLIB : UnOp τ₁ τ₂ → String
   | .vhead   => "vhd"
   | .vtail   => "vtl"
   | .visnil  => "is-vnil"
-  | .mkInj tag arity => s!"of_inj {tag} {arity}"
+  | .ofInj tag arity => s!"of_inj {tag} {arity}"
   | .tagOf   => "tag_of"
   | .arityOf => "arity_of"
   | .payloadOf => "payload_of"
@@ -63,7 +63,7 @@ def UnPred.toSMTLIB : UnPred τ → String
   | .isStr   => "is-of_string"
   | .isLoc   => "is-of_loc"
   | .isTuple => "is-of_tuple"
-  | .isInj _ _ => ""  -- handled specially in Formula.toSMTLIB
+  | .isOfInj => "is-of_inj"
   | .uninterpreted name _ => name
 
 def BinPred.toSMTLIB : BinPred τ₁ τ₂ → String
@@ -114,18 +114,14 @@ def Term.toSMTLIB : Term τ → String
 
 def Pattern.toSMTLIB : Pattern → String
   | .term t => t.toSMTLIB
-  | .unpred p t => match p with
-    | .isInj tag arity => s!"(and (is-of_inj {t.toSMTLIB}) (= (tag_of {t.toSMTLIB}) {tag}) (= (arity_of {t.toSMTLIB}) {arity}))"
-    | _ => s!"({p.toSMTLIB} {t.toSMTLIB})"
+  | .unpred p t => s!"({p.toSMTLIB} {t.toSMTLIB})"
   | .binpred p t₁ t₂ => s!"({p.toSMTLIB} {t₁.toSMTLIB} {t₂.toSMTLIB})"
 
 def Formula.toSMTLIB : Formula → String
   | .true_          => "true"
   | .false_         => "false"
   | .eq _τ a b      => s!"(= {a.toSMTLIB} {b.toSMTLIB})"
-  | .unpred p v     => match p with
-    | .isInj tag arity => s!"(and (is-of_inj {v.toSMTLIB}) (= (tag_of {v.toSMTLIB}) {tag}) (= (arity_of {v.toSMTLIB}) {arity}))"
-    | _ => s!"({p.toSMTLIB} {v.toSMTLIB})"
+  | .unpred p v     => s!"({p.toSMTLIB} {v.toSMTLIB})"
   | .binpred p a b  => s!"({p.toSMTLIB} {a.toSMTLIB} {b.toSMTLIB})"
   | .not φ          => s!"(not {φ.toSMTLIB})"
   | .and φ ψ        => s!"(and {φ.toSMTLIB} {ψ.toSMTLIB})"
@@ -184,7 +180,7 @@ private def termStr (p : Prec) : {τ : Srt} → Term τ → String
     | .vhead   => s!"hd({termStr .bottom a})"
     | .vtail   => s!"tl({termStr .bottom a})"
     | .visnil  => s!"isnil({termStr .bottom a})"
-    | .mkInj tag arity => s!"inj({tag}/{arity}, {termStr .bottom a})"
+    | .ofInj tag arity => s!"ofInj({tag}/{arity}, {termStr .bottom a})"
     | .tagOf   => s!"tag({termStr .bottom a})"
     | .arityOf => s!"arity({termStr .bottom a})"
     | .payloadOf => s!"payload({termStr .bottom a})"
@@ -217,7 +213,7 @@ private def formulaStr (p : Prec) : Formula → String
     | .isStr   => s!"isStr({termStr .bottom v})"
     | .isLoc   => s!"isLoc({termStr .bottom v})"
     | .isTuple => s!"isTuple({termStr .bottom v})"
-    | .isInj tag arity => s!"isInj({tag}/{arity}, {termStr .bottom v})"
+    | .isOfInj => s!"isOfInj({termStr .bottom v})"
     | .uninterpreted name _ => s!"{name}({termStr .bottom v})"
   | .binpred pred a b => match pred with
     | .lt => parens (Prec.lt .cmp p) s!"{termStr .add a} < {termStr .add b}"

--- a/Mica/FOL/Terms.lean
+++ b/Mica/FOL/Terms.lean
@@ -18,7 +18,7 @@ inductive UnOp : Srt → Srt → Type where
   | vhead      : UnOp .vallist .value
   | vtail      : UnOp .vallist .vallist
   | visnil     : UnOp .vallist .bool
-  | mkInj (tag : Nat) (arity : Nat) : UnOp .value .value
+  | ofInj (tag : Nat) (arity : Nat) : UnOp .value .value
   | tagOf                           : UnOp .value .int
   | arityOf                         : UnOp .value .int
   | payloadOf                       : UnOp .value .value
@@ -345,7 +345,7 @@ theorem Term.wfIn_mono (t : Term τ) (h : t.wfIn Δ) (hsub : Δ.Subset Δ') (hwf
   | _, .vhead,   vs => vs.headD .unit
   | _, .vtail,   vs => vs.tail
   | _, .visnil,  vs => vs.isEmpty
-  | _, .mkInj tag arity, v => Runtime.Val.inj tag arity v
+  | _, .ofInj tag arity, v => Runtime.Val.inj tag arity v
   | _, .tagOf,   v => match v with | .inj tag _ _ => (tag : Int) | _ => 0
   | _, .arityOf, v => match v with | .inj _ arity _ => (arity : Int) | _ => 0
   | _, .payloadOf, v => match v with | .inj _ _ payload => payload | _ => Runtime.Val.unit

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -58,7 +58,7 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
   match a with
   | .isint v => .pure (.eq .value v (.unop .ofInt t))
   | .isbool v => .pure (.eq .value v (.unop .ofBool t))
-  | .isinj tag arity v => .pure (.eq .value v (.unop (.mkInj tag arity) t))
+  | .isinj tag arity v => .pure (.eq .value v (.unop (.ofInj tag arity) t))
   | .own l ty => .spatial (.pointsTo l t ty)
   | .rel name arg => .pure (.and (SpecFn.isDefined name arg) (.eq .value (SpecFn.call name arg) t))
 
@@ -90,7 +90,7 @@ def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
     | _ => none
   | .isinj tag arity v =>
     match φ with
-    | .eq .value v' (.unop (.mkInj tag' arity') t) =>
+    | .eq .value v' (.unop (.ofInj tag' arity') t) =>
       if v' = v ∧ tag = tag' ∧ arity = arity' then some t else none
     | _ => none
   | .own _ _ => none
@@ -331,7 +331,13 @@ theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Sign
 def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .isint  v => [(.unpred .isInt v, .unop .toInt v)]
   | .isbool v => [(.unpred .isBool v, .unop .toBool v)]
-  | .isinj tag arity v => [(.unpred (.isInj tag arity) v, .unop .payloadOf v)]
+  | .isinj tag arity v =>
+      [(.and
+          (.unpred .isOfInj v)
+          (.and
+            (.eq .int (.unop .tagOf v) (.const (.i tag)))
+            (.eq .int (.unop .arityOf v) (.const (.i arity)))),
+        .unop .payloadOf v)]
   | .own _ _ => []
   | .rel _ _ => []
 
@@ -352,10 +358,10 @@ theorem Atom.candidates_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {φ : Formul
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isinj tag arity v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
-    simp [Formula.eval, UnPred.eval] at h
+    simp [Formula.eval, UnPred.eval, Term.eval, UnOp.eval, Const.denote] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
     cases hv : v.eval ρ.env <;> simp_all
-    · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
+    exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | own l ty => simp [candidates] at hmem
   | rel name arg => simp [candidates] at hmem
 
@@ -374,7 +380,8 @@ theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Si
   | isinj tag arity v =>
     simp [candidates] at hmem
     obtain ⟨rfl, rfl⟩ := hmem
-    exact ⟨⟨trivial, h⟩, ⟨trivial, h⟩⟩
+    refine ⟨⟨⟨trivial, h⟩, ?_⟩, ⟨trivial, h⟩⟩
+    exact ⟨⟨⟨trivial, h⟩, trivial⟩, ⟨⟨trivial, h⟩, trivial⟩⟩
   | own l ty => simp [candidates] at hmem
   | rel name arg => simp [candidates] at hmem
 

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -199,7 +199,7 @@ mutual
         if tag ≥ arity then VerifM.fatal "inj tag out of range"
         else
           let s ← compile reg Θ Δ_spec S B Γ payload
-          pure (.unop (.mkInj tag arity) s)
+          pure (.unop (.ofInj tag arity) s)
     | .match_ scrut branches ty => do
         let sc ← compile reg Θ Δ_spec S B Γ scrut
         match scrut.ty with
@@ -261,14 +261,14 @@ mutual
         | _ => VerifM.fatal "store location is not a reference"
     | .app _ _ _ | .fix _ _ _ _ => VerifM.fatal "unsupported expression"
 
-  /-- Compile a single match branch: assume the scrutinee is `mkInj i n payload`, then compile the body. -/
+  /-- Compile a single match branch: assume the scrutinee is `ofInj i n payload`, then compile the body. -/
   def compileBranch (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
       (sc : Term .value) (n : Nat) (i : Nat) (ty_i : TinyML.Typ)
       : Binder × Expr → VerifM (Term .value)
     | (binder, body) => do
         VerifM.expectEq "match binder type annotation mismatch" binder.ty ty_i
         let xv ← VerifM.decl binder.name .value
-        VerifM.assume (.pure (.eq .value sc (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value)))))
+        VerifM.assume (.pure (.eq .value sc (.unop (.ofInj i n) (.const (.uninterpreted xv.name .value)))))
         VerifM.assumeAll (TinyML.typeConstraints ty_i (.const (.uninterpreted xv.name .value)))
         match binder.name with
         | some x =>
@@ -2165,13 +2165,13 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
         simpa [st₁] using
           (Term.const_wfIn_addConst_of_fresh (Δ := st.decls) (c := xv) hstwf hxv_fresh)
     have hformula_wf : (Formula.eq .value sc
-        (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value)))).wfIn st₁.decls := by
+        (.unop (.ofInj i n) (.const (.uninterpreted xv.name .value)))).wfIn st₁.decls := by
       refine ⟨Term.wfIn_mono sc hsc_wf (Signature.Subset.subset_addConst _ _)
         (Signature.wf_addConst hstwf hxv_fresh), trivial, hxv_wf⟩
     have hsc_eval_ρ₁ : sc.eval ρ₁.env = sc.eval ρ.env :=
       Term.eval_env_agree hsc_wf (Env.agreeOn_symm (Env.agreeOn_update_fresh_const hxv_fresh))
     have hformula_eval : Formula.eval ρ₁.env
-        (Formula.eq .value sc (.unop (.mkInj i n) (.const (.uninterpreted xv.name .value)))) := by
+        (Formula.eq .value sc (.unop (.ofInj i n) (.const (.uninterpreted xv.name .value)))) := by
       simp [Formula.eval, Term.eval, UnOp.eval]
       rw [hsc_eval_ρ₁, hsc_eval]
       simp [ρ₁, Env.updateConst]

--- a/Mica/Verifier/RelationalEncoding/Monad.lean
+++ b/Mica/Verifier/RelationalEncoding/Monad.lean
@@ -173,7 +173,7 @@ def encodeWith {M : Type} (ops : EncoderOps M) (Δ : Signature)
       encodeWith ops Δ Γ (VarEnv.bindBinder δ b v) body k
   | .inj tag arity payload, k =>
     encodeWith ops Δ Γ δ payload fun v =>
-      k (.unop (.mkInj tag arity) v)
+      k (.unop (.ofInj tag arity) v)
   | .match_ scrut branches _, k =>
     encodeWith ops Δ Γ δ scrut fun v =>
       encodeMatchWith ops Δ Γ δ v branches 0 k
@@ -1255,7 +1255,7 @@ theorem inj (tag arity : Nat) (payload : Typed.Expr)
   refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
   intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
   exact hk hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂
-    (.unop (.mkInj tag arity) v₁) (.unop (.mkInj tag arity) v₂)
+    (.unop (.ofInj tag arity) v₁) (.unop (.ofInj tag arity) v₂)
     ⟨trivial, hv₁⟩ ⟨trivial, hv₂⟩
     (by simp [Term.eval, UnOp.eval, hevalv])
 


### PR DESCRIPTION
This PR exposes more primitives of the SMT encoding in the FOL layer. In exchange, it removes the adhoc encoding of the tester for injections.