### PR TITLE
Guard recursive axioms

### DIFF
--- a/Examples/owned_pair.ml
+++ b/Examples/owned_pair.ml
@@ -1,0 +1,37 @@
+(* Owned-reference lookup is a performance-sensitive path. To resolve `!r`, the
+   verifier walks the ownership context and uses low-effort checks to test
+   whether the dereferenced location equals each candidate's location. *)
+
+type ilist = Nil | Cons of int * ilist
+
+(* A recursive function whose relational encoding contributes guarded axioms. *)
+let rec length (xs : ilist) : int =
+  match xs with
+  | Nil -> 0
+  | Cons p -> 1 + length p.2
+[@@spec fun xs -> ret (fun v -> assert (v >= 0))];;
+
+(* Two owned cells of the same type: each read may skip candidates before the
+   matching points-to is consumed. *)
+let two_cells (x : int) : int =
+  let r1 = ref 1 [@owned] in
+  let r2 = ref 2 [@owned] in
+  let a = !r1 in
+  let b = !r2 in
+  a + b
+[@@spec fun x ->
+  ret (fun v ->
+    assert (v = 3))];;
+
+(* Three owned cells: more candidates exercise more non-matching probes. *)
+let three_cells (x : int) : int =
+  let r1 = ref 1 [@owned] in
+  let r2 = ref 2 [@owned] in
+  let r3 = ref 3 [@owned] in
+  let a = !r1 in
+  let b = !r2 in
+  let c = !r3 in
+  a + b + c
+[@@spec fun x ->
+  ret (fun v ->
+    assert (v = 6))];;

--- a/Mica/Engine/Command.lean
+++ b/Mica/Engine/Command.lean
@@ -7,11 +7,40 @@ An SMT command, indexed by its response type -- Unit for no meaningful response
 - push, pop, assert: Unit
 - declareConst, declareUnary, declareBinary : Unit
 - declareUnaryRel, declareBinaryRel : Unit
-- checkSat: returns sat/unsat/unknown — Smt.Result -/
+- checkSat: returns sat/unsat/unknown — Smt.Result
+- setOption, getOption: write/read a solver option -/
 
 namespace Smt
 
-inductive Command : Type → Type where
+namespace Options
+
+/-- A solver option together with the value to set it to. Options are
+    soundness-irrelevant; `Trace.isSound` imposes nothing on them. -/
+inductive Settable where
+  | timeout (ms : Nat)
+
+/-- A solver option to read back, indexed by the type parsed from Z3's response. -/
+inductive Gettable : Type → Type where
+  | timeout : Gettable Nat
+
+/-- The settings every session starts with. -/
+def Settable.initial : List Settable := [.timeout 3000]
+
+/-- Serialize a settable option to its SMT-LIB2 string. -/
+def Settable.toSMTLIB : Settable → String
+  | .timeout ms => s!"(set-option :timeout {ms})"
+
+/-- Serialize an option read to its SMT-LIB2 string. -/
+def Gettable.toSMTLIB : Gettable α → String
+  | .timeout => "(get-option :timeout)"
+
+/-- Parse the solver's response for an option read. -/
+def Gettable.parse : Gettable α → String → Option α
+  | .timeout, s => s.toNat?
+
+end Options
+
+inductive Command : Type → Type 1 where
   | push : Command Unit
   | pop : Command Unit
   | declareConst (name : String) (sort : Srt) : Command Unit
@@ -21,6 +50,8 @@ inductive Command : Type → Type where
   | declareBinaryRel (name : String) (arg1 arg2 : Srt) : Command Unit
   | assert (expr : Formula) : Command Unit
   | checkSat : Command Result
+  | setOption (s : Options.Settable) : Command Unit
+  | getOption (g : Options.Gettable α) : Command α
 
 /-! ## Serialization -/
 
@@ -37,6 +68,8 @@ def toSMTLIB : Command α → String
   | .declareBinaryRel n a1 a2 => s!"(declare-fun {n} ({a1.toSMTLIB} {a2.toSMTLIB}) Bool)"
   | .assert e => s!"(assert {e.toSMTLIB})"
   | .checkSat => "(check-sat)"
+  | .setOption s => s.toSMTLIB
+  | .getOption g => g.toSMTLIB
 
 /-- Parse the solver's response string for a given command. Returns `none` on unexpected output. -/
 def parse : (cmd : Command α) → String → Option α
@@ -53,6 +86,8 @@ def parse : (cmd : Command α) → String → Option α
     else if s == "unsat" then some .unsat
     else if s == "unknown" then some .unknown
     else none
+  | .setOption _, s => if s == "success" then some () else none
+  | .getOption g, s => g.parse s
 
 end Command
 
@@ -71,6 +106,8 @@ def step : Command β → β → State → State
   | .declareBinaryRel n arg1 arg2, (), s => Smt.State.addBinaryRel s ⟨n, arg1, arg2⟩
   | .assert e, (), s => s.addAssert e
   | .checkSat, _, s => s
+  | .setOption _, (), s => s
+  | .getOption _, _, s => s
 
 end State
 

--- a/Mica/Engine/Command.lean
+++ b/Mica/Engine/Command.lean
@@ -87,7 +87,7 @@ def parse : (cmd : Command α) → String → Option α
     else if s == "unknown" then some .unknown
     else none
   | .setOption _, s => if s == "success" then some () else none
-  | .getOption g, s => g.parse s
+  | .getOption g, s => g.parse s.trimAscii.str
 
 end Command
 

--- a/Mica/Engine/Driver.lean
+++ b/Mica/Engine/Driver.lean
@@ -31,7 +31,7 @@ namespace Session
 def preamble : String := s!"
 ;; preamble
 (set-logic ALL)
-(set-option :timeout 3000) ;; about 3s
+{String.intercalate "\n" (List.map Options.Settable.toSMTLIB Options.Settable.initial)}
 (set-option :smt.qi.eager_threshold 5.0)
 
 (declare-sort Other 0)

--- a/Mica/Engine/Strategy.lean
+++ b/Mica/Engine/Strategy.lean
@@ -90,7 +90,9 @@ theorem bind_traceSound {s : Strategy α} {k : α → Strategy β}
         | checkSat => cases r with
           | sat => trivial
           | unsat => cases hsound; assumption
-          | unknown => trivial)
+          | unknown => trivial
+        | setOption => cases r; trivial
+        | getOption => trivial)
     · simp [Trace.finalState]; exact hsound_tk
     · simp [Trace.finalState]; exact hfin _
 

--- a/Mica/Engine/Trace.lean
+++ b/Mica/Engine/Trace.lean
@@ -48,6 +48,8 @@ def isSound : State → Trace α → Prop
   | s, .step .checkSat .unsat rest =>
       ¬ State.satisfiable s.allDecls s.allAsserts ∧ isSound s rest
   | s, .step .checkSat _ rest => isSound s rest
+  | s, .step (.setOption _) () rest => isSound s rest
+  | s, .step (.getOption _) _ rest => isSound s rest
 
 /-! ## isSound step lemmas -/
 
@@ -64,6 +66,8 @@ theorem isSound.step_rest {cmd : Command β} {r : β} {rest : Trace α} {st : St
   | declareBinaryRel n arg1 arg2 => cases r; exact h
   | assert e => cases r; exact h
   | checkSat => cases r with | sat => exact h | unsat => exact h.2 | unknown => exact h
+  | setOption s => cases r; exact h
+  | getOption g => exact h
 
 /-- Reconstructing isSound for one step from the step obligation and the rest. -/
 theorem isSound.step_cons {cmd : Command β} {r : β} {rest : Trace α} {st : State}
@@ -82,6 +86,8 @@ theorem isSound.step_cons {cmd : Command β} {r : β} {rest : Trace α} {st : St
   | declareBinaryRel n arg1 arg2 => cases r; exact hrest
   | assert e => cases r; exact hrest
   | checkSat => cases r with | sat => exact hrest | unsat => exact ⟨hstep, hrest⟩ | unknown => exact hrest
+  | setOption s => cases r; exact hrest
+  | getOption g => exact hrest
 
 end Trace
 

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -220,7 +220,7 @@ def Zero.toIntrinsic (b : Zero) : Intrinsic where
       pred  := .ret ("ret",
         .assert (.eq .value (.var .value "ret") b.opTerm) (.ret ())) }
   folSym := some b.sym
-  axioms := [b.defAxiom, b.typeAxiom]
+  axioms := [⟨b.defAxiom, .low⟩, ⟨b.typeAxiom, .low⟩]
 
 @[simp] theorem Zero.toWp_eq (b : Zero) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [] Q = Q (b.res.inject b.f) := rfl
@@ -282,13 +282,13 @@ structure Zero.Lawful (b : Zero) where
         iapply Hwand
         exact l.resL.intro Θ b.f
   axiomWf := by
-    intro Δ hsub hwf φ hφ
+    intro Δ hsub hwf a hφ
     simp only [Zero.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
     rcases hφ with rfl | rfl
     · exact Formula.wfIn_mono _ l.defWf hsub hwf
     · exact Formula.wfIn_mono _ l.typeWf hsub hwf
   proof := by
-    intro ρ hdeps φ hφ
+    intro ρ hdeps a hφ
     simp only [Zero.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
     have hresp : ρ.respects (some b.sym) := by
       have h := hdeps b.toIntrinsic (by simp)
@@ -345,7 +345,7 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a"))) (.ret ())) }
   folSym := some b.sym
-  axioms := [b.defAxiom, b.typeAxiom]
+  axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
 
 @[simp] theorem Unary.toWp_eq (b : Unary) (a : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a] Q = iprop(∃ x, ⌜a = b.arg.inject x⌝ ∗ Q (b.res.inject (b.f x))) := rfl
@@ -432,13 +432,13 @@ structure Unary.Lawful (b : Unary) where
         iapply Hwand
         exact l.resL.intro Θ (b.f x)
   axiomWf := by
-    intro Δ hsub hwf φ hφ
+    intro Δ hsub hwf a hφ
     simp only [Unary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
     rcases hφ with rfl | rfl
     · exact Formula.wfIn_mono _ l.defWf hsub hwf
     · exact Formula.wfIn_mono _ l.typeWf hsub hwf
   proof := by
-    intro ρ hdeps φ hφ
+    intro ρ hdeps a hφ
     simp only [Unary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
     have hresp : ρ.respects (some b.sym) := by
       have h := hdeps b.toIntrinsic (by simp)
@@ -504,7 +504,7 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())) }
   folSym := some b.sym
-  axioms := [b.defAxiom, b.typeAxiom]
+  axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
 
 @[simp] theorem Binary.toWp_eq (b : Binary) (a c : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a, c] Q =
@@ -611,13 +611,13 @@ structure Binary.Lawful (b : Binary) where
         iapply Hwand
         exact l.resL.intro Θ (b.f x y)
   axiomWf := by
-    intro Δ hsub hwf φ hφ
+    intro Δ hsub hwf a hφ
     simp only [Binary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
     rcases hφ with rfl | rfl
     · exact Formula.wfIn_mono _ l.defWf hsub hwf
     · exact Formula.wfIn_mono _ l.typeWf hsub hwf
   proof := by
-    intro ρ hdeps φ hφ
+    intro ρ hdeps a hφ
     simp only [Binary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
     have hresp : ρ.respects (some b.sym) := by
       have h := hdeps b.toIntrinsic (by simp)

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -394,7 +394,7 @@ theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Si
 def VerifM.tryCandidates : List (Formula × Term τ) → VerifM (Option (Term τ))
   | [] => pure none
   | (φ, t) :: rest => do
-    if ← VerifM.check φ then pure (some t)
+    if ← VerifM.check .high φ then pure (some t)
     else VerifM.tryCandidates rest
 
 private theorem VerifM.eval_tryCandidates (Θ : TinyML.TypeEnv)
@@ -442,7 +442,7 @@ def VerifM.findMatchIn (lq : Term .value) (ty : TinyML.Typ) :
   | [] => pure none
   | .pointsTo l v ty' :: rest => do
       if ty' == ty then
-        if ← VerifM.check (.eq .value lq l) then
+        if ← VerifM.test (.eq .value lq l) then
           pure (some (0, v))
         else
           return (← VerifM.findMatchIn lq ty rest).map fun (n, v') => (n + 1, v')
@@ -624,7 +624,7 @@ def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
   | _, .own l ty => do
       VerifM.findMatch l ty
   | _, .rel name arg => do
-      if ← VerifM.check (SpecFn.isDefined name arg) then
+      if ← VerifM.check .high (SpecFn.isDefined name arg) then
         pure (some (SpecFn.call name arg))
       else
         pure none
@@ -656,7 +656,7 @@ private theorem VerifM.eval_resolve_pure (Θ : TinyML.TypeEnv) {pred : Atom τ} 
       have hq := VerifM.eval_ret hctx_q
       have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
       have hpred : ⊢ Atom.eval Θ pred ρ (t.eval ρ.env) := by
-        exact (Atom.resolve_correct Θ hres ρ hholds).trans (Atom.toItem_eval Θ).1
+        exact (Atom.resolve_correct Θ hres ρ hholds.asserts).trans (Atom.toItem_eval Θ).1
       have hframe : st.sl Θ ρ ∗ R ⊢
           Atom.eval Θ pred ρ (t.eval ρ.env) ∗ st.sl Θ ρ ∗ R := by
         istart

--- a/Mica/Verifier/Guard.lean
+++ b/Mica/Verifier/Guard.lean
@@ -1,0 +1,154 @@
+-- SUMMARY: The guard constant deactivating quantified axioms in low-effort checks, effort levels, and guarded axioms.
+import Mica.FOL.Formulas
+
+/-! ## The guard constant
+
+The verifier uses a builtin Bool constant `guard!`, declared at the start of
+every run but never asserted by default. Quantified axioms are "guarded" in
+the sense that `guard! = true` is added as an additional premise. The effect
+is that we can enable them locally by assering `guard! = true`. To improve
+performance, the guard is moved inside of quantifiers, which allows Z3 to
+share quantifier instantiations across different asserts. (Otherwise, it
+could only start to instantiate them once the guard is enabled.) -/
+
+def guardConst : FOL.Const := ⟨"guard!", .bool⟩
+
+/-- The formula pinning the guard to true; asserted inside high-effort checks. -/
+def guardFormula : Formula :=
+  .eq .bool (.const (.uninterpreted guardConst.name guardConst.sort)) (.const (.b true))
+
+/-- The formula pinning the guard to false; used only inside fast low-effort
+probes whose positive result is never trusted as a proof. -/
+def guardFalseFormula : Formula :=
+  .eq .bool (.const (.uninterpreted guardConst.name guardConst.sort)) (.const (.b false))
+
+/-- A signature supports guarding if the guard constant is declared. -/
+def Signature.supportsGuarding (Δ : Signature) : Prop := guardConst ∈ Δ.consts
+
+theorem Signature.supportsGuarding.mono {Δ Δ' : Signature} (hsub : Δ.Subset Δ')
+    (h : Δ.supportsGuarding) : Δ'.supportsGuarding :=
+  hsub.consts _ h
+
+/-- The guard formula is well-formed in any signature declaring the guard. -/
+theorem guardFormula.wf {Δ : Signature} (hwf : Δ.wf) (h : Δ.supportsGuarding) :
+    guardFormula.wfIn Δ :=
+  ⟨Term.const_wfIn_of_mem hwf h, trivial⟩
+
+/-- An environment supports guarding if it maps the guard constant to true. -/
+def Env.supportsGuarding (ρ : Env) : Prop := guardFormula.eval ρ
+
+/-- Guard support transfers along environments that agree on a signature
+declaring the guard. -/
+theorem Env.supportsGuarding.agree {Δ : Signature} {ρ ρ' : Env}
+    (hΔ : Δ.supportsGuarding) (hagree : Env.agreeOn Δ ρ ρ')
+    (h : ρ.supportsGuarding) : ρ'.supportsGuarding := by
+  have heq := hagree.2.1 guardConst hΔ
+  simp only [guardConst] at heq
+  simp only [Env.supportsGuarding, guardFormula, Formula.eval, Term.eval, Const.denote,
+    guardConst] at h ⊢
+  rw [← heq]
+  exact h
+
+/-- Pinning the guard constant establishes guard support. -/
+theorem Env.supportsGuarding_updateConst (ρ : Env) :
+    (ρ.updateConst guardConst.sort guardConst.name true).supportsGuarding := by
+  simp [Env.supportsGuarding, guardFormula, Formula.eval, Term.eval, Const.denote,
+    Env.updateConst, guardConst]
+
+/-! ## Guarded formulas -/
+
+namespace Formula
+
+/-- Guard a formula while preserving the outer universal quantifier spine. This
+keeps SMT triggers attached directly to the quantifier they were written for,
+which is substantially friendlier to Z3 than placing the implication outside
+the quantifier. If a binder shadows the guard name, stop pushing and guard the
+whole formula. -/
+def guarded : Formula → Formula
+  | .forall_ x τ ps φ =>
+      if x = guardConst.name then
+        .implies guardFormula (.forall_ x τ ps φ)
+      else
+        .forall_ x τ ps φ.guarded
+  | φ => .implies guardFormula φ
+
+private theorem supportsGuarding_declVar {Δ : Signature} {x : String} {τ : Srt}
+    (hguard : Δ.supportsGuarding) (hx : x ≠ guardConst.name) :
+    (Δ.declVar ⟨x, τ⟩).supportsGuarding := by
+  simp [Signature.supportsGuarding, Signature.declVar, Signature.addVar,
+    Signature.remove, guardConst] at hguard ⊢
+  exact ⟨hguard, fun h => hx h.symm⟩
+
+/-- A true formula remains true after it is guarded. -/
+theorem guarded_eval {φ : Formula} {ρ : Env} (h : φ.eval ρ) : φ.guarded.eval ρ := by
+  induction φ generalizing ρ with
+  | forall_ x τ ps φ ih =>
+      simp only [guarded]
+      split
+      · exact fun _ => h
+      · simp only [Formula.eval]
+        intro v
+        exact ih (h v)
+  | true_ | false_ | eq | unpred | binpred | not | and | or | implies | exists_ =>
+      simp only [guarded, Formula.eval]
+      exact fun _ => h
+
+/-- Guarding preserves well-formedness when the guard constant is declared. -/
+theorem guarded_wfIn {φ : Formula} {Δ : Signature} (hwf : Δ.wf)
+    (hguard : Δ.supportsGuarding) (h : φ.wfIn Δ) : φ.guarded.wfIn Δ := by
+  induction φ generalizing Δ with
+  | forall_ x τ ps φ ih =>
+      simp only [guarded]
+      split
+      · exact ⟨guardFormula.wf hwf hguard, h⟩
+      · exact ⟨h.1, ih (Signature.wf_declVar hwf)
+          (supportsGuarding_declVar hguard ‹x ≠ guardConst.name›) h.2⟩
+  | true_ | false_ | eq | unpred | binpred | not | and | or | implies | exists_ =>
+      simp only [guarded, Formula.wfIn]
+      exact ⟨guardFormula.wf hwf hguard, h⟩
+
+end Formula
+
+/-! ## Effort and guarded axioms -/
+
+/-- Effort level of a satisfiability check: `low` leaves guarded axioms
+inactive, `high` asserts the guard inside the check's scope, activating them. -/
+inductive Effort where
+  | low
+  | high
+  deriving DecidableEq, Repr
+
+/-- A formula tagged with the minimum check effort at which it is active:
+`.high` axioms are guarded and hence participate only in high-effort checks. -/
+structure Axiom where
+  formula : Formula
+  effort : Effort
+
+namespace Axiom
+
+/-- The formula the verifier actually assumes for an axiom: high-effort axioms
+are weakened by guarding the body under leading universal quantifiers. -/
+def assert : Axiom → Formula
+  | ⟨φ, .low⟩ => φ
+  | ⟨φ, .high⟩ => φ.guarded
+
+/-- The formulas the verifier actually assumes for a list of axioms. -/
+def asserts (axs : List Axiom) : List Formula :=
+  axs.map assert
+
+/-- The weakened axiom holds whenever the axiom itself does. -/
+theorem assert_eval {a : Axiom} {ρ : Env} (h : a.formula.eval ρ) : a.assert.eval ρ := by
+  obtain ⟨φ, e⟩ := a
+  cases e
+  · exact h
+  · exact Formula.guarded_eval h
+
+/-- The weakened axiom is well-formed wherever the axiom is, given the guard. -/
+theorem assert_wfIn {a : Axiom} {Δ : Signature} (hwf : Δ.wf)
+    (hguard : Δ.supportsGuarding) (h : a.formula.wfIn Δ) : a.assert.wfIn Δ := by
+  obtain ⟨φ, e⟩ := a
+  cases e
+  · exact h
+  · exact Formula.guarded_wfIn hwf hguard h
+
+end Axiom

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -231,7 +231,7 @@ structure Intrinsic where
       types, return type, and predicate transformer. -/
   spec     : Spec
   folSym   : Option (FOL.Symbol arity)
-  axioms   : List Formula
+  axioms   : List Axiom
 
 /-- A registry is a list of intrinsics. -/
 abbrev Registry := List Intrinsic
@@ -302,7 +302,7 @@ theorem toReduce_two_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .two Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec) (folSym : Option (FOL.Symbol .two)) (axioms : List Formula)
+    (spec : Spec) (folSym : Option (FOL.Symbol .two)) (axioms : List Axiom)
     (a b v : Runtime.Val) (μ μ' : TinyML.Heap) :
     (Intrinsic.mk .two name path reduce wp spec folSym axioms).toReduce [a, b] μ v μ'
       = reduce (a, b) μ v μ' := rfl
@@ -312,7 +312,7 @@ theorem toReduce_one_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .one Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec) (folSym : Option (FOL.Symbol .one)) (axioms : List Formula)
+    (spec : Spec) (folSym : Option (FOL.Symbol .one)) (axioms : List Axiom)
     (a v : Runtime.Val) (μ μ' : TinyML.Heap) :
     (Intrinsic.mk .one name path reduce wp spec folSym axioms).toReduce [a] μ v μ'
       = reduce a μ v μ' := rfl
@@ -322,7 +322,7 @@ theorem toReduce_zero_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .zero Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec) (folSym : Option (FOL.Symbol .zero)) (axioms : List Formula)
+    (spec : Spec) (folSym : Option (FOL.Symbol .zero)) (axioms : List Axiom)
     (v : Runtime.Val) (μ μ' : TinyML.Heap) :
     (Intrinsic.mk .zero name path reduce wp spec folSym axioms).toReduce [] μ v μ'
       = reduce () μ v μ' := rfl
@@ -345,7 +345,7 @@ theorem toWp_two_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .two Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec) (folSym : Option (FOL.Symbol .two)) (axioms : List Formula)
+    (spec : Spec) (folSym : Option (FOL.Symbol .two)) (axioms : List Axiom)
     (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
     (Intrinsic.mk .two name path reduce wp spec folSym axioms).toWp [a, b] Q
       = wp (a, b) Q := rfl
@@ -355,7 +355,7 @@ theorem toWp_one_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .one Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec) (folSym : Option (FOL.Symbol .one)) (axioms : List Formula)
+    (spec : Spec) (folSym : Option (FOL.Symbol .one)) (axioms : List Axiom)
     (a : Runtime.Val) (Q : Runtime.Val → iProp) :
     (Intrinsic.mk .one name path reduce wp spec folSym axioms).toWp [a] Q
       = wp a Q := rfl
@@ -365,7 +365,7 @@ theorem toWp_zero_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .zero Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec) (folSym : Option (FOL.Symbol .zero)) (axioms : List Formula)
+    (spec : Spec) (folSym : Option (FOL.Symbol .zero)) (axioms : List Axiom)
     (Q : Runtime.Val → iProp) :
     (Intrinsic.mk .zero name path reduce wp spec folSym axioms).toWp [] Q
       = wp () Q := rfl
@@ -432,10 +432,10 @@ class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Pr
       ∀ (vs : List Runtime.Val) (Φ : Runtime.Val → iProp),
         i.toWp vs Φ ⊢ wp ctx (.app (.val (.prim i.name)) (vs.map Runtime.Expr.val)) Φ
   axiomWf : ∀ {Δ : Signature}, (Intrinsic.sigOf fragment).Subset Δ → Δ.wf →
-            ∀ φ ∈ i.axioms, Formula.wfIn φ Δ
+            ∀ a ∈ i.axioms, Formula.wfIn a.formula Δ
   proof : ∀ ρ : Env,
             (∀ d ∈ fragment, ρ.respects d.folSym) →
-            ∀ φ ∈ i.axioms, Formula.eval ρ φ
+            ∀ a ∈ i.axioms, Formula.eval ρ a.formula
 
 namespace Registry
 
@@ -646,10 +646,10 @@ theorem stdEnv_respects {R : Registry} (hWf : Wf R) :
 theorem satisfies_of_respects {R : Registry}
     (hSound : Sound R)
     (hRespect : ∀ i ∈ R, ρ.respects i.folSym) :
-    ∀ i ∈ R, ∀ φ ∈ i.axioms, Formula.eval ρ φ := by
+    ∀ i ∈ R, ∀ a ∈ i.axioms, Formula.eval ρ a.formula := by
   suffices h :
       ∀ todo, SoundIn R todo →
-        ∀ i ∈ todo, ∀ φ ∈ i.axioms, Formula.eval ρ φ by
+        ∀ i ∈ todo, ∀ a ∈ i.axioms, Formula.eval ρ a.formula by
     exact h R hSound
   intro todo
   induction todo with
@@ -669,7 +669,7 @@ theorem satisfies_of_respects {R : Registry}
       exact ih hrestSound j hjrest φ hφ
 
 theorem stdEnv_satisfies {R : Registry} (hSound : Sound R) (hWf : Wf R) :
-    ∀ i ∈ R, ∀ φ ∈ i.axioms, Formula.eval (stdEnv R) φ :=
+    ∀ i ∈ R, ∀ a ∈ i.axioms, Formula.eval (stdEnv R) a.formula :=
   satisfies_of_respects hSound (stdEnv_respects hWf)
 
 end Registry
@@ -711,10 +711,10 @@ def declFOLSyms : Registry → VerifM Unit
   | []         => pure ()
   | i :: rest  => do i.declFOLSym; declFOLSyms rest
 
-/-- Assume every registered intrinsic axiom. -/
+/-- Assume every registered intrinsic axiom, weakening guarded axioms. -/
 def assumeAxioms : Registry → VerifM Unit
   | []         => pure ()
-  | i :: rest  => do VerifM.assumeAll i.axioms; assumeAxioms rest
+  | i :: rest  => do VerifM.assumeAxioms i.axioms; assumeAxioms rest
 
 /-- Declare all registered intrinsic FOL symbols first, then assume all
     intrinsic axioms. This keeps axiom validity independent of registry order:
@@ -866,12 +866,12 @@ theorem eval_assumeAxioms_in (full todo : Registry)
     simp only [assumeAxioms] at heval
     have h1 := VerifM.eval_bind _ _ _ _ heval
     rcases hSound with ⟨hiSound, hrestSound⟩
-    have hwfAxioms : ∀ φ ∈ i.axioms, φ.wfIn st.decls := fun φ hφ =>
-      hiSound.axiomWf hSig (VerifM.eval.wf h1).namesDisjoint φ hφ
-    have hevalAxioms : ∀ φ ∈ i.axioms, φ.eval ρ.env :=
+    have hwfAxioms : ∀ a ∈ i.axioms, a.formula.wfIn st.decls := fun a ha =>
+      hiSound.axiomWf hSig (VerifM.eval.wf h1).namesDisjoint a ha
+    have hevalAxioms : ∀ a ∈ i.axioms, a.formula.eval ρ.env :=
       hiSound.proof ρ.env (fun d hd => hRespect ρ VerifM.Env.agreeOn_refl d hd)
     obtain ⟨st1, hdecls1, howns1, hass1, hcont⟩ :=
-      VerifM.eval_assumeAll h1 hwfAxioms hevalAxioms
+      VerifM.eval_assumeAxioms h1 hwfAxioms hevalAxioms
     have hSig1 : (Intrinsic.sigOf full).Subset st1.decls := by
       rw [hdecls1]
       exact hSig
@@ -883,7 +883,7 @@ theorem eval_assumeAxioms_in (full todo : Registry)
     obtain ⟨st', hdecls2, howns2, ⟨extra2, hass2⟩, hQ⟩ :=
       ih hrestSound hSig1 hRespect1 hcont
     refine ⟨st', hdecls2.trans hdecls1, howns2.trans howns1,
-            ⟨extra2 ++ i.axioms.reverse, ?_⟩, hQ⟩
+            ⟨extra2 ++ (Axiom.asserts i.axioms).reverse, ?_⟩, hQ⟩
     rw [hass2, hass1, List.append_assoc]
 
 /-- Effect of `introduceRegistry` on a whole registry. All symbols are declared

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -35,9 +35,10 @@ inductive VerifM : Type → Type 1 where
   | declBinary : Option String → Srt → Srt → Srt → VerifM FOL.Binary
   /-- Add a context item to the verifier state (permanent, no check). -/
   | assume : CtxItem → VerifM Unit
-  /-- Check whether φ is provable from the current context.
-      Returns `true` if UNSAT (provable), `false` otherwise. Never fails. -/
-  | check : Formula → VerifM Bool
+  /-- Check whether φ is provable from the current context. Returns `true` if
+      ¬ φ is unsat, `false` otherwise. Never fails. At `.low` effort guarded
+      axioms are ignored; at `.high` effort they are enabled. -/
+  | check : Effort → Formula → VerifM Bool
   /-- Abort with a fatal error. -/
   | fatal : String → VerifM α
   /-- Abort with a recoverable failure. -/
@@ -65,10 +66,15 @@ def VerifM.ctxPure (f : List Formula → α) : VerifM α :=
 def VerifM.persist : VerifM Unit :=
   VerifM.ctx (fun st => ((), (TransState.persist st).owns))
 
-/-- Assert-and-check: check φ is provable, fail if not. -/
+/-- Assert-and-check: check φ is provable at high effort, fail if not. -/
 def VerifM.assert (φ : Formula) : VerifM Unit := do
-  if ← VerifM.check φ then pure ()
+  if ← VerifM.check .high φ then pure ()
   else VerifM.failed s!"assertion failed"
+
+/-- Quick provability test at low effort: guarded axioms are invisible, so a
+`false` answer is fast and is normal control flow. -/
+def VerifM.test (φ : Formula) : VerifM Bool :=
+  VerifM.check .low φ
 
 /-- Check that two elaboration-time values match exactly, otherwise abort fatally. -/
 def VerifM.expectEq [DecidableEq α] [Repr α] (msg : String) (actual expected : α) : VerifM Unit := do
@@ -110,6 +116,10 @@ def VerifM.declBinaryExact (b : FOL.Binary) : VerifM Unit := do
 def VerifM.assumeAll : List Formula → VerifM Unit
   | [] => pure ()
   | φ :: φs => do VerifM.assume (.pure φ); VerifM.assumeAll φs
+
+/-- Assume a list of axioms, weakening high-effort axioms by the guard. -/
+def VerifM.assumeAxioms (axs : List Axiom) : VerifM Unit :=
+  VerifM.assumeAll (Axiom.asserts axs)
 
 def TransCont α := α → TransState → ScopedM (Except VerifError Unit)
 
@@ -167,12 +177,20 @@ def VerifM.translate :
             k (.ok ()) { st with asserts := φ :: st.asserts })
       | .spatial a =>
           k (.ok ()) { st with owns := a :: st.owns }
-  | .check φ, st, k =>
+  | .check e φ, st, k =>
+      -- Low effort first probes `guard = false ∧ ¬φ`; if that is unsat, it
+      -- reruns the normal `¬φ` check. High effort asserts the guard while
+      -- checking `¬φ`, enabling guarded axioms for that check.
+      let body := ScopedM.assert (.not φ) (fun () =>
+        .checkSat (fun
+          | .unsat => .ret true
+          | _ => .ret false))
       .bracket
-        (ScopedM.assert (.not φ) (fun () =>
-          .checkSat (fun
-            | .unsat => .ret true
-            | _ => .ret false)))
+        (match e with
+         | .low => ScopedM.probe (.and guardFalseFormula (.not φ)) (fun
+            | .unsat => body
+            | _ => .ret false)
+         | .high => ScopedM.assert guardFormula (fun () => body))
         (fun b => k (.ok b) st)
   | .fatal msg, st, k => k (.error (.fatal msg)) st
   | .failed msg, st, k => k (.error (.failed msg)) st
@@ -212,7 +230,7 @@ private def VerifM.eval_rec : VerifM α → TransState → VerifM.Env → (α �
       match item with
       | .pure φ => φ.wfIn st.decls → φ.eval ρ.env → P () { st with asserts := φ :: st.asserts } ρ
       | .spatial a => a.wfIn st.decls → P () { st with owns := a :: st.owns } ρ
-  | .check φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ.env) ∧ P b st ρ
+  | .check _ φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ.env) ∧ P b st ρ
   | .fatal _, _, _, _ => False
   | .failed _, _, _, _ => False
   | .all items, st, ρ, P => ∀ a ∈ items, P a st ρ
@@ -324,10 +342,9 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     have hfresh := Fresh.freshNumbers_not_mem (hint.getD "_v") st.decls.allNames
     have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateConst t w u) := by
       exact VerifM.Env.agreeOn_update_fresh (c := ⟨w, t⟩) hfresh
-    constructor
-    · intro φ hφ
-      exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
-    · exact ⟨TransState.freshConst.wf _ hwf, h⟩
+    refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩, TransState.freshConst.wf _ hwf, h⟩
+    intro φ hφ
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g.asserts φ hφ)
   | declUnaryRel hint τ =>
     simp only [VerifM.eval_rec] at h
     simp only [VerifM.eval_rec]
@@ -337,9 +354,10 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     have hfresh := st.freshUnaryRel_fresh hint τ
     have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnaryRel τ u.name f) := by
       exact VerifM.Env.agreeOn_update_fresh_unaryRel (u := u) hfresh
-    refine ⟨?_, TransState.addUnaryRel.wf st _ hwf hfresh, h⟩
+    refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
+      TransState.addUnaryRel.wf st _ hwf hfresh, h⟩
     intro φ hφ
-    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g.asserts φ hφ)
   | declBinaryRel hint τ₁ τ₂ =>
     simp only [VerifM.eval_rec] at h
     simp only [VerifM.eval_rec]
@@ -349,9 +367,10 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     have hfresh := st.freshBinaryRel_fresh hint τ₁ τ₂
     have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinaryRel τ₁ τ₂ b.name f) := by
       exact VerifM.Env.agreeOn_update_fresh_binaryRel (b := b) hfresh
-    refine ⟨?_, TransState.addBinaryRel.wf st _ hwf hfresh, h⟩
+    refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
+      TransState.addBinaryRel.wf st _ hwf hfresh, h⟩
     intro φ hφ
-    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g.asserts φ hφ)
   | declUnary hint τ₁ τ₂ =>
     simp only [VerifM.eval_rec] at h
     simp only [VerifM.eval_rec]
@@ -361,9 +380,10 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     have hfresh := st.freshUnary_fresh hint τ₁ τ₂
     have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnary τ₁ τ₂ u.name f) := by
       exact VerifM.Env.agreeOn_update_fresh_unary (u := u) hfresh
-    refine ⟨?_, TransState.addUnary.wf st _ hwf hfresh, h⟩
+    refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
+      TransState.addUnary.wf st _ hwf hfresh, h⟩
     intro φ hφ
-    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g.asserts φ hφ)
   | declBinary hint τ₁ τ₂ τ₃ =>
     simp only [VerifM.eval_rec] at h
     simp only [VerifM.eval_rec]
@@ -373,23 +393,24 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     have hfresh := st.freshBinary_fresh hint τ₁ τ₂ τ₃
     have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinary τ₁ τ₂ τ₃ b.name f) := by
       exact VerifM.Env.agreeOn_update_fresh_binary (b := b) hfresh
-    refine ⟨?_, TransState.addBinary.wf st _ hwf hfresh, h⟩
+    refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
+      TransState.addBinary.wf st _ hwf hfresh, h⟩
     intro φ hφ
-    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g φ hφ)
+    exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g.asserts φ hφ)
   | assume item =>
     cases item with
     | pure φ =>
       simp only [VerifM.eval_rec] at h ⊢
       intro hwf' hφ
-      refine ⟨?_, TransState.addAssert.wf _ hwf hwf', h hwf' hφ⟩
+      refine ⟨⟨?_, g.builtins⟩, TransState.addAssert.wf _ hwf hwf', h hwf' hφ⟩
       intro ψ hψ
       cases hψ with
       | head => exact hφ
-      | tail _ hψ => exact g ψ hψ
+      | tail _ hψ => exact g.asserts ψ hψ
     | spatial a =>
       simp only [VerifM.eval_rec] at h ⊢
       intro hwf'
-      exact ⟨g, TransState.addSpatial.wf _ hwf hwf', h hwf'⟩
+      exact ⟨⟨g.asserts, g.builtins⟩, TransState.addSpatial.wf _ hwf hwf', h hwf'⟩
   | check φ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro hwf'
@@ -408,7 +429,8 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
   | ctx f =>
     simp only [VerifM.eval_rec] at h ⊢
     intro howns
-    exact ⟨g, ⟨hwf.assertsWf, hwf.namesDisjoint, howns⟩, h howns⟩
+    exact ⟨⟨g.asserts, g.builtins⟩,
+      ⟨hwf.assertsWf, hwf.namesDisjoint, howns, hwf.builtins⟩, h howns⟩
   | seq m m2 ihm ihf =>
     simp only [VerifM.eval_rec] at h ⊢
     exact ⟨(ihm st ρ h.1 g hwf).mono fun () _ _ _ => trivial,
@@ -520,21 +542,46 @@ private theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ:
       simp only [VerifM.translate] at h
       intro hwf'
       exact ⟨_, h⟩
-  | check φ =>
+  | check e φ =>
     simp only [VerifM.translate] at h
     obtain ⟨b, _, hxx, hk⟩ := ScopedM.eval_bracket h
     intro hwf'
     refine ⟨b, ?_, ⟨_, hk⟩⟩
     intro hb
     subst hb
-    apply ScopedM.eval_assert at hxx
-    apply ScopedM.eval_checkSat at hxx
-    simp at hxx
-    rcases hxx with ⟨hunsat, _⟩ | hfalse
-    · have hunsat' : ¬Smt.State.satisfiable st.decls (Formula.not φ :: st.asserts) := by
-        simp only [FlatCtx.addAssert] at hunsat; exact hunsat
-      exact Smt.State.satisfiable.to_impl' st.decls st.asserts hunsat' ρ.env g
-    · simp [ScopedM.eval_ret] at hfalse
+    cases e with
+    | low =>
+      obtain ⟨r, hproof⟩ := ScopedM.eval_probe hxx
+      cases r with
+      | sat =>
+          simp [ScopedM.eval_ret] at hproof
+      | unknown =>
+          simp [ScopedM.eval_ret] at hproof
+      | unsat =>
+          apply ScopedM.eval_assert at hproof
+          apply ScopedM.eval_checkSat at hproof
+          simp at hproof
+          rcases hproof with ⟨hunsat, _⟩ | hfalse
+          · have hunsat' : ¬Smt.State.satisfiable st.decls (Formula.not φ :: st.asserts) := by
+              simp only [FlatCtx.addAssert] at hunsat; exact hunsat
+            exact Smt.State.satisfiable.to_impl' st.decls st.asserts hunsat' ρ.env g.asserts
+          · simp [ScopedM.eval_ret] at hfalse
+    | high =>
+      apply ScopedM.eval_assert at hxx
+      apply ScopedM.eval_assert at hxx
+      apply ScopedM.eval_checkSat at hxx
+      simp at hxx
+      rcases hxx with ⟨hunsat, _⟩ | hfalse
+      · have hunsat' : ¬Smt.State.satisfiable st.decls
+            (Formula.not φ :: guardFormula :: st.asserts) := by
+          simp only [FlatCtx.addAssert] at hunsat; exact hunsat
+        refine Smt.State.satisfiable.to_impl' st.decls (guardFormula :: st.asserts)
+          hunsat' ρ.env ?_
+        intro ψ hψ
+        cases hψ with
+        | head => exact g.builtins.guard
+        | tail _ hψ => exact g.asserts ψ hψ
+      · simp [ScopedM.eval_ret] at hfalse
   | fatal msg =>
     simp only [VerifM.translate] at h
     exact absurd ⟨Δ, h⟩ (hf (.fatal msg) st)
@@ -699,9 +746,9 @@ theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
       simp [TransState.addItem]
       exact VerifM.eval_assumeSpatial h
 
-theorem VerifM.eval_check {φ : Formula} {st : TransState} {ρ : VerifM.Env}
+theorem VerifM.eval_check {e : Effort} {φ : Formula} {st : TransState} {ρ : VerifM.Env}
     {Q : Bool → TransState → VerifM.Env → Prop}
-    (h : VerifM.eval (.check φ) st ρ Q) :
+    (h : VerifM.eval (.check e φ) st ρ Q) :
     φ.wfIn st.decls →
     ∃ b, (b = true → φ.eval ρ.env) ∧ Q b st ρ :=
   fun hwf =>
@@ -940,6 +987,22 @@ theorem VerifM.eval_assumeAll {φs : List Formula}
     refine ⟨st', by rw [hst'], by rw [howns], ?_, hp⟩
     rw [hass]; simp [List.reverse_cons, List.append_assoc]
 
+theorem VerifM.eval_assumeAxioms {axs : List Axiom}
+    {st : TransState} {ρ : VerifM.Env} {P : Unit → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (VerifM.assumeAxioms axs) st ρ P) :
+    (∀ a ∈ axs, a.formula.wfIn st.decls) →
+    (∀ a ∈ axs, a.formula.eval ρ.env) →
+    ∃ st', st'.decls = st.decls ∧ st'.owns = st.owns ∧
+           st'.asserts = (Axiom.asserts axs).reverse ++ st.asserts ∧ P () st' ρ := by
+  intro hwf heval
+  refine VerifM.eval_assumeAll h ?_ ?_
+  · intro φ hφ
+    obtain ⟨a, ha, rfl⟩ := List.mem_map.mp hφ
+    exact Axiom.assert_wfIn h.1.namesDisjoint h.1.builtins.guard (hwf a ha)
+  · intro φ hφ
+    obtain ⟨a, ha, rfl⟩ := List.mem_map.mp hφ
+    exact Axiom.assert_eval (heval a ha)
+
 
 /-! ### Top-level corollary -/
 
@@ -969,7 +1032,8 @@ theorem VerifM.eval_of_translate (m : VerifM Unit) (st : TransState) (ρ : Verif
   (translate_eval m st ρ topCont topCont_error_propagates Δ h g hwf).mono fun _ _ _ _ => trivial
 
 def VerifM.strategy (m : VerifM Unit) :=
-  let verif := VerifM.translate m TransState.empty VerifM.topCont
+  let verif := ScopedM.declareConst guardConst.name guardConst.sort fun () =>
+    VerifM.translate m TransState.init VerifM.topCont
   let verif' := ScopedM.bind verif fun
     | .ok () => ScopedM.ret (Except.ok ())
     | .error (.failed msg) => ScopedM.ret (Except.error msg)

--- a/Mica/Verifier/OUTLINE.md
+++ b/Mica/Verifier/OUTLINE.md
@@ -5,6 +5,7 @@
 - `Bindings.lean` — Verifier variable-to-constant bindings, their semantic linkage to runtime substitutions, and typing/lookup lemmas.
 - `Expressions.lean` — Compilation of typed TinyML expressions into verifier terms, with weakest-precondition correctness proofs.
 - `Functions.lean` — Verification of function bodies against specifications, including the soundness of specification checking.
+- `Guard.lean` — The guard constant deactivating quantified axioms in low-effort checks, effort levels, and guarded axioms.
 - `Intrinsic.lean` — Data model for verifier intrinsics, with generic theorems characterizing the effect of registry setup.
 - `Monad.lean` — Verification monad with SMT operations, branching, and its operational and semantic correctness interfaces.
 - `PredicateTransformers.lean` — Predicate transformers for function specifications, together with their semantics and call and implementation protocols.

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -54,7 +54,7 @@ def Program.prepare (prog : Untyped.Program (Spec.Body Untyped.Expr)) :
 /-- Globally assembled metadata for declarations marked with `[@@fn]`. -/
 structure RelationSpec where
   symbols : List FOL.BinaryRel
-  axioms : List Formula
+  axioms : List Axiom
   functionMap : List (TinyML.Var × String)
   delta : Signature
 
@@ -68,7 +68,7 @@ def empty : RelationSpec :=
 private structure RelationDecl where
   spec : RelationSpec
   res : TinyML.Var
-  axs : List Formula
+  axs : List Axiom
   f : TinyML.Var
   rel : String
   arg : TinyML.Var
@@ -139,7 +139,7 @@ private def declareAndAssume (acc : RelationSpec) (d : Typed.ValDecl (Spec.Body 
           VerifM.declBinaryRelExact (SpecFn.rel rel)
           VerifM.declUnaryExact (SpecFn.func rel)
           VerifM.declUnaryRelExact (SpecFn.defined rel)
-          VerifM.assumeAll info.axs
+          VerifM.assumeAxioms info.axs
           pure info.spec
 
 private def assembleFrom : RelationSpec → Typed.Program (Spec.Body Typed.Expr) → VerifM RelationSpec
@@ -243,7 +243,7 @@ private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr
         have hst3_decls : st3.decls = Δext := by simp only [st3, Δext, hacc]
         -- Axiom well-formedness via bundle_wfIn.
         have hax_wf_acc := Skolemize.bundle_wfIn hinfoEq hΔwf_acc hΓwf_acc hf
-        have hax_wf : ∀ ax ∈ info.axs, ax.wfIn st3.decls :=
+        have hax_wf : ∀ ax ∈ info.axs, ax.formula.wfIn st3.decls :=
           fun ax hmem => hst3_decls ▸ hax_wf_acc ax hmem
         -- ρ3.env vs (defInterpEnv ...).updateBinaryRel R.
         have hρ3_env_eq :
@@ -253,12 +253,12 @@ private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr
           simp only [ρ3, VerifM.Env.updateUnaryRel_env, VerifM.Env.updateUnary_env,
             VerifM.Env.updateBinaryRel_env, Skolemize.defInterpEnv, Skolemize.splitEnv]
           apply Env.ext <;> rfl
-        have hax_eval : ∀ ax ∈ info.axs, ax.eval ρ3.env := fun ax hmem => by
+        have hax_eval : ∀ ax ∈ info.axs, ax.formula.eval ρ3.env := fun ax hmem => by
           rw [hρ3_env_eq]
           exact Skolemize.bundle_eval_updateBinaryRel
             hinfoEq hsplit hΓwf_acc hΔwf_acc hf hdet R ax hmem
         obtain ⟨st4, hst4_decls, hst4_owns, _, hpure_pre⟩ :=
-          VerifM.eval_assumeAll hbind7 hax_wf hax_eval
+          VerifM.eval_assumeAxioms hbind7 hax_wf hax_eval
         -- Reestablish invariants and apply IH.
         have hst4_owns_eq : st4.owns = [] := by rw [hst4_owns]; exact howns
         have hst4_vars : st4.decls.vars = [] := by

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -723,21 +723,17 @@ theorem Program.verify_correct (reg : Verifier.Registry)
         have hret := (ScopedM.eval_ret.mp hcont).1
         cases hret
   | .ok () =>
-    have hholdsFor : TransState.holdsFor TransState.empty VerifM.Env.empty :=
-      fun φ hφ => by simp [TransState.empty] at hφ
-    have hwf : TransState.wf TransState.empty :=
-      ⟨fun φ hφ => by simp [TransState.empty] at hφ,
-       by simp [TransState.empty, Signature.empty, Signature.allNames],
-       fun a ha => by simp [TransState.empty] at ha⟩
     have hverifM := VerifM.eval_of_translate
                       (do
                         let (Θ, typed) ← Program.prepare p
                         Verifier.Registry.introduceRegistry reg
                         let relations ← RelationSpec.assemble typed
                         Program.check reg Θ relations.delta relations.functionMap ∅ typed)
-                      TransState.empty VerifM.Env.empty ctx_mid hverif hholdsFor hwf
+                      TransState.init VerifM.Env.init ctx_mid
+                      (ScopedM.eval_declareConst hverif)
+                      TransState.init_holdsFor TransState.init_wf
     have hbind := VerifM.eval_bind _ _ _ _ hverifM
-    obtain ⟨Θ, typed, hrt, hrest⟩ := Program.prepare_correct p TransState.empty VerifM.Env.empty hbind
+    obtain ⟨Θ, typed, hrt, hrest⟩ := Program.prepare_correct p TransState.init VerifM.Env.init hbind
     -- Peel the registry setup from the continuation generically.
     have hsetup_bind := VerifM.eval_bind _ _ _ _ hrest
     obtain ⟨st_setup, ρ_setup, _hΔsub, hdep_setup, hvars_setup_eq, howns_setup,

--- a/Mica/Verifier/RelationalEncoding/Axioms.lean
+++ b/Mica/Verifier/RelationalEncoding/Axioms.lean
@@ -1,5 +1,6 @@
 -- SUMMARY: Solver-facing axioms and validity theorems for skolemized relational encoding.
 import Mica.Verifier.RelationalEncoding.SkolemizeCompleteness
+import Mica.Verifier.Guard
 
 
 /-!
@@ -74,17 +75,18 @@ def definedElimAxiom (fn : SpecFn) (x : TinyML.Var) (body : DefVal) : Formula :=
   .all x .value
     (.implies (fn.isDefined (.var .value x)) body.defined)
 
-/-- The solver-facing axioms emitted for a relation-marked function. -/
-def axioms (fn : SpecFn) (x : TinyML.Var) (body : DefVal) : List Formula :=
-  [definedIntroAxiom fn x body, valueAxiom fn x body,
-   definedElimAxiom fn x body]
+/-- The solver-facing axioms emitted for a relation-marked function. All three
+are quantified, so they are guarded (`.high`). -/
+def axioms (fn : SpecFn) (x : TinyML.Var) (body : DefVal) : List Axiom :=
+  [⟨definedIntroAxiom fn x body, .high⟩, ⟨valueAxiom fn x body, .high⟩,
+   ⟨definedElimAxiom fn x body, .high⟩]
 
 theorem axioms_wfIn {Δ : Signature} {fn : SpecFn} {x : String} {body : DefVal}
     (hΔx : (Δ.declVar ⟨x, .value⟩).wf)
     (hbody : body.wfIn (Δ.declVar ⟨x, .value⟩))
     (hfun : fn.func ∈ (Δ.declVar ⟨x, .value⟩).unary)
     (hrel : fn.defined ∈ (Δ.declVar ⟨x, .value⟩).unaryRel) :
-    ∀ ax ∈ axioms fn x body, ax.wfIn Δ := by
+    ∀ ax ∈ axioms fn x body, ax.formula.wfIn Δ := by
   intro ax hmem
   simp [axioms] at hmem
   rcases hmem with rfl | rfl | rfl
@@ -245,7 +247,7 @@ theorem axioms_eval
     (hΔ : Δ.wf) (hheadFresh : HeadFresh Δ fn x res)
     (hρdet : Relation.BinaryRelDet Γ ρ ρ) :
     ∀ ax ∈ axioms fn x body,
-      ax.eval (defInterpEnv Γ Δ ρ f fn x res e body) := by
+      ax.formula.eval (defInterpEnv Γ Δ ρ f fn x res e body) := by
   intro ax hmem
   simp [axioms] at hmem
   rcases hmem with rfl | rfl | rfl
@@ -259,8 +261,7 @@ theorem axioms_eval
 function and its body, it returns the data needed to declare solver symbols
 and assume axioms (the binary relation symbol, the value function, the
 definedness predicate, a fresh pinned result variable, the encoded body, and
-the list of axioms). Stage 2 emits two unary axioms (over the value and
-definedness symbols) instead of stage 1's single binary defining axiom.
+the guarded solver-facing axioms over the split symbols).
 
 The lemmas below lift the corresponding `axioms_*` results to the `bundle`
 level. -/
@@ -344,7 +345,7 @@ so this returns only the data the encoder computes: the canonical pinned-result
 variable, the encoded body, and the list of solver-emitted axioms. -/
 def bundle
     (Γ : FunCtx) (Δ : Signature) (f : TinyML.Var) (fn : SpecFn) (x : String) (e : Typed.Expr) :
-    Except String (String × DefVal × List Formula) := do
+    Except String (String × DefVal × List Axiom) := do
   let res := Fresh.freshName
     (Δ.allNames ++ [x, fn.relName, fn.funcName, fn.defName]) "r"
   let bv ← encodeBody Γ Δ f fn x res e
@@ -362,12 +363,12 @@ theorem bundle_headFresh
 
 theorem bundle_wfIn
     {Γ : FunCtx} {Δ : Signature} {f : TinyML.Var} {fn : SpecFn} {x : String} {e : Typed.Expr}
-    {res : String} {bv : DefVal} {axs : List Formula}
+    {res : String} {bv : DefVal} {axs : List Axiom}
     (hinfo : bundle Γ Δ f fn x e = .ok (res, bv, axs))
     (hΔ : Δ.wf) (hΓwf : Γ.wfIn Δ)
     (hf : InfoFresh Δ fn x) :
     ∀ ax ∈ axs,
-      ax.wfIn (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel fn.defined) := by
+      ax.formula.wfIn (((Δ.addBinaryRel fn.rel).addUnary fn.func).addUnaryRel fn.defined) := by
   unfold bundle at hinfo
   simp only [bind, Except.bind] at hinfo
   split at hinfo
@@ -409,7 +410,7 @@ theorem axioms_eval_updateBinaryRel
     (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (R : ValRel) :
     ∀ ax ∈ axioms fn x body,
-      ax.eval ((defInterpEnv Γ Δ ρ f fn x res e body).updateBinaryRel
+      ax.formula.eval ((defInterpEnv Γ Δ ρ f fn x res e body).updateBinaryRel
         .value .value fn.relName R) := by
   intro ax hmem
   have hbase := axioms_eval henc hΓ hΓwf hΔ hheadFresh hρdet ax hmem
@@ -431,7 +432,7 @@ theorem axioms_eval_updateBinaryRel
     Signature.mem_remove_unary.mpr ⟨List.Mem.head _, fun heq => hxNeFun heq.symm⟩
   have hrel_mem : fn.defined ∈ (Δsmall.declVar ⟨x, .value⟩).unaryRel :=
     Signature.mem_remove_unaryRel.mpr ⟨List.Mem.head _, fun heq => hxNeDef heq.symm⟩
-  have hax_wf : ax.wfIn Δsmall :=
+  have hax_wf : ax.formula.wfIn Δsmall :=
     axioms_wfIn (Δ := Δsmall) hΔbig_wf hbody_wf hfun_mem hrel_mem ax hmem
   have hrelFresh_small : fn.rel.name ∉ Δsmall.allNames :=
     Signature.not_mem_allNames_addUnaryRel
@@ -451,7 +452,7 @@ theorem axioms_eval_updateBinaryRel
 theorem bundle_semrel_functional
     {Γ : FunCtx} {Δ : Signature}
     {f fn x : String} {e : Typed.Expr}
-    {res : String} {bv : DefVal} {axs : List Formula}
+    {res : String} {bv : DefVal} {axs : List Axiom}
     (hinfo : bundle Γ Δ f fn x e = .ok (res, bv, axs))
     (hΓwf : Γ.wfIn Δ)
     (hΔ : Δ.wf) (hf : InfoFresh Δ fn x)
@@ -473,7 +474,7 @@ theorem bundle_semrel_functional
 theorem bundle_semrel_compatible
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
     {f fn x : String} {e : Typed.Expr}
-    {res : String} {bv : DefVal} {axs : List Formula}
+    {res : String} {bv : DefVal} {axs : List Axiom}
     (hinfo : bundle Γ Δ f fn x e = .ok (res, bv, axs))
     (hΓ : Γ.splitCompatible ρ)
     (hΓwf : Γ.wfIn Δ)
@@ -498,7 +499,7 @@ interpretation for the freshly declared `fn` symbol. -/
 theorem bundle_eval_updateBinaryRel
     {Γ : FunCtx} {Δ : Signature} {ρ : Env}
     {f : TinyML.Var} {fn : SpecFn} {x : String} {e : Typed.Expr}
-    {res : String} {bv : DefVal} {axs : List Formula}
+    {res : String} {bv : DefVal} {axs : List Axiom}
     (hinfo : bundle Γ Δ f fn x e = .ok (res, bv, axs))
     (hΓ : Γ.splitCompatible ρ)
     (hΓwf : Γ.wfIn Δ)
@@ -506,7 +507,7 @@ theorem bundle_eval_updateBinaryRel
     (hρdet : Relation.BinaryRelDet Γ ρ ρ)
     (R : ValRel) :
     ∀ ax ∈ axs,
-      ax.eval ((defInterpEnv Γ Δ ρ f fn x res e bv).updateBinaryRel
+      ax.formula.eval ((defInterpEnv Γ Δ ρ f fn x res e bv).updateBinaryRel
         .value .value fn.relName R) := by
   unfold bundle at hinfo
   simp only [bind, Except.bind] at hinfo

--- a/Mica/Verifier/Scoped.lean
+++ b/Mica/Verifier/Scoped.lean
@@ -559,3 +559,32 @@ theorem ScopedM.eval_extends {α} s Δ (r : α) Δ' :
     intro h
     obtain ⟨b, ctx_body, _, hk⟩ := ScopedM.eval_bracket h
     exact ih_k b _ _ _ hk
+
+/-! ## ScopedM.probe -/
+
+/-- The solver time budget for heuristic probes. A timeout is reported as
+    `unknown` and handled conservatively by the caller. -/
+def ScopedM.probeTimeout : Nat := 100 /- 100ms -/
+
+/-- A probe: a quick, scoped peek at whether `φ` is consistent with the current
+    context. The answer only steers the verifier; it is never a soundness
+    justification, which is reflected in `eval_probe` yielding an arbitrary
+    result. Accordingly, the probe runs under a short solver timeout, restoring
+    the ambient timeout afterwards. -/
+def ScopedM.probe (φ : Formula) (k : Result → ScopedM α) : ScopedM α :=
+  .getOption .timeout (fun ambient =>
+    .setOption (.timeout probeTimeout) (fun () =>
+      .bracket (.assert φ (fun () => .checkSat .ret)) (fun r =>
+        .setOption (.timeout ambient) (fun () => k r))))
+
+/-- A probe leaves the context unchanged and hands the continuation an
+    arbitrary result: nothing about the solver's answer can be trusted. -/
+theorem ScopedM.eval_probe {φ : Formula} {k : Result → ScopedM α}
+    {ctx : FlatCtx} {ret : α} {ctx' : FlatCtx} :
+    ScopedM.eval (.probe φ k) ctx ret ctx' →
+      ∃ r, ScopedM.eval (k r) ctx ret ctx' := by
+  intro h
+  obtain ⟨n, h⟩ := eval_getOption h
+  have h := eval_setOption h
+  obtain ⟨r, _, _, h⟩ := eval_bracket h
+  exact ⟨r, eval_setOption h⟩

--- a/Mica/Verifier/Scoped.lean
+++ b/Mica/Verifier/Scoped.lean
@@ -18,6 +18,8 @@ inductive ScopedM : Type → Type 1 where
   | declareBinaryRel : String → Srt → Srt → (Unit → ScopedM α) → ScopedM α
   | assert : Formula → (Unit → ScopedM α) → ScopedM α
   | checkSat : (Result → ScopedM α) → ScopedM α
+  | setOption : Smt.Options.Settable → (Unit → ScopedM α) → ScopedM α
+  | getOption : Smt.Options.Gettable β → (β → ScopedM α) → ScopedM α
   | bracket : ScopedM β → (β → ScopedM α) → ScopedM α
 
 /-! ## translate: ScopedM → Strategy -/
@@ -31,6 +33,8 @@ def ScopedM.translate : ScopedM α → Strategy α
   | .declareBinaryRel n a1 a2 k => .exec (.declareBinaryRel n a1 a2) (fun resp => translate (k resp))
   | .assert e k => .exec (.assert e) (fun r => translate (k r))
   | .checkSat k => .exec .checkSat (fun r => translate (k r))
+  | .setOption s k => .exec (.setOption s) (fun r => translate (k r))
+  | .getOption g k => .exec (.getOption g) (fun r => translate (k r))
   | .bracket body k =>
       .exec .push (fun () =>
         (translate body).bind (fun x =>
@@ -212,6 +216,17 @@ theorem ScopedM.translate_preservesFrames {m : ScopedM α} {f : Frame} {fs : Lis
     dsimp only at hrest
     have ⟨f', hext, hfin⟩ := ih resp hrest (f := f) (fs := fs)
     exact ⟨f', hext, by simp [Trace.finalState, State.step]; exact hfin⟩
+  | setOption s k ih =>
+    cases hgen; rename_i rest resp hrest
+    cases resp
+    dsimp only at hrest
+    have ⟨f', hext, hfin⟩ := ih () hrest (f := f) (fs := fs)
+    exact ⟨f', hext, by simp [Trace.finalState, State.step]; exact hfin⟩
+  | getOption g k ih =>
+    cases hgen; rename_i rest resp hrest
+    dsimp only at hrest
+    have ⟨f', hext, hfin⟩ := ih resp hrest (f := f) (fs := fs)
+    exact ⟨f', hext, by simp [Trace.finalState, State.step]; exact hfin⟩
   | bracket body k ih_body ih_k =>
     simp only [translate] at hgen
     cases hgen; rename_i rest_outer hgen_outer
@@ -355,6 +370,28 @@ theorem ScopedM.eval_checkSat {k : Result → ScopedM α} {ctx : FlatCtx} {ret :
     exact ⟨hunsat, st, st', hflat, hflat', rest, hrest, hsound.2, hst', hret⟩
   | unknown => right; right; exact ⟨st, st', hflat, hflat', rest, hrest, hsound, hst', hret⟩
 
+theorem ScopedM.eval_setOption {s : Smt.Options.Settable}
+    {k : Unit → ScopedM α} {ctx : FlatCtx} {ret : α} {ctx' : FlatCtx} :
+    ScopedM.eval (.setOption s k) ctx ret ctx' →
+      ScopedM.eval (k ()) ctx ret ctx' := by
+  simp only [ScopedM.eval, translate, Strategy.eval]
+  rintro ⟨st, st', hflat, hflat', t, hgen, hsound, hst', hret⟩
+  cases hgen; rename_i rest resp hrest
+  cases resp
+  simp only [Trace.finalState, State.step, Trace.result] at hsound hst' hret
+  exact ⟨st, st', hflat, hflat', rest, hrest, hsound, hst', hret⟩
+
+theorem ScopedM.eval_getOption {g : Smt.Options.Gettable β}
+    {k : β → ScopedM α} {ctx : FlatCtx} {ret : α} {ctx' : FlatCtx} :
+    ScopedM.eval (.getOption g k) ctx ret ctx' →
+      ∃ x, ScopedM.eval (k x) ctx ret ctx' := by
+  simp only [ScopedM.eval, translate, Strategy.eval]
+  rintro ⟨st, st', hflat, hflat', t, hgen, hsound, hst', hret⟩
+  cases hgen; rename_i rest resp hrest
+  dsimp only at hrest
+  simp only [Trace.finalState, State.step, Trace.result] at hsound hst' hret
+  exact ⟨resp, st, st', hflat, hflat', rest, hrest, hsound, hst', hret⟩
+
 theorem ScopedM.eval_bracket {body : ScopedM β} {k : β → ScopedM α}
     {ctx : FlatCtx} {ret : α} {ctx' : FlatCtx} :
     ScopedM.eval (.bracket body k) ctx ret ctx' →
@@ -407,6 +444,8 @@ def ScopedM.bind : ScopedM α → (α → ScopedM β) → ScopedM β
   | .declareBinaryRel n a1 a2 cont, k => .declareBinaryRel n a1 a2 (fun resp => (cont resp).bind k)
   | .assert e cont, k => .assert e (fun r => (cont r).bind k)
   | .checkSat cont, k => .checkSat (fun r => (cont r).bind k)
+  | .setOption s cont, k => .setOption s (fun r => (cont r).bind k)
+  | .getOption g cont, k => .getOption g (fun r => (cont r).bind k)
   | .bracket body cont, k => .bracket body (fun x => (cont x).bind k)
 
 theorem ScopedM.translate_bind (m : ScopedM α) (k : α → ScopedM β) :
@@ -426,6 +465,10 @@ theorem ScopedM.translate_bind (m : ScopedM α) (k : α → ScopedM β) :
   | assert e cont ih =>
     simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext r; exact ih r k
   | checkSat cont ih =>
+    simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext r; exact ih r k
+  | setOption s cont ih =>
+    simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext r; exact ih r k
+  | getOption g cont ih =>
     simp only [ScopedM.bind, translate, Strategy.bind]; congr 1; funext r; exact ih r k
   | bracket body cont _ ih_cont =>
     simp only [ScopedM.bind, translate, Strategy.bind]
@@ -505,6 +548,13 @@ theorem ScopedM.eval_extends {α} s Δ (r : α) Δ' :
     · exact ih .unsat _ _ _ h
     · exact ih .sat _ _ _ h
     · exact ih .unknown _ _ _ h
+  | setOption s k ih =>
+    intro h
+    exact ih () _ _ _ (ScopedM.eval_setOption h)
+  | getOption g k ih =>
+    intro h
+    obtain ⟨n, h⟩ := ScopedM.eval_getOption h
+    exact ih n _ _ _ h
   | bracket body k ih_body ih_k =>
     intro h
     obtain ⟨b, ctx_body, _, hk⟩ := ScopedM.eval_bracket h

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -1,5 +1,6 @@
 -- SUMMARY: Verifier state and environments, together with their well-formedness conditions and fresh-name infrastructure.
 import Mica.Verifier.Scoped
+import Mica.Verifier.Guard
 import Mica.Base.Fresh
 import Mica.SeparationLogic.SpatialAtom
 import Mica.SeparationLogic
@@ -67,6 +68,20 @@ def Env.updateBinaryRel (ρ : Env) (τ₁ τ₂ : Srt) (x : String)
     (f : τ₁.denote → τ₂.denote → Prop) :
     (ρ.updateBinaryRel τ₁ τ₂ x f).env = ρ.env.updateBinaryRel τ₁ τ₂ x f := rfl
 
+/-- Builtin declarations the verifier requires in a signature; extend with a
+field per builtin. -/
+structure Builtins.wf (Δ : Signature) : Prop where
+  guard : Δ.supportsGuarding
+
+theorem Builtins.wf.mono {Δ Δ' : Signature} (hsub : Δ.Subset Δ')
+    (h : Builtins.wf Δ) : Builtins.wf Δ' :=
+  ⟨h.guard.mono hsub⟩
+
+/-- Facts about the environment required by the verifier's builtin constants;
+extend with a field per builtin. -/
+structure Builtins.holdsFor (ρ : Env) : Prop where
+  guard : ρ.env.supportsGuarding
+
 def Env.withEnv (ρ : Env) (env' : _root_.Env) : Env :=
   { ρ with env := env' }
 
@@ -132,6 +147,13 @@ theorem Env.agreeOn_update_fresh_binaryRel {ρ : Env} {b : FOL.BinaryRel}
     Env.agreeOn Δ ρ (ρ.updateBinaryRel b.arg1 b.arg2 b.name f) := by
   simpa [Env.agreeOn, Env.updateBinaryRel] using
     (_root_.Env.agreeOn_update_fresh_binaryRel (ρ := ρ.env) (b := b) (f := f) (Δ := Δ) hfresh)
+
+/-- Builtin facts transfer along environments that agree on a signature
+declaring the builtins. -/
+theorem Builtins.holdsFor.agree {Δ : Signature} {ρ ρ' : Env}
+    (hΔ : Builtins.wf Δ) (hagree : Env.agreeOn Δ ρ ρ')
+    (h : Builtins.holdsFor ρ) : Builtins.holdsFor ρ' :=
+  ⟨h.guard.agree hΔ.guard hagree⟩
 
 end VerifM
 
@@ -210,20 +232,43 @@ def TransState.toFlatCtx (st : TransState) : FlatCtx :=
     { st with asserts := φ :: st.asserts }.toFlatCtx = st.toFlatCtx.addAssert φ := by
   simp [toFlatCtx, FlatCtx.addAssert]
 
-def TransState.empty : TransState := ⟨Signature.empty, [], []⟩
+/-- The initial verifier state: only the builtin guard constant is declared. -/
+def TransState.init : TransState := ⟨Signature.empty.addConst guardConst, [], []⟩
 
-@[simp] theorem TransState.empty_toFlatCtx : TransState.empty.toFlatCtx = FlatCtx.empty := rfl
+@[simp] theorem TransState.init_toFlatCtx :
+    TransState.init.toFlatCtx = FlatCtx.empty.addConst guardConst.name guardConst.sort := rfl
 
-def TransState.holdsFor (st : TransState) (ρ : VerifM.Env) := ∀ φ ∈ st.asserts, φ.eval ρ.env
+/-- The environment satisfies the verifier state: every assertion holds and the
+builtin facts are in force. -/
+structure TransState.holdsFor (st : TransState) (ρ : VerifM.Env) : Prop where
+  asserts : ∀ φ ∈ st.asserts, φ.eval ρ.env
+  builtins : VerifM.Builtins.holdsFor ρ
 
 theorem TransState.holdsFor_mono {st st' : TransState} {ρ : VerifM.Env}
     (hsub : st.asserts ⊆ st'.asserts) (h : st'.holdsFor ρ) : st.holdsFor ρ :=
-  fun φ hφ => h φ (hsub hφ)
+  ⟨fun φ hφ => h.asserts φ (hsub hφ), h.builtins⟩
 
 structure TransState.wf (st : TransState) : Prop where
   assertsWf : st.asserts.wfIn st.decls
   namesDisjoint : st.decls.allNames.Nodup
   ownsWf : st.owns.wfIn st.decls
+  builtins : VerifM.Builtins.wf st.decls
+
+theorem TransState.init_wf : TransState.init.wf where
+  assertsWf := fun φ hφ => by simp [TransState.init] at hφ
+  namesDisjoint := by
+    simp [TransState.init, Signature.allNames, Signature.addConst, Signature.empty]
+  ownsWf := fun a ha => by simp [TransState.init] at ha
+  builtins := ⟨List.Mem.head _⟩
+
+/-- The canonical initial environment: the guard constant pinned to true. -/
+def VerifM.Env.init : VerifM.Env :=
+  VerifM.Env.empty.updateConst guardConst.sort guardConst.name true
+
+theorem TransState.init_holdsFor : TransState.init.holdsFor VerifM.Env.init where
+  asserts := fun φ hφ => by simp [TransState.init] at hφ
+  builtins := ⟨by simpa [VerifM.Env.init] using
+    Env.supportsGuarding_updateConst VerifM.Env.empty.env⟩
 
 def TransState.freshConst (hint : Option String) (t : Srt) (st : TransState) : FOL.Const :=
   let base := hint.getD "_v"
@@ -260,6 +305,7 @@ theorem TransState.freshConst.wf {hint t} (st : TransState) :
   · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addConst _ _) hwf'
   · exact Signature.nodup_allNames_addConst hwf.namesDisjoint hfresh
   · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addConst _ _) hwf'
+  · exact hwf.builtins.mono (Signature.Subset.subset_addConst _ _)
 
 theorem TransState.addUnary.wf (st : TransState) (u : FOL.Unary) :
     TransState.wf st →
@@ -271,6 +317,7 @@ theorem TransState.addUnary.wf (st : TransState) (u : FOL.Unary) :
   · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addUnary _ _) hwf'
   · exact hwf'
   · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addUnary _ _) hwf'
+  · exact hwf.builtins.mono (Signature.Subset.subset_addUnary _ _)
 
 theorem TransState.addBinary.wf (st : TransState) (b : FOL.Binary) :
     TransState.wf st →
@@ -282,6 +329,7 @@ theorem TransState.addBinary.wf (st : TransState) (b : FOL.Binary) :
   · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addBinary _ _) hwf'
   · exact hwf'
   · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addBinary _ _) hwf'
+  · exact hwf.builtins.mono (Signature.Subset.subset_addBinary _ _)
 
 theorem TransState.addUnaryRel.wf (st : TransState) (u : FOL.UnaryRel) :
     TransState.wf st →
@@ -293,6 +341,7 @@ theorem TransState.addUnaryRel.wf (st : TransState) (u : FOL.UnaryRel) :
   · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addUnaryRel _ _) hwf'
   · exact hwf'
   · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addUnaryRel _ _) hwf'
+  · exact hwf.builtins.mono (Signature.Subset.subset_addUnaryRel _ _)
 
 theorem TransState.addBinaryRel.wf (st : TransState) (b : FOL.BinaryRel) :
     TransState.wf st →
@@ -304,6 +353,7 @@ theorem TransState.addBinaryRel.wf (st : TransState) (b : FOL.BinaryRel) :
   · exact Context.wfIn_mono _ hwf.assertsWf (Signature.Subset.subset_addBinaryRel _ _) hwf'
   · exact hwf'
   · exact SpatialContext.wfIn_mono hwf.ownsWf (Signature.Subset.subset_addBinaryRel _ _) hwf'
+  · exact hwf.builtins.mono (Signature.Subset.subset_addBinaryRel _ _)
 
 /-- The name produced by `freshConst` is not in the existing decls. -/
 theorem TransState.freshConst_fresh (st : TransState) (hint : Option String) (τ : Srt) :
@@ -339,6 +389,7 @@ theorem TransState.addAssert.wf (st : TransState) :
     · exact hwf.assertsWf ψ hψ
   · exact hwf.namesDisjoint
   · exact hwf.ownsWf
+  · exact hwf.builtins
 
 theorem TransState.addSpatial.wf (st : TransState) :
     TransState.wf st →
@@ -349,6 +400,7 @@ theorem TransState.addSpatial.wf (st : TransState) :
   · exact hwf.assertsWf
   · exact hwf.namesDisjoint
   · simpa [SpatialContext.wfIn_cons] using And.intro ha hwf.ownsWf
+  · exact hwf.builtins
 
 theorem TransState.persist_wf (st : TransState) :
     TransState.wf st →
@@ -358,3 +410,4 @@ theorem TransState.persist_wf (st : TransState) :
   · exact hwf.assertsWf
   · exact hwf.namesDisjoint
   · simp [TransState.persist]
+  · exact hwf.builtins


### PR DESCRIPTION
This PR introduces a guarding mechanism that allows Mica to guard the axioms it provides to z3. When we check for an assertion locally, we can decide whether the guarded axioms are enabled or not. The functionality is used at the verifier level to provide two different ways of checking formulas:

- `VerifM.test` does a quick check with the guarded axioms disabled. It can be used, for example, for searching for a location in the context (up to equality). 
- `VerifM.assert` ensures that the formula holds with the guarded axioms enabled. It can be used in cases where it's known that a formula must hold.

To ensure that the test remains quick even when Z3 fails to prove satisfiability, this PR also adds support for dynamically adjusting the timeout of Z3. The timeout is reduced to 100ms when using `VerifM.test`.  