### PR TITLE
Mica shadow library for the stdlib 

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -11,6 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
+      - name: Install OCaml
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ocaml
+          ocamlc -version
       - name: Install Z3
         run: |
           Z3_VERSION=4.15.4

--- a/Examples/abs.ml
+++ b/Examples/abs.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Absolute value with an exact functional spec: r = |n|.
    We split on the sign of n using assertion-level if/then/else. *)
 let abs_ (x: int) : int = if x < 0 then 0 - x else x

--- a/Examples/arrays.ml
+++ b/Examples/arrays.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Shared (unowned) arrays.
 
    An [int array] is a heap-allocated block exposing only its length at the

--- a/Examples/avl.ml
+++ b/Examples/avl.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* AVL trees with the same public-bound wrapper style as [bst.ml].
 
    Each internal node stores its cached height:

--- a/Examples/bst.ml
+++ b/Examples/bst.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Binary search trees with a global sortedness invariant hidden behind
    a small public handle.
 

--- a/Examples/composed.ml
+++ b/Examples/composed.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Multi-argument functions and inter-function dependencies.
    Later declarations use the specs of earlier ones as their
    "induction hypotheses" for function calls. *)

--- a/Examples/division.ml
+++ b/Examples/division.ml
@@ -1,3 +1,5 @@
+open Mica
+
 let half (x: int) : int =
   x / 2
 [@@spec fun v ->

--- a/Examples/fib.ml
+++ b/Examples/fib.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Recursive specification function for Fibonacci. *)
 let rec fib (n: int) : int =
   if n < 1 then 0

--- a/Examples/floats.ml
+++ b/Examples/floats.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Float examples *)
 
 (* `fp.leq x x` holds unless x is NaN; loads float_le and float_is_nan. *)

--- a/Examples/gcd.ml
+++ b/Examples/gcd.ml
@@ -1,3 +1,5 @@
+open Mica
+
 let rec gcd (a: int) (b: int) : int =
   if b = 0 then a
   else gcd b (a mod b)

--- a/Examples/in_place_fib.ml
+++ b/Examples/in_place_fib.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* In-place Fibonacci
 
    The runtime loop owns two heap cells.  Each step performs the simultaneous

--- a/Examples/in_place_partition.ml
+++ b/Examples/in_place_partition.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* In-place partition over a recursive list.
 
    The input list is pure, but the two output accumulators are owned heap cells.

--- a/Examples/matrix.ml
+++ b/Examples/matrix.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* A flat [m]-by-[n] matrix stored in a single shared [int array].
 
    The element at row [r], column [c] lives at flat index [r * n + c]. 

--- a/Examples/owned_pair.ml
+++ b/Examples/owned_pair.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Owned-reference lookup is a performance-sensitive path. To resolve `!r`, the
    verifier walks the ownership context and uses low-effort checks to test
    whether the dereferenced location equals each candidate's location. *)

--- a/Examples/owned_ref.ml
+++ b/Examples/owned_ref.ml
@@ -1,3 +1,5 @@
+open Mica
+
 let owned_ref_roundtrip (x : int) : unit =
   let r = ref 0 [@owned] in
   r := 7;

--- a/Examples/owned_transfer.ml
+++ b/Examples/owned_transfer.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Owned references across calls (Phase 6).
 
    The spec-level binder `bind (own r)` introduces the bundled typed points-to

--- a/Examples/qualified_paths.ml
+++ b/Examples/qualified_paths.ml
@@ -1,3 +1,5 @@
+open Mica
+
 let clamp (lo : int) (hi : int) (x : int) : int =
   Int.max (Int.min x hi) lo
 [@@spec fun lo hi x ->

--- a/Examples/recursive.ml
+++ b/Examples/recursive.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Recursive functions and what the verifier can prove about them.
    The verifier uses the spec as the induction hypothesis for recursive calls,
    so a valid spec must be an inductive invariant.

--- a/Examples/recursive_types.ml
+++ b/Examples/recursive_types.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Examples using recursive types.
    `ilist` is an integer list: `Nil` (tag 0) or `Cons of int * ilist` (tag 1). *)
 

--- a/Examples/references.ml
+++ b/Examples/references.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* References combined with recursive datatypes, matching, recursion, integers,
    and booleans.
 

--- a/Examples/sorting.ml
+++ b/Examples/sorting.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* In-place sorting and binary search over shared (unowned) [int array]s.
 
    Arrays expose only their length at the spec level; element contents are not

--- a/Examples/spec_functions.ml
+++ b/Examples/spec_functions.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Spec-level functions: fn-marked definitions introduce SMT functions
    that specifications can call as ordinary applications. *)
 

--- a/Examples/spec_recursion_tuples.ml
+++ b/Examples/spec_recursion_tuples.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Spec-level recursive functions over tuples.
 
    Exercises three pieces of newly-added spec-function machinery in

--- a/Examples/specs.ml
+++ b/Examples/specs.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Single-argument functions with type annotations for the verifier. *)
 
 (* 1. Identity: returns the input unchanged *)

--- a/Examples/strings.ml
+++ b/Examples/strings.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* String lane acceptance tests. *)
 
 let wrap (s : string) : string =

--- a/Examples/sum_classify.ml
+++ b/Examples/sum_classify.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Sum type construction with if/then/else *)
 type result = Ok of int | Err of int
 

--- a/Examples/sum_match.ml
+++ b/Examples/sum_match.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Option type with match expressions *)
 type option_int = None | Some of int
 

--- a/Examples/tuples.ml
+++ b/Examples/tuples.ml
@@ -1,3 +1,5 @@
+open Mica
+
 (* Functions that use tuples as arguments or return values. *)
 
 (* 1. Swap a pair: returns (b, a) given (a, b) as ints *)

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -156,6 +156,7 @@ structure TypeDecl where
   body   : TypeDeclBody
 
 inductive DeclKind where
+  | open_ (path : Path)
   | type_ (decl : TypeDecl)
   | val_ (rec : Bool) (binders : List Pattern) (retTy : Option Typ) (body : Expr)
 

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -31,6 +31,8 @@ inductive ElaborateErrorKind where
   | bareSpecialIdentifier (name : String)
   | missingMatchBranch (tag : Nat) (arity : Nat)
   | emptyMatch
+  | missingOpenMica
+  | unsupportedOpen (path : Path)
   | unsupportedPath (path : Path)
   | internalError (desc : String)
   deriving Inhabited
@@ -57,6 +59,8 @@ def ElaborateErrorKind.toString : ElaborateErrorKind → String
   | .missingMatchBranch tag arity =>
     s!"missing match branch for constructor {tag} (of {arity})"
   | .emptyMatch => "empty match expression"
+  | .missingOpenMica => "source files must begin with `open Mica`"
+  | .unsupportedOpen path => s!"unsupported open '{path}' (only `open Mica` is supported)"
   | .unsupportedPath path => s!"unsupported qualified path '{path}'"
   | .internalError desc => s!"internal error: {desc}"
 
@@ -686,6 +690,11 @@ private def hasAttrRelation (attrs : List Attribute) : ElabM Bool :=
 def Decl.elaborate (env : ElabEnv) (decl : Decl)
     : ElabM (ElabEnv × Option (Untyped.Decl (Spec.Body Untyped.Expr))) := do
   match decl.kind with
+  | .open_ path =>
+    if path == Path.single "Mica" then
+      err decl.loc (.unsupportedFeature "`open Mica` must be the first declaration")
+    else
+      err decl.loc (.unsupportedOpen path)
   | .type_ tdecl => do
     let (env', tdecl') ← TypeDecl.elaborate env decl.loc tdecl
     .ok (env', tdecl'.map Untyped.Decl.type_)
@@ -711,8 +720,18 @@ private def elaborateDecls (env : ElabEnv) :
     | some decl => .ok (decl :: rest)
     | none => .ok rest
 
+private def requireOpenMica : List Decl → ElabM (List Decl)
+  | [] => err default .missingOpenMica
+  | d :: ds =>
+    match d.kind with
+    | .open_ path =>
+      if path == Path.single "Mica" then .ok ds
+      else err d.loc (.unsupportedOpen path)
+    | _ => err d.loc .missingOpenMica
+
 def Program.elaborate (resolver : Resolver) (prog : Frontend.Program) :
-    ElabM (Untyped.Program (Spec.Body Untyped.Expr)) :=
-  elaborateDecls { resolver } prog
+    ElabM (Untyped.Program (Spec.Body Untyped.Expr)) := do
+  let decls ← requireOpenMica prog
+  elaborateDecls { resolver } decls
 
 end Frontend

--- a/Mica/Frontend/Lexer.lean
+++ b/Mica/Frontend/Lexer.lean
@@ -57,6 +57,7 @@ inductive Token where
   | kw_let | kw_rec | kw_in | kw_fun
   | kw_if | kw_then | kw_else
   | kw_match | kw_with
+  | kw_open
   | kw_type | kw_of
   | kw_assert
   | kw_true | kw_false
@@ -90,6 +91,7 @@ def Token.toString : Token → String
   | .kw_let   => "let"   | .kw_rec  => "rec"   | .kw_in   => "in"
   | .kw_fun   => "fun"   | .kw_if   => "if"    | .kw_then => "then"
   | .kw_else  => "else"  | .kw_match => "match" | .kw_with => "with"
+  | .kw_open  => "open"
   | .kw_type  => "type"  | .kw_of   => "of"
   | .kw_assert => "assert"
   | .kw_true  => "true"  | .kw_false => "false"
@@ -169,6 +171,7 @@ private def keyword (s : String) : Token :=
   | "let"    => .kw_let    | "rec"    => .kw_rec    | "in"     => .kw_in
   | "fun"    => .kw_fun    | "if"     => .kw_if     | "then"   => .kw_then
   | "else"   => .kw_else   | "match"  => .kw_match  | "with"   => .kw_with
+  | "open"   => .kw_open
   | "type"   => .kw_type   | "of"     => .kw_of
   | "assert" => .kw_assert
   | "true"   => .kw_true   | "false"  => .kw_false

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -760,11 +760,18 @@ where
 private partial def parseDecl : Parser Decl := fun st =>
   let p := peekLoc st
   match peekTok st with
+  | .kw_open => parseOpenDecl p st
   | .kw_type => parseTypeDecl p st
   | .kw_let  => parseValDecl p st
   | t =>
-    .error { loc := peekLoc st, kind := .unexpectedToken "declaration (let or type)" t }
+    .error { loc := peekLoc st, kind := .unexpectedToken "declaration (open, let, or type)" t }
 where
+  parseOpenDecl (p : Location) : Parser Decl := fun st => do
+    let st ← expect .kw_open st
+    let (head, st) ← expectIdent st
+    let (path, st) ← collectPathTail head [] st
+    .ok ({ loc := spanTo p st, kind := .open_ path, attrs := [] }, st)
+
   parseTypeDecl (p : Location) : Parser Decl := fun st => do
     let st ← expect .kw_type st
     -- optional type parameters: `'a`, `('a, 'b)`, etc.
@@ -901,7 +908,7 @@ private partial def parseProgram : Parser Program := fun st =>
   match peekTok st with
   | .eof => .ok ([], st)
   | .semisemi => parseProgram (advance st)
-  | .kw_let | .kw_type => do
+  | .kw_open | .kw_let | .kw_type => do
     let (decl, st) ← parseDecl st
     -- skip optional `;;`
     let st := if peekTok st == .semisemi then advance st else st

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -248,6 +248,7 @@ partial def Decl.print (d : Decl) : String :=
     | some payload => "\n[@@" ++ attr.name ++ " " ++ Expr.print payload ++ "]"
   let attrsSuffix := joinWith "" attrsStr
   match d.kind with
+  | .open_ path => "open " ++ path.toString
   | .type_ td => printTypeDecl td ++ attrsSuffix
   | .val_ isRec binders retTy body =>
     let recStr := if isRec then "rec " else ""

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -56,11 +56,12 @@ partial def waitForExitOrTimeout {cfg : IO.Process.StdioConfig}
         IO.sleep (UInt32.ofNat sleepMs)
         waitForExitOrTimeout child (remainingMs - sleepMs)
 
-def runProcessWithTimeout (cmd : String) (args : Array String) (timeoutMs : UInt32) :
-    IO ProcessResult := do
+def runProcessWithTimeoutIn? (cmd : String) (args : Array String) (cwd? : Option FilePath)
+    (timeoutMs : UInt32) : IO ProcessResult := do
   let child ← IO.Process.spawn {
     cmd := cmd
     args := args
+    cwd := cwd?
     stdin := .null
     stdout := .piped
     stderr := .piped
@@ -80,9 +81,29 @@ def runProcessWithTimeout (cmd : String) (args : Array String) (timeoutMs : UInt
       let stderr ← IO.ofExcept stderrTask.get
       pure (.terminated { exitCode, stdout, stderr })
 
-def runTest (mica : LeanExe) (file : FilePath) : ScriptM TestOutcome := do
+def runProcessWithTimeout (cmd : String) (args : Array String) (timeoutMs : UInt32) :
+    IO ProcessResult := do
+  runProcessWithTimeoutIn? cmd args none timeoutMs
+
+def runTest (mica : LeanExe) (file : FilePath) : IO TestOutcome := do
   let result ← runProcessWithTimeout mica.file.toString #[file.toString] testTimeoutMs
   return { path := file, result := result }
+
+def runStdlibCompile : IO TestOutcome := do
+  let cwd ← IO.currentDir
+  let path := cwd / "mica.ml"
+  IO.FS.withTempDir fun tmpDir => do
+    let result ←
+      try
+        runProcessWithTimeoutIn? "ocamlc" #["-c", path.toString, "-o", "mica.cmo"]
+          (some tmpDir) testTimeoutMs
+      catch e =>
+        pure (.terminated {
+          exitCode := 127
+          stdout := ""
+          stderr := s!"failed to run ocamlc: {e}\n"
+        })
+    return { path, result }
 
 def parseTestsuiteArgs (args : List String) : ScriptM TestsuiteOptions := do
   let mut summaryOnly := false
@@ -161,8 +182,8 @@ def resultSuffix (result : ProcessResult) : String :=
 def recordFailure (failed : List TestOutcome) (test : TestOutcome) : List TestOutcome :=
   if isFailure test.result then test :: failed else failed
 
-def printTestHeader (filename : String) : IO Unit := do
-  IO.print s!"Checking {filename} ..."
+def printTestHeader (verb filename : String) : IO Unit := do
+  IO.print s!"{verb} {filename} ..."
   (← IO.getStdout).flush
 
 private def bold (s : String) : String := s!"\x1b[1m{s}\x1b[0m"
@@ -174,6 +195,40 @@ def printFailureSummary (failed : List TestOutcome) : IO Unit := do
       | .timeout _ => " (timed out)"
       | .terminated _ => ""
     IO.println s!"- {test.path.fileName.getD test.path.toString}{suffix}"
+
+def reportTestOutcome (options : TestsuiteOptions) (failed : List TestOutcome) (verb : String)
+    (label : String) (test : TestOutcome) : IO (List TestOutcome) := do
+  printTestHeader verb label
+  IO.println (resultSuffix test.result)
+  let failed := recordFailure failed test
+  if !options.summaryOnly || isFailure test.result then
+    printCapturedOutput test
+  pure failed
+
+def runOcamlStdlibTests (options : TestsuiteOptions) (failed : List TestOutcome) :
+    IO (List TestOutcome) := do
+  let test ← runStdlibCompile
+  reportTestOutcome options failed "Compiling" "mica.ml" test
+
+def runMicaExampleTests (options : TestsuiteOptions) (mica : LeanExe)
+    (tests : Array FilePath) (failed : List TestOutcome) : IO (List TestOutcome) := do
+  unless tests.isEmpty do
+    IO.println ""
+  let mut failed := failed
+  for file in tests do
+    let filename := file.fileName.getD file.toString
+    let test ← runTest mica file
+    failed ← reportTestOutcome options failed "Checking" filename test
+  pure failed
+
+def printTestsuiteSummary (failed : List TestOutcome) : IO UInt32 := do
+  IO.println ""
+  if List.isEmpty failed then
+    IO.println (bold "all tests passed")
+    return 0
+  else
+    printFailureSummary failed
+    return 1
 
 def runFileSummaries (extraArgs : Array String) : IO UInt32 := do
   let child ← IO.Process.spawn {
@@ -206,21 +261,6 @@ script testsuite (args) := do
   let options ← parseTestsuiteArgs args
   let inputPath ← resolveInputPath options.dir
   let tests ← discoverTests inputPath
-  let mut failed : List TestOutcome := []
-  for file in tests do
-    let filename := file.fileName.getD file.toString
-    printTestHeader filename
-    let test <- runTest mica file
-    IO.println (resultSuffix test.result)
-    failed := recordFailure failed test
-    if !options.summaryOnly || isFailure test.result then
-      printCapturedOutput test
-
-  IO.println ""
-
-  if List.isEmpty failed then
-    IO.println (bold "all tests passed")
-    return 0
-  else
-    printFailureSummary failed
-    return 1
+  let failed ← runOcamlStdlibTests options []
+  let failed ← runMicaExampleTests options mica tests failed
+  printTestsuiteSummary failed

--- a/mica.ml
+++ b/mica.ml
@@ -1,0 +1,40 @@
+module String = struct
+  let length = Stdlib.String.length
+  let cat = Stdlib.String.cat
+  let equal = Stdlib.String.equal
+  let starts_with prefix s = Stdlib.String.starts_with ~prefix s
+  let ends_with suffix s = Stdlib.String.ends_with ~suffix s
+end
+
+module Int = struct
+  let min = Stdlib.min
+  let max = Stdlib.max
+end
+
+module Float = struct
+  let abs = Stdlib.Float.abs
+  let neg = Stdlib.Float.neg
+  let sqrt = Stdlib.Float.sqrt
+  let is_nan = Stdlib.Float.is_nan
+  let is_finite = Stdlib.Float.is_finite
+  let of_int = Stdlib.Float.of_int
+  let add = Stdlib.Float.add
+  let sub = Stdlib.Float.sub
+  let mul = Stdlib.Float.mul
+  let div = Stdlib.Float.div
+  let min = Stdlib.Float.min
+  let max = Stdlib.Float.max
+  let equal = Stdlib.Float.equal
+  let lt (x : float) y = x < y
+  let le (x : float) y = x <= y
+  let nan = Stdlib.Float.nan
+  let infinity = Stdlib.Float.infinity
+  let neg_infinity = Stdlib.Float.neg_infinity
+end
+
+module Array = struct
+  let make = Stdlib.Array.make
+  let length = Stdlib.Array.length
+  let get = Stdlib.Array.get
+  let set = Stdlib.Array.set
+end


### PR DESCRIPTION
Mica exposes only select functions from the standard library. To ensure the verifier is faithful, we shadow operations from the stdlib with our own such that the supported verifier primitives actually mean what one would expect.