### PR TITLE
Let with patterns

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ocaml
-          ocamlc -version
+          ocamlopt -version
       - name: Install Z3
         run: |
           Z3_VERSION=4.15.4
@@ -24,7 +24,7 @@ jobs:
           unzip -q z3.zip
           sudo install "z3-${Z3_VERSION}-x64-glibc-2.39/bin/z3" /usr/local/bin/z3
           z3 --version
-      - name: Test examples
+      - name: Test and compile examples
         run: |
           lake run testsuite Examples/
 

--- a/Examples/avl.ml
+++ b/Examples/avl.ml
@@ -39,13 +39,13 @@ let max_int (x: int) (y: int) : int =
 let height (tr: tree) : int =
   match tr with
   | Leaf -> 0
-  | Node n -> n.2
+  | Node (v, h, l, r) -> h
 [@@fn];;
 
 let height_impl (tr: tree) : int =
   match tr with
   | Leaf -> 0
-  | Node n -> n.2
+  | Node (v, h, l, r) -> h
 [@@spec fun tr ->
   ret (fun result -> assert (result = height tr))];;
 
@@ -53,17 +53,10 @@ let height_impl (tr: tree) : int =
    - values are in the inclusive BST interval [lo, hi],
    - cached heights are exact and non-negative,
    - every node satisfies the AVL balance bound. *)
-let rec avl_tree_inv (args: tree * int * int) : bool =
-  let tr = args.1 in
-  let lo = args.2 in
-  let hi = args.3 in
+let rec avl_tree_inv ((tr : tree), (lo : int), (hi : int)) : bool =
   match tr with
   | Leaf -> true
-  | Node n ->
-    let v = n.1 in
-    let h = n.2 in
-    let l = n.3 in
-    let r = n.4 in
+  | Node (v, h, l, r) ->
     let right_ok = avl_tree_inv (r, v, hi) in
     let left_ok = avl_tree_inv (l, lo, v) in
     let rh = height r in
@@ -76,10 +69,7 @@ let rec avl_tree_inv (args: tree * int * int) : bool =
 
 let avl_tree (h: t) : bool =
   match h with
-  | Avl p ->
-    let lo = p.1 in
-    let tr = p.2 in
-    let hi = p.3 in
+  | Avl (lo, tr, hi) ->
     let ok = avl_tree_inv (tr, lo, hi) in
     lo <= hi && ok
 [@@fn];;
@@ -109,36 +99,24 @@ let balance (v: int) (lo: int) (hi: int) (l: tree) (r: tree) : tree =
   if lh > rh + 1 then
     match l with
     | Leaf -> (* unreachable *) make_node v lo hi l r
-    | Node ln ->
-      let lv = ln.1 in
-      let ll = ln.3 in
-      let lr = ln.4 in
+    | Node (lv, lh, ll, lr) ->
       if height_impl ll >= height_impl lr then
         make_node lv lo hi ll (make_node v lv hi lr r)
       else
         match lr with
         | Leaf -> (* unreachable *) make_node v lo hi l r
-        | Node lrn ->
-          let lrv = lrn.1 in
-          let lrl = lrn.3 in
-          let lrr = lrn.4 in
+        | Node (lrv, lrh, lrl, lrr) ->
           make_node lrv lo hi (make_node lv lo lrv ll lrl) (make_node v lrv hi lrr r)
   else if rh > lh + 1 then
     match r with
     | Leaf -> (* unreachable *) make_node v lo hi l r
-    | Node rn ->
-      let rv = rn.1 in
-      let rl = rn.3 in
-      let rr = rn.4 in
+    | Node (rv, rh, rl, rr) ->
       if height_impl rr >= height_impl rl then
         make_node rv lo hi (make_node v lo rv l rl) rr
       else
         match rl with
         | Leaf -> (* unreachable *) make_node v lo hi l r
-        | Node rln ->
-          let rlv = rln.1 in
-          let rll = rln.3 in
-          let rlr = rln.4 in
+        | Node (rlv, rlh, rll, rlr) ->
           make_node rlv lo hi (make_node v lo rlv l rll) (make_node rv rlv hi rlr rr)
   else make_node v lo hi l r
 [@@spec fun v lo hi l r ->
@@ -163,10 +141,7 @@ let balance (v: int) (lo: int) (hi: int) (l: tree) (r: tree) : tree =
 let rec widen_tree (lo: int) (hi: int) (new_lo: int) (new_hi: int) (tr: tree) : unit =
   match tr with
   | Leaf -> ()
-  | Node n ->
-    let v = n.1 in
-    let l = n.3 in
-    let r = n.4 in
+  | Node (v, h, l, r) ->
     assert (new_lo <= v);
     assert (v <= new_hi);
     widen_tree lo v new_lo v l;
@@ -180,10 +155,7 @@ let rec widen_tree (lo: int) (hi: int) (new_lo: int) (new_hi: int) (tr: tree) : 
 let rec insert_raw (x: int) (lo: int) (hi: int) (tr: tree) : tree =
   match tr with
   | Leaf -> Node (x, 1, Leaf, Leaf)
-  | Node n ->
-    let v = n.1 in
-    let l = n.3 in
-    let r = n.4 in
+  | Node (v, h, l, r) ->
     if x < v then balance v lo hi (insert_raw x lo v l) r
     else if v < x then balance v lo hi l (insert_raw x v hi r)
     else tr
@@ -203,10 +175,7 @@ let singleton (x: int) : t =
 
 let insert (x: int) (h: t) : t =
   match h with
-  | Avl p ->
-    let lo = p.1 in
-    let tr = p.2 in
-    let hi = p.3 in
+  | Avl (lo, tr, hi) ->
     let new_lo = min_int x lo in
     let new_hi = max_int x hi in
     widen_tree lo hi new_lo new_hi tr;
@@ -217,18 +186,18 @@ let insert (x: int) (h: t) : t =
 
 let min (h: t) : int =
   match h with
-  | Avl p -> p.1
+  | Avl (lo, tr, hi) -> lo
 [@@spec fun h ->
   assert (avl_tree h);
-  bind (isinj 0 1 h) @@ fun (p : int * tree * int) ->
+  bind (isinj 0 1 h) @@ fun ((lo : int), (tr : tree), (hi : int)) ->
   ret (fun result ->
-    assert (result = p.1))];;
+    assert (result = lo))];;
 
 let max (h: t) : int =
   match h with
-  | Avl p -> p.3
+  | Avl (lo, tr, hi) -> hi
 [@@spec fun h ->
   assert (avl_tree h);
-  bind (isinj 0 1 h) @@ fun (p : int * tree * int) ->
+  bind (isinj 0 1 h) @@ fun ((lo : int), (tr : tree), (hi : int)) ->
   ret (fun result ->
-    assert (result = p.3))];;
+    assert (result = hi))];;

--- a/Examples/bst.ml
+++ b/Examples/bst.ml
@@ -36,16 +36,10 @@ let max_int (x: int) (y: int) : int =
    inclusive interval [lo, hi].  Each recursive call tightens the
    interval with the parent value, so descendants are checked against
    every ancestor bound. *)
-let rec sorted (args: tree * int * int) : bool =
-  let tr = args.1 in
-  let lo = args.2 in
-  let hi = args.3 in
+let rec sorted ((tr : tree), (lo : int), (hi : int)) : bool =
   match tr with
   | Leaf -> true
-  | Node n ->
-    let v = n.1 in
-    let l = n.2 in
-    let r = n.3 in
+  | Node (v, l, r) ->
     let right_sorted = sorted (r, v, hi) in
     let left_sorted = sorted (l, lo, v) in
     right_sorted && left_sorted && lo <= v && v <= hi
@@ -54,10 +48,7 @@ let rec sorted (args: tree * int * int) : bool =
 (* The public invariant for handles. *)
 let valid (h: t) : bool =
   match h with
-  | Bst p ->
-    let lo = p.1 in
-    let tr = p.2 in
-    let hi = p.3 in
+  | Bst (lo, tr, hi) ->
     let ok = sorted (tr, lo, hi) in
     lo <= hi && ok
 [@@fn];;
@@ -81,10 +72,7 @@ let make_node (v: int) (lo: int) (hi: int) (l: tree) (r: tree) : tree =
 let rec widen_tree (lo: int) (hi: int) (new_lo: int) (new_hi: int) (tr: tree) : unit =
   match tr with
   | Leaf -> ()
-  | Node n ->
-    let v = n.1 in
-    let l = n.2 in
-    let r = n.3 in
+  | Node (v, l, r) ->
     assert (new_lo <= v);
     assert (v <= new_hi);
     widen_tree lo v new_lo v l;
@@ -101,10 +89,7 @@ let rec widen_tree (lo: int) (hi: int) (new_lo: int) (new_hi: int) (tr: tree) : 
 let rec insert_raw (x: int) (lo: int) (hi: int) (tr: tree) : tree =
   match tr with
   | Leaf -> Node (x, Leaf, Leaf)
-  | Node n ->
-    let v = n.1 in
-    let l = n.2 in
-    let r = n.3 in
+  | Node (v, l, r) ->
     if x < v then make_node v lo hi (insert_raw x lo v l) r
     else if v < x then make_node v lo hi l (insert_raw x v hi r)
     else tr
@@ -126,10 +111,7 @@ let singleton (x: int) : t =
 
 let insert (x: int) (h: t) : t =
   match h with
-  | Bst p ->
-    let lo = p.1 in
-    let tr = p.2 in
-    let hi = p.3 in
+  | Bst (lo, tr, hi) ->
     let new_lo = min_int x lo in
     let new_hi = max_int x hi in
     widen_tree lo hi new_lo new_hi tr;
@@ -143,20 +125,20 @@ let insert (x: int) (h: t) : t =
 
 let min (h: t) : int =
   match h with
-  | Bst p -> p.1
+  | Bst (lo, tr, hi) -> lo
 [@@spec fun h ->
   let vh = valid h in
   assert (vh);
-  bind (isinj 0 1 h) @@ fun (p : int * tree * int) ->
+  bind (isinj 0 1 h) @@ fun ((lo : int), (tr : tree), (hi : int)) ->
   ret (fun result ->
-    assert (result = p.1))];;
+    assert (result = lo))];;
 
 let max (h: t) : int =
   match h with
-  | Bst p -> p.3
+  | Bst (lo, tr, hi) -> hi
 [@@spec fun h ->
   let vh = valid h in
   assert (vh);
-  bind (isinj 0 1 h) @@ fun (p : int * tree * int) ->
+  bind (isinj 0 1 h) @@ fun ((lo : int), (tr : tree), (hi : int)) ->
   ret (fun result ->
-    assert (result = p.3))];;
+    assert (result = hi))];;

--- a/Examples/in_place_fib.ml
+++ b/Examples/in_place_fib.ml
@@ -26,11 +26,12 @@ let rec advance (fuel : int) (a : int ref [@owned]) (b : int ref [@owned]) : uni
   bind (own a) @@ fun (start_a : int) ->
   bind (own b) @@ fun (start_b : int) ->
   ret (fun result ->
-    bind (own a) @@ fun (final_a : int) ->
-    bind (own b) @@ fun (final_b : int) ->
-    let expected = fib_state (start_a, start_b, fuel) in
-    assert (final_a = expected.1);
-    assert (final_b = expected.2))];;
+	    bind (own a) @@ fun (final_a : int) ->
+	    bind (own b) @@ fun (final_b : int) ->
+	    let expected = fib_state (start_a, start_b, fuel) in
+	    let ((expected_a : int), (expected_b : int)) = expected in
+	    assert (final_a = expected_a);
+	    assert (final_b = expected_b))];;
 
 let fib (n : int) : int =
   let a = ref 0 [@owned] in
@@ -38,7 +39,8 @@ let fib (n : int) : int =
   advance n a b;
   !a
 [@@spec fun n ->
-  assert (n >= 0);
-  ret (fun result ->
-    let expected = fib_state (0, 1, n) in
-    assert (result = expected.1))];;
+	  assert (n >= 0);
+	  ret (fun result ->
+	    let expected = fib_state (0, 1, n) in
+	    let ((expected_a : int), (_expected_b : int)) = expected in
+	    assert (result = expected_a))];;

--- a/Examples/in_place_fib.ml
+++ b/Examples/in_place_fib.ml
@@ -7,10 +7,7 @@ open Mica
    proves that after [fuel] steps the two cells contain exactly the tuple
    computed by the pure recurrence [fib_state]. *)
 
-let rec fib_state (s : int * int * int) : int * int =
-  let a = s.1 in
-  let b = s.2 in
-  let fuel = s.3 in
+let rec fib_state ((a : int), (b : int), (fuel : int)) : int * int =
   if fuel <= 0 then (a, b)
   else fib_state (b, a + b, fuel - 1)
 [@@fn];;
@@ -45,4 +42,3 @@ let fib (n : int) : int =
   ret (fun result ->
     let expected = fib_state (0, 1, n) in
     assert (result = expected.1))];;
-

--- a/Examples/in_place_partition.ml
+++ b/Examples/in_place_partition.ml
@@ -14,19 +14,19 @@ type ilist = Nil | Cons of int * ilist
 let rec length (xs : ilist) : int =
   match xs with
   | Nil -> 0
-  | Cons p -> 1 + length p.2
+  | Cons (x, rest) -> 1 + length rest
 [@@fn];;
 
 let rec all_neg (xs : ilist) : bool =
   match xs with
   | Nil -> true
-  | Cons p -> p.1 < 0 && all_neg p.2
+  | Cons (x, rest) -> x < 0 && all_neg rest
 [@@fn];;
 
 let rec all_nonneg (xs : ilist) : bool =
   match xs with
   | Nil -> true
-  | Cons p -> p.1 >= 0 && all_nonneg p.2
+  | Cons (x, rest) -> x >= 0 && all_nonneg rest
 [@@fn];;
 
 let empty (unused : int) : ilist =
@@ -37,15 +37,10 @@ let empty (unused : int) : ilist =
     assert (all_nonneg result);
     assert (length result = 0))];;
 
-let rec partition_counts (s : ilist * int * int) : int * int =
-  let xs = s.1 in
-  let neg_len = s.2 in
-  let nonneg_len = s.3 in
+let rec partition_counts ((xs : ilist), (neg_len : int), (nonneg_len : int)) : int * int =
   match xs with
   | Nil -> (neg_len, nonneg_len)
-  | Cons p ->
-    let x = p.1 in
-    let rest = p.2 in
+  | Cons (x, rest) ->
     if x < 0 then
       partition_counts (rest, neg_len + 1, nonneg_len)
     else
@@ -56,9 +51,7 @@ let rec partition_into
     (xs : ilist) (neg : ilist ref [@owned]) (nonneg : ilist ref [@owned]) : unit =
   match xs with
   | Nil -> ()
-  | Cons p ->
-    let x = p.1 in
-    let rest = p.2 in
+  | Cons (x, rest) ->
     if x < 0 then
       neg := Cons (x, !neg)
     else
@@ -87,10 +80,8 @@ let partition (xs : ilist) : ilist * ilist =
   partition_into xs neg nonneg;
   (!neg, !nonneg)
 [@@spec fun xs ->
-  ret (fun result ->
+  ret (fun ((neg : ilist), (nonneg : ilist)) ->
     let expected = partition_counts (xs, 0, 0) in
-    let neg = result.1 in
-    let nonneg = result.2 in
     assert (all_neg neg);
     assert (all_nonneg nonneg);
     assert (length neg = expected.1);

--- a/Examples/in_place_partition.ml
+++ b/Examples/in_place_partition.ml
@@ -67,12 +67,13 @@ let rec partition_into
   ret (fun result ->
     bind (own neg) @@ fun (final_neg : ilist) ->
     bind (own nonneg) @@ fun (final_nonneg : ilist) ->
-    let expected =
-      partition_counts (xs, start_neg_len, start_nonneg_len) in
-    assert (all_neg final_neg);
-    assert (all_nonneg final_nonneg);
-    assert (length final_neg = expected.1);
-    assert (length final_nonneg = expected.2))];;
+	    let expected =
+	      partition_counts (xs, start_neg_len, start_nonneg_len) in
+	    let ((expected_neg : int), (expected_nonneg : int)) = expected in
+	    assert (all_neg final_neg);
+	    assert (all_nonneg final_nonneg);
+	    assert (length final_neg = expected_neg);
+	    assert (length final_nonneg = expected_nonneg))];;
 
 let partition (xs : ilist) : ilist * ilist =
   let neg = ref (empty 0) [@owned] in
@@ -80,9 +81,10 @@ let partition (xs : ilist) : ilist * ilist =
   partition_into xs neg nonneg;
   (!neg, !nonneg)
 [@@spec fun xs ->
-  ret (fun ((neg : ilist), (nonneg : ilist)) ->
-    let expected = partition_counts (xs, 0, 0) in
-    assert (all_neg neg);
-    assert (all_nonneg nonneg);
-    assert (length neg = expected.1);
-    assert (length nonneg = expected.2))];;
+	  ret (fun ((neg : ilist), (nonneg : ilist)) ->
+	    let expected = partition_counts (xs, 0, 0) in
+	    let ((expected_neg : int), (expected_nonneg : int)) = expected in
+	    assert (all_neg neg);
+	    assert (all_nonneg nonneg);
+	    assert (length neg = expected_neg);
+	    assert (length nonneg = expected_nonneg))];;

--- a/Examples/owned_pair.ml
+++ b/Examples/owned_pair.ml
@@ -10,7 +10,7 @@ type ilist = Nil | Cons of int * ilist
 let rec length (xs : ilist) : int =
   match xs with
   | Nil -> 0
-  | Cons p -> 1 + length p.2
+  | Cons (x, rest) -> 1 + length rest
 [@@spec fun xs -> ret (fun v -> assert (v >= 0))];;
 
 (* Two owned cells of the same type: each read may skip candidates before the

--- a/Examples/records.ml
+++ b/Examples/records.ml
@@ -1,0 +1,41 @@
+open Mica
+
+(* Record syntax elaborates to tuple-shaped products in the frontend. *)
+
+type point = { x : int; y : int }
+
+type wrapped_point = Empty | Wrap of point
+
+let sum_record_binding (p : point) : int =
+  let { y = yy; x = xx } = p in
+  xx + yy
+[@@spec fun p ->
+  ret (fun v ->
+    assert (v = p.x + p.y))];;
+
+let sum_record_argument { y = yy; x = xx } : int =
+  xx + yy
+[@@spec fun p ->
+  ret (fun v ->
+    assert (v = p.x + p.y))];;
+
+let sum_record_literal (n : int) : int =
+  let { y = yy; x = xx } = { y = 2; x = 1 } in
+  xx + yy + n - n
+[@@spec fun n ->
+  ret (fun v ->
+    assert (v = 3))];;
+
+let sum_wrapped (w : wrapped_point) : int =
+  match w with
+  | Empty -> 0
+  | Wrap { y = yy; x = xx } -> xx + yy
+[@@spec fun w ->
+  ret (fun v ->
+    ret ())];;
+
+let result =
+  sum_record_binding { y = 4; x = 3 }
+  + sum_record_argument { y = 6; x = 5 }
+  + sum_record_literal 0
+  + sum_wrapped (Wrap { y = 8; x = 7 });;

--- a/Examples/recursive_types.ml
+++ b/Examples/recursive_types.ml
@@ -9,17 +9,17 @@ type ilist = Nil | Cons of int * ilist
 let head_or_zero (l: ilist) : int =
   match l with
   | Nil -> 0
-  | Cons x -> x.1
+  | Cons (x, rest) -> x
 [@@spec fun l ->
-  bind (isinj 1 2 l) @@ fun (payload : int * ilist) ->
+  bind (isinj 1 2 l) @@ fun ((x : int), (rest : ilist)) ->
   ret (fun v ->
-    assert (v = payload.1))];;
+    assert (v = x))];;
 
 (* Length is non-negative. *)
 let rec list_length (l: ilist) : int =
   match l with
   | Nil -> 0
-  | Cons x -> 1 + list_length x.2
+  | Cons (x, rest) -> 1 + list_length rest
 [@@spec fun l ->
   ret (fun v ->
     assert (v >= 0))];;
@@ -31,10 +31,10 @@ let result = list_length (Cons (1, Cons (2, Cons (3, Cons (4, Cons (5, Nil))))))
 let second_or_zero (l: ilist) : int =
   match l with
   | Nil -> 0
-  | Cons x ->
-    match x.2 with
+  | Cons (x, rest) ->
+    match rest with
     | Nil -> 0
-    | Cons y -> if y.1 <= 0 then 0 else y.1
+    | Cons (y, rest2) -> if y <= 0 then 0 else y
 [@@spec fun l ->
   ret (fun v ->
     assert (v >= 0))];;

--- a/Examples/references.ml
+++ b/Examples/references.ml
@@ -14,7 +14,7 @@ type ilist = Nil | Cons of int * ilist
 let rec length (xs : ilist) : int =
   match xs with
   | Nil -> 0
-  | Cons p -> 1 + length p.2
+  | Cons (x, rest) -> 1 + length rest
 [@@spec fun xs ->
   ret (fun v ->
     assert (v >= 0))];;
@@ -29,17 +29,16 @@ let singleton (x : int) : ilist =
   Cons (x, Nil)
 [@@spec fun x ->
   ret (fun r ->
-    bind (isinj 1 2 r) @@ fun (payload : int * ilist) ->
-    let tail = payload.2 in
+    bind (isinj 1 2 r) @@ fun ((head : int), (tail : ilist)) ->
     bind (isinj 0 2 tail) @@ fun (tail_payload : unit) ->
-    assert (payload.1 = x))];;
+    assert (head = x))];;
 
 let pop_or_zero (stack : ilist ref) : int =
   match !stack with
   | Nil -> 0
-  | Cons p ->
-    stack := p.2;
-    p.1
+  | Cons (x, rest) ->
+    stack := rest;
+    x
 [@@spec fun stack ->
   ret (fun r ->
     ret ())];;
@@ -47,7 +46,7 @@ let pop_or_zero (stack : ilist ref) : int =
 let top_is_positive (stack : ilist ref) : bool =
   match !stack with
   | Nil -> false
-  | Cons p -> p.1 > 0
+  | Cons (x, rest) -> x > 0
 [@@spec fun stack ->
   ret (fun r ->
     ret ())];;
@@ -58,9 +57,9 @@ let rec transfer (fuel : int) (src : ilist ref) (dst : ilist ref) : unit =
   else
     match !src with
     | Nil -> ()
-    | Cons p ->
-      src := p.2;
-      dst := Cons (p.1, !dst);
+    | Cons (x, rest) ->
+      src := rest;
+      dst := Cons (x, !dst);
       transfer (fuel - 1) src dst
 [@@spec fun fuel src dst ->
   ret (fun r ->

--- a/Examples/references.ml
+++ b/Examples/references.ml
@@ -85,8 +85,8 @@ let worklist_demo (a : int) (b : int) (c : int) (prefer_left : bool) : unit =
     transfer 3 todo done_
   else
     transfer 1 done_ todo;
-  let dropped_todo = pop_or_zero todo in
-  let dropped_done = pop_or_zero done_ in
+  let _ = pop_or_zero todo in
+  let _ = pop_or_zero done_ in
   ()
 [@@spec fun a b c prefer_left ->
   ret (fun r ->

--- a/Examples/spec_recursion_tuples.ml
+++ b/Examples/spec_recursion_tuples.ml
@@ -23,9 +23,7 @@ open Mica
 
 (* Spec-level recursive definition. The `[@@fn]` annotation registers
    it as an SMT function; specs invoke it by its OCaml name `sum_acc`. *)
-let rec sum_acc (s: int * int) : int =
-  let acc = s.1 in
-  let i   = s.2 in
+let rec sum_acc ((acc : int), (i : int)) : int =
   if i < 1 then acc
   else sum_acc (acc + i, i - 1)
 [@@fn];;
@@ -34,14 +32,12 @@ let rec sum_acc (s: int * int) : int =
    function exactly. Each recursive runtime call discharges
    `sum_acc (acc+i, i-1) = result`; the postcondition's
    `sum_acc s` is then equal to that, by one body unfolding. *)
-let rec sum_acc_impl (s: int * int) : int =
-  let acc = s.1 in
-  let i   = s.2 in
+let rec sum_acc_impl ((acc : int), (i : int)) : int =
   if i < 1 then acc
   else sum_acc_impl (acc + i, i - 1)
-[@@spec fun s ->
+[@@spec fun ((acc : int), (i : int)) ->
   ret (fun v ->
-    let expected = sum_acc s in
+    let expected = sum_acc (acc, i) in
     assert (v = expected))];;
 
 (* Closed entry point.  This function does not carry recursion itself,

--- a/Examples/tuples.ml
+++ b/Examples/tuples.ml
@@ -3,18 +3,15 @@ open Mica
 (* Functions that use tuples as arguments or return values. *)
 
 (* 1. Swap a pair: returns (b, a) given (a, b) as ints *)
-let swap_pair (p: int * int) : int * int =
-  let a = p.1 in
-  let b = p.2 in
+let swap_pair ((a : int), (b : int)) : int * int =
   (b, a)
-[@@spec fun p ->
-  ret (fun v ->
-    assert (p.1 = v.2);
-    assert (p.2 = v.1))];;
+[@@spec fun ((a : int), (b : int)) ->
+  ret (fun ((c : int), (d : int)) ->
+    assert (a = d);
+    assert (b = c))];;
 
-let sum_pair_pattern (p: int * int) : int =
-  let (x, y) = p in
+let sum_pair_pattern ((x : int), (y : int)) : int =
   x + y
-[@@spec fun p ->
+[@@spec fun ((x : int), (y : int)) ->
   ret (fun v ->
-    assert (v = p.1 + p.2))];;
+    assert (v = x + y))];;

--- a/Examples/tuples.ml
+++ b/Examples/tuples.ml
@@ -11,3 +11,10 @@ let swap_pair (p: int * int) : int * int =
   ret (fun v ->
     assert (p.1 = v.2);
     assert (p.2 = v.1))];;
+
+let sum_pair_pattern (p: int * int) : int =
+  let (x, y) = p in
+  x + y
+[@@spec fun p ->
+  ret (fun v ->
+    assert (v = p.1 + p.2))];;

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -104,6 +104,7 @@ mutual
     | const (c : Const)
     | ctor (path : Path) (payload : Option Pattern)
     | tuple (pats : List Pattern)
+    | record (fields : List (FieldName × Pattern))
 
   structure Pattern where
     loc  : Location

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -243,7 +243,6 @@ private def patternRecordFieldsToBinders (env : ElabEnv)
 private def patternToProductBinders (env : ElabEnv) (pat : Pattern) :
     ElabM (List Untyped.Binder) :=
   match pat.kind with
-  | .tuple [] => err pat.loc (.unsupportedPattern "unit is not a product binder")
   | .tuple pats => patternListToAnnotatedBinders env pats
   | .record fields => do
       let fieldInfo ← recordFieldsFor env pat.loc fields
@@ -271,7 +270,6 @@ private def patternComponentTypes? (env : ElabEnv) :
 
 private def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM TinyML.Typ :=
   match pat.kind with
-  | .tuple [] => err pat.loc (.unsupportedPattern "unit is not a product binder")
   | .tuple pats => do
       match ← patternComponentTypes? env pats with
       | some tys => .ok (TinyML.Typ.tuple tys)
@@ -285,7 +283,6 @@ private def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM TinyML.
 private def isProductPattern (pat : Pattern) : Bool :=
   match pat.kind with
   | .tuple (_ :: _) | .record _ => true
-  | .tuple [] => false
   | _ => false
 
 private def productArgumentName (stem : String) (idx : Nat) : String :=

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -76,9 +76,9 @@ instance : ToString ElaborateError := ⟨ElaborateError.toString⟩
 
 structure ElabEnv where
   types    : List TypeConstructor                            := []
-  ctors    : List (Constructor × (Nat × Nat))                := []
+  ctors    : List (Constructor × (Nat × Nat × TinyML.Typ))   := []
   fields   : List (FieldName × (TypeConstructor × Nat))      := []
-  records  : List (TypeConstructor × List FieldName)         := []
+  records  : List (TypeConstructor × List (FieldName × TinyML.Typ)) := []
   resolver : Resolver
 
 -- ---------------------------------------------------------------------------
@@ -133,6 +133,11 @@ def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyM
       | [arg] => .ok (.array arg)
       | _ => err loc (.arityMismatch 1 args'.length)
     | _ =>
+      match List.lookup name env.records with
+      | some fields =>
+          if args'.isEmpty then .ok (.tuple (fields.map Prod.snd))
+          else err loc (.arityMismatch 0 args'.length)
+      | none =>
       if env.types.elem name then .ok (.named name args')
       else err loc (.unknownType name)
   | .arrow dom cod => do
@@ -192,13 +197,59 @@ private def patternListToAnnotatedBinders (env : ElabEnv) :
     let bs ← patternListToAnnotatedBinders env ps
     .ok (b :: bs)
 
+private def checkRecordFieldSet (loc : Location) (fieldOrder : List FieldName) :
+    List (FieldName × α) → ElabM Unit
+  | [] => .ok ()
+  | (name, _) :: rest =>
+      if !fieldOrder.any (· == name) then
+        err loc (.unknownField name)
+      else if rest.any (fun (other, _) => other == name) then
+        err loc (.duplicateField name)
+      else
+        checkRecordFieldSet loc fieldOrder rest
+
+private def reorderFields (loc : Location) (provided : List (FieldName × α)) :
+    List FieldName → ElabM (List α)
+  | [] => .ok []
+  | fieldName :: rest => do
+    match provided.find? (fun (n, _) => n == fieldName) with
+    | some (_, a) =>
+      let rest' ← reorderFields loc provided rest
+      .ok (a :: rest')
+    | none => err loc (.unknownField fieldName)
+
+private def recordFieldsFor (env : ElabEnv) (loc : Location) (fields : List (FieldName × α)) :
+    ElabM (List (FieldName × TinyML.Typ)) :=
+  match fields with
+  | [] => err loc (.unsupportedFeature "empty record pattern")
+  | (name, _) :: _ =>
+      match List.lookup name env.fields with
+      | none => err loc (.unknownField name)
+      | some (tyName, _) =>
+          match List.lookup tyName env.records with
+          | none => err loc (.unknownType tyName)
+          | some fieldInfo => do
+              checkRecordFieldSet loc (fieldInfo.map Prod.fst) fields
+              .ok fieldInfo
+
+private def patternRecordFieldsToBinders (env : ElabEnv)
+    : List (FieldName × Pattern) → ElabM (List (FieldName × Untyped.Binder))
+  | [] => .ok []
+  | (name, pat) :: rest => do
+      let binder ← patternToBinderTyped env pat
+      let binders ← patternRecordFieldsToBinders env rest
+      .ok ((name, binder) :: binders)
+
 private def patternToProductBinders (env : ElabEnv) (pat : Pattern) :
     ElabM (List Untyped.Binder) :=
   match pat.kind with
   | .tuple [] => err pat.loc (.unsupportedPattern "unit is not a product binder")
   | .tuple pats => patternListToAnnotatedBinders env pats
-  | .const .unit => .ok []
-  | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
+  | .record fields => do
+      let fieldInfo ← recordFieldsFor env pat.loc fields
+      let binders ← patternRecordFieldsToBinders env fields
+      reorderFields pat.loc binders (fieldInfo.map Prod.fst)
+  | _ => err pat.loc (.unsupportedPattern "expected a flat product binder")
 
 private def patternComponentType? (env : ElabEnv) (pat : Pattern) : ElabM (Option TinyML.Typ) :=
   match pat.kind with
@@ -226,12 +277,14 @@ private def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM TinyML.
       | some tys => .ok (TinyML.Typ.tuple tys)
       | none =>
           err pat.loc (.unsupportedPattern "tuple function arguments must annotate each component")
-  | .const .unit => .ok (TinyML.Typ.tuple [])
-  | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
+  | .record fields => do
+      let fieldInfo ← recordFieldsFor env pat.loc fields
+      .ok (TinyML.Typ.tuple (fieldInfo.map Prod.snd))
+  | _ => err pat.loc (.unsupportedPattern "expected a flat product binder")
 
 private def isProductPattern (pat : Pattern) : Bool :=
   match pat.kind with
-  | .tuple (_ :: _) => true
+  | .tuple (_ :: _) | .record _ => true
   | .tuple [] => false
   | _ => false
 
@@ -275,25 +328,12 @@ private def insertBranch (env : ElabEnv) (loc : Location) (arity : Nat)
     : ElabM (List (Option (Untyped.Binder × Untyped.Expr))) :=
   match List.lookup name env.ctors with
   | none => .error { loc, kind := .unknownConstructor name }
-  | some (tag, arity') =>
+  | some (tag, arity', _) =>
     if arity' != arity then
       .error { loc, kind := .arityMismatch arity arity' }
     else
       let b := binder.getD .none
       .ok (listSet acc tag (some (b, body)))
-
--- ---------------------------------------------------------------------------
--- Record helpers (outside mutual block — no recursion into Expr)
-
-private def reorderElaborated (loc : Location) (elaborated : List (FieldName × Untyped.Expr))
-    : List FieldName → ElabM (List Untyped.Expr)
-  | [] => .ok []
-  | fieldName :: rest => do
-    match elaborated.find? (fun (n, _) => n == fieldName) with
-    | some (_, e) =>
-      let rest' ← reorderElaborated loc elaborated rest
-      .ok (e :: rest')
-    | none => err loc (.unknownField fieldName)
 
 -- ---------------------------------------------------------------------------
 -- Expression elaboration
@@ -311,7 +351,7 @@ private def elaborateBinOp (loc : Location) : BinOp → ElabM TinyML.BinOp
 private def elaborateCtorLookup (env : ElabEnv) (loc : Location) (name : String)
     (arg : Option Untyped.Expr) : ElabM Untyped.Expr :=
   match List.lookup name env.ctors with
-  | some (tag, arity) => .ok (.inj tag arity (arg.getD (.const .unit)))
+  | some (tag, arity, _) => .ok (.inj tag arity (arg.getD (.const .unit)))
   | none => err loc (.unknownConstructor name)
 
 /-- Apply a single expression attribute to an already-elaborated term. One arm
@@ -360,7 +400,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
       | "ref" | "not" => err loc (.bareSpecialIdentifier name)
       | _ =>
         match List.lookup name env.ctors with
-        | some (tag, arity) => .ok (.inj tag arity (.const .unit))
+        | some (tag, arity, _) => .ok (.inj tag arity (.const .unit))
         | none => .ok (.var name)
 
   | .ctor path =>
@@ -537,25 +577,24 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
       if isRec then
         err loc (.unsupportedFeature "let rec requires function arguments")
       else
-        match pat.kind with
-        | .tuple _ | .const .unit => do
+        if isProductPattern pat then
           let names ← patternToProductBinders env pat
           .ok (.letProd names bound' body')
-        | _ => do
+        else do
           let name ← patternToBinder pat
           .ok (.letIn name bound' body')
     | pat :: args => do
       let name ← patternToBinder pat
       let self := if isRec then name else .none
       let bound' ← Expr.elaborate env bound
-      let (args', bound'') ← elaborateFunctionArgs env "__param" 0 args bound'
+      let (args', bound'') ← elaborateFunctionArgs env "$param" 0 args bound'
       let body' ← Expr.elaborate env body
       .ok (.letIn name (.fix self args' none bound'') body')
 
   | .fun_ args retTy body => do
     let retTy' ← elaborateOptTyp env retTy
     let body' ← Expr.elaborate env body
-    let (args', body'') ← elaborateFunctionArgs env "__param" 0 args body'
+    let (args', body'') ← elaborateFunctionArgs env "$param" 0 args body'
     .ok (.fix .none args' retTy' body'')
 
   | .match_ scrut arms => do
@@ -566,7 +605,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     | (ctorName, _, _) :: _ =>
       match List.lookup ctorName env.ctors with
       | none => err loc (.unknownConstructor ctorName)
-      | some (_, arity) => do
+      | some (_, arity, _) => do
         let init : List (Option (Untyped.Binder × Untyped.Expr)) := List.replicate arity none
         let filled ← arms'.foldlM
           (fun acc (name, binder, body) => insertBranch env loc arity acc name binder body)
@@ -578,19 +617,11 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     let es' ← Expr.elaborateList env es
     .ok (.tuple es')
 
-  | .record flds =>
-    match flds with
-    | [] => err loc (.unsupportedFeature "empty record")
-    | (name, _) :: _ =>
-      match List.lookup name env.fields with
-      | none => err loc (.unknownField name)
-      | some (tyName, _) =>
-        match List.lookup tyName env.records with
-        | none => err loc (.unknownType tyName)
-        | some fieldOrder => do
-          let elaborated ← Expr.elaborateRecordFields env flds
-          let es' ← reorderElaborated loc elaborated fieldOrder
-          .ok (.tuple es')
+  | .record flds => do
+    let fieldInfo ← recordFieldsFor env loc flds
+    let elaborated ← Expr.elaborateRecordFields env flds
+    let es' ← reorderFields loc elaborated (fieldInfo.map Prod.fst)
+    .ok (.tuple es')
 
   | .recordUpdate _ _ => err loc .unsupportedRecordUpdate
 
@@ -623,16 +654,30 @@ def MatchArm.elaborateList (env : ElabEnv)
           | some (.aliased n) => .ok n
           | none => err pat.loc (.unsupportedPath path)
         else .ok path.head
+        let payloadTy ← match List.lookup name env.ctors with
+          | some (_, _, ty) => .ok ty
+          | none => err pat.loc (.unknownConstructor name)
         let (binder, body'') ← match payload with
           | some p =>
-            if isProductPattern p then do
-              let names ← patternToProductBinders env p
-              let argName := "__arg0"
-              pure (some (.named argName none), .letProd names (.var argName) body')
-            else do
-              let b ← patternToBinder p
-              pure (some b, body')
-          | none => pure (none, body')
+            match payloadTy with
+            | .tuple _ =>
+                if isProductPattern p then do
+                  let names ← patternToProductBinders env p
+                  let argName := "$arg0"
+                  pure (some (.named argName none), .letProd names (.var argName) body')
+                else
+                  err p.loc (.unsupportedPattern
+                    "constructor tuple or record payload must be destructured in the constructor pattern")
+            | _ =>
+                if isProductPattern p then
+                  err p.loc (.unsupportedPattern "constructor payload is not a product")
+                else do
+                  let b ← patternToBinder p
+                  pure (some b, body')
+          | none =>
+            match payloadTy with
+            | .prim .unit => pure (none, body')
+            | _ => err pat.loc (.unsupportedPattern "constructor payload must be matched")
         pure (name, binder, body'')
       | _ => err pat.loc (.unsupportedPattern "only constructor patterns are allowed in match")
     let rest ← MatchArm.elaborateList env arms
@@ -652,7 +697,7 @@ end
 
 private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
     (ctorDefs : List (Constructor × Option Typ)) (tag : Nat) (arity : Nat)
-    : ElabM (List TinyML.Typ × List (Constructor × (Nat × Nat))) :=
+    : ElabM (List TinyML.Typ × List (Constructor × (Nat × Nat × TinyML.Typ))) :=
   match ctorDefs with
   | [] => .ok ([], [])
   | (ctorName, payloadTy) :: rest => do
@@ -664,7 +709,7 @@ private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
       | none => .ok .unit
     let (restTypes, restCtors) ← elaborateCtorDefs env loc rest (tag + 1) arity
     .ok (payloadTy' :: restTypes,
-         (ctorName, (tag, arity)) :: restCtors)
+         (ctorName, (tag, arity, payloadTy')) :: restCtors)
 
 private def elaborateVariant (env : ElabEnv) (loc : Location) (name : TypeConstructor)
     (tparams : List TinyML.TyVar) (ctorDefs : List (Constructor × Option Typ))
@@ -696,11 +741,14 @@ private def elaborateRecordDecl (env : ElabEnv) (loc : Location) (name : TypeCon
     (fieldDefs : List (FieldName × Typ)) : ElabM ElabEnv := do
   if env.types.elem name then
     return ← err loc (.duplicateType name)
+  let envWithSelf := { env with types := name :: env.types }
   let newFields ← elaborateFieldDefs env loc name fieldDefs 0
-  let fieldNames := fieldDefs.map Prod.fst
+  let fieldTypes ← fieldDefs.mapM (fun (fieldName, ty) => do
+    let ty' ← Typ.elaborate envWithSelf ty
+    pure (fieldName, ty'))
   .ok { env with
     types := name :: env.types
-    records := (name, fieldNames) :: env.records
+    records := (name, fieldTypes) :: env.records
     fields := newFields ++ env.fields }
 
 def TypeDecl.elaborate (env : ElabEnv) (loc : Location) (decl : TypeDecl)
@@ -734,7 +782,7 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
     let self := if isRec then name else .none
     let retTy' ← elaborateOptTyp env retTy
     let body' ← Expr.elaborate env body
-    let (args', body'') ← elaborateFunctionArgs env "__param" 0 args body'
+    let (args', body'') ← elaborateFunctionArgs env "$param" 0 args body'
     .ok { name, body := .fix self args' retTy' body'', declMeta := md }
 
 -- ---------------------------------------------------------------------------

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -23,6 +23,7 @@ inductive ElaborateErrorKind where
   | duplicateConstructor (name : String)
   | duplicateType (name : String)
   | duplicateField (name : String)
+  | missingField (name : String)
   | unsupportedChar
   | unsupportedRecordUpdate
   | unsupportedPattern (desc : String)
@@ -46,6 +47,7 @@ def ElaborateErrorKind.toString : ElaborateErrorKind → String
   | .unknownConstructor name => s!"unknown constructor '{name}'"
   | .unknownType name => s!"unknown type '{name}'"
   | .unknownField name => s!"unknown field '{name}'"
+  | .missingField name => s!"missing field '{name}'"
   | .duplicateConstructor name => s!"duplicate constructor '{name}'"
   | .duplicateType name => s!"duplicate type name '{name}'"
   | .duplicateField name =>
@@ -216,7 +218,7 @@ private def reorderFields (loc : Location) (provided : List (FieldName × α)) :
     | some (_, a) =>
       let rest' ← reorderFields loc provided rest
       .ok (a :: rest')
-    | none => err loc (.unknownField fieldName)
+    | none => err loc (.missingField fieldName)
 
 private def recordFieldsFor (env : ElabEnv) (loc : Location) (fields : List (FieldName × α)) :
     ElabM (List (FieldName × TinyML.Typ)) :=

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -199,6 +199,56 @@ private def patternToProductBinders (env : ElabEnv) (pat : Pattern) :
   | .const .unit => .ok []
   | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
 
+private def patternComponentType? (env : ElabEnv) (pat : Pattern) : ElabM (Option TinyML.Typ) :=
+  match pat.kind with
+  | .binder _ (some ty) => do
+      let ty' ← Typ.elaborate env ty
+      .ok (some ty')
+  | .binder _ none | .wildcard => .ok none
+  | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
+
+private def patternComponentTypes? (env : ElabEnv) :
+    List Pattern → ElabM (Option (List TinyML.Typ))
+  | [] => .ok (some [])
+  | p :: ps => do
+      let ty? ← patternComponentType? env p
+      let tys? ← patternComponentTypes? env ps
+      match ty?, tys? with
+      | some ty, some tys => .ok (some (ty :: tys))
+      | _, _ => .ok none
+
+private def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM TinyML.Typ :=
+  match pat.kind with
+  | .tuple pats => do
+      match ← patternComponentTypes? env pats with
+      | some tys => .ok (TinyML.Typ.tuple tys)
+      | none =>
+          err pat.loc (.unsupportedPattern "tuple function arguments must annotate each component")
+  | .const .unit => .ok (TinyML.Typ.tuple [])
+  | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
+
+private def isProductPattern (pat : Pattern) : Bool :=
+  match pat.kind with
+  | .tuple _ | .const .unit => true
+  | _ => false
+
+private def productArgumentName (stem : String) (idx : Nat) : String :=
+  s!"{stem}{idx}"
+
+private def elaborateFunctionArgs (env : ElabEnv) (stem : String) :
+    Nat → List Pattern → Untyped.Expr → ElabM (List Untyped.Binder × Untyped.Expr)
+  | _, [], body => .ok ([], body)
+  | idx, pat :: pats, body => do
+      let (restArgs, restBody) ← elaborateFunctionArgs env stem (idx + 1) pats body
+      if isProductPattern pat then
+        let argName := productArgumentName stem idx
+        let argTy ← patternToProductType env pat
+        let names ← patternToProductBinders env pat
+        .ok (.named argName (some argTy) :: restArgs, .letProd names (.var argName) restBody)
+      else
+        let arg ← patternToBinderTyped env pat
+        .ok (arg :: restArgs, restBody)
+
 -- ---------------------------------------------------------------------------
 -- Match branch assembly
 
@@ -493,17 +543,17 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
           .ok (.letIn name bound' body')
     | pat :: args => do
       let name ← patternToBinder pat
-      let args' ← Pattern.toAnnotatedBinders env args
       let self := if isRec then name else .none
       let bound' ← Expr.elaborate env bound
+      let (args', bound'') ← elaborateFunctionArgs env "__param" 0 args bound'
       let body' ← Expr.elaborate env body
-      .ok (.letIn name (.fix self args' none bound') body')
+      .ok (.letIn name (.fix self args' none bound'') body')
 
   | .fun_ args retTy body => do
-    let args' ← Pattern.toAnnotatedBinders env args
     let retTy' ← elaborateOptTyp env retTy
     let body' ← Expr.elaborate env body
-    .ok (.fix .none args' retTy' body')
+    let (args', body'') ← elaborateFunctionArgs env "__param" 0 args body'
+    .ok (.fix .none args' retTy' body'')
 
   | .match_ scrut arms => do
     let scrut' ← Expr.elaborate env scrut
@@ -563,22 +613,27 @@ def MatchArm.elaborateList (env : ElabEnv)
   | [] => .ok []
   | ⟨pat, body⟩ :: arms => do
     let body' ← Expr.elaborate env body
-    let (ctorName, binder) ← match pat.kind with
+    let (ctorName, binder, body'') ← match pat.kind with
       | .ctor path payload => do
         let name ← if path.isQualified then
           match env.resolver.ctor path with
           | some (.aliased n) => .ok n
           | none => err pat.loc (.unsupportedPath path)
         else .ok path.head
-        let binder ← match payload with
-          | some p => do
-            let b ← patternToBinder p
-            pure (some b)
-          | none => pure none
-        pure (name, binder)
+        let (binder, body'') ← match payload with
+          | some p =>
+            if isProductPattern p then do
+              let names ← patternToProductBinders env p
+              let argName := "__arg0"
+              pure (some (.named argName none), .letProd names (.var argName) body')
+            else do
+              let b ← patternToBinder p
+              pure (some b, body')
+          | none => pure (none, body')
+        pure (name, binder, body'')
       | _ => err pat.loc (.unsupportedPattern "only constructor patterns are allowed in match")
     let rest ← MatchArm.elaborateList env arms
-    .ok ((ctorName, binder, body') :: rest)
+    .ok ((ctorName, binder, body'') :: rest)
 
 def Pattern.toAnnotatedBinders (env : ElabEnv)
     : List Pattern → ElabM (List Untyped.Binder)
@@ -674,10 +729,10 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
   | pat :: args =>
     let name ← patternToBinder pat
     let self := if isRec then name else .none
-    let args' ← Pattern.toAnnotatedBinders env args
     let retTy' ← elaborateOptTyp env retTy
     let body' ← Expr.elaborate env body
-    .ok { name, body := .fix self args' retTy' body', declMeta := md }
+    let (args', body'') ← elaborateFunctionArgs env "__param" 0 args body'
+    .ok { name, body := .fix self args' retTy' body'', declMeta := md }
 
 -- ---------------------------------------------------------------------------
 -- Program elaboration

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -184,6 +184,21 @@ private def patternToBinderTyped (env : ElabEnv) (pat : Pattern) : ElabM Untyped
     .ok (.named n ty')
   | _ => err pat.loc (.unsupportedPattern "expected a simple binder (variable or wildcard)")
 
+private def patternListToAnnotatedBinders (env : ElabEnv) :
+    List Pattern → ElabM (List Untyped.Binder)
+  | [] => .ok []
+  | p :: ps => do
+    let b ← patternToBinderTyped env p
+    let bs ← patternListToAnnotatedBinders env ps
+    .ok (b :: bs)
+
+private def patternToProductBinders (env : ElabEnv) (pat : Pattern) :
+    ElabM (List Untyped.Binder) :=
+  match pat.kind with
+  | .tuple pats => patternListToAnnotatedBinders env pats
+  | .const .unit => .ok []
+  | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
+
 -- ---------------------------------------------------------------------------
 -- Match branch assembly
 
@@ -464,13 +479,18 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     match binders with
     | [] => err loc (.unsupportedFeature "let with no binders")
     | [pat] => do
-      let name ← patternToBinder pat
       let bound' ← Expr.elaborate env bound
       let body' ← Expr.elaborate env body
       if isRec then
         err loc (.unsupportedFeature "let rec requires function arguments")
       else
-        .ok (.letIn name bound' body')
+        match pat.kind with
+        | .tuple _ | .const .unit => do
+          let names ← patternToProductBinders env pat
+          .ok (.letProd names bound' body')
+        | _ => do
+          let name ← patternToBinder pat
+          .ok (.letIn name bound' body')
     | pat :: args => do
       let name ← patternToBinder pat
       let args' ← Pattern.toAnnotatedBinders env args

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -195,6 +195,7 @@ private def patternListToAnnotatedBinders (env : ElabEnv) :
 private def patternToProductBinders (env : ElabEnv) (pat : Pattern) :
     ElabM (List Untyped.Binder) :=
   match pat.kind with
+  | .tuple [] => err pat.loc (.unsupportedPattern "unit is not a product binder")
   | .tuple pats => patternListToAnnotatedBinders env pats
   | .const .unit => .ok []
   | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
@@ -219,6 +220,7 @@ private def patternComponentTypes? (env : ElabEnv) :
 
 private def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM TinyML.Typ :=
   match pat.kind with
+  | .tuple [] => err pat.loc (.unsupportedPattern "unit is not a product binder")
   | .tuple pats => do
       match ← patternComponentTypes? env pats with
       | some tys => .ok (TinyML.Typ.tuple tys)
@@ -229,7 +231,8 @@ private def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM TinyML.
 
 private def isProductPattern (pat : Pattern) : Bool :=
   match pat.kind with
-  | .tuple _ | .const .unit => true
+  | .tuple (_ :: _) => true
+  | .tuple [] => false
   | _ => false
 
 private def productArgumentName (stem : String) (idx : Nat) : String :=

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -292,7 +292,7 @@ private partial def parsePattern : Parser Pattern := fun st =>
       -- constructor pattern (possibly qualified, e.g. `Option.Some x`)
       let (path, st') ← collectPathTail name [] (advance st)
       match peekTok st' with
-      | .ident _ | .underscore | .intLit _ | .charLit _ | .kw_true | .kw_false | .lparen => do
+      | .ident _ | .underscore | .intLit _ | .charLit _ | .kw_true | .kw_false | .lparen | .lbrace => do
         let (payload, st'') ← parsePattern st'
         .ok (mkPat p st'' (.ctor path (some payload)), st'')
       | _ =>
@@ -325,6 +325,11 @@ private partial def parsePattern : Parser Pattern := fun st =>
         .ok (pat, advance st')
       | t =>
         .error { loc := peekLoc st', kind := .unexpectedToken "')' or ',' in pattern" t }
+  | .lbrace => do
+    let st' := advance st
+    let (fields, st') ← parseRecordPatFields st'
+    let st' ← expect .rbrace st'
+    .ok (mkPat p st' (.record fields), st')
   | t =>
     .error { loc := peekLoc st, kind := .unexpectedToken "pattern" t }
 where
@@ -358,13 +363,26 @@ where
       .ok (p :: rest, st)
     | _ => .ok ([], st)
 
+  parseRecordPatFields : Parser (List (FieldName × Pattern)) := fun st => do
+    let (name, st) ← expectIdent st
+    let st ← expect .eq st
+    let (pat, st) ← parsePattern st
+    match peekTok st with
+    | .semi =>
+      if peekTok (advance st) == .rbrace then
+        .ok ([(name, pat)], advance st)
+      else do
+        let (rest, st) ← parseRecordPatFields (advance st)
+        .ok ((name, pat) :: rest, st)
+    | _ => .ok ([(name, pat)], st)
+
 -- ---------------------------------------------------------------------------
 -- Shared binder helpers
 -- These are top-level so both parseExpr (parseLet/parseFun) and parseDecl
 -- (parseValDecl) can call them directly.
 
 private def isPatStart : Token → Bool
-  | .ident _ | .underscore | .lparen | .intLit _ | .kw_true | .kw_false => true
+  | .ident _ | .underscore | .lparen | .lbrace | .intLit _ | .kw_true | .kw_false => true
   | _ => false
 
 private partial def parsePatternBinder : Parser Pattern := fun st =>
@@ -387,6 +405,11 @@ private partial def parsePatternBinder : Parser Pattern := fun st =>
       | .rparen => .ok (pat, advance st')
       | t =>
         .error { loc := peekLoc st', kind := .unexpectedToken "')' in binder" t }
+  | .lbrace => do
+    let st' := advance st
+    let (fields, st') ← parsePattern.parseRecordPatFields st'
+    let st' ← expect .rbrace st'
+    .ok (mkPat p st' (.record fields), st')
   | t =>
     .error { loc := peekLoc st, kind := .unexpectedToken "binder" t }
 

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -130,6 +130,8 @@ partial def Pattern.print (p : Pattern) : String :=
   | .ctor path none => path.toString
   | .ctor path (some pat) => s!"{path.toString} {parenIf (!Pattern.isAtom pat) (Pattern.print pat)}"
   | .tuple pats => parens (joinWith ", " (pats.map Pattern.print))
+  | .record fields =>
+    "{ " ++ joinWith "; " (fields.map fun (name, pat) => name ++ " = " ++ Pattern.print pat) ++ " }"
 
 -- ---------------------------------------------------------------------------
 -- Expression printing

--- a/Mica/Frontend/SpecParser.lean
+++ b/Mica/Frontend/SpecParser.lean
@@ -21,6 +21,15 @@ private def parsePred : Untyped.Expr → M Pred
   | .app (.var "own") [.var loc] => .ok (.own loc)
   | e => .error s!"expected predicate (isinj, own) over a variable, got {repr e}"
 
+private def addProductLets (bound : Untyped.Expr) :
+    Nat → List Untyped.Binder → Assert Untyped.Expr α → M (Assert Untyped.Expr α)
+  | _, [], rest => .ok rest
+  | idx, binder :: binders, rest => do
+      let rest' ← addProductLets bound (idx + 1) binders rest
+      match binder with
+      | .named x _ => .ok (.let_ x (.unop (.proj idx) bound) rest')
+      | .none => .ok rest'
+
 private def parseAssert (inner : Untyped.Expr → M α)
     (bareAssert : Untyped.Expr → M (Assert Untyped.Expr α)) :
     Untyped.Expr → M (Assert Untyped.Expr α)
@@ -37,6 +46,9 @@ private def parseAssert (inner : Untyped.Expr → M α)
   | .letIn .none (.assert cond) body => do
     let rest ← parseAssert inner bareAssert body
     .ok (.assert cond rest)
+  | .letProd names bound body => do
+    let rest ← parseAssert inner bareAssert body
+    addProductLets bound 0 names rest
   | .assert cond => bareAssert cond
   | .ifThenElse cond thn els => do
     .ok (.ite cond (← parseAssert inner bareAssert thn) (← parseAssert inner bareAssert els))

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -99,6 +99,12 @@ theorem wp_bind_if {cond thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
     R ⊢ wp pctx (.ifThenElse cond thn els) Q :=
   h.trans (wp.bind (k := TinyML.K.ifCond .hole thn els))
 
+theorem wp_bind_letProd {names : List Runtime.Binder} {bound body : Runtime.Expr}
+    {Q : Runtime.Val → iProp} {R : iProp}
+    (h : R ⊢ wp pctx bound (fun v => wp pctx (.letProd names (.val v) body) Q)) :
+    R ⊢ wp pctx (.letProd names bound body) Q :=
+  h.trans (wp.bind (k := TinyML.K.letProdK names .hole body))
+
 /-- Conditional on `true`: context unchanged. -/
 theorem wp_if_true {thn els : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}

--- a/Mica/SeparationLogic/Wp.lean
+++ b/Mica/SeparationLogic/Wp.lean
@@ -179,6 +179,14 @@ theorem wp.if_false {ctx : TinyML.PrimCtx} {thn els : Runtime.Expr} {Q : Runtime
     wp ctx els Q ⊢ wp ctx (.ifThenElse (.val (.bool false)) thn els) Q :=
   wp.pure_step (fun _ => .ifFalse) (by rintro μ e' μ' h; cases h; exact ⟨rfl, rfl⟩)
 
+theorem wp.letProd_val {ctx : TinyML.PrimCtx} {names : List Runtime.Binder}
+    {vs : List Runtime.Val} {body : Runtime.Expr} {Q : Runtime.Val → iProp}
+    (hlen : names.length = vs.length) :
+    wp ctx (body.subst (Runtime.Subst.id.updateAllBinder names vs)) Q ⊢
+      wp ctx (.letProd names (.val (.tuple vs)) body) Q :=
+  wp.pure_step (fun _ => .letProd hlen)
+    (by rintro μ e' μ' h; cases h; exact ⟨rfl, rfl⟩)
+
 /-- `assert true` returns unit; `assert false` is stuck. -/
 theorem wp.assert {ctx : TinyML.PrimCtx} {P : Runtime.Val → iProp} :
     P .unit ⊢ wp ctx (.assert (.val (.bool true))) P :=

--- a/Mica/TinyML/Language.lean
+++ b/Mica/TinyML/Language.lean
@@ -47,6 +47,7 @@ inductive KItem where
   | appArgs (fn : Runtime.Expr) (left : Runtime.Exprs) (right : Runtime.Vals)
   | appFn   (vs : Runtime.Vals)
   | ifCond (thn els : Runtime.Expr)
+  | letProdK (names : List Runtime.Binder) (body : Runtime.Expr)
   | ref
   | deref
   | storeR (loc : Runtime.Expr)
@@ -72,6 +73,7 @@ def KItem.fill : KItem → Runtime.Expr → Runtime.Expr
   | .appArgs fn left right, e => .app fn (left ++ [e] ++ right.map .val)
   | .appFn vs,            e => .app e (vs.map .val)
   | .ifCond thn els,      e => .ifThenElse e thn els
+  | .letProdK names body, e => .letProd names e body
   | .ref,                 e => .ref e
   | .deref,               e => .deref e
   | .storeR loc,          e => .store loc e
@@ -266,6 +268,7 @@ def K.items : K → List KItem
   | .appArgs fn left k right => k.items ++ [.appArgs fn left right]
   | .appFn k vs => k.items ++ [.appFn vs]
   | .ifCond k thn els => k.items ++ [.ifCond thn els]
+  | .letProdK names k body => k.items ++ [.letProdK names body]
   | .ref k => k.items ++ [.ref]
   | .deref k => k.items ++ [.deref]
   | .storeR loc k => k.items ++ [.storeR loc]
@@ -300,6 +303,7 @@ def KItem.toK : KItem → K
   | .appArgs fn left right => .appArgs fn left .hole right
   | .appFn vs => .appFn .hole vs
   | .ifCond thn els => .ifCond .hole thn els
+  | .letProdK names body => .letProdK names .hole body
   | .ref => .ref .hole
   | .deref => .deref .hole
   | .storeR loc => .storeR loc .hole

--- a/Mica/TinyML/OpSem.lean
+++ b/Mica/TinyML/OpSem.lean
@@ -41,6 +41,7 @@ inductive K where
   | appArgs (fn : Runtime.Expr) (left : Runtime.Exprs) (k : K) (right : Runtime.Vals)  -- evaluating one arg in a list
   | appFn   (k : K)    (vs : Runtime.Vals)                             -- fn in focus, all args are values
   | ifCond (k : K) (thn els : Runtime.Expr)
+  | letProdK (names : List Runtime.Binder) (k : K) (body : Runtime.Expr)
   | ref    (k : K)
   | deref  (k : K)
   | storeR (loc : Runtime.Expr) (k : K)                 -- val in focus (eval first)
@@ -66,6 +67,7 @@ def K.fill : K → Runtime.Expr → Runtime.Expr
   | .appArgs fn left k right, e => .app fn (left ++ [k.fill e] ++ right.map Runtime.Expr.val)
   | .appFn k vs,              e => .app (k.fill e) (vs.map Runtime.Expr.val)
   | .ifCond k thn els,  e => .ifThenElse (k.fill e) thn els
+  | .letProdK names k body, e => .letProd names (k.fill e) body
   | .ref k,             e => .ref (k.fill e)
   | .deref k,           e => .deref (k.fill e)
   | .storeR loc k,      e => .store loc (k.fill e)
@@ -92,6 +94,7 @@ def K.comp : K → K → K
   | .appArgs fn left k1 right, k2 => .appArgs fn left (k1.comp k2) right
   | .appFn k1 vs,              k2 => .appFn (k1.comp k2) vs
   | .ifCond k1 thn els, k2 => .ifCond (k1.comp k2) thn els
+  | .letProdK names k1 body, k2 => .letProdK names (k1.comp k2) body
   | .ref k1,            k2 => .ref (k1.comp k2)
   | .deref k1,          k2 => .deref (k1.comp k2)
   | .storeR loc k1,     k2 => .storeR loc (k1.comp k2)
@@ -138,6 +141,11 @@ inductive Head (ctx : PrimCtx) : Runtime.Expr → Heap → Runtime.Expr → Heap
   | ifTrue  : Head ctx (.ifThenElse (.val (.bool true))  thn els) μ thn μ
   /-- Conditional on false. -/
   | ifFalse : Head ctx (.ifThenElse (.val (.bool false)) thn els) μ els μ
+
+  /-- Product binding destructures a tuple value into the binder list. -/
+  | letProd : names.length = vs.length →
+      Head ctx (.letProd names (.val (.tuple vs)) body) μ
+        (body.subst (Runtime.Subst.id.updateAllBinder names vs)) μ
 
   /-- Allocate a fresh location holding a singleton block. -/
   | ref : Heap.Fresh l μ →

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -71,6 +71,7 @@ mutual
 partial def printExpr : Untyped.Expr → String
   | .letIn .none bound body => s!"{printOr bound};\n{printExpr body}"
   | .letIn name bound body => printLetIn name bound body
+  | .letProd names bound body => s!"let ({", ".intercalate (names.map Binder.print)}) = {printExpr bound} in\n{printExpr body}"
   | .ifThenElse cond thn els =>
     s!"if {printExpr cond} then {printExpr thn} else {printExpr els}"
   | .match_ scrut branches =>

--- a/Mica/TinyML/RuntimeExpr.lean
+++ b/Mica/TinyML/RuntimeExpr.lean
@@ -43,6 +43,7 @@ mutual
     | fix (self : Binder) (args : List Binder) (body : Expr)
     | app (fn : Expr) (args : List Expr)
     | ifThenElse (cond thn els : Expr)
+    | letProd (names : List Binder) (bound body : Expr)
     | ref    (e : Expr)
     | deref  (e : Expr)
     | store  (loc val : Expr)
@@ -163,6 +164,12 @@ mutual
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case ifThenElse.ifThenElse c1 t1 e1 c2 t2 e2 =>
       exact match c1.decEq c2, t1.decEq t2, e1.decEq e2 with
+      | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
+      | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case letProd.letProd bs1 d1 y1 bs2 d2 y2 =>
+      exact match decEq bs1 bs2, d1.decEq d2, y1.decEq y2 with
       | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
       | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
@@ -317,6 +324,7 @@ def Expr.subst (σ : Subst) : Expr → Expr
     .fix f args (body.subst (σ.remove' f |>.removeAll' args))
   | .app fn args => .app (fn.subst σ) (args.map (Expr.subst σ))
   | .ifThenElse c t e => .ifThenElse (c.subst σ) (t.subst σ) (e.subst σ)
+  | .letProd bs bound body => .letProd bs (bound.subst σ) (body.subst (σ.removeAll' bs))
   | .ref e => .ref (e.subst σ)
   | .deref e => .deref (e.subst σ)
   | .store loc v => .store (loc.subst σ) (v.subst σ)
@@ -336,6 +344,11 @@ def Expr.subst (σ : Subst) : Expr → Expr
 @[simp] theorem Expr.letIn_subst (σ : Subst) (name : Binder) (bound body : Expr) :
     (Expr.letIn name bound body).subst σ = Expr.letIn name (bound.subst σ) (body.subst (σ.remove' name)) := by
   simp [Expr.letIn, Expr.subst, Subst.remove'_none, Subst.removeAll'_cons, Subst.removeAll'_nil]
+
+@[simp] theorem Expr.letProd_subst (σ : Subst) (names : List Binder) (bound body : Expr) :
+    (Expr.letProd names bound body).subst σ =
+      Expr.letProd names (bound.subst σ) (body.subst (σ.removeAll' names)) := by
+  simp [Expr.subst]
 
 theorem Expr.isFunc_subst {e : Expr} {σ : Subst} (h : e.isFunc = true) :
     (e.subst σ).isFunc = true := by
@@ -403,6 +416,11 @@ theorem Expr.subst_comp (e : Expr) (σ ρ : Subst) :
     simp only [Subst.removeAll'_eq]
     cases f <;> simp [Subst.remove', Subst.remove] <;> split <;> simp_all
     all_goals (split <;> simp_all)
+  case letProd names bound body ihBound ihBody =>
+    congr 1
+    funext z
+    simp only [Subst.removeAll'_eq]
+    split <;> simp_all
 /-- Removing a binder from γ and then substituting it back yields the same as just updating γ.
     Used to prove Program.subst_remove_update. -/
 theorem Expr.subst_remove'_updateBinder (e : Expr) (γ : Subst) (b : Binder) (v : Val) :
@@ -423,6 +441,8 @@ def Expr.freeVars : Expr → List Var
     body.freeVars.filter (fun v => f != .named v && !args.any (· == .named v))
   | .app fn args => fn.freeVars ++ args.flatMap Expr.freeVars
   | .ifThenElse c t e => c.freeVars ++ t.freeVars ++ e.freeVars
+  | .letProd bs bound body =>
+    bound.freeVars ++ body.freeVars.filter (fun v => !bs.any (· == .named v))
   | .ref e => e.freeVars
   | .deref e => e.freeVars
   | .store loc v => loc.freeVars ++ v.freeVars
@@ -492,6 +512,19 @@ theorem Expr.freeVars_subst (γ1 γ2 : Var → Option Val) (e : Expr) :
     simp [Expr.subst, ihc γ1 γ2 (fun x hx => h x (by simp [hx])),
                        iht γ1 γ2 (fun x hx => h x (by simp [hx])),
                        ihe γ1 γ2 (fun x hx => h x (by simp [hx]))]
+  case letProd names bound body ihBound ihBody =>
+    intro h
+    simp only [Expr.subst]
+    rw [ihBound γ1 γ2]
+    · rw [ihBody (Subst.removeAll' γ1 names) (Subst.removeAll' γ2 names)]
+      intro x hx
+      simp only [Subst.removeAll'_eq]
+      by_cases hb : names.any (· == Binder.named x)
+      · simp [hb]
+      · simp [hb]
+        exact h x (by simp [Expr.freeVars, hx, hb])
+    · intro x hx
+      exact h x (by simp [Expr.freeVars, hx])
   case ref e ih =>
     intro h; simp only [Expr.freeVars] at h
     simp [Expr.subst, ih γ1 γ2 h]
@@ -725,6 +758,15 @@ private theorem Subst.removeAll'_updateAllBinder_comp (γ : Subst) (bs : Binders
     = (γ.updateAllBinder bs vs) z := by
   rw [removeAll'_updateAllBinder_gen _ _ hlen]
   congr 1; funext w; simp [Subst.id]; split <;> simp_all
+
+theorem Expr.subst_removeAll'_updateAllBinder (body : Expr) (γ : Subst)
+    (bs : Binders) (vs : Vals) (hlen : bs.length = vs.length) :
+    (body.subst (γ.removeAll' bs)).subst (Subst.id.updateAllBinder bs vs) =
+      body.subst (γ.updateAllBinder bs vs) := by
+  rw [Expr.subst_comp]
+  congr 1
+  funext z
+  exact Subst.removeAll'_updateAllBinder_comp γ bs vs hlen z
 
 -- Substitution composition lemma for the fix body.
 theorem Expr.subst_fix_comp (body : Expr)

--- a/Mica/TinyML/Typed.lean
+++ b/Mica/TinyML/Typed.lean
@@ -50,6 +50,7 @@ inductive Expr where
   | app (fn : Expr) (args : List Expr) (ty : Typ)
   | ifThenElse (cond thn els : Expr) (ty : Typ)
   | letIn (name : Binder) (bound body : Expr)
+  | letProd (names : List Binder) (bound body : Expr)
   | ref    (owned : Bool) (e : Expr)
   | deref  (e : Expr) (ty : Typ)
   | store  (loc val : Expr)
@@ -135,6 +136,11 @@ mutual
       | _, _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case letIn.letIn b1 d1 y1 b2 d2 y2 => exact match decEq b1 b2, d1.decEq d2, y1.decEq y2 with
+      | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
+      | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case letProd.letProd bs1 d1 y1 bs2 d2 y2 => exact match decEq bs1 bs2, d1.decEq d2, y1.decEq y2 with
       | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
       | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
@@ -246,6 +252,7 @@ def Expr.ty : Expr → Typ
   | .app _ _ ty => ty
   | .ifThenElse _ _ _ ty => ty
   | .letIn _ _ body => body.ty
+  | .letProd _ _ body => body.ty
   | .ref owned e => if owned then .owned e.ty else .ref e.ty
   | .deref _ ty => ty
   | .store _ _ => .unit
@@ -309,6 +316,7 @@ mutual
     | .app fn args _ => .app fn.runtime (args.map Expr.runtime)
     | .ifThenElse c t e _ => .ifThenElse c.runtime t.runtime e.runtime
     | .letIn b bound body => .letIn (b.runtime) bound.runtime body.runtime
+    | .letProd bs bound body => .letProd (bs.map (·.runtime)) bound.runtime body.runtime
     | .ref _ e => .ref e.runtime
     | .deref e _ => .deref e.runtime
     | .store loc val => .store loc.runtime val.runtime

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -131,6 +131,22 @@ def extendTyped (Γ : TinyML.TyCtx) (b : Typed.Binder) : TinyML.TyCtx :=
   | none => Γ
   | some x => Γ.extend x b.ty
 
+def extendTypedList (Γ : TinyML.TyCtx) (bs : List Typed.Binder) : TinyML.TyCtx :=
+  bs.foldl extendTyped Γ
+
+def inferProductBinders (Θ : TypeEnv) :
+    List Untyped.Binder → List Typ → Except TypeError (List Typed.Binder)
+  | [], [] => .ok []
+  | binder :: binders, ty :: tys => do
+      let binderTy := Typed.Binder.expectedTy binder ty
+      if Typ.sub Θ ty binderTy then
+        let typedBinder := Typed.Binder.ofUntyped binder binderTy
+        let rest ← inferProductBinders Θ binders tys
+        .ok (typedBinder :: rest)
+      else
+        .error (.subsumptionFailure ty binderTy)
+  | binders, tys => .error (.arityMismatch tys.length binders.length)
+
 def joinAll (Θ : TypeEnv) : List Typ → Typ
   | [] => .value
   | t :: ts => ts.foldl (Typ.join Θ) t
@@ -270,6 +286,14 @@ mutual
         let typedName := Typed.Binder.ofUntyped name (match name with | .named _ (some ty) => ty | _ => boundTy)
         let (bodyTy, body') ← infer prims Θ (extendTyped Γ typedName) body
         .ok (bodyTy, .letIn typedName bound' body')
+    | .letProd names bound body => do
+        let (boundTy, bound') ← infer prims Θ Γ bound
+        let tys ← match boundTy with
+          | .tuple tys => .ok tys
+          | _ => .error (.typeMismatch (.tuple []) boundTy)
+        let typedNames ← inferProductBinders Θ names tys
+        let (bodyTy, body') ← infer prims Θ (extendTypedList Γ typedNames) body
+        .ok (bodyTy, .letProd typedNames bound' body')
     | .ref owned e => do
         let (ty, e') ← infer prims Θ Γ e
         .ok ((if owned then .owned ty else .ref ty), .ref owned e')
@@ -389,6 +413,26 @@ end
 theorem Binder.ofUntyped_runtime (b : Untyped.Binder) (ty : Typ) :
     (Typed.Binder.ofUntyped b ty).runtime = b.runtime := by
   cases b <;> rfl
+
+theorem inferProductBinders_runtime (Θ : TypeEnv) :
+    ∀ (binders : List Untyped.Binder) (tys : List Typ) (typed : List Typed.Binder),
+      inferProductBinders Θ binders tys = .ok typed →
+        typed.map Typed.Binder.runtime = binders.map Untyped.Binder.runtime
+  | [], [], typed, h => by
+      simp [inferProductBinders] at h
+      subst h
+      rfl
+  | b :: bs, ty :: tys, typed, h => by
+      simp [inferProductBinders] at h
+      split at h
+      · have ⟨rest, hrest, hcont⟩ := Except.bind_ok h
+        cases hcont
+        simp [Binder.ofUntyped_runtime, inferProductBinders_runtime Θ bs tys rest hrest]
+      · cases h
+  | [], _ :: _, typed, h => by
+      simp [inferProductBinders] at h
+  | _ :: _, [], typed, h => by
+      simp [inferProductBinders] at h
 
 /-! ## Specification elaboration
 
@@ -691,6 +735,32 @@ mutual
                 simp [typedName, Binder.ofUntyped_runtime]
               simp [Expr.runtime, Untyped.Expr.runtime, ihBound _ hbound, ihBody _ hbody,
                 hname_rt]
+    | .letProd names bound body => by
+        let ihBound := infer_runtime prims Θ Γ bound
+        intro result h
+        unfold Typed.infer at h
+        have ⟨p, hbound, hcont⟩ := Except.bind_ok h
+        cases p with
+        | mk boundTy bound' =>
+          cases boundTy with
+          | tuple tys =>
+            have hcont' :
+                (do
+                  let typedNames ← inferProductBinders Θ names tys
+                  let p ← infer prims Θ (extendTypedList Γ typedNames) body
+                  Except.ok (p.1, Expr.letProd typedNames bound' p.2)) = .ok result := by
+              simpa using hcont
+            have ⟨typedNames, hnames, hcont⟩ := Except.bind_ok hcont'
+            let ihBody := infer_runtime prims Θ (extendTypedList Γ typedNames) body
+            have ⟨p, hbody, hcont⟩ := Except.bind_ok hcont
+            cases p with
+            | mk bodyTy body' =>
+              rcases (by simpa [hbody] using hcont) with ⟨rfl, rfl⟩
+              simp [Expr.runtime, Untyped.Expr.runtime, ihBound _ hbound, ihBody _ hbody,
+                inferProductBinders_runtime Θ names tys typedNames hnames]
+          | _ =>
+            simp at hcont
+            cases hcont
     | .ref owned e => by
         let ih := infer_runtime prims Θ Γ e
         intro result h

--- a/Mica/TinyML/Untyped.lean
+++ b/Mica/TinyML/Untyped.lean
@@ -31,6 +31,7 @@ inductive Expr where
   | app (fn : Expr) (args : List Expr)
   | ifThenElse (cond thn els : Expr)
   | letIn (name : Binder) (bound body : Expr)
+  | letProd (names : List Binder) (bound body : Expr)
   | ref    (owned : Bool) (e : Expr)
   | deref  (e : Expr)
   | store  (loc val : Expr)
@@ -102,6 +103,11 @@ mutual
       | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case letIn.letIn b1 d1 y1 b2 d2 y2 => exact match decEq b1 b2, d1.decEq d2, y1.decEq y2 with
+      | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
+      | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case letProd.letProd bs1 d1 y1 bs2 d2 y2 => exact match decEq bs1 bs2, d1.decEq d2, y1.decEq y2 with
       | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
       | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
@@ -230,6 +236,7 @@ def Expr.runtime : Untyped.Expr → Runtime.Expr
   | .app fn args => .app fn.runtime (args.map Expr.runtime)
   | .ifThenElse c t e => .ifThenElse c.runtime t.runtime e.runtime
   | .letIn b bound body => .letIn (b.runtime) bound.runtime body.runtime
+  | .letProd bs bound body => .letProd (bs.map (·.runtime)) bound.runtime body.runtime
   | .ref _ e => .ref e.runtime
   | .deref e => .deref e.runtime
   | .store loc val => .store loc.runtime val.runtime

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -111,6 +111,91 @@ theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : VerifM.En
 
 /-! ### Compiler and Top-Level Verifier -/
 
+def compileProductBindersFrom (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (names : List Binder) (tys : List TinyML.Typ) (tl : Term .vallist) :
+    VerifM (SpecMap × Bindings × TinyML.TyCtx) := do
+  match names, tys with
+  | [], [] => pure (S, B, Γ)
+  | b :: bs, ty :: tys => do
+      VerifM.expectEq "letProd binder type mismatch" b.ty ty
+      let si := Term.unop UnOp.vhead tl
+      let rest := Term.unop UnOp.vtail tl
+      match b.name with
+      | none => compileProductBindersFrom S B Γ bs tys rest
+      | some x =>
+          let x' ← VerifM.decl (some x) .value
+          VerifM.assume (.pure (Formula.eq .value (.const (.uninterpreted x'.name .value)) si))
+          compileProductBindersFrom (Finmap.erase x S) ((x, x') :: B) (Γ.extend x ty) bs tys rest
+  | _, _ => VerifM.fatal "letProd arity mismatch"
+
+def compileProductBinders (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (names : List Binder) (tys : List TinyML.Typ) (se : Term .value) :
+    VerifM (SpecMap × Bindings × TinyML.TyCtx) :=
+  compileProductBindersFrom S B Γ names tys (.unop .toValList se)
+
+omit [MicaGS HasLC.hasLC Sig] in
+theorem compileProductBindersFrom_length {S : SpecMap} {B : Bindings} {Γ : TinyML.TyCtx}
+    {names : List Binder} {tys : List TinyML.Typ} {tl : Term .vallist}
+    {st : TransState} {ρ : VerifM.Env}
+    {Ψ : SpecMap × Bindings × TinyML.TyCtx → TransState → VerifM.Env → Prop}
+    (htl_wf : tl.wfIn st.decls)
+    (heval : VerifM.eval (compileProductBindersFrom S B Γ names tys tl) st ρ Ψ) :
+    names.length = tys.length := by
+  induction names generalizing S B Γ tys tl st ρ Ψ with
+  | nil =>
+      cases tys with
+      | nil => rfl
+      | cons ty tys =>
+          simp only [compileProductBindersFrom] at heval
+          exact (VerifM.eval_fatal heval).elim
+  | cons b bs ih =>
+      cases tys with
+      | nil =>
+          simp only [compileProductBindersFrom] at heval
+          exact (VerifM.eval_fatal heval).elim
+      | cons ty tys =>
+          simp only [compileProductBindersFrom] at heval
+          have hexpect := VerifM.eval_bind _ _ _ _ heval
+          obtain ⟨hbty, hcont⟩ := VerifM.eval_expectEq hexpect
+          cases hname : b.name with
+          | none =>
+              simp [hname] at hcont
+              have htail_wf : (Term.unop UnOp.vtail tl).wfIn st.decls := ⟨trivial, htl_wf⟩
+              simp [ih htail_wf hcont]
+          | some x =>
+              simp [hname] at hcont
+              have hdecl_eval := VerifM.eval_bind _ _ _ _ hcont
+              have hdecl := VerifM.eval_decl hdecl_eval
+              let x' := st.freshConst (some x) .value
+              have hafter_decl := hdecl ((Term.unop UnOp.vhead tl).eval ρ.env)
+              have hassume := VerifM.eval_assumePure (VerifM.eval_bind _ _ _ _ hafter_decl)
+              have hstwf : st.decls.wf := (VerifM.eval.wf hdecl_eval).namesDisjoint
+              have hfresh : x'.name ∉ st.decls.allNames := by
+                simpa [x'] using TransState.freshConst_fresh st (some x) .value
+              have hhead_wf : (Term.unop UnOp.vhead tl).wfIn st.decls := ⟨trivial, htl_wf⟩
+              have htail_wf : (Term.unop UnOp.vtail tl).wfIn st.decls := ⟨trivial, htl_wf⟩
+              have hwf :
+                  (Formula.eq .value (.const (.uninterpreted x'.name .value))
+                    (Term.unop UnOp.vhead tl)).wfIn { st with decls := st.decls.addConst x' }.decls := by
+                simpa [x'] using
+                  (Formula.eq_wfIn_addConst_of_fresh (Δ := st.decls) (c := x')
+                    hstwf hhead_wf hfresh)
+              have hholds :
+                  (Formula.eq .value (.const (.uninterpreted x'.name .value))
+                    (Term.unop UnOp.vhead tl)).eval
+                      (ρ.updateConst .value x'.name ((Term.unop UnOp.vhead tl).eval ρ.env)).env := by
+                have hagree_head : Env.agreeOn st.decls ρ.env
+                    (ρ.updateConst .value x'.name ((Term.unop UnOp.vhead tl).eval ρ.env)).env :=
+                  Env.agreeOn_update_fresh_const hfresh
+                have hhead_same := Term.eval_env_agree hhead_wf hagree_head
+                simpa [Formula.eval, Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
+                  using hhead_same
+              have hrec_eval := hassume hwf hholds
+              have hlen := ih (Term.wfIn_mono (Term.unop UnOp.vtail tl) htail_wf
+                (Signature.Subset.subset_addConst st.decls x')
+                (Signature.wf_addConst hstwf hfresh)) hrec_eval
+              simp [hlen]
+
 mutual
   def compile (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
     | .const (.int n)  => pure (.unop .ofInt  (.const (.i n)))
@@ -162,8 +247,13 @@ mutual
           let x' ← VerifM.decl (some x) .value
           VerifM.assume (.pure (Formula.eq .value (.const (.uninterpreted x'.name .value)) se))
           compile reg Θ Δ_spec (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
-    | .letProd _ _ _ => do
-        VerifM.fatal "letProd verification is not implemented yet"
+    | .letProd names e body => do
+        let se ← compile reg Θ Δ_spec S B Γ e
+        let tys ← match e.ty with
+          | .tuple tys => pure tys
+          | _ => VerifM.fatal "letProd expected tuple type"
+        let (S', B', Γ') ← compileProductBinders S B Γ names tys se
+        compile reg Θ Δ_spec S' B' Γ' body
     | .ifThenElse cond thn els ty => do
         let sc ← compile reg Θ Δ_spec S B Γ cond
         VerifM.expectEq "if condition type mismatch" cond.ty .bool
@@ -2063,12 +2153,320 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
     obtain ⟨_, _, hΨ'⟩ := hΨ
     exact hpost v' ρ' st' se' hΨ' hs hw
 
-theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (e body : Expr) :
+theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr)
+    (ihBody : correctExpr reg body) :
+    ∀ (names : List Binder) (tys : List TinyML.Typ) (tl : Term .vallist)
+      (vals : List Runtime.Val) (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap)
+      (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env)
+      (γ : Runtime.Subst) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+      (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
+      VerifM.eval (compileProductBindersFrom S B Γ names tys tl) st ρ
+        (fun p st' ρ' => (compile reg Θ Δ_spec p.1 p.2.1 p.2.2 body).eval st' ρ' Ψ) →
+      B.agreeOnLinked ρ.env γ →
+      B.wfIn st.decls →
+      S.wfIn Δ_spec →
+      Δ_spec.wf →
+      Δ_spec.vars = [] →
+      Δ_spec.Subset st.decls →
+      VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
+      Verifier.Registry.symSubset reg Δ_spec →
+      Verifier.Registry.symAgree reg ρ_spec.env →
+      tl.wfIn st.decls →
+      Term.eval ρ.env tl = vals →
+      (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
+        st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v body.ty ∗ R ⊢ Φ v) →
+      st.sl Θ ρ ∗
+          (TinyML.ValsHaveTypes Θ vals tys ∗
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+              Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+        wp reg.primCtx
+          (body.runtime.subst (γ.updateAllBinder (names.map Binder.runtime) vals)) Φ
+  | [], [], tl, vals, Θ, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
+      heval, hagree, hbwf, hSwf, hΔwf, hΔvars, hΔspec, hρspec, hΔreg, hρreg,
+      htl_wf, htl_eval, hpost => by
+      simp only [compileProductBindersFrom] at heval
+      have hbody_eval : (compile reg Θ Δ_spec S B Γ body).eval st ρ Ψ := by
+        simpa using VerifM.eval_ret heval
+      cases vals with
+      | nil =>
+          have hbody_wp :=
+            ihBody Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hbody_eval hagree hbwf hSwf
+              hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+          simpa using
+            ((show st.sl Θ ρ ∗
+                (TinyML.ValsHaveTypes Θ [] [] ∗
+                  (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+                    Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+                st.sl Θ ρ ∗
+                  (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+                    Bindings.typedSubst Θ B Γ γ ∗ R) by
+                iintro ⟨Hsl, Hvals, Hctx⟩
+                ihave Hemp := (TinyML.ValsHaveTypes.nil Θ).1 $$ Hvals
+                isplitl [Hsl]
+                · iexact Hsl
+                · iexact Hctx).trans hbody_wp)
+      | cons v vs =>
+          exact (show st.sl Θ ρ ∗
+              (TinyML.ValsHaveTypes Θ (v :: vs) [] ∗
+                (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+                  Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+                wp reg.primCtx (body.runtime.subst (γ.updateAllBinder ([] : List Runtime.Binder) (v :: vs))) Φ by
+            iintro ⟨_Hsl, Hvals, _Hctx⟩
+            ihave Hfalse := (TinyML.ValsHaveTypes.cons_nil Θ v vs).1 $$ Hvals
+            iapply false_elim
+            iexact Hfalse)
+  | [], ty :: tys, tl, vals, Θ, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
+      heval, _hagree, _hbwf, _hSwf, _hΔwf, _hΔvars, _hΔspec, _hρspec, _hΔreg, _hρreg,
+      _htl_wf, _htl_eval, _hpost => by
+      simp only [compileProductBindersFrom] at heval
+      exact (VerifM.eval_fatal heval).elim
+  | b :: bs, [], tl, vals, Θ, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
+      heval, _hagree, _hbwf, _hSwf, _hΔwf, _hΔvars, _hΔspec, _hρspec, _hΔreg, _hρreg,
+      _htl_wf, _htl_eval, _hpost => by
+      simp only [compileProductBindersFrom] at heval
+      exact (VerifM.eval_fatal heval).elim
+  | b :: bs, ty :: tys, tl, vals, Θ, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
+      heval, hagree, hbwf, hSwf, hΔwf, hΔvars, hΔspec, hρspec, hΔreg, hρreg,
+      htl_wf, htl_eval, hpost => by
+      cases vals with
+      | nil =>
+          exact (show st.sl Θ ρ ∗
+              (TinyML.ValsHaveTypes Θ [] (ty :: tys) ∗
+                (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+                  Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+                wp reg.primCtx
+                  (body.runtime.subst (γ.updateAllBinder ((b :: bs).map Binder.runtime) [])) Φ by
+            iintro ⟨_Hsl, Hvals, _Hctx⟩
+            ihave Hfalse := (TinyML.ValsHaveTypes.nil_cons Θ ty tys).1 $$ Hvals
+            iapply false_elim
+            iexact Hfalse)
+      | cons v vs =>
+          simp only [compileProductBindersFrom] at heval
+          have hexpect : (VerifM.expectEq "letProd binder type mismatch" b.ty ty).eval st ρ _ :=
+            VerifM.eval_bind _ _ _ _ heval
+          obtain ⟨hbty, hcont⟩ := VerifM.eval_expectEq hexpect
+          have hhead_wf : (Term.unop UnOp.vhead tl).wfIn st.decls := ⟨trivial, htl_wf⟩
+          have htail_wf : (Term.unop UnOp.vtail tl).wfIn st.decls := ⟨trivial, htl_wf⟩
+          have hhead_eval : (Term.unop UnOp.vhead tl).eval ρ.env = v := by
+            simp [Term.eval, UnOp.eval, htl_eval]
+          have htail_eval : (Term.unop UnOp.vtail tl).eval ρ.env = vs := by
+            simp [Term.eval, UnOp.eval, htl_eval]
+          cases hname : b.name with
+          | none =>
+              simp [hname] at hcont
+              have hrec := compileProductBindersFrom_correct reg body ihBody bs tys
+                (Term.unop UnOp.vtail tl) vs Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ
+                hcont hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg
+                htail_wf htail_eval hpost
+              refine (show st.sl Θ ρ ∗
+                  (TinyML.ValsHaveTypes Θ (v :: vs) (ty :: tys) ∗
+                    (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+                      Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+                    st.sl Θ ρ ∗
+                      (TinyML.ValsHaveTypes Θ vs tys ∗
+                        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+                          Bindings.typedSubst Θ B Γ γ ∗ R)) by
+                iintro ⟨Hsl, Hvals, Hctx⟩
+                ihave Hpair := (TinyML.ValsHaveTypes.cons Θ v vs ty tys).1 $$ Hvals
+                icases Hpair with ⟨_Hv, Hvs⟩
+                isplitl [Hsl]
+                · iexact Hsl
+                · isplitl [Hvs]
+                  · iexact Hvs
+                  · iexact Hctx).trans ?_
+              simpa [Binder.runtime_of_name_none hname, Runtime.Subst.updateBinder]
+                using hrec
+          | some x =>
+              simp [hname] at hcont
+              have hdecl_eval := VerifM.eval_bind _ _ _ _ hcont
+              have hdecl := VerifM.eval_decl hdecl_eval
+              set x' := st.freshConst (some x) .value
+              set st₁ : TransState := { st with decls := st.decls.addConst x' }
+              set ρ₁ := ρ.updateConst .value x'.name v
+              have hafter_decl : _ := hdecl v
+              have hassume_eval := VerifM.eval_bind _ _ _ _ hafter_decl
+              have hassume := VerifM.eval_assumePure hassume_eval
+              have hfresh : x'.name ∉ st.decls.allNames := by
+                simpa [x'] using TransState.freshConst_fresh st (some x) .value
+              have hformula_wf :
+                  (Formula.eq .value (.const (.uninterpreted x'.name .value))
+                    (Term.unop UnOp.vhead tl)).wfIn st₁.decls := by
+                have hstwf : st.decls.wf := (VerifM.eval.wf hdecl_eval).namesDisjoint
+                simpa [x', st₁] using
+                  (Formula.eq_wfIn_addConst_of_fresh (Δ := st.decls) (c := x')
+                    hstwf hhead_wf hfresh)
+              have hformula_eval :
+                  (Formula.eq .value (.const (.uninterpreted x'.name .value))
+                    (Term.unop UnOp.vhead tl)).eval ρ₁.env := by
+                have hagree_head : Env.agreeOn st.decls ρ.env ρ₁.env :=
+                  Env.agreeOn_update_fresh_const hfresh
+                have hhead_same := Term.eval_env_agree hhead_wf hagree_head
+                have hval_same : v = (Term.unop UnOp.vhead tl).eval ρ₁.env := by
+                  exact hhead_eval.symm.trans hhead_same
+                simpa [Formula.eval, Term.eval, Const.denote, ρ₁, VerifM.Env.updateConst,
+                  Env.updateConst] using hval_same
+              have hrec_eval := hassume hformula_wf hformula_eval
+              set st₂ : TransState := { st₁ with
+                asserts := (Formula.eq .value (.const (.uninterpreted x'.name .value))
+                  (Term.unop UnOp.vhead tl)) :: st₁.asserts }
+              have hagreeOn_body : Env.agreeOn st.decls ρ.env ρ₁.env :=
+                Env.agreeOn_update_fresh_const hfresh
+              have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁.env ρ.env := by
+                constructor
+                · intro y hy; cases hy
+                · constructor
+                  · intro y' hy'
+                    obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hy'
+                    exact (hagreeOn_body.2.1 p.2 (hbwf p hp)).symm
+                  · constructor
+                    · intro z hz; cases hz
+                    · constructor
+                      · intro z hz; cases hz
+                      · constructor
+                        · intro z hz; cases hz
+                        · intro z hz; cases hz
+              have hρ_lookup : ρ₁.env.consts .value x'.name = v := by
+                simp [ρ₁, VerifM.Env.updateConst, Env.updateConst]
+              have hagree₁ : Bindings.agreeOnLinked ((x, x') :: B) ρ₁.env
+                  (Runtime.Subst.update γ x v) := by
+                have h := Bindings.agreeOnLinked_cons (x := x) (v := x') (γ := γ)
+                  hagree hρ_agree (hvty := (rfl : x'.sort = .value))
+                rwa [hρ_lookup] at h
+              have hbwf₁ : Bindings.wfIn ((x, x') :: B) st₂.decls := by
+                simpa [st₂, st₁] using Bindings.wfIn_cons hbwf
+              have hspecInv := specInvariants_mono hΔspec hρspec
+                (Signature.Subset.subset_addConst st.decls x') hagreeOn_body
+              have hrec := compileProductBindersFrom_correct reg body ihBody bs tys
+                (Term.unop UnOp.vtail tl) vs Θ R (Finmap.erase x S) ((x, x') :: B)
+                (Γ.extend x ty) st₂ ρ₁ (Runtime.Subst.update γ x v) Δ_spec ρ_spec Ψ Φ
+                hrec_eval hagree₁ hbwf₁ (SpecMap.wfIn_erase hSwf) hΔwf hΔvars
+                hspecInv.1 hspecInv.2 hΔreg hρreg
+                (by
+                  have htail_wf₁ := Term.wfIn_mono (Term.unop UnOp.vtail tl) htail_wf
+                    (Signature.Subset.subset_addConst st.decls x')
+                    (Signature.wf_addConst (VerifM.eval.wf hdecl_eval).namesDisjoint hfresh)
+                  simpa [st₂, st₁] using htail_wf₁)
+                (by
+                  rw [Term.eval_env_agree htail_wf (Env.agreeOn_symm hagreeOn_body)]
+                  exact htail_eval)
+                hpost
+              have hctx :
+                  st.sl Θ ρ ∗
+                    (TinyML.ValsHaveTypes Θ (v :: vs) (ty :: tys) ∗
+                      (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+                        Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+                    st₂.sl Θ ρ₁ ∗
+                      (TinyML.ValsHaveTypes Θ vs tys ∗
+                        (SpecMap.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (Finmap.erase x S)
+                          (Runtime.Subst.update γ x v) ∗
+                          Bindings.typedSubst Θ ((x, x') :: B) (Γ.extend x ty)
+                            (Runtime.Subst.update γ x v) ∗ R)) := by
+                iintro ⟨Hsl, Hvals, #HS, #HT, HR⟩
+                ihave Hpair := (TinyML.ValsHaveTypes.cons Θ v vs ty tys).1 $$ Hvals
+                icases Hpair with ⟨Hv, Hvs⟩
+                have hinterp_eq : SpatialContext.interp Θ ρ.env st.owns ⊢
+                    SpatialContext.interp Θ ρ₁.env st.owns :=
+                  (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hdecl_eval).ownsWf
+                    (Env.agreeOn_update_fresh_const hfresh)).1
+                isplitl [Hsl]
+                · simp only [TransState.sl_eq]
+                  iapply hinterp_eq
+                  iexact Hsl
+                · isplitl [Hvs]
+                  · iexact Hvs
+                  · isplitr [Hv HR]
+                    · iapply (SpecMap.satisfiedBy_erase (Θ := Θ) (S := S) (γ := γ)
+                        (x := x) (v := v))
+                      iexact HS
+                    · isplitl [Hv]
+                      · iapply (Bindings.typedSubst_cons (Θ := Θ) (B := B) (Γ := Γ)
+                          (γ := γ) (x := x) (v := x') (te := ty) (w := v))
+                        · iexact HT
+                        · iexact Hv
+                      · iexact HR
+              refine hctx.trans ?_
+              simpa [Binder.runtime_of_name_some hname, Runtime.Subst.updateBinder,
+                Runtime.Subst.updateAllBinder_cons]
+                using hrec
+
+theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (e body : Expr)
+    (ihE : correctExpr reg e) (ihBody : correctExpr reg body) :
     correctExpr reg (.letProd names e body) := by
   intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval
     hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [compile] at heval
-  exact (VerifM.eval_fatal heval).elim
+  simp only [Expr.ty] at hpost
+  unfold Expr.runtime
+  simp only [Runtime.Expr.letProd_subst]
+  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ :=
+    VerifM.eval_bind _ _ _ _ heval
+  have hstart :
+      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
+        st.sl Θ ρ ∗
+          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
+    Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+  refine SpatialContext.wp_bind_letProd <| hstart.trans <|
+    ihE Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)
+      S B Γ st ρ γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec
+      hΔreg hρreg ?_
+  intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
+  obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
+  cases hty : e.ty with
+  | tuple tys =>
+      simp [hty] at hΨ_e
+      have hpure_eval := VerifM.eval_bind _ _ _ _ hΨ_e
+      have hprod_body :
+          (do
+            let p ← compileProductBinders S B Γ names tys se
+            compile reg Θ Δ_spec p.1 p.2.1 p.2.2 body).eval st₁ ρ_e Ψ :=
+        VerifM.eval_ret hpure_eval
+      have hprod_eval := VerifM.eval_bind _ _ _ _ hprod_body
+      have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
+      have hbwf_e : B.wfIn st₁.decls := fun p hp => hdecls_e.consts _ (hbwf p hp)
+      have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
+      refine (show st₁.sl Θ ρ_e ∗
+          (TinyML.ValHasType Θ v_e (.tuple tys) ∗
+            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
+              Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
+            wp reg.primCtx
+              (Runtime.Expr.letProd (names.map Binder.runtime) (.val v_e)
+                (Runtime.Expr.subst (γ.removeAll' (names.map Binder.runtime)) body.runtime)) Φ from ?_)
+      iintro ⟨Hsl, Hve, #HS, #HT, HR⟩
+      ihave Htuple := (TinyML.ValHasType.tuple Θ v_e tys).1 $$ Hve
+      icases Htuple with ⟨%vs, %hveq, Hvals⟩
+      subst hveq
+      ihave %hlen_vals := (TinyML.ValsHaveTypes.length_eq (Θ := Θ) (vs := vs) (ts := tys)) $$ Hvals
+      have hnames_len : (names.map Binder.runtime).length = vs.length := by
+        have htl_wf : (Term.unop UnOp.toValList se).wfIn st₁.decls := ⟨trivial, hse_wf⟩
+        have hlen_compile := compileProductBindersFrom_length htl_wf hprod_eval
+        simp [hlen_compile, hlen_vals]
+      have hbody_subst := Runtime.Expr.subst_removeAll'_updateAllBinder body.runtime γ
+        (names.map Binder.runtime) vs hnames_len
+      iapply (wp.letProd_val (ctx := reg.primCtx) (names := names.map Binder.runtime)
+        (vs := vs)
+        (body := Runtime.Expr.subst (γ.removeAll' (names.map Binder.runtime)) body.runtime)
+        hnames_len)
+      rw [hbody_subst]
+      iapply (compileProductBindersFrom_correct reg body ihBody names tys
+        (Term.unop UnOp.toValList se) vs Θ R S B Γ st₁ ρ_e γ Δ_spec ρ_spec Ψ Φ
+        hprod_eval hagree_e hbwf_e hSwf hΔwf hΔvars hspecInv_e.1 hspecInv_e.2
+        hΔreg hρreg ?_ ?_ hpost)
+      · exact ⟨trivial, hse_wf⟩
+      · simp [Term.eval, UnOp.eval, heval_se]
+      · isplitl [Hsl]
+        · iexact Hsl
+        · isplitl [Hvals]
+          · iexact Hvals
+          · isplitl []
+            · iexact HS
+            · isplitl []
+              · iexact HT
+              · iexact HR
+  | prim _ | sum _ | arrow _ _ | ref _ | array _ | owned _ | empty | value | tvar _ | named _ _ =>
+      simp [hty] at hΨ_e
+      exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ hΨ_e)).elim
 
 theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr) (ty : TinyML.Typ)
     (ihCond : correctExpr reg cond) (ihThn : correctExpr reg thn) (ihEls : correctExpr reg els) :
@@ -2905,6 +3303,7 @@ theorem compile_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.So
     simpa using compileFix_correct reg self args retTy body
   | letProd names e body =>
     simpa using compileLetProd_correct reg names e body
+      (compile_correct reg hSound e) (compile_correct reg hSound body)
   | ref owned e =>
     simpa using compileRef_correct reg owned e (compile_correct reg hSound e)
   | deref e ty =>

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -162,6 +162,8 @@ mutual
           let x' ← VerifM.decl (some x) .value
           VerifM.assume (.pure (Formula.eq .value (.const (.uninterpreted x'.name .value)) se))
           compile reg Θ Δ_spec (Finmap.erase x S) ((x, x') :: B) (Γ.extend x e.ty) body
+    | .letProd _ _ _ => do
+        VerifM.fatal "letProd verification is not implemented yet"
     | .ifThenElse cond thn els ty => do
         let sc ← compile reg Θ Δ_spec S B Γ cond
         VerifM.expectEq "if condition type mismatch" cond.ty .bool
@@ -2061,6 +2063,13 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
     obtain ⟨_, _, hΨ'⟩ := hΨ
     exact hpost v' ρ' st' se' hΨ' hs hw
 
+theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (e body : Expr) :
+    correctExpr reg (.letProd names e body) := by
+  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval
+    hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  simp only [compile] at heval
+  exact (VerifM.eval_fatal heval).elim
+
 theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr) (ty : TinyML.Typ)
     (ihCond : correctExpr reg cond) (ihThn : correctExpr reg thn) (ihEls : correctExpr reg els) :
     correctExpr reg (.ifThenElse cond thn els ty) := by
@@ -2894,6 +2903,8 @@ theorem compile_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.So
     simpa using compileAssert_correct reg e (compile_correct reg hSound e)
   | fix self args retTy body =>
     simpa using compileFix_correct reg self args retTy body
+  | letProd names e body =>
+    simpa using compileLetProd_correct reg names e body
   | ref owned e =>
     simpa using compileRef_correct reg owned e (compile_correct reg hSound e)
   | deref e ty =>

--- a/Mica/Verifier/RelationalEncoding/Monad.lean
+++ b/Mica/Verifier/RelationalEncoding/Monad.lean
@@ -172,6 +172,9 @@ def encodeWith {M : Type} (ops : EncoderOps M) (Δ : Signature)
   | .letIn b bound body, k =>
     encodeWith ops Δ Γ δ bound fun v =>
       encodeWith ops Δ Γ (VarEnv.bindBinder δ b v) body k
+  | .letProd bs bound body, k =>
+    encodeWith ops Δ Γ δ bound fun v =>
+      encodeWith ops Δ Γ (VarEnv.bindBinders δ bs v) body k
   | .inj tag arity payload, k =>
     encodeWith ops Δ Γ δ payload fun v =>
       k (.unop (.ofInj tag arity) v)
@@ -345,7 +348,7 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
       | error _ => simp; exact hops.error_ind
       | ok _    => simp; exact hk _
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
-  | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
+  | .ifThenElse .., _ | .letIn .., _ | .letProd .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .arrayMake .., _ | .arrayLen _, _ | .arrayGet .., _ | .arraySet .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
   | .var _ _, [] | .var _ _, _ :: _ :: _ =>
@@ -367,6 +370,13 @@ theorem prim (name : String) (inst : List (TinyML.TyVar × TinyML.Typ))
 theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
     (ihBound : EncodeWithInd bound) (ihBody : EncodeWithInd body) :
     EncodeWithInd (.letIn name bound body) := by
+  intro _ _ _ _ _ _ _ hops hk
+  simp only [encodeWith]
+  exact ihBound hops fun _ => ihBody hops hk
+
+theorem letProd (names : List Typed.Binder) (bound body : Typed.Expr)
+    (ihBound : EncodeWithInd bound) (ihBody : EncodeWithInd body) :
+    EncodeWithInd (.letProd names bound body) := by
   intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   exact ihBound hops fun _ => ihBody hops hk
@@ -475,6 +485,8 @@ theorem encodeWith_ind_def : ∀ (e : Typed.Expr), EncodeWithInd e
   | .fix self args retTy body => Ind.fix self args retTy body
   | .letIn name bound body =>
       Ind.letIn name bound body (encodeWith_ind_def bound) (encodeWith_ind_def body)
+  | .letProd names bound body =>
+      Ind.letProd names bound body (encodeWith_ind_def bound) (encodeWith_ind_def body)
   | .ref owned e => Ind.ref owned e
   | .deref e ty => Ind.deref e ty
   | .store loc val => Ind.store loc val
@@ -675,7 +687,7 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
           simp
           exact hk hsub'' hΔ'' v (encodePrim_wfIn hraw (hsub.trans hsub'') hΔ'' hvs)
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
-  | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
+  | .ifThenElse .., _ | .letIn .., _ | .letProd .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .arrayMake .., _ | .arrayLen _, _ | .arrayGet .., _ | .arraySet .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
   | .var _ _, [] | .var _ _, _ :: _ :: _ =>
@@ -704,6 +716,19 @@ theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
   have hΓ'' := hops.ctx_mono hΓ hsub''
   exact ihBody hops (hsub.trans hsub'') hΔ'' hΓ''
     (VarEnv.wfIn.bindBinder
+      (fun y w h => Term.wfIn_mono w (hδ y w h) hsub'' hΔ'') hv)
+    (fun hsub''' hΔ''' w hw => hk (hsub''.trans hsub''') hΔ''' w hw)
+
+theorem letProd (names : List Typed.Binder) (bound body : Typed.Expr)
+    (ihBound : EncodeWithIndSig bound) (ihBody : EncodeWithIndSig body) :
+    EncodeWithIndSig (.letProd names bound body) := by
+  intro _ _ _ _ _ _ _ δ _ hops hsub hΔ' hΓ hδ hk
+  simp only [encodeWith]
+  refine ihBound hops hsub hΔ' hΓ hδ ?_
+  intro Δ'' hsub'' hΔ'' v hv
+  have hΓ'' := hops.ctx_mono hΓ hsub''
+  exact ihBody hops (hsub.trans hsub'') hΔ'' hΓ''
+    (VarEnv.wfIn.bindBinders
       (fun y w h => Term.wfIn_mono w (hδ y w h) hsub'' hΔ'') hv)
     (fun hsub''' hΔ''' w hw => hk (hsub''.trans hsub''') hΔ''' w hw)
 
@@ -836,6 +861,9 @@ theorem encodeWith_indWithSig_def : ∀ (e : Typed.Expr), EncodeWithIndSig e
   | .fix self args retTy body => IndSig.fix self args retTy body
   | .letIn name bound body =>
       IndSig.letIn name bound body
+        (encodeWith_indWithSig_def bound) (encodeWith_indWithSig_def body)
+  | .letProd names bound body =>
+      IndSig.letProd names bound body
         (encodeWith_indWithSig_def bound) (encodeWith_indWithSig_def body)
   | .ref owned e => IndSig.ref owned e
   | .deref e ty => IndSig.deref e ty
@@ -1243,7 +1271,7 @@ theorem app (fn : Typed.Expr) (args : List Typed.Expr) (ty : TinyML.Typ)
             (encodePrim_wfIn hraw₂ (hsub₂.trans hsa₂) hwa₂ hvs₂)
             (encodePrim_eval hraw₁ hraw₂ hagree_a hevals)
   | .const _, _ | .unop .., _ | .binop .., _ | .fix .., _ | .app .., _
-  | .ifThenElse .., _ | .letIn .., _ | .ref .., _ | .deref .., _ | .store .., _
+  | .ifThenElse .., _ | .letIn .., _ | .letProd .., _ | .ref .., _ | .deref .., _ | .store .., _
   | .arrayMake .., _ | .arrayLen _, _ | .arrayGet .., _ | .arraySet .., _
   | .assert _, _ | .tuple _, _ | .inj .., _ | .match_ .., _ | .cast .., _
   | .var _ _, [] | .var _ _, _ :: _ :: _ =>
@@ -1276,6 +1304,21 @@ theorem letIn (name : Typed.Binder) (bound body : Typed.Expr)
     EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk
   exact ihBody hops (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
     hagree_a (VarEnv.Agree.bindBinder henv_a hv₁ hv₂ hevalv) hka
+
+theorem letProd (names : List Typed.Binder) (bound body : Typed.Expr)
+    (ihBound : EncodeWithBindBinary bound) (ihBody : EncodeWithBindBinary body) :
+    EncodeWithBindBinary (.letProd names bound body) := by
+  intro _ _ _ Δ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
+  simp only [encodeWith]
+  refine ihBound hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
+  intro Δa₁ Δa₂ ρa₁ ρa₂ hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ v₁ v₂ hv₁ hv₂ hevalv
+  have henv_a := VarEnv.Agree.mono hsa₁ hsa₂ hwa₁ hwa₂ haa₁ haa₂ henv
+  have hagree_a : Env.agreeOn Δ ρa₁ ρa₂ :=
+    Env.agreeOn_of_extensions hsub₁ hsub₂ hagree haa₁ haa₂
+  have hka : EncoderContSpec _ Δa₁ Δa₂ ρa₁ ρa₂ _ _ :=
+    EncoderContSpec.mono hsa₁ hsa₂ haa₁ haa₂ hk
+  exact ihBody hops (hsub₁.trans hsa₁) (hsub₂.trans hsa₂) hwa₁ hwa₂
+    hagree_a (VarEnv.Agree.bindBinders henv_a hv₁ hv₂ hevalv) hka
 
 theorem ref (owned : Bool) (e : Typed.Expr) : EncodeWithBindBinary (.ref owned e) := by
   intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
@@ -1445,6 +1488,9 @@ theorem encodeWith_bind_binary_def : ∀ (e : Typed.Expr), EncodeWithBindBinary 
   | .fix self args retTy body => BindBinary.fix self args retTy body
   | .letIn name bound body =>
       BindBinary.letIn name bound body
+        (encodeWith_bind_binary_def bound) (encodeWith_bind_binary_def body)
+  | .letProd names bound body =>
+      BindBinary.letProd names bound body
         (encodeWith_bind_binary_def bound) (encodeWith_bind_binary_def body)
   | .ref owned e => BindBinary.ref owned e
   | .deref e ty => BindBinary.deref e ty

--- a/Mica/Verifier/RelationalEncoding/Variables.lean
+++ b/Mica/Verifier/RelationalEncoding/Variables.lean
@@ -316,6 +316,16 @@ def bindBinder (ρ : VarEnv) (b : Typed.Binder) (v : Term .value) : VarEnv :=
   | none => ρ
   | some x => ρ.bind x v
 
+def prodProj (v : Term .value) (i : Nat) : Term .value :=
+  .unop .vhead (vtailN (.unop .toValList v) i)
+
+def bindBindersFrom (ρ : VarEnv) (v : Term .value) : List Typed.Binder → Nat → VarEnv
+  | [], _ => ρ
+  | b :: bs, i => bindBindersFrom (ρ.bindBinder b (prodProj v i)) v bs (i + 1)
+
+def bindBinders (ρ : VarEnv) (bs : List Typed.Binder) (v : Term .value) : VarEnv :=
+  bindBindersFrom ρ v bs 0
+
 /-- Initial local environment induced by value variables declared in a FOL
 signature. -/
 def ofSignature (Δ : Signature) : VarEnv :=
@@ -359,6 +369,28 @@ theorem wfIn.bindBinder {Δ : Signature} {δ : VarEnv} {b : Typed.Binder}
       cases name with
       | none => simpa [bindBinder] using henv
       | some x => simpa [bindBinder] using henv.bind hv
+
+theorem prodProj_wfIn {Δ : Signature} {v : Term .value} (hv : v.wfIn Δ) (i : Nat) :
+    (prodProj v i).wfIn Δ := by
+  unfold prodProj
+  have hto : (Term.unop UnOp.toValList v).wfIn Δ := by
+    change UnOp.toValList.wfIn Δ ∧ v.wfIn Δ
+    exact And.intro trivial hv
+  change UnOp.vhead.wfIn Δ ∧ (vtailN (.unop .toValList v) i).wfIn Δ
+  exact And.intro trivial (vtailN_wfIn hto i)
+
+theorem wfIn.bindBindersFrom {Δ : Signature} {δ : VarEnv} {v : Term .value}
+    (henv : δ.wfIn Δ) (hv : v.wfIn Δ) :
+    ∀ bs i, (bindBindersFrom δ v bs i).wfIn Δ
+  | [], _ => henv
+  | _ :: bs, i =>
+      wfIn.bindBindersFrom
+        (wfIn.bindBinder henv (prodProj_wfIn hv i)) hv bs (i + 1)
+
+theorem wfIn.bindBinders {Δ : Signature} {δ : VarEnv} {bs : List Typed.Binder}
+    {v : Term .value} (henv : δ.wfIn Δ) (hv : v.wfIn Δ) :
+    (δ.bindBinders bs v).wfIn Δ := by
+  simpa [bindBinders] using wfIn.bindBindersFrom henv hv bs 0
 
 theorem ofSignature_wfIn {Δ : Signature} (hΔ : Δ.wf) :
     (ofSignature Δ).wfIn Δ := by
@@ -427,6 +459,34 @@ theorem Agree.bindBinder {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
       cases name with
       | none => simpa [bindBinder] using henv
       | some x => simpa [bindBinder] using henv.bind hv₁ hv₂ heval
+
+theorem prodProj_eval {ρ₁ ρ₂ : Env} {v₁ v₂ : Term .value} (i : Nat)
+    (heval : Term.eval ρ₁ v₁ = Term.eval ρ₂ v₂) :
+    Term.eval ρ₁ (prodProj v₁ i) = Term.eval ρ₂ (prodProj v₂ i) := by
+  simp [prodProj, Term.eval, UnOp.eval, vtailN_eval, heval]
+
+theorem Agree.bindBindersFrom {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
+    {δ₁ δ₂ : VarEnv} {v₁ v₂ : Term .value}
+    (henv : Agree Δ₁ Δ₂ ρ₁ ρ₂ δ₁ δ₂)
+    (hv₁ : v₁.wfIn Δ₁) (hv₂ : v₂.wfIn Δ₂)
+    (heval : Term.eval ρ₁ v₁ = Term.eval ρ₂ v₂) :
+    ∀ bs i,
+      Agree Δ₁ Δ₂ ρ₁ ρ₂
+        (bindBindersFrom δ₁ v₁ bs i) (bindBindersFrom δ₂ v₂ bs i)
+  | [], _ => henv
+  | _ :: bs, i =>
+      Agree.bindBindersFrom
+        (Agree.bindBinder henv
+          (prodProj_wfIn hv₁ i) (prodProj_wfIn hv₂ i) (prodProj_eval i heval))
+        hv₁ hv₂ heval bs (i + 1)
+
+theorem Agree.bindBinders {Δ₁ Δ₂ : Signature} {ρ₁ ρ₂ : Env}
+    {δ₁ δ₂ : VarEnv} {bs : List Typed.Binder} {v₁ v₂ : Term .value}
+    (henv : Agree Δ₁ Δ₂ ρ₁ ρ₂ δ₁ δ₂)
+    (hv₁ : v₁.wfIn Δ₁) (hv₂ : v₂.wfIn Δ₂)
+    (heval : Term.eval ρ₁ v₁ = Term.eval ρ₂ v₂) :
+    Agree Δ₁ Δ₂ ρ₁ ρ₂ (δ₁.bindBinders bs v₁) (δ₂.bindBinders bs v₂) := by
+  simpa [bindBinders] using Agree.bindBindersFrom henv hv₁ hv₂ heval bs 0
 
 theorem Agree.mono {Δ₁ Δ₂ Δ₁' Δ₂' : Signature} {ρ₁ ρ₂ ρ₁' ρ₂' : Env}
     {δ₁ δ₂ : VarEnv}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -89,21 +89,35 @@ def runTest (mica : LeanExe) (file : FilePath) : IO TestOutcome := do
   let result ← runProcessWithTimeout mica.file.toString #[file.toString] testTimeoutMs
   return { path := file, result := result }
 
-def runStdlibCompile : IO TestOutcome := do
+def runStdlibCompileIn (tmpDir : FilePath) : IO TestOutcome := do
   let cwd ← IO.currentDir
   let path := cwd / "mica.ml"
-  IO.FS.withTempDir fun tmpDir => do
-    let result ←
-      try
-        runProcessWithTimeoutIn? "ocamlc" #["-c", path.toString, "-o", "mica.cmo"]
-          (some tmpDir) testTimeoutMs
-      catch e =>
-        pure (.terminated {
-          exitCode := 127
-          stdout := ""
-          stderr := s!"failed to run ocamlc: {e}\n"
-        })
-    return { path, result }
+  let result ←
+    try
+      runProcessWithTimeoutIn? "ocamlopt" #["-c", path.toString, "-o", "mica.cmx"]
+        (some tmpDir) testTimeoutMs
+    catch e =>
+      pure (.terminated {
+        exitCode := 127
+        stdout := ""
+        stderr := s!"failed to run ocamlopt: {e}\n"
+      })
+  return { path, result }
+
+def runOcamlExampleCompileIn (tmpDir : FilePath) (idx : Nat) (file : FilePath) : IO TestOutcome := do
+  let out := tmpDir / s!"example_{idx}.cmx"
+  let result ←
+    try
+      runProcessWithTimeoutIn? "ocamlopt"
+        #["-I", tmpDir.toString, "-c", file.toString, "-o", out.toString]
+        (some tmpDir) testTimeoutMs
+    catch e =>
+      pure (.terminated {
+        exitCode := 127
+        stdout := ""
+        stderr := s!"failed to run ocamlopt: {e}\n"
+      })
+  return { path := file, result := result }
 
 def parseTestsuiteArgs (args : List String) : ScriptM TestsuiteOptions := do
   let mut summaryOnly := false
@@ -205,10 +219,20 @@ def reportTestOutcome (options : TestsuiteOptions) (failed : List TestOutcome) (
     printCapturedOutput test
   pure failed
 
-def runOcamlStdlibTests (options : TestsuiteOptions) (failed : List TestOutcome) :
+def runOcamlCompileTests (options : TestsuiteOptions) (tests : Array FilePath)
+    (failed : List TestOutcome) :
     IO (List TestOutcome) := do
-  let test ← runStdlibCompile
-  reportTestOutcome options failed "Compiling" "mica.ml" test
+  IO.FS.withTempDir fun tmpDir => do
+    let stdlib ← runStdlibCompileIn tmpDir
+    let mut failed ← reportTestOutcome options failed "Compiling" "mica.ml" stdlib
+    if !isFailure stdlib.result then
+      let mut idx := 0
+      for file in tests do
+        let filename := file.fileName.getD file.toString
+        let test ← runOcamlExampleCompileIn tmpDir idx file
+        failed ← reportTestOutcome options failed "Compiling" filename test
+        idx := idx + 1
+    pure failed
 
 def runMicaExampleTests (options : TestsuiteOptions) (mica : LeanExe)
     (tests : Array FilePath) (failed : List TestOutcome) : IO (List TestOutcome) := do
@@ -261,6 +285,6 @@ script testsuite (args) := do
   let options ← parseTestsuiteArgs args
   let inputPath ← resolveInputPath options.dir
   let tests ← discoverTests inputPath
-  let failed ← runOcamlStdlibTests options []
+  let failed ← runOcamlCompileTests options tests []
   let failed ← runMicaExampleTests options mica tests failed
   printTestsuiteSummary failed


### PR DESCRIPTION
This PR adds support for let-bindings that destruct product types like records and pairs. They are kept as a separate constructor to the normal `let x = e1 in e2`, because they _always_ destruct. They effectively act as an eliminator for products. 