### PR TITLE
Support for owned arrays

### DIFF
--- a/Examples/owned_arrays.ml
+++ b/Examples/owned_arrays.ml
@@ -1,0 +1,49 @@
+open Mica
+
+(* Owned arrays carry an immutable vector snapshot in specifications. Reads
+   preserve that snapshot, writes replace it with [Vec.set], and ownership is
+   threaded linearly through the postcondition. *)
+
+let swap (a : int array [@owned]) (i : int) (j : int) : unit =
+  let x = a.(i) in
+  let y = a.(j) in
+  a.(i) <- y;
+  a.(j) <- x
+[@@spec fun a i j ->
+  assert (0 <= i);
+  assert (i < Array.length a);
+  assert (0 <= j);
+  assert (j < Array.length a);
+  bind (arr a) @@ fun (before : int vec) ->
+  ret (fun result ->
+    bind (arr a) @@ fun (after : int vec) ->
+    assert (Vec.length after = Vec.length before);
+    assert (Vec.get after i = Vec.get before j);
+    assert (Vec.get after j = Vec.get before i))];;
+
+(* Length plus all four element equations is an exact extensional reverse
+   postcondition; no vector equality or bounded quantifier is needed. *)
+let reverse4 (a : int array [@owned]) : unit =
+  let x0 = a.(0) in
+  let x3 = a.(3) in
+  a.(0) <- x3;
+  a.(3) <- x0;
+  let x1 = a.(1) in
+  let x2 = a.(2) in
+  a.(1) <- x2;
+  a.(2) <- x1
+[@@spec fun a ->
+  assert (Array.length a = 4);
+  bind (arr a) @@ fun (before : int vec) ->
+  ret (fun result ->
+    bind (arr a) @@ fun (after : int vec) ->
+    assert (Vec.length after = 4);
+    assert (Vec.get after 0 = Vec.get before 3);
+    assert (Vec.get after 1 = Vec.get before 2);
+    assert (Vec.get after 2 = Vec.get before 1);
+    assert (Vec.get after 3 = Vec.get before 0))];;
+
+let allocate_owned (x : int) : unit =
+  let _a = Array.make 4 x [@owned] in
+  ()
+[@@spec fun x -> ret (fun result -> assert (true))];;

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -99,8 +99,8 @@ private def applyTypAttr (loc : Location) (t : TinyML.Typ) : String → ElabM Ti
   | "owned" =>
     match t with
     | .ref inner => .ok (.owned inner)
-    | .array _ => err loc (.unsupportedFeature "[@owned] arrays are not supported")
-    | _ => err loc (.unsupportedFeature "[@owned] only applies to a 'ref' type")
+    | .array inner => .ok (.ownedArray inner)
+    | _ => err loc (.unsupportedFeature "[@owned] only applies to a 'ref' or 'array' type")
   | name => err loc (.unsupportedFeature s!"unknown type attribute [@{name}]")
 
 mutual
@@ -363,7 +363,8 @@ private def applyAttr (loc : Location) (e : Untyped.Expr) : Attribute → ElabM 
   | { name := "owned", payload := none } =>
       match e with
       | .ref _ inner => .ok (.ref true inner)
-      | _ => err loc (.unsupportedFeature "[@owned] only applies to 'ref'")
+      | .arrayMake _ len init => .ok (.arrayMake true len init)
+      | _ => err loc (.unsupportedFeature "[@owned] only applies to 'ref' or 'Array.make'")
   | { name, .. } => err loc (.unsupportedFeature s!"unknown expression attribute [@{name}]")
 
 private def bareSpecial (loc : Location) (path : Path) : ElabM Untyped.Expr :=
@@ -443,7 +444,7 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
             | [len, init] => do
               let len' ← Expr.elaborate env len
               let init' ← Expr.elaborate env init
-              .ok (.arrayMake len' init')
+              .ok (.arrayMake false len' init')
             | _ => err loc (.arityMismatch 2 args.length)
         | some (.special .arrayLength) =>
             match args with

--- a/Mica/Frontend/SpecParser.lean
+++ b/Mica/Frontend/SpecParser.lean
@@ -19,7 +19,8 @@ private def parsePred : Untyped.Expr → M Pred
   | .app (.var "isinj") [.const (.int tag), .const (.int arity), .var scrut] =>
     .ok (.isinj tag.toNat arity.toNat scrut)
   | .app (.var "own") [.var loc] => .ok (.own loc)
-  | e => .error s!"expected predicate (isinj, own) over a variable, got {repr e}"
+  | .app (.var "arr") [.var loc] => .ok (.arr loc)
+  | e => .error s!"expected predicate (isinj, own, arr) over a variable, got {repr e}"
 
 private def addProductLets (bound : Untyped.Expr) :
     Nat → List Untyped.Binder → Assert Untyped.Expr α → M (Assert Untyped.Expr α)

--- a/Mica/SeparationLogic/Interpretations.lean
+++ b/Mica/SeparationLogic/Interpretations.lean
@@ -25,6 +25,9 @@ theorem interp_env_agree (Θ : TinyML.TypeEnv) {a : SpatialAtom} {Δ : Signature
   | pointsTo l v ty =>
     simp only [interp, Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
     exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
+  | arrayPointsTo a v ty =>
+    simp only [interp, Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
+    exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 
 /-- If a points-to atom's location term evaluates to `loc`, its interpretation
     is equivalent to the raw heap ownership together with the bundled value
@@ -53,6 +56,74 @@ theorem interp_pointsTo (Θ : TinyML.TypeEnv) {ρ : Env} {lt vt : Term .value}
     · isplitl [Hpt]
       · iexact Hpt
       · iexact Hty
+
+/-- If an owned-array atom's array and snapshot terms evaluate to the same
+    runtime block, its interpretation exposes ownership of that whole block
+    together with the element-typing fact carried by the vector snapshot. -/
+theorem interp_arrayPointsTo (Θ : TinyML.TypeEnv) {ρ : Env} {arrt vt : Term .value}
+    {ty : TinyML.Typ} {loc : Runtime.Location} {vs : List Runtime.Val}
+    (harr : Term.eval ρ arrt = .array vs.length loc)
+    (hvec : Term.eval ρ vt = .vec vs) :
+    interp Θ ρ (.arrayPointsTo arrt vt ty) ⊣⊢
+      loc ↦ vs ∗ TinyML.ValHasType Θ (.vec vs) (.vec ty) := by
+  constructor
+  · simp only [interp]
+    istart
+    iintro ⟨%loc', %vs', %Harr', %Hvec', Hpt, Hty⟩
+    have hloc : loc' = loc := by
+      exact Runtime.Val.array.inj (Harr'.symm.trans harr) |>.2
+    have hvs : vs' = vs := Runtime.Val.vec.inj (Hvec'.symm.trans hvec)
+    subst hloc
+    subst hvs
+    isplitl [Hpt]
+    · iexact Hpt
+    · iexact Hty
+  · simp only [interp]
+    istart
+    iintro ⟨Hpt, Hty⟩
+    iexists loc, vs
+    isplitr
+    · ipureintro
+      exact harr
+    · isplitr
+      · ipureintro
+        exact hvec
+      · isplitl [Hpt]
+        · iexact Hpt
+        · iexact Hty
+
+/-- An atom's interpretation implies its pure facts. -/
+theorem interp_facts (Θ : TinyML.TypeEnv) {ρ : Env} (a : SpatialAtom) :
+    interp Θ ρ a ⊢ ⌜∀ φ ∈ a.facts, φ.eval ρ⌝ ∗ interp Θ ρ a := by
+  cases a with
+  | pointsTo l v ty =>
+    istart
+    iintro H
+    isplitr [H]
+    · ipureintro
+      simp [facts]
+    · iexact H
+  | arrayPointsTo a v ty =>
+    simp only [interp]
+    istart
+    iintro H
+    icases H with ⟨%loc, %vs, %ha, %hv, Hpt, Hty⟩
+    isplitl []
+    · ipureintro
+      intro φ hφ
+      simp only [facts, List.mem_cons, List.not_mem_nil, or_false] at hφ
+      subst hφ
+      simp [Formula.eval, Term.eval, UnOp.eval, ha, hv]
+    · iexists loc, vs
+      isplitr
+      · ipureintro
+        exact ha
+      · isplitr
+        · ipureintro
+          exact hv
+        · isplitl [Hpt]
+          · iexact Hpt
+          · iexact Hty
 
 end SpatialAtom
 

--- a/Mica/SeparationLogic/Interpretations.lean
+++ b/Mica/SeparationLogic/Interpretations.lean
@@ -92,6 +92,53 @@ theorem interp_arrayPointsTo (Θ : TinyML.TypeEnv) {ρ : Env} {arrt vt : Term .v
         · iexact Hpt
         · iexact Hty
 
+/-- Destruct an owned-array atom at an in-bounds index: expose the underlying
+block, the integer index witness, and the persistent element typing of the
+snapshot. -/
+theorem interp_arrayPointsTo_lookup (Θ : TinyML.TypeEnv) {ρ : Env}
+    {arr contents idx : Term .value} {elemTy : TinyML.Typ} {vidx : Runtime.Val}
+    (hidx : Term.eval ρ idx = vidx)
+    (hi : 0 ≤ Term.eval ρ (.unop .toInt idx))
+    (hlt : Term.eval ρ (.unop .toInt idx) < Term.eval ρ (.unop .arrayLengthOf arr)) :
+    SpatialAtom.interp Θ ρ (.arrayPointsTo arr contents elemTy) ⊢
+      TinyML.ValHasType Θ vidx .int -∗
+      ∃ (loc : Runtime.Location) (vs : List Runtime.Val) (i : Int),
+        ⌜Term.eval ρ arr = .array vs.length loc⌝ ∗ ⌜Term.eval ρ contents = .vec vs⌝ ∗
+        ⌜vidx = .int i⌝ ∗ ⌜0 ≤ i⌝ ∗ ⌜i.toNat < vs.length⌝ ∗
+        loc ↦ vs ∗ □ TinyML.ValHasType Θ (.vec vs) (.vec elemTy) := by
+  simp only [SpatialAtom.interp]
+  istart
+  iintro Hatom
+  iintro HidxTy
+  icases Hatom with ⟨%loc, %vs, %ha, %hv, Hpt, #HvecTy⟩
+  ihave Hidx' := (TinyML.ValHasType.int Θ vidx).1 $$ HidxTy
+  icases Hidx' with ⟨%i, %hvidx⟩
+  have hi' : 0 ≤ i := by simpa [Term.eval, UnOp.eval, hidx, hvidx] using hi
+  have hlt' : i.toNat < vs.length := by
+    have : i < (vs.length : Int) := by
+      simpa [Term.eval, UnOp.eval, ha, hidx, hvidx] using hlt
+    omega
+  iexists loc, vs, i
+  isplitr
+  · ipureintro
+    exact ha
+  · isplitr
+    · ipureintro
+      exact hv
+    · isplitr
+      · ipureintro
+        exact hvidx
+      · isplitr
+        · ipureintro
+          exact hi'
+        · isplitr
+          · ipureintro
+            exact hlt'
+          · isplitl [Hpt]
+            · iexact Hpt
+            · imodintro
+              iexact HvecTy
+
 /-- An atom's interpretation implies its pure facts. -/
 theorem interp_facts (Θ : TinyML.TypeEnv) {ρ : Env} (a : SpatialAtom) :
     interp Θ ρ a ⊢ ⌜∀ φ ∈ a.facts, φ.eval ρ⌝ ∗ interp Θ ρ a := by

--- a/Mica/SeparationLogic/LogicalRelation.lean
+++ b/Mica/SeparationLogic/LogicalRelation.lean
@@ -68,6 +68,7 @@ mutual
     | .tvar _     => iprop(False)
     | .ref t      => iprop(∃ l, ⌜v = .loc l⌝ ∗ locinv l (fun w => R w t))
     | .array t    => iprop(∃ len l, ⌜v = .array len l⌝ ∗ arrayinv len l (fun w => R w t))
+    | .ownedArray _ => iprop(∃ len l, ⌜v = .array len l⌝)
     | .vec t      =>
         iprop(∃ vs, ⌜v = .vec vs⌝ ∗ [∗list] w ∈ vs, ValRelBody R w t k)
     | .owned _    => iprop(∃ l, ⌜v = .loc l⌝)
@@ -132,7 +133,7 @@ mutual
     | .prim _ =>
         iintro _ H
         iexact H
-    | .value | .empty | .arrow _ _ | .tvar _ | .ref _ | .array _ | .owned _ =>
+    | .value | .empty | .arrow _ _ | .tvar _ | .ref _ | .array _ | .ownedArray _ | .owned _ =>
         iintro _ H
         iexact H
 
@@ -200,6 +201,8 @@ mutual
         apply Contractive.distLater_dist (f := fun I : Runtime.Val → iProp => arrayinv len l I)
         intro m hm w
         exact hR m hm w t
+    | .ownedArray _ =>
+        exact Dist.rfl
     | .named T args =>
         exact hk v T args
     | .tuple ts =>
@@ -367,7 +370,7 @@ mutual
     match t with
     | .prim _ =>
         exact PrimitiveType.valRelBody_persistent _ v
-    | .value | .empty | .arrow _ _ | .tvar _ | .owned _ =>
+    | .value | .empty | .arrow _ _ | .tvar _ | .owned _ | .ownedArray _ =>
         infer_instance
     | .ref _ =>
         have := locinv_persistent
@@ -513,6 +516,12 @@ theorem ValHasType.array (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
     ValHasType Θ v (.array t) ⊣⊢
       iprop(∃ len l, ⌜v = .array len l⌝ ∗ arrayinv len l (fun w => ValHasType Θ w t)) := by
   exact equiv_iff.mp (ValHasType.unfold Θ v (.array t))
+
+/-- Owned arrays expose their runtime shape; contents are carried by the
+spatial owned-array assertion. -/
+theorem ValHasType.ownedArray (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
+    ValHasType Θ v (.ownedArray t) ⊣⊢ iprop(∃ len l, ⌜v = .array len l⌝) := by
+  exact equiv_iff.mp (ValHasType.unfold Θ v (.ownedArray t))
 
 theorem ValHasType.vec (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
     ValHasType Θ v (.vec t) ⊣⊢
@@ -1100,7 +1109,7 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
               · iexact Hwitness)
           iapply (ValsHaveTypes.of_getElem? (Θ := Θ) (vs := vs) (ts := ts) (n := n) (t := ty) hty)
           iexact Hvs
-      | prim _ | sum _ | arrow _ _ | ref _ | array _ | vec _ | owned _ | empty | value | tvar _
+      | prim _ | sum _ | arrow _ _ | ref _ | array _ | ownedArray _ | vec _ | owned _ | empty | value | tvar _
       | named _ _ =>
           simp [UnOp.typeOf, PrimitiveType.unOpTypeOf] at hty
 
@@ -1195,6 +1204,8 @@ def typeConstraints (ty : TinyML.Typ) (t : Term .value) : List Formula :=
   | .owned _ => [.unpred .isLoc t]
   | .array _ =>
       [.binpred .le (.const (.i 0)) (.unop .arrayLengthOf t)]
+  | .ownedArray _ =>
+      [.binpred .le (.const (.i 0)) (.unop .arrayLengthOf t)]
   | .vec _ =>
       [.unpred .isVec t,
        .binpred .le (.const (.i 0)) (.unop .vecLen (.unop .toVec t))]
@@ -1223,7 +1234,7 @@ mutual
     | owned _ =>
       simp [typeConstraints]
       simp only [Formula.wfIn]; exact ⟨trivial, ht⟩
-    | array _ =>
+    | array _ | ownedArray _ =>
       simp only [typeConstraints, List.mem_cons, List.not_mem_nil]
       intro φ hφ
       rcases hφ with rfl | hfalse
@@ -1282,6 +1293,16 @@ mutual
       refine (TinyML.ValHasType.array Θ v inner).1.trans ?_
       iintro Hty
       icases Hty with ⟨%len, %l, %hv, _⟩
+      ipureintro
+      intro φ hφ
+      simp only [typeConstraints, List.mem_cons, List.not_mem_nil] at hφ
+      rcases hφ with rfl | hfalse
+      · simp [Formula.eval, Term.eval, UnOp.eval, ht, hv]
+      · cases hfalse
+    | ownedArray inner =>
+      refine (TinyML.ValHasType.ownedArray Θ v inner).1.trans ?_
+      iintro Hty
+      icases Hty with ⟨%len, %l, %hv⟩
       ipureintro
       intro φ hφ
       simp only [typeConstraints, List.mem_cons, List.not_mem_nil] at hφ

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -362,6 +362,61 @@ theorem wp_arrayGet_inv (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
       · iexact Hw
       · iexact HR
 
+/-- `Array.get` through an owned-array atom: consume the atom, read the
+selected element, and restore the unchanged snapshot. -/
+theorem wp_arrayGet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
+    {ρ : Env} {R : iProp}
+    {arr contents idx result : Term .value} {elemTy : TinyML.Typ}
+    {rest : SpatialContext} {varr vidx : Runtime.Val}
+    (harr : Term.eval ρ arr = varr) (hidx : Term.eval ρ idx = vidx)
+    (hi : 0 ≤ Term.eval ρ (.unop .toInt idx))
+    (hlt : Term.eval ρ (.unop .toInt idx) < Term.eval ρ (.unop .arrayLengthOf arr))
+    (hresult : result = .binop .vecGet (.unop .toVec contents) (.unop .toInt idx))
+    (h : (insert (.arrayPointsTo arr contents elemTy) rest).interp Θ ρ ∗
+      TinyML.ValHasType Θ (Term.eval ρ result) elemTy ∗ R ⊢ Q (Term.eval ρ result)) :
+    SpatialAtom.interp Θ ρ (.arrayPointsTo arr contents elemTy) ∗ rest.interp Θ ρ ∗
+      TinyML.ValHasType Θ varr (.ownedArray elemTy) ∗
+      TinyML.ValHasType Θ vidx .int ∗ R ⊢
+      wp pctx (.arrayGet (.val varr) (.val vidx)) Q := by
+  istart
+  iintro ⟨Hatom, Hrest, _HarrTy, HidxTy, HR⟩
+  ihave Hacc := (SpatialAtom.interp_arrayPointsTo_lookup Θ hidx hi hlt) $$ Hatom
+  ispecialize Hacc $$ HidxTy
+  icases Hacc with ⟨%loc, %vs, %i, %ha, %hv, %hvidx, %hi', %hlt', Hpt, #HvecTy⟩
+  have hvarr : varr = .array vs.length loc := harr ▸ ha
+  subst hvarr
+  subst hvidx
+  have hraw : iprop(loc ↦ vs ∗ (loc ↦ vs -∗ Q vs[i.toNat])) ⊢
+      wp pctx (.arrayGet (.val (.array vs.length loc)) (.val (.int i))) Q :=
+    wp.arrayGet hi' hlt' rfl BIBase.Entails.rfl
+  iapply hraw
+  isplitl [Hpt]
+  · iexact Hpt
+  · iintro HptNew
+    have hlookup : vs[i.toNat]? = some vs[i.toNat] := List.getElem?_eq_getElem hlt'
+    ihave Helem := (TinyML.ValHasType.vec Θ (.vec vs) elemTy).1 $$ HvecTy
+    icases Helem with ⟨%ws, %hws, Htys⟩
+    have hws_eq : ws = vs := Runtime.Val.vec.inj hws.symm
+    subst ws
+    ihave Hty := (BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType Θ w elemTy) hlookup) $$ Htys
+    have hresult_eval : Term.eval ρ result = vs[i.toNat] := by
+      subst hresult
+      simp [Term.eval, UnOp.eval, BinOp.eval, hv, hidx, hi', hlookup]
+    rw [← hresult_eval]
+    iapply h
+    isplitl [HptNew HvecTy Hrest]
+    · simp only [SpatialContext.interp]
+      isplitr [Hrest]
+      · iapply (SpatialAtom.interp_arrayPointsTo Θ ha hv).2
+        isplitl [HptNew]
+        · iexact HptNew
+        · iexact HvecTy
+      · iexact Hrest
+    · isplitl [Hty]
+      · rw [hresult_eval]
+        iexact Hty
+      · iexact HR
+
 /-- `Array.set` under evaluation: evaluate `val`, then `idx`, then `arr`. -/
 theorem wp_bind_arraySet {arr idx val : Runtime.Expr} {Q : Runtime.Val → iProp}
     {R : iProp}
@@ -426,6 +481,66 @@ theorem wp_arraySet_inv (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
       · isplitl []
         · iapply TinyML.ValHasType.unit_intro
         · iexact HR
+
+/-- `Array.set` through an owned-array atom: consume the old snapshot and
+restore ownership with the selected element updated. -/
+theorem wp_arraySet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
+    {ρ : Env} {R : iProp}
+    {arr contents contents' idx val : Term .value} {elemTy : TinyML.Typ}
+    {rest : SpatialContext} {varr vidx vval : Runtime.Val}
+    (harr : Term.eval ρ arr = varr) (hidx : Term.eval ρ idx = vidx)
+    (hval : Term.eval ρ val = vval)
+    (hi : 0 ≤ Term.eval ρ (.unop .toInt idx))
+    (hlt : Term.eval ρ (.unop .toInt idx) < Term.eval ρ (.unop .arrayLengthOf arr))
+    (hcontents' : contents' = .unop .ofVec
+      (.terop .vecSet (.unop .toVec contents) (.unop .toInt idx) val))
+    (h : (insert (.arrayPointsTo arr contents' elemTy) rest).interp Θ ρ ∗
+      TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Q .unit) :
+    SpatialAtom.interp Θ ρ (.arrayPointsTo arr contents elemTy) ∗ rest.interp Θ ρ ∗
+      TinyML.ValHasType Θ varr (.ownedArray elemTy) ∗
+      TinyML.ValHasType Θ vidx .int ∗ TinyML.ValHasType Θ vval elemTy ∗ R ⊢
+      wp pctx (.arraySet (.val varr) (.val vidx) (.val vval)) Q := by
+  istart
+  iintro ⟨Hatom, Hrest, _HarrTy, HidxTy, #HvalTy, HR⟩
+  ihave Hacc := (SpatialAtom.interp_arrayPointsTo_lookup Θ hidx hi hlt) $$ Hatom
+  ispecialize Hacc $$ HidxTy
+  icases Hacc with ⟨%loc, %vs, %i, %ha, %hv, %hvidx, %hi', %hlt', Hpt, #HvecTy⟩
+  have hvarr : varr = .array vs.length loc := harr ▸ ha
+  subst hvarr
+  subst hvidx
+  have hraw : iprop(loc ↦ vs ∗ (loc ↦ vs.set i.toNat vval -∗ Q .unit)) ⊢
+      wp pctx (.arraySet (.val (.array vs.length loc)) (.val (.int i)) (.val vval)) Q :=
+    wp.arraySet hi' hlt' rfl BIBase.Entails.rfl
+  iapply hraw
+  isplitl [Hpt]
+  · iexact Hpt
+  · iintro HptNew
+    have hlookup : vs[i.toNat]? = some vs[i.toNat] := List.getElem?_eq_getElem hlt'
+    ihave Hvec := (TinyML.ValHasType.vec Θ (.vec vs) elemTy).1 $$ HvecTy
+    icases Hvec with ⟨%ws, %hws, Htys⟩
+    have hws_eq : ws = vs := Runtime.Val.vec.inj hws.symm
+    subst ws
+    ihave HvecTyNew : iprop(TinyML.ValHasType Θ (.vec (vs.set i.toNat vval)) (.vec elemTy))
+        $$ [Htys HvalTy]
+    · iapply (TinyML.ValHasType.vec_set Θ hlookup)
+      isplitl [Htys]
+      · iexact Htys
+      · iexact HvalTy
+    have hcontents'_eval : Term.eval ρ contents' = .vec (vs.set i.toNat vval) := by
+      subst hcontents'
+      simp [Term.eval, UnOp.eval, TerOp.eval, hv, hidx, hval, hi']
+    iapply h
+    isplitl [HptNew HvecTyNew Hrest]
+    · simp only [SpatialContext.interp]
+      isplitr [Hrest]
+      · iapply (SpatialAtom.interp_arrayPointsTo Θ (by simpa using ha) hcontents'_eval).2
+        isplitl [HptNew]
+        · iexact HptNew
+        · iexact HvecTyNew
+      · iexact Hrest
+    · isplitl []
+      · iapply TinyML.ValHasType.unit_intro
+      · iexact HR
 
 /-- Store at values: replace the selected points-to atom with the updated one. -/
 theorem wp_store (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}

--- a/Mica/SeparationLogic/SpatialAtom.lean
+++ b/Mica/SeparationLogic/SpatialAtom.lean
@@ -13,11 +13,13 @@ A `SpatialContext` is a list of such items. We define their well-formedness
 and basic operations (insert = cons, lookup+remove), plus interpretation of a
 single atom. -/
 
-/-- A syntactic ownership item. Initially, only points-to assertions. -/
+/-- A syntactic ownership item. -/
 inductive SpatialAtom where
   /-- Field `0` of the block at location term `l` holds value term `v`, whose TinyML type is `ty`.
   The interpretation carries the value typing fact as part of the same spatial atom. -/
   | pointsTo : Term .value → Term .value → TinyML.Typ → SpatialAtom
+  /-- An owned mutable array and its immutable vector snapshot. -/
+  | arrayPointsTo : Term .value → Term .value → TinyML.Typ → SpatialAtom
   deriving DecidableEq
 
 /-- The spatial part of the verifier state: a list of ownership items. -/
@@ -28,12 +30,14 @@ namespace SpatialAtom
 /-- A spatial atom is well-formed in a signature when all terms it mentions are. -/
 def wfIn : SpatialAtom → Signature → Prop
   | .pointsTo l v _, Δ => l.wfIn Δ ∧ v.wfIn Δ
+  | .arrayPointsTo a v _, Δ => a.wfIn Δ ∧ v.wfIn Δ
 
 /-- Well-formedness is stable under signature extension. -/
 theorem wfIn_mono {a : SpatialAtom} {Δ Δ' : Signature}
     (h : a.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : a.wfIn Δ' := by
   cases a with
   | pointsTo l v _ => exact ⟨Term.wfIn_mono l h.1 hsub hwf, Term.wfIn_mono v h.2 hsub hwf⟩
+  | arrayPointsTo a v _ => exact ⟨Term.wfIn_mono a h.1 hsub hwf, Term.wfIn_mono v h.2 hsub hwf⟩
 
 /-- Iris interpretation of a single spatial atom. -/
 def interp [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (ρ : Env) :
@@ -41,6 +45,10 @@ def interp [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (ρ : Env) :
   | .pointsTo l v ty => ∃ (loc : Runtime.Location),
       ⌜Term.eval ρ l = .loc loc⌝ ∗ loc ↦ [Term.eval ρ v] ∗
         TinyML.ValHasType Θ (Term.eval ρ v) ty
+  | .arrayPointsTo a v ty => ∃ (loc : Runtime.Location) (vs : List Runtime.Val),
+      ⌜Term.eval ρ a = .array vs.length loc⌝ ∗
+      ⌜Term.eval ρ v = .vec vs⌝ ∗ loc ↦ vs ∗
+        TinyML.ValHasType Θ (.vec vs) (.vec ty)
 
 /-- Congruence for points-to interpretation under equal location and value evaluation. -/
 theorem pointsTo_congr [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) {ρ : Env}
@@ -50,6 +58,24 @@ theorem pointsTo_congr [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) {ρ : Env}
     interp Θ ρ (.pointsTo l v ty) ⊣⊢ interp Θ ρ (.pointsTo l' v' ty) := by
   simp only [interp, hl, hv]
   exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
+
+/-- Pure formulas implied by an atom's interpretation. They are assumed
+alongside the atom whenever it enters the verifier's spatial context. -/
+def facts : SpatialAtom → List Formula
+  | .pointsTo .. => []
+  | .arrayPointsTo a v _ =>
+      [.eq .int (.unop .vecLen (.unop .toVec v)) (.unop .arrayLengthOf a)]
+
+/-- The pure facts of a well-formed atom are well-formed. -/
+theorem facts_wfIn {a : SpatialAtom} {Δ : Signature} (h : a.wfIn Δ) :
+    ∀ φ ∈ a.facts, φ.wfIn Δ := by
+  cases a with
+  | pointsTo l v ty => simp [facts]
+  | arrayPointsTo a v ty =>
+    intro φ hφ
+    simp only [facts, List.mem_cons, List.not_mem_nil, or_false] at hφ
+    subst hφ
+    exact ⟨⟨trivial, ⟨trivial, h.2⟩⟩, ⟨trivial, h.1⟩⟩
 
 end SpatialAtom
 

--- a/Mica/SeparationLogic/SpatialAtom.lean
+++ b/Mica/SeparationLogic/SpatialAtom.lean
@@ -27,10 +27,65 @@ abbrev SpatialContext := List SpatialAtom
 
 namespace SpatialAtom
 
+/-- The head constructor of a spatial atom. Both constructors carry a key
+term, a value term, and a type, so atoms can be processed generically by
+kind. -/
+inductive Kind where
+  | ref
+  | array
+  deriving DecidableEq
+
+/-- The atom of a given kind, from its key term, value term, and type. -/
+def Kind.atom : Kind → Term .value → Term .value → TinyML.Typ → SpatialAtom
+  | .ref => .pointsTo
+  | .array => .arrayPointsTo
+
+/-- Human-readable name of an atom kind, for error messages. -/
+def Kind.print : Kind → String
+  | .ref => "points-to"
+  | .array => "owned array"
+
+/-- The kind of an atom. -/
+def kind : SpatialAtom → Kind
+  | .pointsTo .. => .ref
+  | .arrayPointsTo .. => .array
+
+/-- The key term an atom asserts ownership of: the location of a points-to,
+the array value of an owned array. -/
+def key : SpatialAtom → Term .value
+  | .pointsTo l _ _ => l
+  | .arrayPointsTo a _ _ => a
+
+/-- The value term stored under an atom's key: the contents of a reference,
+the vector snapshot of an owned array. -/
+def val : SpatialAtom → Term .value
+  | .pointsTo _ v _ => v
+  | .arrayPointsTo _ v _ => v
+
+/-- The element type carried by an atom. -/
+def ty : SpatialAtom → TinyML.Typ
+  | .pointsTo _ _ ty => ty
+  | .arrayPointsTo _ _ ty => ty
+
+@[simp] theorem eta (a : SpatialAtom) : a.kind.atom a.key a.val a.ty = a := by
+  cases a <;> rfl
+
 /-- A spatial atom is well-formed in a signature when all terms it mentions are. -/
 def wfIn : SpatialAtom → Signature → Prop
   | .pointsTo l v _, Δ => l.wfIn Δ ∧ v.wfIn Δ
   | .arrayPointsTo a v _, Δ => a.wfIn Δ ∧ v.wfIn Δ
+
+@[simp] theorem atom_wfIn {k : Kind} {t v : Term .value} {ty : TinyML.Typ} {Δ : Signature} :
+    (k.atom t v ty).wfIn Δ ↔ t.wfIn Δ ∧ v.wfIn Δ := by
+  cases k <;> exact Iff.rfl
+
+/-- The key term of a well-formed atom is well-formed. -/
+theorem wfIn.key {a : SpatialAtom} {Δ : Signature} (h : a.wfIn Δ) : a.key.wfIn Δ := by
+  cases a <;> exact h.1
+
+/-- The value term of a well-formed atom is well-formed. -/
+theorem wfIn.val {a : SpatialAtom} {Δ : Signature} (h : a.wfIn Δ) : a.val.wfIn Δ := by
+  cases a <;> exact h.2
 
 /-- Well-formedness is stable under signature extension. -/
 theorem wfIn_mono {a : SpatialAtom} {Δ Δ' : Signature}
@@ -50,14 +105,14 @@ def interp [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (ρ : Env) :
       ⌜Term.eval ρ v = .vec vs⌝ ∗ loc ↦ vs ∗
         TinyML.ValHasType Θ (.vec vs) (.vec ty)
 
-/-- Congruence for points-to interpretation under equal location and value evaluation. -/
-theorem pointsTo_congr [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) {ρ : Env}
-    {l l' v v' : Term .value} {ty : TinyML.Typ}
-    (hl : Term.eval ρ l = Term.eval ρ l')
+/-- Congruence of interpretation in the key and value terms, at equal evaluation. -/
+theorem congr [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) {ρ : Env} {k : Kind}
+    {t t' v v' : Term .value} {ty : TinyML.Typ}
+    (ht : Term.eval ρ t = Term.eval ρ t')
     (hv : Term.eval ρ v = Term.eval ρ v') :
-    interp Θ ρ (.pointsTo l v ty) ⊣⊢ interp Θ ρ (.pointsTo l' v' ty) := by
-  simp only [interp, hl, hv]
-  exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
+    interp Θ ρ (k.atom t v ty) ⊣⊢ interp Θ ρ (k.atom t' v' ty) := by
+  cases k <;> simp only [Kind.atom, interp, ht, hv] <;>
+    exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 
 /-- Pure formulas implied by an atom's interpretation. They are assumed
 alongside the atom whenever it enters the verifier's spatial context. -/

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -173,6 +173,7 @@ namespace Spec
 def Pred.print : Spec.Pred → String
   | .isinj tag arity scrut => s!"isinj {tag} {arity} {scrut}"
   | .own loc => s!"own {loc}"
+  | .arr loc => s!"arr {loc}"
 
 private def typString (ty : Typ) : String :=
   ty.print

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -15,6 +15,7 @@ def Typ.print : Typ → String
   | .arrow t1 t2 => s!"{wrapArg t1 (Typ.print t1)} -> {Typ.print t2}"
   | .ref t => s!"ref {wrapArg t (Typ.print t)}"
   | .array t => s!"array {wrapArg t (Typ.print t)}"
+  | .ownedArray t => s!"owned-array {wrapArg t (Typ.print t)}"
   | .vec t => s!"vec {wrapArg t (Typ.print t)}"
   | .owned t => s!"owned {wrapArg t (Typ.print t)}"
   | .empty => "empty"

--- a/Mica/TinyML/Spec.lean
+++ b/Mica/TinyML/Spec.lean
@@ -19,6 +19,8 @@ scope, whose encoded value the translator looks up directly. -/
 inductive Pred where
   | isinj (tag arity : Nat) (scrut : String)
   | own (loc : String)
+  /-- Ownership of a mutable array `loc`, binding its vector snapshot. -/
+  | arr (loc : String)
   deriving Inhabited
 
 /-- The assertion language, parametric in the embedded leaf expression type `ε`

--- a/Mica/TinyML/Typed.lean
+++ b/Mica/TinyML/Typed.lean
@@ -54,7 +54,7 @@ inductive Expr where
   | ref    (owned : Bool) (e : Expr)
   | deref  (e : Expr) (ty : Typ)
   | store  (loc val : Expr)
-  | arrayMake (len init : Expr)
+  | arrayMake (owned : Bool) (len init : Expr)
   | arrayLen (arr : Expr)
   | arrayGet (arr idx : Expr) (ty : Typ)
   | arraySet (arr idx val : Expr)
@@ -157,10 +157,11 @@ mutual
       | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
       | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-    case arrayMake.arrayMake n1 v1 n2 v2 => exact match n1.decEq n2, v1.decEq v2 with
-      | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
-      | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
-      | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case arrayMake.arrayMake o1 n1 v1 o2 n2 v2 => exact match decEq o1 o2, n1.decEq n2, v1.decEq v2 with
+      | isTrue h0, isTrue h1, isTrue h2 => isTrue (by subst h0; subst h1; subst h2; rfl)
+      | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case arrayLen.arrayLen a1 a2 => exact match a1.decEq a2 with
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -257,7 +258,7 @@ def Expr.ty : Expr → Typ
   | .ref owned e => if owned then .owned e.ty else .ref e.ty
   | .deref _ ty => ty
   | .store _ _ => .unit
-  | .arrayMake _ init => .array init.ty
+  | .arrayMake owned _ init => if owned then .ownedArray init.ty else .array init.ty
   | .arrayLen _ => .int
   | .arrayGet _ _ ty => ty
   | .arraySet _ _ _ => .unit
@@ -321,7 +322,7 @@ mutual
     | .ref _ e => .ref e.runtime
     | .deref e _ => .deref e.runtime
     | .store loc val => .store loc.runtime val.runtime
-    | .arrayMake len init => .arrayMake len.runtime init.runtime
+    | .arrayMake _ len init => .arrayMake len.runtime init.runtime
     | .arrayLen arr => .arrayLen arr.runtime
     | .arrayGet arr idx _ => .arrayGet arr.runtime idx.runtime
     | .arraySet arr idx val => .arraySet arr.runtime idx.runtime val.runtime

--- a/Mica/TinyML/Types.lean
+++ b/Mica/TinyML/Types.lean
@@ -111,6 +111,9 @@ inductive Typ where
   | ref (t: Typ)
   /-- Shared array whose elements have type `t`. -/
   | array (t : Typ)
+  /-- An owned mutable array. Its contents are tracked by an immutable vector
+  snapshot in the ambient spatial context. -/
+  | ownedArray (t : Typ)
   /-- Immutable vector whose elements have type `t`. Unlike `array`, a vector is
   a pure value: its contents live in the value itself, not in the heap. -/
   | vec (t : Typ)
@@ -159,6 +162,9 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
   | .array s, .array t => match s.decEq t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .ownedArray s, .ownedArray t => match s.decEq t with
+    | isTrue h => isTrue (by subst h; rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .vec s, .vec t => match s.decEq t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -176,6 +182,15 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
     | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
     | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
     | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .ownedArray .., .prim _ | .ownedArray .., .sum _ | .ownedArray .., .arrow _ _
+  | .ownedArray .., .ref _ | .ownedArray .., .array _ | .ownedArray .., .vec _
+  | .ownedArray .., .owned _ | .ownedArray .., .empty | .ownedArray .., .value
+  | .ownedArray .., .tuple _ | .ownedArray .., .tvar _ | .ownedArray .., .named _ _
+  | .prim _, .ownedArray .. | .sum _, .ownedArray .. | .arrow _ _, .ownedArray ..
+  | .ref _, .ownedArray .. | .array _, .ownedArray .. | .vec _, .ownedArray ..
+  | .owned _, .ownedArray .. | .empty, .ownedArray .. | .value, .ownedArray ..
+  | .tuple _, .ownedArray .. | .tvar _, .ownedArray .. | .named _ _, .ownedArray .. =>
+      isFalse (by intro h; cases h)
   | .prim _, .sum .. | .prim _, .arrow ..
   | .prim _, .ref .. | .prim _, .array .. | .prim _, .owned .. | .prim _, .empty | .prim _, .value | .prim _, .tuple ..
   | .prim _, .tvar .. | .prim _, .named .. | .prim _, .vec ..
@@ -243,6 +258,7 @@ def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
   | .arrow t1 t2 => .arrow (Typ.subst _σ t1) (Typ.subst _σ t2)
   | .ref t => .ref (Typ.subst _σ t)
   | .array t => .array (Typ.subst _σ t)
+  | .ownedArray t => .ownedArray (Typ.subst _σ t)
   | .vec t => .vec (Typ.subst _σ t)
   | .owned t => .owned (Typ.subst _σ t)
   | .empty => .empty
@@ -258,6 +274,7 @@ def Typ.closed : Typ → Bool
   | .arrow t1 t2 => Typ.closed t1 && Typ.closed t2
   | .ref t => Typ.closed t
   | .array t => Typ.closed t
+  | .ownedArray t => Typ.closed t
   | .vec t => Typ.closed t
   | .owned t => Typ.closed t
   | .empty => true
@@ -299,6 +316,7 @@ mutual
     | .arrow t1 t2 => 1 + Typ.weight t1 + Typ.weight t2
     | .ref t => 1 + Typ.weight t
     | .array t => 1 + Typ.weight t
+    | .ownedArray t => 1 + Typ.weight t
     | .vec t => 1 + Typ.weight t
     | .owned t => 1 + Typ.weight t
     | .tuple ts => 1 + Typ.weights ts
@@ -318,6 +336,7 @@ mutual
     | .arrow t1 t2 => 1 + max (Typ.depth t1) (Typ.depth t2)
     | .ref t => 1 + Typ.depth t
     | .array t => 1 + Typ.depth t
+    | .ownedArray t => 1 + Typ.depth t
     | .vec t => 1 + Typ.depth t
     | .owned t => 1 + Typ.depth t
     | .tuple ts => 1 + Typ.depths ts
@@ -524,6 +543,7 @@ mutual
     | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.meet Θ s1 t1) (Typ.join Θ s2 t2)
     | .ref s,       .ref t       => if s == t then .ref s else .value
     | .array s,     .array t     => if s == t then .array s else .value
+    | .ownedArray s, .ownedArray t => if s == t then .ownedArray s else .value
     | .vec s,       .vec t       => if s == t then .vec s else .value
     | .owned s,     .owned t     => if s == t then .owned s else .value
     | .tuple ss,    .tuple ts    => if ss.length == ts.length
@@ -543,6 +563,7 @@ mutual
     | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.join Θ s1 t1) (Typ.meet Θ s2 t2)
     | .ref s,       .ref t       => if s == t then .ref s else .empty
     | .array s,     .array t     => if s == t then .array s else .empty
+    | .ownedArray s, .ownedArray t => if s == t then .ownedArray s else .empty
     | .vec s,       .vec t       => if s == t then .vec s else .empty
     | .owned s,     .owned t     => if s == t then .owned s else .empty
     | .tuple ss,    .tuple ts    => if ss.length == ts.length

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -454,7 +454,23 @@ def elabAssert (prims : Prims) (Θ : TypeEnv) (inner : TyCtx → α → Except T
     let (ty, e') ← infer prims Θ Γ e
     .ok (.let_ x e' (← elabAssert prims Θ inner (Γ.extend x ty) rest))
   | Γ, .bind p x ty rest => do
-    .ok (.bind p x ty (← elabAssert prims Θ inner (Γ.extend x ty) rest))
+    let p' ← match p with
+      | .isinj tag arity scrut => .ok (.isinj tag arity scrut)
+      | .own loc =>
+        match Γ loc with
+        | some (.owned innerTy) =>
+          if innerTy == ty then .ok (.own loc)
+          else .error (.spec s!"own {loc} must bind {repr innerTy}, not {repr ty}")
+        | some other => .error (.spec s!"own {loc} requires an owned reference, got {repr other}")
+        | none => .error (.spec s!"unknown ownership variable '{loc}'")
+      | .arr loc =>
+        match Γ loc with
+        | some (.ownedArray innerTy) =>
+          if (.vec innerTy) == ty then .ok (.arr loc)
+          else .error (.spec s!"arr {loc} must bind a vector snapshot of type {repr (TinyML.Typ.vec innerTy)}, not {repr ty}")
+        | some other => .error (.spec s!"arr {loc} requires an owned array, got {repr other}")
+        | none => .error (.spec s!"unknown ownership variable '{loc}'")
+    .ok (.bind p' x ty (← elabAssert prims Θ inner (Γ.extend x ty) rest))
   | Γ, .ite cond thn els => do
     let cond' ← check prims Θ Γ cond .bool
     .ok (.ite cond' (← elabAssert prims Θ inner Γ thn) (← elabAssert prims Θ inner Γ els))

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -309,26 +309,26 @@ mutual
             let val' ← check prims Θ Γ val inner
             .ok (.unit, .store loc' val')
         | _ => .error (.notARef locTy)
-    | .arrayMake len init => do
+    | .arrayMake owned len init => do
         let len' ← check prims Θ Γ len .int
         let (elemTy, init') ← infer prims Θ Γ init
-        .ok (.array elemTy, .arrayMake len' init')
+        .ok ((if owned then .ownedArray elemTy else .array elemTy), .arrayMake owned len' init')
     | .arrayLen arr => do
         let (arrTy, arr') ← infer prims Θ Γ arr
         match arrTy with
-        | .array _ => .ok (.int, .arrayLen arr')
+        | .array _ | .ownedArray _ => .ok (.int, .arrayLen arr')
         | _ => .error (.notAnArray arrTy)
     | .arrayGet arr idx => do
         let (arrTy, arr') ← infer prims Θ Γ arr
         let idx' ← check prims Θ Γ idx .int
         match arrTy with
-        | .array elemTy => .ok (elemTy, .arrayGet arr' idx' elemTy)
+        | .array elemTy | .ownedArray elemTy => .ok (elemTy, .arrayGet arr' idx' elemTy)
         | _ => .error (.notAnArray arrTy)
     | .arraySet arr idx val => do
         let (arrTy, arr') ← infer prims Θ Γ arr
         let idx' ← check prims Θ Γ idx .int
         match arrTy with
-        | .array elemTy =>
+        | .array elemTy | .ownedArray elemTy =>
             let val' ← check prims Θ Γ val elemTy
             .ok (.unit, .arraySet arr' idx' val')
         | _ => .error (.notAnArray arrTy)
@@ -802,7 +802,7 @@ mutual
             have ⟨val', hval, hcont⟩ := Except.bind_ok hcont
             rcases (by simpa using hcont) with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ihLoc _ hloc, ihVal _ hval]
-    | .arrayMake len init => by
+    | .arrayMake owned len init => by
         let ihLen := check_runtime prims Θ Γ len .int
         let ihInit := infer_runtime prims Θ Γ init
         intro result h
@@ -821,7 +821,7 @@ mutual
         cases p with
         | mk arrTy arr' =>
           cases arrTy <;> simp at hcont
-          case array elemTy =>
+          case array elemTy | ownedArray elemTy =>
             rcases hcont with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ih _ harr]
     | .arrayGet arr idx => by
@@ -834,7 +834,7 @@ mutual
         | mk arrTy arr' =>
           have ⟨idx', hidx, hcont⟩ := Except.bind_ok hcont
           cases arrTy <;> simp at hcont
-          case array elemTy =>
+          case array elemTy | ownedArray elemTy =>
             rcases hcont with ⟨rfl, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime, ihArr _ harr, ihIdx _ hidx]
     | .arraySet arr idx val => by
@@ -847,7 +847,7 @@ mutual
         | mk arrTy arr' =>
           have ⟨idx', hidx, hcont⟩ := Except.bind_ok hcont
           cases arrTy <;> simp at hcont
-          case array =>
+          case array | ownedArray =>
             have ⟨val', hval, hcont⟩ := Except.bind_ok hcont
             rcases hcont with ⟨rfl, rfl⟩
             have hval_rt := check_runtime prims Θ Γ val _ val' hval

--- a/Mica/TinyML/Untyped.lean
+++ b/Mica/TinyML/Untyped.lean
@@ -35,7 +35,7 @@ inductive Expr where
   | ref    (owned : Bool) (e : Expr)
   | deref  (e : Expr)
   | store  (loc val : Expr)
-  | arrayMake (len init : Expr)
+  | arrayMake (owned : Bool) (len init : Expr)
   | arrayLen (arr : Expr)
   | arrayGet (arr idx : Expr)
   | arraySet (arr idx val : Expr)
@@ -123,10 +123,11 @@ mutual
       | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
       | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-    case arrayMake.arrayMake n1 v1 n2 v2 => exact match n1.decEq n2, v1.decEq v2 with
-      | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
-      | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
-      | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case arrayMake.arrayMake o1 n1 v1 o2 n2 v2 => exact match decEq o1 o2, n1.decEq n2, v1.decEq v2 with
+      | isTrue h0, isTrue h1, isTrue h2 => isTrue (by subst h0; subst h1; subst h2; rfl)
+      | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case arrayLen.arrayLen a1 a2 => exact match a1.decEq a2 with
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -240,7 +241,7 @@ def Expr.runtime : Untyped.Expr → Runtime.Expr
   | .ref _ e => .ref e.runtime
   | .deref e => .deref e.runtime
   | .store loc val => .store loc.runtime val.runtime
-  | .arrayMake len init => .arrayMake len.runtime init.runtime
+  | .arrayMake _ len init => .arrayMake len.runtime init.runtime
   | .arrayLen arr => .arrayLen arr.runtime
   | .arrayGet arr idx => .arrayGet arr.runtime idx.runtime
   | .arraySet arr idx val => .arraySet arr.runtime idx.runtime val.runtime

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -328,7 +328,7 @@ def Assertion.assume (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst �
   | .pred v p k => do
     let v' ← VerifM.decl (some v.name) v.sort
     let σ' := σ.rename v v'.name
-    VerifM.assume ((p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort)))
+    VerifM.acquire ((p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort)))
     Assertion.assume σ' k
   | .ite φ kt ke => do
     let branch ← VerifM.all [true, false]
@@ -547,20 +547,21 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
         · iapply hφ_entail
           simp [VerifM.Env.withEnv]
         icases Hφ with %hφ
-        have hb2' : (VerifM.assume (.pure φ)).eval
+        have hb2' : (VerifM.acquire (.pure φ)).eval
             { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
             (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
           simpa [item, hitem] using hb2
         have hitem_wf' : (.pure φ : CtxItem).wfIn (st.decls.addConst v') := by
           simpa [item, hitem] using hitem_wf
-        have hassume := VerifM.eval_assume hb2' hitem_wf' hφ
-        have hih := ih Δ_base σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ))
-          (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
+        obtain ⟨st'', hdecls'', howns'', hassume⟩ :=
+          VerifM.eval_acquire hb2' hitem_wf' hφ (by simp [CtxItem.facts])
+        have hσ''wf : σ'.wfIn Δ_base st''.decls := by rw [hdecls'']; exact hσ'wf
+        have hih := ih Δ_base σ' st''
+          (ρ.updateConst v.sort v'.name u) Ψ hσ''wf hkwf' hassume hpost
         have hframe :
             st.sl Θ ρ ∗ R ⊢
-              (TransState.addItem { st with decls := st.decls.addConst v' } (.pure φ)).sl
-                Θ (ρ.updateConst v.sort v'.name u) ∗ R := by
-          simp [TransState.addItem]
+              st''.sl Θ (ρ.updateConst v.sort v'.name u) ∗ R := by
+          simp only [TransState.sl_eq, howns'', TransState.addItem]
           exact sep_mono
             (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
               (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
@@ -575,15 +576,12 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
           hΦ)
         iexact Howns
       | spatial a =>
-        have hb2' : (VerifM.assume (.spatial a)).eval
+        have hb2' : (VerifM.acquire (.spatial a)).eval
             { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
             (fun r st' ρ' => (Assertion.assume σ' k).eval st' ρ' Ψ) := by
           simpa [item, hitem] using hb2
         have hitem_wf' : (.spatial a : CtxItem).wfIn (st.decls.addConst v') := by
           simpa [item, hitem] using hitem_wf
-        have hassume := VerifM.eval_assume hb2' hitem_wf' trivial
-        have hih := ih Δ_base σ' (TransState.addItem { st with decls := st.decls.addConst v' } (.spatial a))
-          (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
         have hitem_interp :
             p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
               CtxItem.interp Θ (ρ.updateConst v.sort v'.name u) item := by
@@ -595,6 +593,16 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
             p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
               SpatialAtom.interp Θ (ρ.updateConst v.sort v'.name u).env a := by
           simpa [item, hitem, CtxItem.interp] using hitem_interp
+        ihave Ha : SpatialAtom.interp Θ (ρ.updateConst v.sort v'.name u).env a $$ [Hpu]
+        · iapply hspatial_interp
+          simp [VerifM.Env.withEnv]
+        ihave Hfacts := SpatialAtom.interp_facts Θ a $$ Ha
+        icases Hfacts with ⟨%hfacts, Ha⟩
+        obtain ⟨st'', hdecls'', howns'', hassume⟩ :=
+          VerifM.eval_acquire hb2' hitem_wf' trivial (by simpa [CtxItem.facts] using hfacts)
+        have hσ''wf : σ'.wfIn Δ_base st''.decls := by rw [hdecls'']; exact hσ'wf
+        have hih := ih Δ_base σ' st''
+          (ρ.updateConst v.sort v'.name u) Ψ hσ''wf hkwf' hassume hpost
         have howns_agree :
             st.sl Θ ρ ⊢
               st.sl Θ (ρ.updateConst v.sort v'.name u) :=
@@ -606,20 +614,13 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
                 (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
           hΦ)
-        simp [TransState.addItem]
+        simp only [TransState.sl_eq, howns'', TransState.addItem, SpatialContext.interp]
         icases Howns with ⟨HS, HR⟩
         isplitr [HR]
-        · isplitr [HS]
-          · have hspatial_interp' :
-              p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-                SpatialAtom.interp Θ (Env.updateConst ρ.env v.sort v'.name u) a := by
-              simpa [VerifM.Env.updateConst] using hspatial_interp
-            iapply hspatial_interp'
-            simp [VerifM.Env.withEnv]
-          · have howns_agree' :
-              st.sl Θ ρ ⊢ SpatialContext.interp Θ (Env.updateConst ρ.env v.sort v'.name u) st.owns := by
-              simpa [TransState.sl, VerifM.Env.updateConst] using howns_agree
-            iapply howns_agree'
+        · isplitl [Ha]
+          · iexact Ha
+          · simp only [← TransState.sl_eq]
+            iapply howns_agree
             simp [TransState.sl]
         · iexact HR
   | ite φ kt ke iht ihe =>

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -29,6 +29,7 @@ inductive Atom : Srt → Type where
   | isbool : Term .value → Atom .bool
   | isinj  (tag : Nat) (arity : Nat) : Term .value → Atom .value
   | own    : Term .value → TinyML.Typ → Atom .value
+  | arr : Term .value → TinyML.Typ → Atom .value
   | rel    (name : String) : Term .value → Atom .value
 
 
@@ -38,6 +39,7 @@ def Atom.pure {τ: Srt} (a : Atom τ) : Bool :=
   | isbool _ => true
   | isinj _ _ _ => true
   | own _ _ => false
+  | arr _ _ => false
   | rel _ _ => true
 
 
@@ -50,6 +52,7 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
   | .isbool t => .isbool (t.subst σ)
   | .isinj tag arity t => .isinj tag arity (t.subst σ)
   | .own t ty => .own (t.subst σ) ty
+  | .arr t ty => .arr (t.subst σ) ty
   | .rel name t => .rel name (t.subst σ)
 
 
@@ -60,6 +63,7 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
   | .isbool v => .pure (.eq .value v (.unop .ofBool t))
   | .isinj tag arity v => .pure (.eq .value v (.unop (.ofInj tag arity) t))
   | .own l ty => .spatial (.pointsTo l t ty)
+  | .arr a ty => .spatial (.arrayPointsTo a t ty)
   | .rel name arg => .pure (.and (SpecFn.isDefined name arg) (.eq .value (SpecFn.call name arg) t))
 
 -- ---------------------------------------------------------------------------
@@ -73,6 +77,9 @@ def Atom.eval (Θ : TinyML.TypeEnv) {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) :
   | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ.env⌝
   | own l ty => λ v => ∃ loc : Runtime.Location,
       ⌜l.eval ρ.env = .loc loc⌝ ∗ loc ↦ [v] ∗ TinyML.ValHasType Θ v ty
+  | arr a ty => λ v => ∃ loc : Runtime.Location, ∃ vs : List Runtime.Val,
+      ⌜a.eval ρ.env = .array vs.length loc⌝ ∗ ⌜v = .vec vs⌝ ∗ loc ↦ vs ∗
+        TinyML.ValHasType Θ (.vec vs) (.vec ty)
   | rel name arg => λ v =>
     ⌜(SpecFn.isDefined name arg).eval ρ.env ∧ (SpecFn.call name arg).eval ρ.env = v⌝
 
@@ -94,6 +101,7 @@ def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
       if v' = v ∧ tag = tag' ∧ arity = arity' then some t else none
     | _ => none
   | .own _ _ => none
+  | .arr _ _ => none
   | .rel _ _ => none
 
 omit [MicaGS HasLC.hasLC Sig] in
@@ -110,6 +118,7 @@ theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : 
     simp only [Formula.matchAtom] at h
     split at h <;> simp_all [Formula.wfIn, Term.wfIn]
   | own l ty => simp only [Formula.matchAtom] at h; cases h
+  | arr a ty => simp only [Formula.matchAtom] at h; cases h
   | rel name arg => simp only [Formula.matchAtom] at h; cases h
 
 
@@ -128,6 +137,7 @@ theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
     split at h <;> simp_all
     obtain ⟨⟨rfl, rfl, rfl⟩, rfl⟩ := h; rfl
   | own l ty => simp only [Formula.matchAtom] at h; cases h
+  | arr a ty => simp only [Formula.matchAtom] at h; cases h
   | rel name arg => simp only [Formula.matchAtom] at h; cases h
 
 
@@ -163,6 +173,7 @@ def Atom.toStringHum : {τ : Srt} → Atom τ → String
   | _, .isbool t => s!"isbool {t.toStringHum}"
   | _, .isinj tag arity t => s!"isinj {tag}/{arity} {t.toStringHum}"
   | _, .own t ty => s!"own {t.toStringHum} : {reprStr ty}"
+  | _, .arr t ty => s!"arr {t.toStringHum} : {reprStr ty}"
   | _, .rel name t => s!"call {name} {t.toStringHum}"
 
 -- ---------------------------------------------------------------------------
@@ -175,6 +186,7 @@ def Atom.wfIn (Δ : Signature) : Atom τ → Prop
   | .isbool t => t.wfIn Δ
   | .isinj _ _ t => t.wfIn Δ
   | .own t _  => t.wfIn Δ
+  | .arr t _ => t.wfIn Δ
   | .rel name t => (SpecFn.isDefined name t).wfIn Δ ∧ (SpecFn.call name t).wfIn Δ
 
 def Atom.checkWf (p : Atom τ) (Δ : Signature) : Except String Unit :=
@@ -183,6 +195,7 @@ def Atom.checkWf (p : Atom τ) (Δ : Signature) : Except String Unit :=
   | .isbool t => t.checkWf Δ
   | .isinj _ _ t => t.checkWf Δ
   | .own t _  => t.checkWf Δ
+  | .arr t _ => t.checkWf Δ
   | .rel name t => do
       (SpecFn.isDefined name t).checkWf Δ
       (SpecFn.call name t).checkWf Δ
@@ -194,6 +207,7 @@ theorem Atom.checkWf_ok {p : Atom τ} {Δ : Signature} (h : p.checkWf Δ = .ok (
   | isbool t => exact Term.checkWf_ok h
   | isinj tag arity t => exact Term.checkWf_ok h
   | own t ty => exact Term.checkWf_ok h
+  | arr t ty => exact Term.checkWf_ok h
   | rel name t =>
     have ⟨w, hd, hv⟩ := Except.bind_ok h
     exact ⟨Formula.checkWf_ok hd, Term.checkWf_ok hv⟩
@@ -206,6 +220,7 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | isbool t => exact Term.wfIn_mono t h hmono hwf
   | isinj tag arity t => exact Term.wfIn_mono t h hmono hwf
   | own t ty => exact Term.wfIn_mono t h hmono hwf
+  | arr t ty => exact Term.wfIn_mono t h hmono hwf
   | rel name t =>
     exact ⟨Formula.wfIn_mono _ h.1 hmono hwf, Term.wfIn_mono _ h.2 hmono hwf⟩
 
@@ -216,6 +231,7 @@ theorem Atom.eval_env_agree (Θ : TinyML.TypeEnv) {p : Atom τ} {ρ ρ' : VerifM
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isinj tag arity t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | own l ty => simp [Atom.eval, Term.eval_env_agree hwf hagree]
+  | arr a ty => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | rel name t =>
     simp only [Atom.eval]
     funext v
@@ -239,6 +255,9 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
   | own l ty =>
     simp only [Atom.toItem, CtxItem.wfIn, SpatialAtom.wfIn]
     exact ⟨hp, ht⟩
+  | arr a ty =>
+    simp only [Atom.toItem, CtxItem.wfIn, SpatialAtom.wfIn]
+    exact ⟨hp, ht⟩
   | rel name arg =>
     simp only [Atom.toItem, CtxItem.wfIn, Formula.wfIn]
     exact ⟨hp.1, hp.2, ht⟩
@@ -250,6 +269,9 @@ theorem Atom.toItem_eval (Θ : TinyML.TypeEnv) {p : Atom τ} {t : Term τ} {ρ :
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isinj tag arity v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | own l ty =>
+    simp only [Atom.eval, Atom.toItem, CtxItem.interp, SpatialAtom.interp]
+    exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
+  | arr a ty =>
     simp only [Atom.eval, Atom.toItem, CtxItem.interp, SpatialAtom.interp]
     exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
   | rel name arg =>
@@ -265,6 +287,9 @@ theorem Atom.eval_purePart (Θ : TinyML.TypeEnv) {p : Atom τ} {t : Term τ} {ρ
   | isinj tag arity v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
   | own l ty =>
+    simp only [Atom.toItem, CtxItem.purePart]
+    exact pure_intro trivial
+  | arr a ty =>
     simp only [Atom.toItem, CtxItem.purePart]
     exact pure_intro trivial
   | rel name arg =>
@@ -296,6 +321,10 @@ theorem Atom.eval_subst (Θ : TinyML.TypeEnv) {p : Atom τ} {σ : Subst} {ρ : V
     funext v
     simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
     rw [Term.eval_subst hp hσ hwfΔ']
+  | arr a ty =>
+    funext v
+    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
+    rw [Term.eval_subst hp hσ hwfΔ']
   | rel name t =>
     funext v
     simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env, SpecFn.isDefined,
@@ -314,6 +343,7 @@ theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Sign
   | isbool t => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
   | isinj tag arity t => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
   | own t ty => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
+  | arr t ty => exact Term.subst_wfIn hp hσ hdom hsymbols hwf
   | rel name t =>
     refine ⟨?_, ?_⟩
     · exact SpecFn.isDefined_wfIn (hsymbols.unaryRel _ hp.1.1.1) hwf
@@ -339,6 +369,7 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
             (.eq .int (.unop .arityOf v) (.const (.i arity)))),
         .unop .payloadOf v)]
   | .own _ _ => []
+  | .arr _ _ => []
   | .rel _ _ => []
 
 theorem Atom.candidates_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : VerifM.Env}
@@ -363,6 +394,7 @@ theorem Atom.candidates_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {φ : Formul
     cases hv : v.eval ρ.env <;> simp_all
     exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | own l ty => simp [candidates] at hmem
+  | arr a ty => simp [candidates] at hmem
   | rel name arg => simp [candidates] at hmem
 
 omit [MicaGS HasLC.hasLC Sig] in
@@ -383,6 +415,7 @@ theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Si
     refine ⟨⟨⟨trivial, h⟩, ?_⟩, ⟨trivial, h⟩⟩
     exact ⟨⟨⟨trivial, h⟩, trivial⟩, ⟨⟨trivial, h⟩, trivial⟩⟩
   | own l ty => simp [candidates] at hmem
+  | arr a ty => simp [candidates] at hmem
   | rel name arg => simp [candidates] at hmem
 
 
@@ -622,12 +655,72 @@ theorem VerifM.eval_findMatchForce (Θ : TinyML.TypeEnv) {k : SpatialAtom.Kind}
     exact (VerifM.eval_fatal hQ).elim
 
 
+-- ---------------------------------------------------------------------------
+-- Acquisition (adding items to the context)
+-- ---------------------------------------------------------------------------
+
+/-- Assume a context item together with the pure facts implied by its
+    interpretation, making them available to the solver. -/
+def VerifM.acquire (item : CtxItem) : VerifM Unit := do
+  VerifM.assume item
+  VerifM.assumeAll item.facts
+
+omit [MicaGS HasLC.hasLC Sig] in
+/-- Correctness of `acquire`: the resulting state extends the input state by
+    the item; its pure facts must hold in the current environment. -/
+theorem VerifM.eval_acquire {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (VerifM.acquire item) st ρ Q)
+    (hwf : item.wfIn st.decls)
+    (hpure : item.purePart ρ)
+    (hfacts : ∀ φ ∈ item.facts, φ.eval ρ.env) :
+    ∃ st', st'.decls = st.decls ∧ st'.owns = (st.addItem item).owns ∧ Q () st' ρ := by
+  unfold VerifM.acquire at h
+  have hb := VerifM.eval_bind _ _ _ _ h
+  have h1 := VerifM.eval_assume hb hwf (by cases item <;> exact hpure)
+  have hfacts_wf : ∀ φ ∈ item.facts, φ.wfIn (st.addItem item).decls := by
+    have hdecls : (st.addItem item).decls = st.decls := by cases item <;> rfl
+    rw [hdecls]
+    exact CtxItem.facts_wfIn hwf
+  obtain ⟨st', hdecls', howns', _hasserts', hq⟩ := VerifM.eval_assumeAll h1 hfacts_wf hfacts
+  refine ⟨st', ?_, howns', hq⟩
+  rw [hdecls']
+  cases item <;> rfl
+
+/-- CPS correctness for acquiring a spatial atom: the ownership context is
+    extended by the atom, whose pure facts are justified from its
+    interpretation. -/
+theorem VerifM.eval_acquireSpatial (Θ : TinyML.TypeEnv) {a : SpatialAtom}
+    {st : TransState} {ρ : VerifM.Env}
+    {Q : Unit → TransState → VerifM.Env → Prop} {R Φ : iProp}
+    (h : VerifM.eval (VerifM.acquire (.spatial a)) st ρ Q)
+    (hwf : a.wfIn st.decls)
+    (hk : ∀ st', Q () st' ρ → st'.decls = st.decls → st'.owns = a :: st.owns →
+      st'.sl Θ ρ ∗ R ⊢ Φ) :
+    SpatialAtom.interp Θ ρ.env a ∗ st.sl Θ ρ ∗ R ⊢ Φ := by
+  istart
+  iintro ⟨Ha, Howns, HR⟩
+  ihave Hfacts := SpatialAtom.interp_facts Θ a $$ Ha
+  icases Hfacts with ⟨%hfacts, Ha⟩
+  obtain ⟨st', hdecls, howns, hq⟩ := VerifM.eval_acquire h hwf trivial hfacts
+  have howns' : st'.owns = a :: st.owns := howns
+  iapply (hk st' hq hdecls howns')
+  simp only [TransState.sl_eq, howns', SpatialContext.interp]
+  isplitl [Ha Howns]
+  · isplitl [Ha]
+    · iexact Ha
+    · iexact Howns
+  · iexact HR
+
+
 /-- Look up an atom in the assertion context.
     Tier 1: syntactic search through the context.
     Tier 2: try candidate resolutions via the SMT solver. -/
 def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
   | _, .own l ty => do
       VerifM.findMatch .ref l ty
+  | _, .arr a ty => do
+      VerifM.findMatch .array a ty
   | _, .rel name arg => do
       if ← VerifM.check .high (SpecFn.isDefined name arg) then
         pure (some (SpecFn.call name arg))
@@ -713,6 +806,20 @@ theorem VerifM.eval_resolve (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransSt
       have hsome' := hsome v st' ρ hqsome hsub VerifM.Env.agreeOn_refl hvwf'
       have heq : SpatialAtom.interp Θ ρ.env (SpatialAtom.Kind.ref.atom l v ty) ⊢
           Atom.eval Θ (Atom.own l ty) ρ (v.eval ρ.env) := by
+        simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
+        exact BIBase.Entails.rfl
+      exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
+    · intros hqnone
+      exact hnone st ρ hqnone (Signature.Subset.refl _) VerifM.Env.agreeOn_refl
+  | .arr a ty, hwf, hsome, h =>
+    simp only [VerifM.resolve] at h
+    refine VerifM.eval_findMatch Θ (R := R) (Φ := Φ) h hwf ?_ ?_
+    · intros v st' hqsome hdecls hvwf
+      have hsub : st.decls.Subset st'.decls := by rw [hdecls]; exact Signature.Subset.refl _
+      have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
+      have hsome' := hsome v st' ρ hqsome hsub VerifM.Env.agreeOn_refl hvwf'
+      have heq : SpatialAtom.interp Θ ρ.env (SpatialAtom.Kind.array.atom a v ty) ⊢
+          Atom.eval Θ (Atom.arr a ty) ρ (v.eval ρ.env) := by
         simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -434,28 +434,29 @@ private theorem VerifM.eval_tryCandidates (Θ : TinyML.TypeEnv)
 -- Spatial resolution (linear search over st.owns)
 -- ---------------------------------------------------------------------------
 
-/-- Walk a spatial context and return the index and stored value at the first
-    `pointsTo` whose location the SMT solver can prove equal to `lq`. The
-    returned index is into the input list; consumption is the caller's job. -/
-def VerifM.findMatchIn (lq : Term .value) (ty : TinyML.Typ) :
+/-- Walk a spatial context and return the index and stored value term at the
+    first atom of kind `k` and type `ty` whose key the SMT solver can prove
+    equal to `tq`. The returned index is into the input list; consumption is
+    the caller's job. -/
+def VerifM.findMatchIn (k : SpatialAtom.Kind) (tq : Term .value) (ty : TinyML.Typ) :
     SpatialContext → VerifM (Option (Nat × Term .value))
   | [] => pure none
-  | .pointsTo l v ty' :: rest => do
-      if ty' == ty then
-        if ← VerifM.test (.eq .value lq l) then
-          pure (some (0, v))
+  | a :: rest => do
+      if a.kind == k && a.ty == ty then
+        if ← VerifM.test (.eq .value tq a.key) then
+          pure (some (0, a.val))
         else
-          return (← VerifM.findMatchIn lq ty rest).map fun (n, v') => (n + 1, v')
+          return (← VerifM.findMatchIn k tq ty rest).map fun (n, v') => (n + 1, v')
       else
-        return (← VerifM.findMatchIn lq ty rest).map fun (n, v') => (n + 1, v')
-  | .arrayPointsTo _ _ _ :: rest => do
-      return (← VerifM.findMatchIn lq ty rest).map fun (n, v') => (n + 1, v')
+        return (← VerifM.findMatchIn k tq ty rest).map fun (n, v') => (n + 1, v')
 
-/-- Search the current ownership context for a `pointsTo` at location `lq`,
-    returning the stored value and consuming the matched entry from `st.owns`. -/
-def VerifM.findMatch (lq : Term .value) (ty : TinyML.Typ) : VerifM (Option (Term .value)) := do
+/-- Search the current ownership context for an atom of kind `k` with key `tq`,
+    returning its stored value term and consuming the matched entry from
+    `st.owns`. -/
+def VerifM.findMatch (k : SpatialAtom.Kind) (tq : Term .value) (ty : TinyML.Typ) :
+    VerifM (Option (Term .value)) := do
   let owns ← VerifM.ctx (fun st => (st.owns, st.owns))
-  match ← VerifM.findMatchIn lq ty owns with
+  match ← VerifM.findMatchIn k tq ty owns with
   | none => pure none
   | some (n, v) =>
       match SpatialContext.remove owns n with
@@ -466,111 +467,91 @@ def VerifM.findMatch (lq : Term .value) (ty : TinyML.Typ) : VerifM (Option (Term
 
 omit [MicaGS HasLC.hasLC Sig] in
 /-- Correctness of `findMatchIn`: on a `some (n, v)` result, `remove ctx n`
-    extracts a points-to whose location the solver has proved equal to `lq`. -/
-theorem VerifM.eval_findMatchIn {lq : Term .value} {ty : TinyML.Typ} {ctx : SpatialContext}
-    {st : TransState} {ρ : VerifM.Env}
+    extracts an atom of kind `k` whose key the solver has proved equal to `tq`. -/
+theorem VerifM.eval_findMatchIn {k : SpatialAtom.Kind} {tq : Term .value} {ty : TinyML.Typ}
+    {ctx : SpatialContext} {st : TransState} {ρ : VerifM.Env}
     {Q : Option (Nat × Term .value) → TransState → VerifM.Env → Prop}
-    (h : VerifM.eval (VerifM.findMatchIn lq ty ctx) st ρ Q)
-    (hlq : lq.wfIn st.decls) (hctx : ctx.wfIn st.decls) :
+    (h : VerifM.eval (VerifM.findMatchIn k tq ty ctx) st ρ Q)
+    (htq : tq.wfIn st.decls) (hctx : ctx.wfIn st.decls) :
     ∃ result,
       Q result st ρ ∧
       (∀ n v, result = some (n, v) →
-        ∃ l rest,
-          SpatialContext.remove ctx n = some (.pointsTo l v ty, rest) ∧
-          Term.eval ρ.env lq = Term.eval ρ.env l) := by
+        ∃ t rest,
+          SpatialContext.remove ctx n = some (k.atom t v ty, rest) ∧
+          Term.eval ρ.env tq = Term.eval ρ.env t) := by
   induction ctx generalizing Q with
   | nil =>
     simp only [VerifM.findMatchIn] at h
     refine ⟨none, VerifM.eval_ret h, ?_⟩
     intros n v hvr; simp at hvr
   | cons a ctx ih =>
-    cases a with
-    | pointsTo l v ty' =>
-      simp only [VerifM.findMatchIn] at h
-      have hcons := (SpatialContext.wfIn_cons _ _ _).1 hctx
-      have hwfeq : (Formula.eq .value lq l).wfIn st.decls := ⟨hlq, hcons.1.1⟩
-      have hrecurse :
-          VerifM.eval
-            (return (← VerifM.findMatchIn lq ty ctx).map fun (n, v') => (n + 1, v'))
-            st ρ Q →
-          ∃ result,
-            Q result st ρ ∧
-            (∀ n v', result = some (n, v') →
-              ∃ l' rest',
-                SpatialContext.remove (.pointsTo l v ty' :: ctx) n =
-                  some (.pointsTo l' v' ty, rest') ∧
-                Term.eval ρ.env lq = Term.eval ρ.env l') := by
-        intro hrec
-        have hb' := VerifM.eval_bind _ _ _ _ hrec
-        obtain ⟨result', hres', hsome'⟩ := ih hb' hcons.2
-        cases result' with
-        | none =>
-          simp at hres'
-          refine ⟨none, VerifM.eval_ret hres', ?_⟩
-          intros n' v' hnv; simp at hnv
-        | some pair =>
-          obtain ⟨n₀, v₀⟩ := pair
-          simp at hres'
-          refine ⟨some (n₀ + 1, v₀), VerifM.eval_ret hres', ?_⟩
-          intros n' v' hnv
-          simp at hnv
-          obtain ⟨rfl, rfl⟩ := hnv
-          obtain ⟨l', rest', hrem, heq⟩ := hsome' n₀ v₀ rfl
-          refine ⟨l', .pointsTo l v ty' :: rest', ?_, heq⟩
-          simp [SpatialContext.remove, hrem]
-      split at h
-      · -- the type matches, so ask the solver whether the locations are equal
-        rename_i hty
-        have hb := VerifM.eval_bind _ _ _ _ h
-        obtain ⟨b, hb_sound, hq⟩ := VerifM.eval_check hb hwfeq
-        split at hq
-        · -- the solver proved the locations equal
-          rename_i hbtrue
-          refine ⟨some (0, v), VerifM.eval_ret hq, ?_⟩
-          intros n' v' hnv
-          simp at hnv
-          obtain ⟨rfl, rfl⟩ := hnv
-          have heq : Term.eval ρ.env lq = Term.eval ρ.env l := by
-            simpa [Formula.eval] using hb_sound hbtrue
-          exact ⟨l, ctx, by simp [beq_iff_eq.mp hty], heq⟩
-        · exact hrecurse hq
-      · -- the type does not match, so skip the solver and keep searching
-        exact hrecurse h
-    | arrayPointsTo a v elemTy =>
-      simp only [VerifM.findMatchIn] at h
-      have hcons := (SpatialContext.wfIn_cons _ _ _).1 hctx
-      have hb := VerifM.eval_bind _ _ _ _ h
-      obtain ⟨result, hres, hsome⟩ := ih hb hcons.2
-      cases result with
+    simp only [VerifM.findMatchIn] at h
+    have hcons := (SpatialContext.wfIn_cons _ _ _).1 hctx
+    have hrecurse :
+        VerifM.eval
+          (return (← VerifM.findMatchIn k tq ty ctx).map fun (n, v') => (n + 1, v'))
+          st ρ Q →
+        ∃ result,
+          Q result st ρ ∧
+          (∀ n v', result = some (n, v') →
+            ∃ t' rest',
+              SpatialContext.remove (a :: ctx) n = some (k.atom t' v' ty, rest') ∧
+              Term.eval ρ.env tq = Term.eval ρ.env t') := by
+      intro hrec
+      have hb' := VerifM.eval_bind _ _ _ _ hrec
+      obtain ⟨result', hres', hsome'⟩ := ih hb' hcons.2
+      cases result' with
       | none =>
-        simp at hres
-        refine ⟨none, VerifM.eval_ret hres, ?_⟩
-        intros n' v' hnv
-        simp at hnv
+        simp at hres'
+        refine ⟨none, VerifM.eval_ret hres', ?_⟩
+        intros n' v' hnv; simp at hnv
       | some pair =>
         obtain ⟨n₀, v₀⟩ := pair
-        simp at hres
-        refine ⟨some (n₀ + 1, v₀), VerifM.eval_ret hres, ?_⟩
+        simp at hres'
+        refine ⟨some (n₀ + 1, v₀), VerifM.eval_ret hres', ?_⟩
         intros n' v' hnv
         simp at hnv
         obtain ⟨rfl, rfl⟩ := hnv
-        obtain ⟨l', rest', hrem, heq⟩ := hsome n₀ v₀ rfl
-        refine ⟨l', .arrayPointsTo a v elemTy :: rest', ?_, heq⟩
+        obtain ⟨t', rest', hrem, heq⟩ := hsome' n₀ v₀ rfl
+        refine ⟨t', a :: rest', ?_, heq⟩
         simp [SpatialContext.remove, hrem]
+    split at h
+    · -- the kind and type match, so ask the solver whether the keys are equal
+      rename_i hmatch
+      have hwfeq : (Formula.eq .value tq a.key).wfIn st.decls :=
+        ⟨htq, SpatialAtom.wfIn.key hcons.1⟩
+      have hb := VerifM.eval_bind _ _ _ _ h
+      obtain ⟨b, hb_sound, hq⟩ := VerifM.eval_check hb hwfeq
+      split at hq
+      · -- the solver proved the keys equal
+        rename_i hbtrue
+        refine ⟨some (0, a.val), VerifM.eval_ret hq, ?_⟩
+        intros n' v' hnv
+        simp at hnv
+        obtain ⟨rfl, rfl⟩ := hnv
+        have heq : Term.eval ρ.env tq = Term.eval ρ.env a.key := by
+          simpa [Formula.eval] using hb_sound hbtrue
+        simp only [Bool.and_eq_true, beq_iff_eq] at hmatch
+        refine ⟨a.key, ctx, ?_, heq⟩
+        simp [SpatialContext.remove, ← hmatch.1, ← hmatch.2]
+      · exact hrecurse hq
+    · -- the kind or type does not match, so skip the solver and keep searching
+      exact hrecurse h
 
 /-- Correctness of `findMatch` in CPS style: the caller supplies Iris-level
     continuations for the `some` and `none` branches. On `some v`, the
-    postcondition state has the matched points-to consumed from `st.owns`, and
-    the caller receives separate ownership of `lq ↦ v`. -/
-theorem VerifM.eval_findMatch (Θ : TinyML.TypeEnv) {lq : Term .value} {ty : TinyML.Typ}
+    postcondition state has the matched atom consumed from `st.owns`, and the
+    caller receives its interpretation at key `tq` separately. -/
+theorem VerifM.eval_findMatch (Θ : TinyML.TypeEnv) {k : SpatialAtom.Kind}
+    {tq : Term .value} {ty : TinyML.Typ}
     {st : TransState} {ρ : VerifM.Env}
     {Q : Option (Term .value) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
-    (h : VerifM.eval (VerifM.findMatch lq ty) st ρ Q)
-    (hlq : lq.wfIn st.decls)
+    (h : VerifM.eval (VerifM.findMatch k tq ty) st ρ Q)
+    (htq : tq.wfIn st.decls)
     (hsome : ∀ v st', Q (some v) st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp Θ ρ.env (.pointsTo lq v ty) ∗ st'.sl Θ ρ ∗ R ⊢ Φ)
+        SpatialAtom.interp Θ ρ.env (k.atom tq v ty) ∗ st'.sl Θ ρ ∗ R ⊢ Φ)
     (hnone : Q none st ρ → st.sl Θ ρ ∗ R ⊢ Φ) :
     st.sl Θ ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatch at h
@@ -580,58 +561,59 @@ theorem VerifM.eval_findMatch (Θ : TinyML.TypeEnv) {lq : Term .value} {ty : Tin
   rw [hst_eq] at hk
   have hk' := hk howns
   have hb2 := VerifM.eval_bind _ _ _ _ hk'
-  obtain ⟨result, hres, hprop⟩ := eval_findMatchIn hb2 hlq howns
+  obtain ⟨result, hres, hprop⟩ := eval_findMatchIn hb2 htq howns
   cases result with
   | none =>
     simp at hres
     exact hnone (VerifM.eval_ret hres)
   | some pair =>
     obtain ⟨n, v⟩ := pair
-    obtain ⟨l, rest, hrem, heq⟩ := hprop n v rfl
+    obtain ⟨t, rest, hrem, heq⟩ := hprop n v rfl
     have hrest_wf : SpatialContext.wfIn rest st.decls :=
       (SpatialContext.wfIn_remove howns hrem).2
-    have hatom_wf : SpatialAtom.wfIn (.pointsTo l v ty) st.decls :=
+    have hatom_wf : SpatialAtom.wfIn (k.atom t v ty) st.decls :=
       (SpatialContext.wfIn_remove howns hrem).1
-    have hv_wf : v.wfIn st.decls := hatom_wf.2
+    have hv_wf : v.wfIn st.decls := (SpatialAtom.atom_wfIn.1 hatom_wf).2
     simp [hrem] at hres
-    -- hres : (VerifM.ctx (fun _ => ((), rest)) >>= fun _ => pure (some v)).eval st ρ Q
     have hb3 := VerifM.eval_bind _ _ _ _ hres
     have ⟨hk3, _, _, _⟩ := VerifM.eval_ctx hb3
     have hk3' := hk3 hrest_wf
     have hQ : Q (some v) { st with owns := rest } ρ := VerifM.eval_ret hk3'
     have hsplit := SpatialContext.interp_remove Θ ρ.env st.owns n _ _ hrem
-    have hcong := SpatialAtom.pointsTo_congr Θ (l := l) (l' := lq) (v := v) (v' := v)
+    have hcong := SpatialAtom.congr Θ (k := k) (t := t) (t' := tq) (v := v) (v' := v)
       (ty := ty) heq.symm rfl
     -- goal: st.owns.interp ρ ∗ R ⊢ Φ
-    -- st.owns.interp ρ ⊣⊢ (pointsTo l v ty).interp ρ ∗ rest.interp ρ
-    --                ⊣⊢ (pointsTo lq v ty).interp ρ ∗ rest.interp ρ
+    -- st.owns.interp ρ ⊣⊢ (k.atom t v ty).interp ρ ∗ rest.interp ρ
+    --                ⊣⊢ (k.atom tq v ty).interp ρ ∗ rest.interp ρ
     refine (Iris.BI.sep_mono hsplit.1 BIBase.Entails.rfl).trans ?_
     refine (Iris.BI.sep_mono (Iris.BI.sep_mono hcong.1 BIBase.Entails.rfl) BIBase.Entails.rfl).trans ?_
     refine Iris.BI.sep_assoc.1.trans ?_
     exact hsome v { st with owns := rest } hQ rfl hv_wf
 
-/-- Like `findMatch`, but aborts with a fatal error if no matching points-to
-    is found in the current ownership context. -/
-def VerifM.findMatchForce (lq : Term .value) (ty : TinyML.Typ) : VerifM (Term .value) := do
-  match ← VerifM.findMatch lq ty with
+/-- Like `findMatch`, but aborts with a fatal error if no matching atom is
+    found in the current ownership context. -/
+def VerifM.findMatchForce (k : SpatialAtom.Kind) (tq : Term .value) (ty : TinyML.Typ) :
+    VerifM (Term .value) := do
+  match ← VerifM.findMatch k tq ty with
   | some v => pure v
-  | none => VerifM.fatal s!"no matching points-to for location"
+  | none => VerifM.fatal s!"no matching {k.print}"
 
 /-- CPS correctness for `findMatchForce`: only a `some`-style continuation is
     required, since the `none` branch is discharged by the fatal error. -/
-theorem VerifM.eval_findMatchForce (Θ : TinyML.TypeEnv) {lq : Term .value} {ty : TinyML.Typ}
+theorem VerifM.eval_findMatchForce (Θ : TinyML.TypeEnv) {k : SpatialAtom.Kind}
+    {tq : Term .value} {ty : TinyML.Typ}
     {st : TransState} {ρ : VerifM.Env}
     {Q : Term .value → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
-    (h : VerifM.eval (VerifM.findMatchForce lq ty) st ρ Q)
-    (hlq : lq.wfIn st.decls)
+    (h : VerifM.eval (VerifM.findMatchForce k tq ty) st ρ Q)
+    (htq : tq.wfIn st.decls)
     (hsome : ∀ v st', Q v st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp Θ ρ.env (.pointsTo lq v ty) ∗ st'.sl Θ ρ ∗ R ⊢ Φ) :
+        SpatialAtom.interp Θ ρ.env (k.atom tq v ty) ∗ st'.sl Θ ρ ∗ R ⊢ Φ) :
     st.sl Θ ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatchForce at h
   have hb := VerifM.eval_bind _ _ _ _ h
-  refine eval_findMatch Θ (R := R) (Φ := Φ) hb hlq ?_ ?_
+  refine eval_findMatch Θ (R := R) (Φ := Φ) hb htq ?_ ?_
   · intros v st' hQ hdecls hv
     simp at hQ
     exact hsome v st' (VerifM.eval_ret hQ) hdecls hv
@@ -645,7 +627,7 @@ theorem VerifM.eval_findMatchForce (Θ : TinyML.TypeEnv) {lq : Term .value} {ty 
     Tier 2: try candidate resolutions via the SMT solver. -/
 def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
   | _, .own l ty => do
-      VerifM.findMatch l ty
+      VerifM.findMatch .ref l ty
   | _, .rel name arg => do
       if ← VerifM.check .high (SpecFn.isDefined name arg) then
         pure (some (SpecFn.call name arg))
@@ -729,8 +711,9 @@ theorem VerifM.eval_resolve (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransSt
       have hsub : st.decls.Subset st'.decls := by rw [hdecls]; exact Signature.Subset.refl _
       have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
       have hsome' := hsome v st' ρ hqsome hsub VerifM.Env.agreeOn_refl hvwf'
-      have heq : SpatialAtom.interp Θ ρ.env (.pointsTo l v ty) ⊢ Atom.eval Θ (Atom.own l ty) ρ (v.eval ρ.env) := by
-        simp only [Atom.eval, SpatialAtom.interp]
+      have heq : SpatialAtom.interp Θ ρ.env (SpatialAtom.Kind.ref.atom l v ty) ⊢
+          Atom.eval Θ (Atom.own l ty) ρ (v.eval ρ.env) := by
+        simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
     · intros hqnone

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -448,6 +448,8 @@ def VerifM.findMatchIn (lq : Term .value) (ty : TinyML.Typ) :
           return (← VerifM.findMatchIn lq ty rest).map fun (n, v') => (n + 1, v')
       else
         return (← VerifM.findMatchIn lq ty rest).map fun (n, v') => (n + 1, v')
+  | .arrayPointsTo _ _ _ :: rest => do
+      return (← VerifM.findMatchIn lq ty rest).map fun (n, v') => (n + 1, v')
 
 /-- Search the current ownership context for a `pointsTo` at location `lq`,
     returning the stored value and consuming the matched entry from `st.owns`. -/
@@ -534,6 +536,27 @@ theorem VerifM.eval_findMatchIn {lq : Term .value} {ty : TinyML.Typ} {ctx : Spat
         · exact hrecurse hq
       · -- the type does not match, so skip the solver and keep searching
         exact hrecurse h
+    | arrayPointsTo a v elemTy =>
+      simp only [VerifM.findMatchIn] at h
+      have hcons := (SpatialContext.wfIn_cons _ _ _).1 hctx
+      have hb := VerifM.eval_bind _ _ _ _ h
+      obtain ⟨result, hres, hsome⟩ := ih hb hcons.2
+      cases result with
+      | none =>
+        simp at hres
+        refine ⟨none, VerifM.eval_ret hres, ?_⟩
+        intros n' v' hnv
+        simp at hnv
+      | some pair =>
+        obtain ⟨n₀, v₀⟩ := pair
+        simp at hres
+        refine ⟨some (n₀ + 1, v₀), VerifM.eval_ret hres, ?_⟩
+        intros n' v' hnv
+        simp at hnv
+        obtain ⟨rfl, rfl⟩ := hnv
+        obtain ⟨l', rest', hrem, heq⟩ := hsome n₀ v₀ rfl
+        refine ⟨l', .arrayPointsTo a v elemTy :: rest', ?_, heq⟩
+        simp [SpatialContext.remove, hrem]
 
 /-- Correctness of `findMatch` in CPS style: the caller supplies Iris-level
     continuations for the `some` and `none` branches. On `some v`, the

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -331,7 +331,7 @@ mutual
         | .owned ty' => do
             VerifM.expectEq "deref type annotation mismatch" ty' ty
             let lq ← compile reg Θ Δ_spec S B Γ e
-            let v ← VerifM.findMatchForce lq ty
+            let v ← VerifM.findMatchForce .ref lq ty
             VerifM.assume (.spatial (.pointsTo lq v ty))
             pure v
         | .ref ty' => do
@@ -348,7 +348,7 @@ mutual
             VerifM.expectEq "store location type mismatch" ty val.ty
             let v ← compile reg Θ Δ_spec S B Γ val
             let lq ← compile reg Θ Δ_spec S B Γ loc
-            let _ ← VerifM.findMatchForce lq val.ty
+            let _ ← VerifM.findMatchForce .ref lq val.ty
             VerifM.assume (.spatial (.pointsTo lq v val.ty))
             pure (Term.const .unit)
         | .ref ty => do
@@ -357,7 +357,8 @@ mutual
             let _ ← compile reg Θ Δ_spec S B Γ loc
             pure (Term.const .unit)
         | _ => VerifM.fatal "store location is not a reference"
-    | .arrayMake len init => do
+    | .arrayMake owned len init => do
+        if owned then VerifM.fatal "owned Array.make is not yet compiled" else
         VerifM.expectEq "array length must be int" len.ty .int
         let _ ← compile reg Θ Δ_spec S B Γ init
         let sl ← compile reg Θ Δ_spec S B Γ len
@@ -1207,7 +1208,7 @@ theorem compileDeref_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.T
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
-  | prim _ | sum _ | arrow _ _ | array _ | vec _ | empty | value | tuple _ | tvar _ | named _ _ =>
+  | prim _ | sum _ | arrow _ _ | array _ | ownedArray _ | vec _ | empty | value | tuple _ | tvar _ | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -1390,19 +1391,19 @@ theorem compileStore_correct (reg : Verifier.Registry) (loc val : Expr)
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
-  | prim _ | sum _ | arrow _ _ | array _ | vec _ | empty | value | tuple _ | tvar _ | named _ _ =>
+  | prim _ | sum _ | arrow _ _ | array _ | ownedArray _ | vec _ | empty | value | tuple _ | tvar _ | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
 
-theorem compileArrayMake_correct (reg : Verifier.Registry) (len init : Expr)
+theorem compileArrayMakeShared_correct (reg : Verifier.Registry) (len init : Expr)
     (ihLen : correctExpr reg len) (ihInit : correctExpr reg init) :
-    correctExpr reg (.arrayMake len init) := by
+    correctExpr reg (.arrayMake false len init) := by
   intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  simp only [Expr.ty] at hpost
+  simp only [Expr.ty, Bool.false_eq_true, if_false] at hpost
   obtain ⟨hlenty, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_init : (compile reg Θ Δ_spec S B Γ init).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_arrayMake <| ?_
@@ -1518,6 +1519,18 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (len init : Expr)
         · iexact HR
   exact hwp
 
+/-- Array allocation correctness, dispatching shared allocation to the
+invariant-backed proof. The owned branch is completed by the owned-array
+symbolic-execution rule below. -/
+theorem compileArrayMake_correct (reg : Verifier.Registry) (owned : Bool) (len init : Expr)
+    (ihLen : correctExpr reg len) (ihInit : correctExpr reg init) :
+    correctExpr reg (.arrayMake owned len init) := by
+  cases owned with
+  | false => exact compileArrayMakeShared_correct reg len init ihLen ihInit
+  | true =>
+    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+    exact (VerifM.eval_fatal (by simpa [compile] using heval)).elim
+
 theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
     (ihArr : correctExpr reg arr) :
     correctExpr reg (.arrayLen arr) := by
@@ -1561,6 +1574,10 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
           · iapply (TinyML.ValHasType.int_intro Θ)
           · iexact HR
       exact hwp
+  | ownedArray elem =>
+      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+      simp only [compile, hty] at heval
+      exact (VerifM.eval_fatal heval).elim
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
@@ -1668,6 +1685,10 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
               · iexact Hw
               · iexact HR))
     exact hwp
+  | ownedArray elemTy =>
+    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+    simp only [compile, hty] at heval
+    exact (VerifM.eval_fatal heval).elim
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
@@ -1772,6 +1793,10 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
               · iapply (TinyML.ValHasType.unit_intro Θ)
               · iexact HR))
     exact hwp
+  | ownedArray elemTy =>
+    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+    simp only [compile, hty] at heval
+    exact (VerifM.eval_fatal heval).elim
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
@@ -2482,7 +2507,7 @@ theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (
             · isplitl []
               · iexact HT
               · iexact HR
-  | prim _ | sum _ | arrow _ _ | ref _ | array _ | vec _ | owned _ | empty | value | tvar _
+  | prim _ | sum _ | arrow _ _ | ref _ | array _ | ownedArray _ | vec _ | owned _ | empty | value | tvar _
   | named _ _ =>
       simp [hty] at hΨ_e
       exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ hΨ_e)).elim
@@ -2894,7 +2919,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
   intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se
   obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
   cases hscrut_ty : scrut.ty with
-  | prim _ | arrow _ _ | ref _ | array _ | vec _ | owned _ | empty | value | tuple _ | tvar _
+  | prim _ | arrow _ _ | ref _ | array _ | ownedArray _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
     simp only [hscrut_ty] at hΨ_scrut
     exact (VerifM.eval_fatal hΨ_scrut).elim
@@ -3327,8 +3352,8 @@ theorem compile_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.So
     simpa using compileDeref_correct reg e ty (compile_correct reg hSound e)
   | store loc val =>
     simpa using compileStore_correct reg loc val (compile_correct reg hSound val) (compile_correct reg hSound loc)
-  | arrayMake len init =>
-    simpa using compileArrayMake_correct reg len init
+  | arrayMake owned len init =>
+    simpa using compileArrayMake_correct reg owned len init
       (compile_correct reg hSound len) (compile_correct reg hSound init)
   | arrayLen arr =>
     simpa using compileArrayLen_correct reg arr (compile_correct reg hSound arr)

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -358,48 +358,64 @@ mutual
             pure (Term.const .unit)
         | _ => VerifM.fatal "store location is not a reference"
     | .arrayMake owned len init => do
-        if owned then VerifM.fatal "owned Array.make is not yet compiled" else
         VerifM.expectEq "array length must be int" len.ty .int
-        let _ ← compile reg Θ Δ_spec S B Γ init
+        let s_init ← compile reg Θ Δ_spec S B Γ init
         let sl ← compile reg Θ Δ_spec S B Γ len
         VerifM.assert (.binpred .le (.const (.i 0)) (.unop .toInt sl))
         let a ← VerifM.decl none .value
         let sa := Term.const (.uninterpreted a.name .value)
         VerifM.assume (.pure (.eq .int (.unop .arrayLengthOf sa) (.unop .toInt sl)))
-        VerifM.assumeAll (TinyML.typeConstraints (.array init.ty) sa)
+        if owned then
+          let contents := Term.unop .ofVec (.binop .vecMake (.unop .toInt sl) s_init)
+          VerifM.acquire (.spatial (.arrayPointsTo sa contents init.ty))
+          VerifM.assumeAll (TinyML.typeConstraints (.ownedArray init.ty) sa)
+        else
+          VerifM.assumeAll (TinyML.typeConstraints (.array init.ty) sa)
         pure sa
     | .arrayLen arr => do
         match arr.ty with
-        | .array _ =>
+        | .array _ | .ownedArray _ =>
             let sa ← compile reg Θ Δ_spec S B Γ arr
             pure (.unop .ofInt (.unop .arrayLengthOf sa))
         | _ => VerifM.fatal "Array.length operand is not an array"
     | .arrayGet arr idx ty => do
-        match arr.ty with
-        | .array elemTy => do
-            VerifM.expectEq "array get element type mismatch" elemTy ty
-            VerifM.expectEq "array index must be int" idx.ty .int
-            let si ← compile reg Θ Δ_spec S B Γ idx
-            let sa ← compile reg Θ Δ_spec S B Γ arr
-            VerifM.assert (.binpred .le (.const (.i 0)) (.unop .toInt si))
-            VerifM.assert (.binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa))
-            let v ← VerifM.decl none .value
-            let sv := Term.const (.uninterpreted v.name .value)
-            VerifM.assumeAll (TinyML.typeConstraints ty sv)
-            pure sv
-        | _ => VerifM.fatal "Array.get operand is not an array"
+        let (elemTy, owned) ← match arr.ty with
+          | .array elemTy => pure (elemTy, false)
+          | .ownedArray elemTy => pure (elemTy, true)
+          | _ => VerifM.fatal "Array.get operand is not an array"
+        VerifM.expectEq "array get element type mismatch" elemTy ty
+        VerifM.expectEq "array index must be int" idx.ty .int
+        let si ← compile reg Θ Δ_spec S B Γ idx
+        let sa ← compile reg Θ Δ_spec S B Γ arr
+        VerifM.assert (.binpred .le (.const (.i 0)) (.unop .toInt si))
+        VerifM.assert (.binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa))
+        if owned then
+          let contents ← VerifM.findMatchForce .array sa elemTy
+          VerifM.acquire (.spatial (.arrayPointsTo sa contents elemTy))
+          pure (.binop .vecGet (.unop .toVec contents) (.unop .toInt si))
+        else
+          let v ← VerifM.decl none .value
+          let sv := Term.const (.uninterpreted v.name .value)
+          VerifM.assumeAll (TinyML.typeConstraints ty sv)
+          pure sv
     | .arraySet arr idx val => do
-        match arr.ty with
-        | .array elemTy => do
-            VerifM.expectEq "array set element type mismatch" elemTy val.ty
-            VerifM.expectEq "array index must be int" idx.ty .int
-            let _ ← compile reg Θ Δ_spec S B Γ val
-            let si ← compile reg Θ Δ_spec S B Γ idx
-            let sa ← compile reg Θ Δ_spec S B Γ arr
-            VerifM.assert (.binpred .le (.const (.i 0)) (.unop .toInt si))
-            VerifM.assert (.binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa))
-            pure (Term.const .unit)
-        | _ => VerifM.fatal "Array.set operand is not an array"
+        let (elemTy, owned) ← match arr.ty with
+          | .array elemTy => pure (elemTy, false)
+          | .ownedArray elemTy => pure (elemTy, true)
+          | _ => VerifM.fatal "Array.set operand is not an array"
+        VerifM.expectEq "array set element type mismatch" elemTy val.ty
+        VerifM.expectEq "array index must be int" idx.ty .int
+        let sv ← compile reg Θ Δ_spec S B Γ val
+        let si ← compile reg Θ Δ_spec S B Γ idx
+        let sa ← compile reg Θ Δ_spec S B Γ arr
+        VerifM.assert (.binpred .le (.const (.i 0)) (.unop .toInt si))
+        VerifM.assert (.binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa))
+        if owned then
+          let contents ← VerifM.findMatchForce .array sa elemTy
+          let contents' := Term.unop .ofVec
+            (.terop .vecSet (.unop .toVec contents) (.unop .toInt si) sv)
+          VerifM.acquire (.spatial (.arrayPointsTo sa contents' elemTy))
+        pure (Term.const .unit)
     | .app _ _ _ | .fix _ _ _ _ => VerifM.fatal "unsupported expression"
 
   /-- Compile a single match branch: assume the scrutinee is `ofInj i n payload`, then compile the body. -/
@@ -1396,14 +1412,39 @@ theorem compileStore_correct (reg : Verifier.Registry) (loc val : Expr)
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
 
-theorem compileArrayMakeShared_correct (reg : Verifier.Registry) (len init : Expr)
+omit [MicaGS HasLC.hasLC Sig] in
+/-- Peel the two bounds assertions guarding an array access. -/
+private theorem VerifM.eval_assertBounds {si sa : Term .value} {α : Type}
+    {k : VerifM α} {st : TransState} {ρ : VerifM.Env}
+    {Q : α → TransState → VerifM.Env → Prop}
+    (h : VerifM.eval (do
+      VerifM.assert (.binpred .le (.const (.i 0)) (.unop .toInt si))
+      VerifM.assert (.binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa))
+      k) st ρ Q)
+    (hsi : si.wfIn st.decls) (hsa : sa.wfIn st.decls) :
+    0 ≤ Term.eval ρ.env (.unop .toInt si) ∧
+    Term.eval ρ.env (.unop .toInt si) < Term.eval ρ.env (.unop .arrayLengthOf sa) ∧
+    VerifM.eval k st ρ Q := by
+  have hwf1 : (Formula.binpred .le (.const (.i 0)) (.unop .toInt si)).wfIn st.decls := by
+    simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, BinPred.wfIn] using hsi
+  obtain ⟨hφ1, hcont1⟩ := VerifM.eval_assert (VerifM.eval_bind _ _ _ _ h) hwf1
+  have hwf2 : (Formula.binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa)).wfIn st.decls := by
+    simpa [Formula.wfIn, Term.wfIn, UnOp.wfIn, BinPred.wfIn] using And.intro hsi hsa
+  obtain ⟨hφ2, hcont2⟩ := VerifM.eval_assert (VerifM.eval_bind _ _ _ _ hcont1) hwf2
+  refine ⟨?_, ?_, hcont2⟩
+  · simpa [Formula.eval, BinPred.eval, Term.eval, Const.denote] using hφ1
+  · simpa [Formula.eval, BinPred.eval] using hφ2
+
+/-- Array allocation correctness: after evaluating the initial value and the
+length, the shared branch allocates behind the array invariant while the
+owned branch acquires a fresh owned-array atom. -/
+theorem compileArrayMake_correct (reg : Verifier.Registry) (owned : Bool) (len init : Expr)
     (ihLen : correctExpr reg len) (ihInit : correctExpr reg init) :
-    correctExpr reg (.arrayMake false len init) := by
+    correctExpr reg (.arrayMake owned len init) := by
   intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  simp only [Expr.ty, Bool.false_eq_true, if_false] at hpost
   obtain ⟨hlenty, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_init : (compile reg Θ Δ_spec S B Γ init).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
   refine SpatialContext.wp_bind_arrayMake <| ?_
@@ -1427,11 +1468,10 @@ theorem compileArrayMakeShared_correct (reg : Verifier.Registry) (len init : Exp
   intro v_len ρ_len st₂ slen hΨ_len hslen_wf heval_slen
   obtain ⟨hdecls_len, hagreeOn_len, hΨ_len⟩ := hΨ_len
   -- Discharge the nonnegative-length obligation.
-  set φ : Formula := .binpred .le (.const (.i 0)) (.unop .toInt slen) with hφ_def
+  set φ : Formula := .binpred .le (.const (.i 0)) (.unop .toInt slen)
   have hwf_φ : φ.wfIn st₂.decls := by
     simpa [φ, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, BinPred.wfIn] using hslen_wf
-  have heval_assert : (VerifM.assert φ).eval st₂ ρ_len _ := VerifM.eval_bind _ _ _ _ hΨ_len
-  obtain ⟨hφ, hcont⟩ := VerifM.eval_assert heval_assert hwf_φ
+  obtain ⟨hφ, hcont⟩ := VerifM.eval_assert (VerifM.eval_bind _ _ _ _ hΨ_len) hwf_φ
   -- The fresh constant standing for the allocated array.
   have hdecl_eval := VerifM.eval_bind _ _ _ _ hcont
   have hdecl := VerifM.eval_decl hdecl_eval
@@ -1440,22 +1480,19 @@ theorem compileArrayMakeShared_correct (reg : Verifier.Registry) (len init : Exp
   set sa : Term .value := .const (.uninterpreted c.name .value)
   have hc_fresh : c.name ∉ st₂.decls.allNames := TransState.freshConst_fresh st₂ none .value
   have hc_wf : sa.wfIn (st₂.decls.addConst c) := by
-    simpa [sa] using
-      (Term.const_wfIn_addConst_of_fresh (Δ := st₂.decls) (c := c)
-        (VerifM.eval.wf hdecl_eval).namesDisjoint hc_fresh)
-  have hwp :
-      st₂.sl Θ ρ_len ∗ TinyML.ValHasType Θ v_len len.ty ∗ (TinyML.ValHasType Θ v_init init.ty ∗ R) ⊢
-        wp reg.primCtx (.arrayMake (.val v_len) (.val v_init)) Φ := by
-    rw [hlenty]
-    istart
-    iintro ⟨Howns, Hlen, #Hinit, HR⟩
-    ihave Hlen' := (TinyML.ValHasType.int Θ v_len).1 $$ Hlen
-    icases Hlen' with ⟨%n, %hv_len⟩
-    have hn : (0 : Int) ≤ n := by
-      have h := hφ
-      simp only [φ, Formula.eval, BinPred.eval, Term.eval, Const.denote, UnOp.eval,
-        heval_slen, hv_len] at h
-      exact h
+    simpa [sa] using Term.const_wfIn_addConst_of_fresh (Δ := st₂.decls) (c := c)
+      hst₂_wf.namesDisjoint hc_fresh
+  rw [hlenty]
+  istart
+  iintro ⟨Howns, Hlen, #Hinit, HR⟩
+  ihave Hlen' := (TinyML.ValHasType.int Θ v_len).1 $$ Hlen
+  icases Hlen' with ⟨%n, %hv_len⟩
+  have hn : (0 : Int) ≤ n := by
+    simpa [φ, Formula.eval, BinPred.eval, Term.eval, Const.denote, UnOp.eval,
+      heval_slen, hv_len] using hφ
+  cases owned with
+  | false =>
+    simp only [Expr.ty, Bool.false_eq_true, if_false] at hpost
     iapply (SpatialContext.wp_arrayMake_inv (vlen := v_len) (init := v_init) (n := n)
       (I := fun w => TinyML.ValHasType Θ w init.ty) (Q := Φ) hv_len hn)
     isplitl []
@@ -1466,7 +1503,7 @@ theorem compileArrayMakeShared_correct (reg : Verifier.Registry) (len init : Exp
       -- freshly allocated array value `.array n.toNat l`.
       have hbody := hdecl (.array n.toNat l)
       have hassume_eval := VerifM.eval_bind _ _ _ _ hbody
-      set ρ' : VerifM.Env := ρ_len.updateConst .value c.name (.array n.toNat l) with hρ'_def
+      set ρ' : VerifM.Env := ρ_len.updateConst .value c.name (.array n.toNat l)
       set st_c : TransState := { st₂ with decls := st₂.decls.addConst c } with hst_c_def
       have hsa_eval : sa.eval ρ'.env = .array n.toNat l := by
         simp [sa, ρ', Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
@@ -1517,19 +1554,92 @@ theorem compileArrayMakeShared_correct (reg : Verifier.Registry) (len init : Exp
           · ipureintro; rfl
           · iexact Hinv_l
         · iexact HR
-  exact hwp
-
-/-- Array allocation correctness, dispatching shared allocation to the
-invariant-backed proof. The owned branch is completed by the owned-array
-symbolic-execution rule below. -/
-theorem compileArrayMake_correct (reg : Verifier.Registry) (owned : Bool) (len init : Expr)
-    (ihLen : correctExpr reg len) (ihInit : correctExpr reg init) :
-    correctExpr reg (.arrayMake owned len init) := by
-  cases owned with
-  | false => exact compileArrayMakeShared_correct reg len init ihLen ihInit
   | true =>
-    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
-    exact (VerifM.eval_fatal (by simpa [compile] using heval)).elim
+    simp only [Expr.ty, if_true] at hpost
+    iapply (SpatialContext.wp_arrayMake (vlen := v_len) (init := v_init) (n := n)
+      (Q := Φ) hv_len hn)
+    iintro %l Hpt
+    have hbody := hdecl (.array n.toNat l)
+    set ρ' : VerifM.Env := ρ_len.updateConst .value c.name (.array n.toNat l)
+    set st_c : TransState := { st₂ with decls := st₂.decls.addConst c }
+    have hsa_eval : sa.eval ρ'.env = .array n.toNat l := by
+      simp [sa, ρ', Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
+    have hslen_eval' : slen.eval ρ'.env = .int n :=
+      (Term.eval_env_agree hslen_wf
+        (VerifM.Env.agreeOn_update_fresh (c := c) (u := Runtime.Val.array n.toNat l) hc_fresh)).symm.trans
+        (heval_slen.trans hv_len)
+    have hsinit_wf₂ : s_init.wfIn st₂.decls :=
+      Term.wfIn_mono s_init hsinit_wf hdecls_len hst₂_wf.namesDisjoint
+    have hsinit_eval_len : s_init.eval ρ_len.env = v_init := by
+      rw [Term.eval_env_agree hsinit_wf (Env.agreeOn_symm hagreeOn_len)]
+      exact heval_sinit
+    have hsinit_eval' : s_init.eval ρ'.env = v_init :=
+      (Term.eval_env_agree hsinit_wf₂
+        (VerifM.Env.agreeOn_update_fresh (c := c) (u := Runtime.Val.array n.toNat l) hc_fresh)).symm.trans
+        hsinit_eval_len
+    have hstc_wf : (st₂.decls.addConst c).wf := Signature.wf_addConst hst₂_wf.namesDisjoint hc_fresh
+    have hslen_wf_c := Term.wfIn_mono slen hslen_wf (Signature.Subset.subset_addConst _ _) hstc_wf
+    have hsinit_wf_c := Term.wfIn_mono s_init hsinit_wf₂ (Signature.Subset.subset_addConst _ _) hstc_wf
+    have heq_wf : (CtxItem.pure
+        (.eq .int (.unop .arrayLengthOf sa) (.unop .toInt slen))).wfIn st_c.decls :=
+      ⟨⟨trivial, hc_wf⟩, ⟨trivial, hslen_wf_c⟩⟩
+    have heq_hold : Formula.eval ρ'.env
+        (.eq .int (.unop .arrayLengthOf sa) (.unop .toInt slen)) := by
+      simp [Formula.eval, Term.eval, UnOp.eval, hsa_eval, hslen_eval']
+      omega
+    have hassume := VerifM.eval_assume (VerifM.eval_bind _ _ _ _ hbody) heq_wf heq_hold
+    let contents : Term .value := .unop .ofVec
+      (.binop .vecMake (.unop .toInt slen) s_init)
+    have hcontents_wf : contents.wfIn st_c.decls :=
+      ⟨trivial, ⟨trivial, ⟨trivial, hslen_wf_c⟩, hsinit_wf_c⟩⟩
+    have hatom_wf : (SpatialAtom.arrayPointsTo sa contents init.ty).wfIn st_c.decls :=
+      ⟨hc_wf, hcontents_wf⟩
+    have hcontents_eval : contents.eval ρ'.env = .vec (List.replicate n.toNat v_init) := by
+      simp [contents, Term.eval, UnOp.eval, BinOp.eval, hslen_eval', hsinit_eval', hn]
+    -- Acquire the owned-array atom; its length fact holds by construction.
+    have hfacts : ∀ ψ ∈ (CtxItem.spatial (.arrayPointsTo sa contents init.ty)).facts,
+        ψ.eval ρ'.env := by
+      simp [CtxItem.facts, SpatialAtom.facts, Formula.eval, Term.eval, UnOp.eval,
+        hcontents_eval, hsa_eval]
+    obtain ⟨st_a, hdecls_a, howns_a, hq_a⟩ :=
+      VerifM.eval_acquire (VerifM.eval_bind _ _ _ _ hassume) hatom_wf trivial hfacts
+    ihave HvecTy : iprop(TinyML.ValHasType Θ (.vec (List.replicate n.toNat v_init)) (.vec init.ty)) $$ [Hinit]
+    · iapply TinyML.ValHasType.vec_replicate
+      iexact Hinit
+    have hArrTy : ⊢ TinyML.ValHasType Θ (.array n.toNat l) (.ownedArray init.ty) := by
+      iapply (TinyML.ValHasType.ownedArray Θ _ _).2
+      iexists n.toNat, l
+      ipureintro; rfl
+    ihave HarrTy := hArrTy
+    ihave %htyped := TinyML.typeConstraints_hold (ty := .ownedArray init.ty) (t := sa)
+      (ρ := ρ'.env) (Θ := Θ) hsa_eval $$ HarrTy
+    obtain ⟨st_final, hdecls_final, howns_final, _, heval_ret⟩ :=
+      VerifM.eval_assumeAll (VerifM.eval_bind _ _ _ _ hq_a)
+        (fun ψ hψ => by rw [hdecls_a]; exact TinyML.typeConstraints_wfIn hc_wf ψ hψ)
+        (fun ψ hψ => htyped ψ hψ)
+    have hret := VerifM.eval_ret heval_ret
+    have hsa_wf_final : sa.wfIn st_final.decls := by
+      rw [hdecls_final, hdecls_a]; exact hc_wf
+    have hsl_agree : SpatialContext.interp Θ ρ_len.env st₂.owns ⊢
+        SpatialContext.interp Θ ρ'.env st₂.owns := by
+      rw [show ρ'.env = ρ_len.env.updateConst .value c.name (.array n.toNat l) by rfl]
+      exact (SpatialContext.interp_env_agree Θ hst₂_wf.ownsWf
+        (Env.agreeOn_update_fresh_const (ρ := ρ_len.env) (c := c)
+          (u := Runtime.Val.array n.toNat l) hc_fresh)).1
+    iapply (hpost (.array n.toNat l) ρ' st_final sa hret hsa_wf_final hsa_eval)
+    isplitl [Hpt HvecTy Howns]
+    · simp only [TransState.sl_eq, howns_final, howns_a, TransState.addItem, st_c,
+        SpatialContext.interp]
+      isplitl [Hpt HvecTy]
+      · iapply (SpatialAtom.interp_arrayPointsTo Θ (by simpa using hsa_eval) hcontents_eval).2
+        isplitl [Hpt]
+        · iexact Hpt
+        · iexact HvecTy
+      · iapply hsl_agree
+        iexact Howns
+    · isplitl [HarrTy]
+      · iexact HarrTy
+      · iexact HR
 
 theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
     (ihArr : correctExpr reg arr) :
@@ -1575,9 +1685,38 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
           · iexact HR
       exact hwp
   | ownedArray elem =>
-      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+      unfold Expr.runtime
+      simp only [Runtime.Expr.subst]
       simp only [compile, hty] at heval
-      exact (VerifM.eval_fatal heval).elim
+      have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st ρ _ :=
+        VerifM.eval_bind _ _ _ _ heval
+      refine SpatialContext.wp_bind_arrayLen <| ihArr Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+        (VerifM.eval.decls_grow ρ heval_arr) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+      intro v_arr ρ_arr st₁ sa hΨ_arr hsa_wf heval_sa
+      obtain ⟨_, _, hΨ_arr⟩ := hΨ_arr
+      obtain hret := VerifM.eval_ret hΨ_arr
+      set t : Term .value := .unop .ofInt (.unop .arrayLengthOf sa)
+      have ht_wf : t.wfIn st₁.decls := ⟨trivial, ⟨trivial, hsa_wf⟩⟩
+      rw [hty]
+      istart
+      iintro ⟨Howns, Harr, HR⟩
+      ihave Harr' := (TinyML.ValHasType.ownedArray Θ v_arr elem).1 $$ Harr
+      icases Harr' with ⟨%len, %loc, %hv_arr⟩
+      have ht_eval : t.eval ρ_arr.env = Runtime.Val.int len := by
+        simp [t, Term.eval, UnOp.eval, heval_sa, hv_arr]
+      have hgoal :
+          st₁.sl Θ ρ_arr ∗ TinyML.ValHasType Θ (.int len) TinyML.Typ.int ∗ R ⊢
+            Φ (.int len) := by
+        simpa [Expr.ty] using hpost (.int len) ρ_arr st₁ t hret ht_wf ht_eval
+      iapply (SpatialContext.wp_arrayLen
+        (R := st₁.sl Θ ρ_arr ∗ TinyML.ValHasType Θ (.int len) TinyML.Typ.int ∗ R)
+        (Q := Φ) (v := v_arr) (len := len) (l := loc) hv_arr hgoal)
+      isplitl [Howns]
+      · iexact Howns
+      · isplitl []
+        · iapply (TinyML.ValHasType.int_intro Θ)
+        · iexact HR
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
@@ -1594,6 +1733,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
     simp only [Expr.ty] at hpost
+    replace heval := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
     obtain ⟨helem, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
     subst helem
@@ -1620,16 +1760,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
       Term.wfIn_mono si hsi_wf hdecls_arr (VerifM.eval.wf hΨ_arr).namesDisjoint
     have hsi_ρ_arr : si.eval ρ_arr.env = v_idx := by
       rw [Term.eval_env_agree hsi_wf (Env.agreeOn_symm hagreeOn_arr)]; exact heval_si
-    set φ1 : Formula := .binpred .le (.const (.i 0)) (.unop .toInt si) with hφ1_def
-    have hwf_φ1 : φ1.wfIn st₂.decls := by
-      simpa [φ1, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, BinPred.wfIn] using hsi_wf₂
-    have heval_assert1 : (VerifM.assert φ1).eval st₂ ρ_arr _ := VerifM.eval_bind _ _ _ _ hΨ_arr
-    obtain ⟨hφ1, hcont1⟩ := VerifM.eval_assert heval_assert1 hwf_φ1
-    set φ2 : Formula := .binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa) with hφ2_def
-    have hwf_φ2 : φ2.wfIn st₂.decls := by
-      simpa [φ2, Formula.wfIn, Term.wfIn, UnOp.wfIn, BinPred.wfIn] using And.intro hsi_wf₂ hsa_wf
-    have heval_assert2 : (VerifM.assert φ2).eval st₂ ρ_arr _ := VerifM.eval_bind _ _ _ _ hcont1
-    obtain ⟨hφ2, hcont2⟩ := VerifM.eval_assert heval_assert2 hwf_φ2
+    obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₂ hsa_wf
     have hdecl_eval := VerifM.eval_bind _ _ _ _ hcont2
     have hdecl := VerifM.eval_decl hdecl_eval
     set c : FOL.Const := st₂.freshConst none .value
@@ -1644,11 +1775,6 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
           (TinyML.ValHasType Θ v_idx idx.ty ∗ R) ⊢
           wp reg.primCtx (.arrayGet (.val v_arr) (.val v_idx)) Φ := by
       rw [hty, hidxty]
-      have hi : (0 : Int) ≤ Term.eval ρ_arr.env (.unop .toInt si) := by
-        simpa [hφ1_def, Formula.eval, BinPred.eval, Term.eval, Const.denote] using hφ1
-      have hlt : Term.eval ρ_arr.env (.unop .toInt si) <
-          Term.eval ρ_arr.env (.unop .arrayLengthOf sa) := by
-        simpa [hφ2_def, Formula.eval, BinPred.eval] using hφ2
       simpa [TransState.sl_eq] using
         (SpatialContext.wp_arrayGet_inv (pctx := reg.primCtx) (Θ := Θ)
           (ctx := st₂.owns) (ρ := ρ_arr.env) (arr := sa) (idx := si)
@@ -1686,14 +1812,77 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
               · iexact HR))
     exact hwp
   | ownedArray elemTy =>
-    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    unfold Expr.runtime
+    simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
-    exact (VerifM.eval_fatal heval).elim
+    simp only [Expr.ty] at hpost
+    replace heval := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
+    obtain ⟨helem, heval⟩ := VerifM.eval_bind_expectEq heval
+    obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
+    subst ty
+    have heval_idx : (compile reg Θ Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_arrayGet <| ?_
+    have hstart := Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+    refine hstart.trans <| ihIdx Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
+      S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_idx)
+      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    intro v_idx ρ_idx st₁ si hΨ_idx hsi_wf heval_si
+    obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
+    have hagree_idx := Bindings.agreeOnLinked_env_agree hagree hagreeOn_idx hbwf
+    have hbwf_idx : B.wfIn st₁.decls := fun p hp => hdecls_idx.consts _ (hbwf p hp)
+    have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind _ _ _ _ hΨ_idx
+    have harrStart := Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_idx γ R v_idx idx.ty
+    have hspecInv_idx := specInvariants_mono hΔspec hρspec hdecls_idx hagreeOn_idx
+    refine harrStart.trans <| ihArr Θ (TinyML.ValHasType Θ v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ Δ_spec ρ_spec _ _
+      (VerifM.eval.decls_grow ρ_idx heval_arr) hagree_idx hbwf_idx hSwf hΔwf hΔvars
+      hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
+    intro v_arr ρ_arr st₂ sa hΨ_arr hsa_wf heval_sa
+    obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
+    have hsi_wf₂ := Term.wfIn_mono si hsi_wf hdecls_arr (VerifM.eval.wf hΨ_arr).namesDisjoint
+    have hsi_eval : si.eval ρ_arr.env = v_idx := by
+      rw [Term.eval_env_agree hsi_wf (Env.agreeOn_symm hagreeOn_arr)]; exact heval_si
+    obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₂ hsa_wf
+    have hfind := VerifM.eval_bind _ _ _ _ hcont2
+    rw [hty, hidxty]
+    refine VerifM.eval_findMatchForce Θ
+      (R := TinyML.ValHasType Θ v_arr (.ownedArray elemTy) ∗ TinyML.ValHasType Θ v_idx .int ∗ R)
+      (Φ := wp reg.primCtx (.arrayGet (.val v_arr) (.val v_idx)) Φ) hfind hsa_wf ?_
+    intro contents st₃ hQ hdecls hcontents_wf
+    have hatom_wf : (SpatialAtom.arrayPointsTo sa contents elemTy).wfIn st₃.decls := by
+      rw [hdecls]; exact ⟨hsa_wf, hcontents_wf⟩
+    let result : Term .value := .binop .vecGet (.unop .toVec contents) (.unop .toInt si)
+    simpa [TransState.sl_eq] using
+      (SpatialContext.wp_arrayGet_owned (pctx := reg.primCtx) (Θ := Θ)
+        (rest := st₃.owns) (arr := sa) (contents := contents) (idx := si)
+        (result := result) (elemTy := elemTy) (varr := v_arr) (vidx := v_idx)
+        (Q := Φ) (R := R) heval_sa hsi_eval hi hlt rfl (by
+          -- Acquire the restored atom, then conclude with the postcondition.
+          have hstep := VerifM.eval_acquireSpatial Θ
+            (R := TinyML.ValHasType Θ (Term.eval ρ_arr.env result) elemTy ∗ R)
+            (Φ := Φ (Term.eval ρ_arr.env result)) (VerifM.eval_bind _ _ _ _ hQ) hatom_wf
+            (fun st₄ hq₄ hdecls₄ _howns₄ =>
+              hpost (Term.eval ρ_arr.env result) ρ_arr st₄ result (VerifM.eval_ret hq₄)
+                (by rw [hdecls₄, hdecls]
+                    exact ⟨trivial, ⟨trivial, hcontents_wf⟩, ⟨trivial, hsi_wf₂⟩⟩)
+                rfl)
+          simp only [SpatialContext.interp_insert]
+          istart
+          iintro ⟨⟨Hatom, Howns⟩, HresTy, HR⟩
+          iapply hstep
+          isplitl [Hatom]
+          · iexact Hatom
+          · isplitl [Howns]
+            · simp only [TransState.sl_eq]
+              iexact Howns
+            · isplitl [HresTy]
+              · iexact HresTy
+              · iexact HR))
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
-      exact (VerifM.eval_fatal heval).elim
+      exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim
 
 theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     (ihArr : correctExpr reg arr) (ihIdx : correctExpr reg idx) (ihVal : correctExpr reg val) :
@@ -1705,6 +1894,7 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
     simp only [Expr.ty] at hpost
+    replace heval := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
     obtain ⟨helemTy, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
     have heval_val : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
@@ -1750,17 +1940,8 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     have hsi_ρ_arr : si.eval ρ_arr.env = v_idx := by
       rw [Term.eval_env_agree hsi_wf (Env.agreeOn_symm hagreeOn_arr)]; exact heval_si
     -- Discharge the two bounds obligations.
-    set φ1 : Formula := .binpred .le (.const (.i 0)) (.unop .toInt si) with hφ1_def
-    have hwf_φ1 : φ1.wfIn st₃.decls := by
-      simpa [φ1, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, BinPred.wfIn] using hsi_wf₃
-    have heval_assert1 : (VerifM.assert φ1).eval st₃ ρ_arr _ := VerifM.eval_bind _ _ _ _ hΨ_arr
-    obtain ⟨hφ1, hcont1⟩ := VerifM.eval_assert heval_assert1 hwf_φ1
-    set φ2 : Formula := .binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa) with hφ2_def
-    have hwf_φ2 : φ2.wfIn st₃.decls := by
-      simpa [φ2, Formula.wfIn, Term.wfIn, UnOp.wfIn, BinPred.wfIn] using And.intro hsi_wf₃ hsa_wf
-    have heval_assert2 : (VerifM.assert φ2).eval st₃ ρ_arr _ := VerifM.eval_bind _ _ _ _ hcont1
-    obtain ⟨hφ2, hcont2⟩ := VerifM.eval_assert heval_assert2 hwf_φ2
-    have hret := VerifM.eval_ret hcont2
+    obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₃ hsa_wf
+    have hret := VerifM.eval_ret (VerifM.eval_ret (VerifM.eval_bind _ _ _ _ hcont2))
     have hunit_wf : (Term.const .unit).wfIn st₃.decls := by simp [Term.wfIn, Const.wfIn]
     have hgoal :
         st₃.sl Θ ρ_arr ∗ TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Φ .unit :=
@@ -1770,11 +1951,6 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
           (TinyML.ValHasType Θ v_idx idx.ty ∗ (TinyML.ValHasType Θ v_val val.ty ∗ R)) ⊢
           wp reg.primCtx (.arraySet (.val v_arr) (.val v_idx) (.val v_val)) Φ := by
       rw [hty, hidxty, ← helemTy]
-      have hi : (0 : Int) ≤ Term.eval ρ_arr.env (.unop .toInt si) := by
-        simpa [hφ1_def, Formula.eval, BinPred.eval, Term.eval, Const.denote] using hφ1
-      have hlt : Term.eval ρ_arr.env (.unop .toInt si) <
-          Term.eval ρ_arr.env (.unop .arrayLengthOf sa) := by
-        simpa [hφ2_def, Formula.eval, BinPred.eval] using hφ2
       simpa [TransState.sl_eq] using
         (SpatialContext.wp_arraySet_inv (pctx := reg.primCtx) (Θ := Θ)
           (ctx := st₃.owns) (ρ := ρ_arr.env) (arr := sa) (idx := si)
@@ -1794,14 +1970,103 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
               · iexact HR))
     exact hwp
   | ownedArray elemTy =>
-    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    unfold Expr.runtime
+    simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
-    exact (VerifM.eval_fatal heval).elim
+    simp only [Expr.ty] at hpost
+    replace heval := VerifM.eval_ret (VerifM.eval_bind _ _ _ _ heval)
+    obtain ⟨helemTy, heval⟩ := VerifM.eval_bind_expectEq heval
+    obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
+    have heval_val : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind _ _ _ _ heval
+    refine SpatialContext.wp_bind_arraySet <| ?_
+    have hstart := Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+    refine hstart.trans <| ihVal Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
+      S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_val)
+      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    intro v_val ρ_val st₁ sv hΨ_val hsv_wf heval_sv
+    obtain ⟨hdecls_val, hagreeOn_val, hΨ_val⟩ := hΨ_val
+    have hagree_val := Bindings.agreeOnLinked_env_agree hagree hagreeOn_val hbwf
+    have hbwf_val : B.wfIn st₁.decls := fun p hp => hdecls_val.consts _ (hbwf p hp)
+    have heval_idx : (compile reg Θ Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind _ _ _ _ hΨ_val
+    have hspecInv_val := specInvariants_mono hΔspec hρspec hdecls_val hagreeOn_val
+    have hstepB :=
+      (Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_val γ R v_val val.ty).trans
+        (Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_val γ (TinyML.ValHasType Θ v_val val.ty ∗ R))
+    refine hstepB.trans <| ihIdx Θ
+      (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ (TinyML.ValHasType Θ v_val val.ty ∗ R)))
+      S B Γ st₁ ρ_val γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ_val heval_idx)
+      hagree_val hbwf_val hSwf hΔwf hΔvars hspecInv_val.1 hspecInv_val.2 hΔreg hρreg ?_
+    intro v_idx ρ_idx st₂ si hΨ_idx hsi_wf heval_si
+    obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
+    have hagree_idx := Bindings.agreeOnLinked_env_agree hagree_val hagreeOn_idx hbwf_val
+    have hbwf_idx : B.wfIn st₂.decls := fun p hp => hdecls_idx.consts _ (hbwf_val p hp)
+    have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind _ _ _ _ hΨ_idx
+    have hspecInv_idx := specInvariants_mono hspecInv_val.1 hspecInv_val.2 hdecls_idx hagreeOn_idx
+    have hstepC := Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₂ ρ_idx γ
+      (TinyML.ValHasType Θ v_val val.ty ∗ R) v_idx idx.ty
+    refine hstepC.trans <| ihArr Θ
+      (TinyML.ValHasType Θ v_idx idx.ty ∗ (TinyML.ValHasType Θ v_val val.ty ∗ R))
+      S B Γ st₂ ρ_idx γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ_idx heval_arr)
+      hagree_idx hbwf_idx hSwf hΔwf hΔvars hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
+    intro v_arr ρ_arr st₃ sa hΨ_arr hsa_wf heval_sa
+    obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
+    have hsi_wf₃ := Term.wfIn_mono si hsi_wf hdecls_arr (VerifM.eval.wf hΨ_arr).namesDisjoint
+    have hsv_wf₃ : sv.wfIn st₃.decls :=
+      Term.wfIn_mono sv hsv_wf (hdecls_idx.trans hdecls_arr) (VerifM.eval.wf hΨ_arr).namesDisjoint
+    have hsv_wf₂ : sv.wfIn st₂.decls :=
+      Term.wfIn_mono sv hsv_wf hdecls_idx (VerifM.eval.wf hΨ_idx).namesDisjoint
+    have hsi_eval : si.eval ρ_arr.env = v_idx := by
+      rw [Term.eval_env_agree hsi_wf (Env.agreeOn_symm hagreeOn_arr)]; exact heval_si
+    have hsv_eval : sv.eval ρ_arr.env = v_val := by
+      rw [Term.eval_env_agree hsv_wf₂ (Env.agreeOn_symm hagreeOn_arr)]
+      rw [Term.eval_env_agree hsv_wf (Env.agreeOn_symm hagreeOn_idx)]
+      exact heval_sv
+    obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₃ hsa_wf
+    have hfind := VerifM.eval_bind _ _ _ _ hcont2
+    rw [hty, hidxty, ← helemTy]
+    refine VerifM.eval_findMatchForce Θ
+      (R := TinyML.ValHasType Θ v_arr (.ownedArray elemTy) ∗ TinyML.ValHasType Θ v_idx .int ∗
+        TinyML.ValHasType Θ v_val elemTy ∗ R)
+      (Φ := wp reg.primCtx (.arraySet (.val v_arr) (.val v_idx) (.val v_val)) Φ) hfind hsa_wf ?_
+    intro contents st₄ hQ hdecls hcontents_wf
+    let contents' : Term .value := .unop .ofVec
+      (.terop .vecSet (.unop .toVec contents) (.unop .toInt si) sv)
+    have hcontents'_wf : contents'.wfIn st₄.decls := by
+      rw [hdecls]
+      exact ⟨trivial, ⟨trivial, ⟨trivial, hcontents_wf⟩, ⟨trivial, hsi_wf₃⟩, hsv_wf₃⟩⟩
+    have hatom_wf : (SpatialAtom.arrayPointsTo sa contents' elemTy).wfIn st₄.decls := by
+      rw [hdecls]; exact ⟨hsa_wf, by simpa [hdecls] using hcontents'_wf⟩
+    have hunit_wf : (Term.const .unit).wfIn st₄.decls := by simp [Term.wfIn, Const.wfIn]
+    simpa [TransState.sl_eq] using
+      (SpatialContext.wp_arraySet_owned (pctx := reg.primCtx) (Θ := Θ)
+        (rest := st₄.owns) (arr := sa) (contents := contents) (contents' := contents')
+        (idx := si) (val := sv) (elemTy := elemTy) (varr := v_arr) (vidx := v_idx)
+        (vval := v_val) (Q := Φ) (R := R) heval_sa hsi_eval hsv_eval hi hlt rfl (by
+          -- Acquire the updated atom, then conclude with the postcondition.
+          have hstep := VerifM.eval_acquireSpatial Θ
+            (R := TinyML.ValHasType Θ .unit .unit ∗ R)
+            (Φ := Φ .unit) (VerifM.eval_bind _ _ _ _ hQ) hatom_wf
+            (fun st₅ hq₅ hdecls₅ _howns₅ =>
+              hpost .unit ρ_arr st₅ (.const .unit) (VerifM.eval_ret hq₅)
+                (by rw [hdecls₅]; exact hunit_wf) (by simp [Term.eval]))
+          simp only [SpatialContext.interp_insert]
+          istart
+          iintro ⟨⟨Hatom, Howns⟩, HunitTy, HR⟩
+          iapply hstep
+          isplitl [Hatom]
+          · iexact Hatom
+          · isplitl [Howns]
+            · simp only [TransState.sl_eq]
+              iexact Howns
+            · isplitl [HunitTy]
+              · iexact HunitTy
+              · iexact HR))
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
       intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
-      exact (VerifM.eval_fatal heval).elim
+      exact (VerifM.eval_fatal (VerifM.eval_bind _ _ _ _ heval)).elim
 
 theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
     (ih : correctExpr reg e) :

--- a/Mica/Verifier/RelationalEncoding/Monad.lean
+++ b/Mica/Verifier/RelationalEncoding/Monad.lean
@@ -391,7 +391,7 @@ theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithInd (.deref e ty) :
 theorem store (loc val : Typed.Expr) : EncodeWithInd (.store loc val) :=
   fun hops _ => hops.error_ind
 
-theorem arrayMake (len init : Typed.Expr) : EncodeWithInd (.arrayMake len init) :=
+theorem arrayMake (owned : Bool) (len init : Typed.Expr) : EncodeWithInd (.arrayMake owned len init) :=
   fun hops _ => hops.error_ind
 
 theorem arrayLen (arr : Typed.Expr) (ih : EncodeWithInd arr) :
@@ -491,7 +491,7 @@ theorem encodeWith_ind_def : ∀ (e : Typed.Expr), EncodeWithInd e
   | .ref owned e => Ind.ref owned e
   | .deref e ty => Ind.deref e ty
   | .store loc val => Ind.store loc val
-  | .arrayMake len init => Ind.arrayMake len init
+  | .arrayMake owned len init => Ind.arrayMake owned len init
   | .arrayLen arr => Ind.arrayLen arr (encodeWith_ind_def arr)
   | .arrayGet arr idx ty => Ind.arrayGet arr idx ty
   | .arraySet arr idx val => Ind.arraySet arr idx val
@@ -742,7 +742,7 @@ theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithIndSig (.deref e ty
 theorem store (loc val : Typed.Expr) : EncodeWithIndSig (.store loc val) :=
   fun hops _ _ _ _ _ => hops.error_ind
 
-theorem arrayMake (len init : Typed.Expr) : EncodeWithIndSig (.arrayMake len init) :=
+theorem arrayMake (owned : Bool) (len init : Typed.Expr) : EncodeWithIndSig (.arrayMake owned len init) :=
   fun hops _ _ _ _ _ => hops.error_ind
 
 theorem arrayLen (arr : Typed.Expr) (ih : EncodeWithIndSig arr) :
@@ -869,7 +869,7 @@ theorem encodeWith_indWithSig_def : ∀ (e : Typed.Expr), EncodeWithIndSig e
   | .ref owned e => IndSig.ref owned e
   | .deref e ty => IndSig.deref e ty
   | .store loc val => IndSig.store loc val
-  | .arrayMake len init => IndSig.arrayMake len init
+  | .arrayMake owned len init => IndSig.arrayMake owned len init
   | .arrayLen arr => IndSig.arrayLen arr (encodeWith_indWithSig_def arr)
   | .arrayGet arr idx ty => IndSig.arrayGet arr idx ty
   | .arraySet arr idx val => IndSig.arraySet arr idx val
@@ -1330,7 +1330,7 @@ theorem deref (e : Typed.Expr) (ty : TinyML.Typ) : EncodeWithBindBinary (.deref 
 theorem store (loc val : Typed.Expr) : EncodeWithBindBinary (.store loc val) := by
   intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
 
-theorem arrayMake (len init : Typed.Expr) : EncodeWithBindBinary (.arrayMake len init) := by
+theorem arrayMake (owned : Bool) (len init : Typed.Expr) : EncodeWithBindBinary (.arrayMake owned len init) := by
   intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ _ _ _ _ _ _ _; exact hops.error_binary
 
 theorem arrayLen (arr : Typed.Expr) (ih : EncodeWithBindBinary arr) :
@@ -1496,7 +1496,7 @@ theorem encodeWith_bind_binary_def : ∀ (e : Typed.Expr), EncodeWithBindBinary 
   | .ref owned e => BindBinary.ref owned e
   | .deref e ty => BindBinary.deref e ty
   | .store loc val => BindBinary.store loc val
-  | .arrayMake len init => BindBinary.arrayMake len init
+  | .arrayMake owned len init => BindBinary.arrayMake owned len init
   | .arrayLen arr => BindBinary.arrayLen arr (encodeWith_bind_binary_def arr)
   | .arrayGet arr idx ty => BindBinary.arrayGet arr idx ty
   | .arraySet arr idx val => BindBinary.arraySet arr idx val

--- a/Mica/Verifier/SpecTranslation.lean
+++ b/Mica/Verifier/SpecTranslation.lean
@@ -46,6 +46,10 @@ private def assertAll (φs : List Formula) (k : Assertion α) : Assertion α :=
 def translatePred (δ : VarEnv) (ty : TinyML.Typ) : Spec.Pred → M (Atom .value)
   | .isinj tag arity scrut => do .ok (.isinj tag arity (← lookupVar δ scrut))
   | .own loc => do .ok (.own (← lookupVar δ loc) ty)
+  | .arr loc =>
+    match ty with
+    | .vec elemTy => do .ok (.arr (← lookupVar δ loc) elemTy)
+    | _ => .error "owned-array predicates must bind a vector snapshot"
 
 /-- Translate a spec assertion, asserting each leaf's definedness before its value. -/
 def translateAssert (Δ : Signature) (Γfn : FunCtx) (inner : VarEnv → α → M β) :

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -183,6 +183,33 @@ def CtxItem.purePart (i : CtxItem) (ρ : VerifM.Env) : Prop :=
   | .pure φ => φ.eval ρ.env
   | .spatial _ => True
 
+/-- Pure formulas implied by an item's interpretation. -/
+def CtxItem.facts : CtxItem → List Formula
+  | .pure _ => []
+  | .spatial a => a.facts
+
+/-- The pure facts of a well-formed item are well-formed. -/
+theorem CtxItem.facts_wfIn {i : CtxItem} {Δ : Signature} (h : i.wfIn Δ) :
+    ∀ φ ∈ i.facts, φ.wfIn Δ := by
+  cases i with
+  | pure φ => simp [facts]
+  | spatial a => exact SpatialAtom.facts_wfIn h
+
+/-- An item's interpretation implies its pure facts. -/
+theorem CtxItem.interp_facts [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+    (ρ : VerifM.Env) (i : CtxItem) :
+    i.interp Θ ρ ⊢ ⌜∀ φ ∈ i.facts, φ.eval ρ.env⌝ ∗ i.interp Θ ρ := by
+  cases i with
+  | pure φ =>
+    istart
+    iintro H
+    isplitr [H]
+    · ipureintro
+      simp [facts]
+    · iexact H
+  | spatial a =>
+    exact SpatialAtom.interp_facts Θ a
+
 def TransState.sl [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
     (st : TransState) (ρ : VerifM.Env) : iProp :=
   SpatialContext.interp Θ ρ.env st.owns

--- a/docs/owned-array-get-typing.md
+++ b/docs/owned-array-get-typing.md
@@ -1,0 +1,30 @@
+# Known gap: no SMT type constraints for owned `Array.get` results
+
+Status: known limitation, deliberately not fixed yet.
+
+For a **shared** array, `compile` translates `Array.get` by declaring a fresh
+constant for the result and assuming `TinyML.typeConstraints ty sv` for it, so
+the solver knows the result's type (e.g. that an `int` element is in the image
+of `toInt`).
+
+For an **owned** array, the result is the *term*
+`vecGet (toVec contents) (toInt si)` built from the atom's snapshot. No type
+constraints are assumed for it. Consequently, pure reasoning that depends on
+the element's type (e.g. arithmetic on an element read from an owned
+`int array`) can fail even though the corresponding shared-array program
+verifies.
+
+Semantically the information is available — the atom's interpretation carries
+`ValHasType Θ (.vec vs) (.vec elemTy)` for the snapshot — but it is not
+exported to the solver for the selected element.
+
+Possible fixes, for later:
+
+- Mirror the shared case: declare a fresh constant `sv`, assume
+  `sv = vecGet (toVec contents) (toInt si)` plus
+  `typeConstraints elemTy sv`. The correctness proof gets the semantic typing
+  fact from the big-sep over the snapshot (`BigSepL.bigSepL_lookup`), as
+  `wp_arrayGet_owned` already does.
+- Alternatively, emit elementwise type constraints for the whole snapshot when
+  an owned-array atom enters the context (as an atom-level fact, like the
+  length fact), quantifying over indices.


### PR DESCRIPTION
After the recent introduction of vector support (#114), this PR adds support for owned arrays. Owned arrays are analogous to owned references. At the spec level, their contents are a vector `t vec`. 

One caveat that is currently only documented and not yet implemented is that type information about the contents of the array (e.g., `Vec.get vs i` is an integer) is currently lost. The limitation is documented. 