### PR TITLE
Generalize intrinsic builders

### DIFF
--- a/Mica/Stdlib/CharStd.lean
+++ b/Mica/Stdlib/CharStd.lean
@@ -52,6 +52,7 @@ def charCodeB : Pure.Unary where
   arg      := .char
   res      := .int
   f        := (fun c => (c.toNat : Int) : UInt8 → Int)
+  typing   := monoTyping .one
   defAxiom := charCodeDefAxiom
 
 def charCode : Intrinsic := charCodeB.toIntrinsic
@@ -275,9 +276,11 @@ def charEqualDefAxiom : Formula :=
 def charEqualB : Pure.Binary where
   name     := "char_equal"
   path     := some ("Char", ["equal"])
-  arg      := .char
+  arg₁     := .char
+  arg₂     := .char
   res      := .bool
   f        := (fun x y => x == y : UInt8 → UInt8 → Bool)
+  typing   := monoTyping .two
   defAxiom := charEqualDefAxiom
 
 def charEqual : Intrinsic := charEqualB.toIntrinsic
@@ -286,7 +289,8 @@ def charEqual : Intrinsic := charEqualB.toIntrinsic
 @[simp] theorem charEqual_folSym : charEqual.folSym = some charEqualSym := rfl
 
 def charEqualLawful : charEqualB.Lawful where
-  argL       := Embedding.lawfulChar
+  argL₁      := Embedding.lawfulChar
+  argL₂      := Embedding.lawfulChar
   resL       := Embedding.lawfulBool
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl

--- a/Mica/Stdlib/CharStd.lean
+++ b/Mica/Stdlib/CharStd.lean
@@ -54,7 +54,6 @@ def charCodeB : Pure.Unary where
   f        := (fun c => (c.toNat : Int) : UInt8 → Int)
   dom      := fun _ => True
   pre      := none
-  typing   := monoTyping .one
   defAxiom := charCodeDefAxiom
 
 def charCode : Intrinsic := charCodeB.toIntrinsic
@@ -104,7 +103,6 @@ def charChrB : Pure.Unary where
   f        := charChrByte
   dom      := (fun n => 0 ≤ n ∧ n < 256 : Int → Prop)
   pre      := some charChrPre
-  typing   := monoTyping .one
   defAxiom := charChrDefAxiom
 
 def charChr : Intrinsic := charChrB.toIntrinsic
@@ -162,7 +160,6 @@ def charEqualB : Pure.Binary where
   f        := (fun x y => x == y : UInt8 → UInt8 → Bool)
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := charEqualDefAxiom
 
 def charEqual : Intrinsic := charEqualB.toIntrinsic

--- a/Mica/Stdlib/CharStd.lean
+++ b/Mica/Stdlib/CharStd.lean
@@ -63,13 +63,14 @@ def charCode : Intrinsic := charCodeB.toIntrinsic
 @[simp] theorem charCode_folSym : charCode.folSym = some charCodeSym := rfl
 
 def charCodeLawful : charCodeB.Lawful where
-  argL       := Embedding.lawfulChar
-  resL       := Embedding.lawfulInt
-  domSound   := fun _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  argL         := Embedding.lawfulChar
+  resL         := Embedding.lawfulInt
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     intrinsic_def_eval [unTerm, charCodeB, charCodeDefAxiom]
     intro v
     rfl
@@ -112,17 +113,18 @@ def charChr : Intrinsic := charChrB.toIntrinsic
 @[simp] theorem charChr_folSym : charChr.folSym = some charChrSym := rfl
 
 def charChrLawful : charChrB.Lawful where
-  argL       := Embedding.lawfulInt
-  resL       := Embedding.lawfulChar
-  domSound   := by
+  argL         := Embedding.lawfulInt
+  resL         := Embedding.lawfulChar
+  domSound     := by
     intro ρ n h
     have hpre := h charChrPre rfl
     simpa [charChrB, charChrPre, Embedding.int, Formula.eval, Term.eval, Const.denote,
       Env.lookupConst_updateConst_same, valInt] using hpre
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     have hsym : charChrB.sym = charChrSym := rfl
     intro ρ hresp
     rw [hsym] at hresp
@@ -169,14 +171,15 @@ def charEqual : Intrinsic := charEqualB.toIntrinsic
 @[simp] theorem charEqual_folSym : charEqual.folSym = some charEqualSym := rfl
 
 def charEqualLawful : charEqualB.Lawful where
-  argL₁      := Embedding.lawfulChar
-  argL₂      := Embedding.lawfulChar
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  argL₁        := Embedding.lawfulChar
+  argL₂        := Embedding.lawfulChar
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     intrinsic_def_eval [binTerm, charEqualB, charEqualDefAxiom, Bool.beq_eq_decide_eq]
     intros; rfl
 

--- a/Mica/Stdlib/CharStd.lean
+++ b/Mica/Stdlib/CharStd.lean
@@ -52,6 +52,8 @@ def charCodeB : Pure.Unary where
   arg      := .char
   res      := .int
   f        := (fun c => (c.toNat : Int) : UInt8 → Int)
+  dom      := fun _ => True
+  pre      := none
   typing   := monoTyping .one
   defAxiom := charCodeDefAxiom
 
@@ -63,6 +65,7 @@ def charCode : Intrinsic := charCodeB.toIntrinsic
 def charCodeLawful : charCodeB.Lawful where
   argL       := Embedding.lawfulChar
   resL       := Embedding.lawfulInt
+  domSound   := fun _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -75,193 +78,68 @@ instance : IntrinsicSound [charCode] charCode := charCodeLawful.sound
 
 /-! ## `Char.chr` -/
 
-def charChrPre : Formula :=
-  let n := .unop .toInt (.var .value "n")
+/-- The FOL precondition of `Char.chr`, as a function of the argument name. -/
+def charChrPre (n : String) : Formula :=
+  let t := .unop .toInt (.var .value n)
   .and
-    (.binpred .le (.const (.i 0)) n)
-    (.binpred .lt n (.const (.i 256)))
-
-/-- The value-level FOL term for `Char.chr n`. -/
-def charChrTerm (n : Term .value) : Term .value :=
-  unTerm "char_chr" n
-
-/-- The byte result of the FOL-level `Char.chr` interpretation. Outside OCaml's
-    valid range it is zero, matching `charChrByte`. -/
-def charChrVal (n : Int) : Runtime.Val :=
-  .char (charChrByte n)
+    (.binpred .le (.const (.i 0)) t)
+    (.binpred .lt t (.const (.i 256)))
 
 def charChrDefAxiom : Formula :=
   .forall_ "n" .value [.term (unTerm "char_chr" (.var .value "n"))] <|
-    .implies charChrPre <|
+    .implies (charChrPre "n") <|
       .eq .char
         (.unop .toChar (unTerm "char_chr" (.var .value "n")))
         (.unop .intToChar (.unop .toInt (.var .value "n")))
 
-def charChrTypeAxiom : Formula :=
-  .forall_ "n" .value [.term (charChrTerm (.var .value "n"))] <|
-    .unpred .isChar (charChrTerm (.var .value "n"))
-
-private theorem char_respects_argsEnv_one {s : FOL.Symbol .one} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
-  | [], _, _, h => h
-  | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
-      simp only [Spec.argsEnv]
-      refine char_respects_argsEnv_one rest vs ?_
-      rw [VerifM.Env.updateConst_env]
-      simpa only [Env.respects, Env.updateConst_unary] using h
-
 /-- `Char.chr`: integer to byte, with the OCaml precondition `0 <= n < 256`.
     The defining axiom only constrains the valid range, matching the spec
     precondition that rules out OCaml's raising cases. -/
-def charChr : Intrinsic where
-  arity  := .one
-  name   := "char_chr"
-  path   := some ("Char", ["chr"])
-  reduce := Reduce.pure fun a v =>
-    ∃ n, a = .int n ∧ 0 ≤ n ∧ n < 256 ∧ v = charChrVal n
-  wp     := fun a Q =>
-    iprop(∃ n, ⌜a = .int n ∧ 0 ≤ n ∧ n < 256⌝ ∗ Q (charChrVal n))
-  spec   :=
-    { args  := [("n", .int)]
-      retTy := .char
-      pred  := .assert charChrPre <|
-        .ret ("ret",
-          .assert (.eq .value (.var .value "ret") (charChrTerm (.var .value "n")))
-            (.ret ())) }
-  typing := monoTyping .one
-  folSym := some charChrSym
-  axioms := [⟨charChrDefAxiom, .high⟩, ⟨charChrTypeAxiom, .high⟩]
+def charChrB : Pure.Unary where
+  name     := "char_chr"
+  path     := some ("Char", ["chr"])
+  arg      := .int
+  res      := .char
+  f        := charChrByte
+  dom      := (fun n => 0 ≤ n ∧ n < 256 : Int → Prop)
+  pre      := some charChrPre
+  typing   := monoTyping .one
+  defAxiom := charChrDefAxiom
+
+def charChr : Intrinsic := charChrB.toIntrinsic
 
 @[simp] theorem charChr_arity : charChr.arity = .one := rfl
 @[simp] theorem charChr_folSym : charChr.folSym = some charChrSym := rfl
 
-@[simp] theorem charChr.toWp_eq (a : Runtime.Val) (Q : Runtime.Val → iProp) :
-    charChr.toWp [a] Q =
-      iprop(∃ n, ⌜a = .int n ∧ 0 ≤ n ∧ n < 256⌝ ∗ Q (charChrVal n)) := rfl
+def charChrLawful : charChrB.Lawful where
+  argL       := Embedding.lawfulInt
+  resL       := Embedding.lawfulChar
+  domSound   := by
+    intro ρ n h
+    have hpre := h charChrPre rfl
+    simpa [charChrB, charChrPre, Embedding.int, Formula.eval, Term.eval, Const.denote,
+      Env.lookupConst_updateConst_same, valInt] using hpre
+  specBaseWf := by apply PredTrans.checkWf_ok; rfl
+  defWf      := by apply Formula.checkWf_ok; rfl
+  typeWf     := by apply Formula.checkWf_ok; rfl
+  defEval    := by
+    have hsym : charChrB.sym = charChrSym := rfl
+    intro ρ hresp
+    rw [hsym] at hresp
+    simp only [charChrB, charChrDefAxiom, Formula.eval]
+    intro x hpre
+    have hun : (ρ.updateConst .value "n" x).unary .value .value "char_chr" =
+        charChrSym.interp := by
+      rw [Env.updateConst_unary]
+      simpa [Env.respects] using hresp
+    have hbounds : 0 ≤ valInt x ∧ valInt x < 256 := by
+      simpa [charChrPre, Formula.eval, Term.eval, Const.denote,
+        Env.lookupConst_updateConst_same, valInt] using hpre
+    simp [unTerm, Term.eval, Env.lookupConst_updateConst_same, hun, charChrSym]
+    cases x <;> simp [valInt, charChrByte] at hbounds ⊢
+    rw [if_pos hbounds.1, if_pos hbounds.2, Int.emod_eq_of_lt hbounds.1 hbounds.2]
 
-@[simp] theorem charChr.toReduce_eq (a v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    charChr.toReduce [a] μ v μ' =
-      ((∃ n, a = .int n ∧ 0 ≤ n ∧ n < 256 ∧ v = charChrVal n) ∧ μ' = μ) := rfl
-
-@[simp] theorem charChr.instantiate_args (σ : TinyML.TyVar → TinyML.Typ) :
-    (charChr.spec.instantiate σ).args = [("n", .int)] := by
-  simp [charChr, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem charChr.instantiate_retTy (σ : TinyML.TyVar → TinyML.Typ) :
-    (charChr.spec.instantiate σ).retTy = .char := by
-  simp [charChr, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem charChr.spec_pred :
-    charChr.spec.pred = .assert charChrPre
-      (.ret ("ret",
-        .assert (.eq .value (.var .value "ret") (charChrTerm (.var .value "n")))
-          (.ret ()))) := rfl
-
-instance : IntrinsicSound [charChr] charChr where
-  specWf := fun _ hsub hwf =>
-    specWf_of_base (by apply PredTrans.checkWf_ok; rfl) hsub hwf
-  wp_sound := by
-    intro _ ctx hctx vs Φ
-    match vs with
-    | [] => exact false_elim
-    | _ :: _ :: _ => exact false_elim
-    | [a] =>
-      have hred : ∀ n μ v μ',
-          ctx charChr.name [.int n] μ v μ'
-            ↔ (0 ≤ n ∧ n < 256 ∧ v = charChrVal n) ∧ μ' = μ := by
-        intro n μ v μ'
-        rw [hctx]
-        simp only [charChr.toReduce_eq]
-        constructor
-        · rintro ⟨⟨n', harg, hlo, hhi, hv⟩, hμ⟩
-          cases harg
-          exact ⟨⟨hlo, hhi, hv⟩, hμ⟩
-        · rintro ⟨⟨hlo, hhi, hv⟩, hμ⟩
-          exact ⟨⟨n, rfl, hlo, hhi, hv⟩, hμ⟩
-      show iprop(∃ n, ⌜a = .int n ∧ 0 ≤ n ∧ n < 256⌝ ∗ Φ (charChrVal n)) ⊢ _
-      istart
-      iintro ⟨%n, %ha, HΦ⟩
-      obtain ⟨rfl, hlo, hhi⟩ := ha
-      iapply (wp.prim_pure (hred n) ⟨charChrVal n, hlo, hhi, rfl⟩)
-      iintro %v %hv
-      obtain ⟨_, _, rfl⟩ := hv
-      iexact HΦ
-  bridge := by
-    intro _ σ Θ vs ρ Φ hρ
-    simp only [charChr.instantiate_args, charChr.instantiate_retTy,
-      Spec.instantiate_pred, charChr.spec_pred, List.map_cons, List.map_nil]
-    match vs with
-    | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | _ :: _ :: _ =>
-        exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [v] =>
-      simp only [PredTrans.apply, Assertion.pre]
-      iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v [] _ _).1 $$ Hvs
-      icases Hcons with ⟨Hv, _⟩
-      ihave Hveq := (TinyML.ValHasType.int Θ v).1 $$ Hv
-      ipure Hveq
-      obtain ⟨n, rfl⟩ := Hveq
-      icases Hpred with ⟨%hpre, Hpost⟩
-      have hbounds : 0 ≤ n ∧ n < 256 := by
-        simpa [charChrPre, Spec.argsEnv, Formula.eval, Term.eval, Const.denote,
-          VerifM.Env.updateConst_env, Env.lookupConst_updateConst_same] using hpre
-      simp only [charChr.toWp_eq]
-      iexists n
-      isplitr [Hpost]
-      · ipureintro
-        exact ⟨rfl, hbounds.1, hbounds.2⟩
-      · have hassert : (Formula.eq .value (.var .value "ret")
-            (charChrTerm (.var .value "n"))).eval
-            ((Spec.argsEnv ρ charChr.specArgs [.int n]).updateConst
-              .value "ret" (charChrVal n)).env := by
-          have hargs := char_respects_argsEnv_one charChr.specArgs [.int n] hρ
-          have hun : (Spec.argsEnv ρ charChr.specArgs [.int n]).env.unary
-              .value .value "char_chr" = charChrSym.interp := by
-            simpa [Env.respects, charChrSym] using hargs
-          show charChrVal n =
-            (Spec.argsEnv ρ charChr.specArgs [.int n]).env.unary
-              .value .value "char_chr" (.int n)
-          simp [charChrVal, charChrSym, hun, valInt]
-        refine (assert_ret_apply Θ _ "ret" _ _ (charChrVal n) hassert).trans ?_
-        iintro Hwand
-        iapply Hwand
-        exact TinyML.ValHasType.char_intro Θ (charChrByte n)
-  axiomWf := by
-    intro Δ hsub hwf a hφ
-    simp only [charChr, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-  proof := by
-    intro ρ hdeps a hφ
-    simp only [charChr, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    have hresp : ρ.respects (some charChrSym) := by
-      have h := hdeps charChr (by simp)
-      simpa [charChr] using h
-    rcases hφ with rfl | rfl
-    · simp only [charChrDefAxiom, Formula.eval]
-      intro x hpre
-      have hun : (ρ.updateConst .value "n" x).unary .value .value "char_chr" =
-          charChrSym.interp := by
-        rw [Env.updateConst_unary]
-        simpa [Env.respects] using hresp
-      have hbounds : 0 ≤ valInt x ∧ valInt x < 256 := by
-        simpa [charChrPre, Formula.eval, Term.eval, Const.denote,
-          Env.lookupConst_updateConst_same, valInt] using hpre
-      simp [unTerm, Term.eval, Env.lookupConst_updateConst_same, hun, charChrSym]
-      cases x <;> simp [valInt, charChrByte] at hbounds ⊢
-      rw [if_pos hbounds.1, if_pos hbounds.2, Int.emod_eq_of_lt hbounds.1 hbounds.2]
-    · simp only [charChrTypeAxiom, Formula.eval]
-      intro x
-      have hun : (ρ.updateConst .value "n" x).unary .value .value "char_chr" =
-          charChrSym.interp := by
-        rw [Env.updateConst_unary]
-        simpa [Env.respects] using hresp
-      simp [charChrTerm, unTerm, Term.eval, Env.lookupConst_updateConst_same,
-        hun, charChrSym, valInt]
+instance : IntrinsicSound [charChr] charChr := charChrLawful.sound
 
 /-! ## `Char.equal` -/
 
@@ -280,6 +158,8 @@ def charEqualB : Pure.Binary where
   arg₂     := .char
   res      := .bool
   f        := (fun x y => x == y : UInt8 → UInt8 → Bool)
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := charEqualDefAxiom
 
@@ -292,6 +172,7 @@ def charEqualLawful : charEqualB.Lawful where
   argL₁      := Embedding.lawfulChar
   argL₂      := Embedding.lawfulChar
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -26,6 +26,33 @@ theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (Φ : Ru
   ipureintro
   exact hφ
 
+/-- Wrap an optional precondition around a spec predicate: `some φ` prepends an
+    `.assert φ`; `none` leaves the predicate untouched, keeping the emitted spec
+    of precondition-free intrinsics unchanged. -/
+def withPre : Option Formula → PredTrans → PredTrans
+  | none,   post => post
+  | some φ, post => .assert φ post
+
+/-- Eliminate `withPre`: applying the wrapped predicate yields the precondition
+    as a pure fact (vacuous for `none`) alongside the unwrapped application. -/
+theorem withPre_apply [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
+    (pre : Option Formula) (post : PredTrans) (ρ : VerifM.Env) :
+    PredTrans.apply Θ Φ (withPre pre post) ρ ⊢
+      iprop(⌜∀ φ, pre = some φ → φ.eval ρ.env⌝ ∗ PredTrans.apply Θ Φ post ρ) := by
+  cases pre with
+  | none =>
+    simp only [withPre]
+    iintro H
+    isplitl []
+    · ipureintro; exact fun φ h => nomatch h
+    · iexact H
+  | some φ =>
+    simp only [withPre, PredTrans.apply, Assertion.pre]
+    iintro ⟨%hφ, H⟩
+    isplitl []
+    · ipureintro; intro φ' h; cases h; exact hφ
+    · iexact H
+
 /-- A length-mismatched argument list makes the typing premise inconsistent, so
     it entails anything. -/
 theorem valsHaveTypes_off_shape [MicaGS HasLC.hasLC Sig] {Θ : TinyML.TypeEnv}
@@ -349,13 +376,18 @@ name/path, the argument and result embeddings, the carrier function `f`, and the
 SMT defining axiom. From this alone the `Intrinsic` and its FOL symbol are built
 (`toIntrinsic`). The proof obligations live in `Pure.Unary.Lawful`. -/
 
-/-- The computational data of a pure unary intrinsic. -/
+/-- The computational data of a pure unary intrinsic. `dom` is the carrier-level
+    domain guarding `reduce`/`wp`; `pre` is the matching FOL precondition as a
+    function of the spec's argument name (the builder applies it at `"a"`). For
+    total intrinsics: `dom := fun _ => True`, `pre := none`. -/
 structure Unary where
   name     : String
   path     : Option (String × List String)
   arg      : Embedding
   res      : Embedding
   f        : arg.carrier → res.carrier
+  dom      : arg.carrier → Prop
+  pre      : Option (String → Formula)
   typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
@@ -378,12 +410,13 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
   arity  := .one
   name   := b.name
   path   := b.path
-  reduce := Reduce.pure fun a v => ∃ x, a = b.arg.inject x ∧ v = b.res.inject (b.f x)
-  wp     := fun a Q => iprop(∃ x, ⌜a = b.arg.inject x⌝ ∗ Q (b.res.inject (b.f x)))
+  reduce := Reduce.pure fun a v =>
+    ∃ x, a = b.arg.inject x ∧ b.dom x ∧ v = b.res.inject (b.f x)
+  wp     := fun a Q => iprop(∃ x, ⌜a = b.arg.inject x ∧ b.dom x⌝ ∗ Q (b.res.inject (b.f x)))
   spec   :=
     { args  := [("a", b.arg.typ)]
       retTy := b.res.typ
-      pred  := .ret ("ret",
+      pred  := withPre (b.pre.map (· "a")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a"))) (.ret ())) }
   typing := b.typing
@@ -391,10 +424,18 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
   axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
 
 @[simp] theorem Unary.toWp_eq (b : Unary) (a : Runtime.Val) (Q : Runtime.Val → iProp) :
-    b.toIntrinsic.toWp [a] Q = iprop(∃ x, ⌜a = b.arg.inject x⌝ ∗ Q (b.res.inject (b.f x))) := rfl
+    b.toIntrinsic.toWp [a] Q
+      = iprop(∃ x, ⌜a = b.arg.inject x ∧ b.dom x⌝ ∗ Q (b.res.inject (b.f x))) := rfl
 
 @[simp] theorem Unary.toReduce_eq (b : Unary) (a v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    b.toIntrinsic.toReduce [a] μ v μ' = ((∃ x, a = b.arg.inject x ∧ v = b.res.inject (b.f x)) ∧ μ' = μ) := rfl
+    b.toIntrinsic.toReduce [a] μ v μ' =
+      ((∃ x, a = b.arg.inject x ∧ b.dom x ∧ v = b.res.inject (b.f x)) ∧ μ' = μ) := rfl
+
+@[simp] theorem Unary.spec_pred (b : Unary) :
+    b.toIntrinsic.spec.pred = withPre (b.pre.map (· "a"))
+      (.ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (b.opTerm (.var .value "a"))) (.ret ()))) := rfl
 
 @[simp] theorem Unary.instantiate_args (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
     (b.toIntrinsic.spec.instantiate σ).args = [("a", b.arg.typ.subst σ)] := rfl
@@ -402,10 +443,17 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
 @[simp] theorem Unary.instantiate_retTy (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
     (b.toIntrinsic.spec.instantiate σ).retTy = b.res.typ.subst σ := rfl
 
-/-- Proof obligations for a pure unary intrinsic. -/
+/-- Proof obligations for a pure unary intrinsic. `domSound` extracts the
+    carrier-level domain from the evaluated precondition; when `pre = none` the
+    hypothesis is vacuous, so `dom` must hold unconditionally
+    (`fun _ _ _ => trivial` for `dom := fun _ => True`). -/
 structure Unary.Lawful (b : Unary) where
   argL       : b.arg.Lawful
   resL       : b.res.Lawful
+  domSound   : ∀ (ρ : Env) (x : b.arg.carrier),
+                 (∀ p, b.pre = some p →
+                   (p "a").eval (ρ.updateConst .value "a" (b.arg.inject x))) →
+                 b.dom x
   specBaseWf : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
@@ -423,33 +471,33 @@ structure Unary.Lawful (b : Unary) where
     | [] => exact false_elim
     | _ :: _ :: _ => exact false_elim
     | [a] =>
-      have hred : ∀ x μ v μ',
+      have hred : ∀ x, b.dom x → ∀ μ v μ',
           ctx b.toIntrinsic.name [b.arg.inject x] μ v μ'
             ↔ v = b.res.inject (b.f x) ∧ μ' = μ := by
-        intro x μ v μ'
+        intro x hdom μ v μ'
         rw [hctx]
         simp only [Unary.toIntrinsic, Intrinsic.toReduce_one_of_arity, Reduce.pure]
         constructor
-        · rintro ⟨⟨x', hx, hv⟩, hμ⟩
+        · rintro ⟨⟨x', hx, _, hv⟩, hμ⟩
           have hxx : x = x' := by
             have := congrArg b.arg.project hx
             rwa [l.argL.project_inject, l.argL.project_inject] at this
           subst hxx
           exact ⟨hv, hμ⟩
         · rintro ⟨hv, hμ⟩
-          exact ⟨⟨x, rfl, hv⟩, hμ⟩
-      show iprop(∃ x, ⌜a = b.arg.inject x⌝ ∗ Φ (b.res.inject (b.f x))) ⊢ _
+          exact ⟨⟨x, rfl, hdom, hv⟩, hμ⟩
+      show iprop(∃ x, ⌜a = b.arg.inject x ∧ b.dom x⌝ ∗ Φ (b.res.inject (b.f x))) ⊢ _
       istart
       iintro ⟨%x, %ha, HΦ⟩
-      obtain rfl := ha
-      iapply (wp.prim_pure (hred x) ⟨_, rfl⟩)
+      obtain ⟨rfl, hdom⟩ := ha
+      iapply (wp.prim_pure (hred x hdom) ⟨_, rfl⟩)
       iintro %v %hv
       subst hv
       iexact HΦ
   bridge := by
     intro _ σ Θ vs ρ Φ hρ
     simp only [Unary.instantiate_args, Unary.instantiate_retTy,
-      Spec.instantiate_pred, List.map_cons, List.map_nil]
+      Spec.instantiate_pred, Unary.spec_pred, List.map_cons, List.map_nil]
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | _ :: _ :: _ =>
@@ -461,10 +509,16 @@ structure Unary.Lawful (b : Unary) where
       ihave Hveq := (l.argL.member σ Θ v).1 $$ Hv
       ipure Hveq
       obtain ⟨x, rfl⟩ := Hveq
+      ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
+      icases Hsplit with ⟨%hpre, Hpost⟩
+      have hdom : b.dom x := by
+        refine l.domSound ρ.env x fun p hp => ?_
+        have h := hpre (p "a") (by rw [hp]; rfl)
+        simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
       simp only [Unary.toIntrinsic, Intrinsic.toWp_one_of_arity]
       iexists x
-      isplitr [Hpred]
-      · ipureintro; rfl
+      isplitr [Hpost]
+      · ipureintro; exact ⟨rfl, hdom⟩
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a"))).eval
             ((Spec.argsEnv ρ b.toIntrinsic.specArgs [b.arg.inject x]).updateConst
@@ -511,7 +565,10 @@ its name/path, the argument and result embeddings, the carrier function `f`, and
 the SMT defining axiom. From this alone the `Intrinsic` and its FOL symbol are
 built (`toIntrinsic`). The proof obligations live in `Pure.Binary.Lawful`. -/
 
-/-- The computational data of a pure binary intrinsic. -/
+/-- The computational data of a pure binary intrinsic. `dom` is the carrier-level
+    domain guarding `reduce`/`wp`; `pre` is the matching FOL precondition as a
+    function of the spec's argument names (the builder applies it at `"a"`/`"b"`).
+    For total intrinsics: `dom := fun _ _ => True`, `pre := none`. -/
 structure Binary where
   name     : String
   path     : Option (String × List String)
@@ -519,6 +576,8 @@ structure Binary where
   arg₂     : Embedding
   res      : Embedding
   f        : arg₁.carrier → arg₂.carrier → res.carrier
+  dom      : arg₁.carrier → arg₂.carrier → Prop
+  pre      : Option (String → String → Formula)
   typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
@@ -546,13 +605,14 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
   name   := b.name
   path   := b.path
   reduce := Reduce.pure fun (a, c) v =>
-    ∃ x y, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ v = b.res.inject (b.f x y)
+    ∃ x y, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ b.dom x y ∧ v = b.res.inject (b.f x y)
   wp     := fun (a, c) Q =>
-    iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y⌝ ∗ Q (b.res.inject (b.f x y)))
+    iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ b.dom x y⌝ ∗
+      Q (b.res.inject (b.f x y)))
   spec   :=
     { args  := [("a", b.arg₁.typ), ("b", b.arg₂.typ)]
       retTy := b.res.typ
-      pred  := .ret ("ret",
+      pred  := withPre (b.pre.map (· "a" "b")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())) }
   typing := b.typing
@@ -561,11 +621,19 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
 
 @[simp] theorem Binary.toWp_eq (b : Binary) (a c : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a, c] Q =
-      iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y⌝ ∗ Q (b.res.inject (b.f x y))) := rfl
+      iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ b.dom x y⌝ ∗
+        Q (b.res.inject (b.f x y))) := rfl
 
 @[simp] theorem Binary.toReduce_eq (b : Binary) (a c v : Runtime.Val) (μ μ' : TinyML.Heap) :
     b.toIntrinsic.toReduce [a, c] μ v μ' =
-      ((∃ x y, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ v = b.res.inject (b.f x y)) ∧ μ' = μ) := rfl
+      ((∃ x y, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ b.dom x y ∧
+        v = b.res.inject (b.f x y)) ∧ μ' = μ) := rfl
+
+@[simp] theorem Binary.spec_pred (b : Binary) :
+    b.toIntrinsic.spec.pred = withPre (b.pre.map (· "a" "b"))
+      (.ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ()))) := rfl
 
 @[simp] theorem Binary.instantiate_args (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
     (b.toIntrinsic.spec.instantiate σ).args
@@ -582,6 +650,11 @@ structure Binary.Lawful (b : Binary) where
   argL₁      : b.arg₁.Lawful
   argL₂      : b.arg₂.Lawful
   resL       : b.res.Lawful
+  domSound   : ∀ (ρ : Env) (x : b.arg₁.carrier) (y : b.arg₂.carrier),
+                 (∀ p, b.pre = some p →
+                   (p "a" "b").eval ((ρ.updateConst .value "a" (b.arg₁.inject x)).updateConst
+                     .value "b" (b.arg₂.inject y))) →
+                 b.dom x y
   specBaseWf : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
@@ -600,14 +673,14 @@ structure Binary.Lawful (b : Binary) where
     | [_] => exact false_elim
     | _ :: _ :: _ :: _ => exact false_elim
     | [a, c] =>
-      have hred : ∀ x y μ v μ',
+      have hred : ∀ x y, b.dom x y → ∀ μ v μ',
           ctx b.toIntrinsic.name [b.arg₁.inject x, b.arg₂.inject y] μ v μ'
             ↔ v = b.res.inject (b.f x y) ∧ μ' = μ := by
-        intro x y μ v μ'
+        intro x y hdom μ v μ'
         rw [hctx]
         simp only [Binary.toIntrinsic, Intrinsic.toReduce_two_of_arity, Reduce.pure]
         constructor
-        · rintro ⟨⟨x', y', hx, hy, hv⟩, hμ⟩
+        · rintro ⟨⟨x', y', hx, hy, _, hv⟩, hμ⟩
           have hxx : x = x' := by
             have := congrArg b.arg₁.project hx
             rwa [l.argL₁.project_inject, l.argL₁.project_inject] at this
@@ -617,19 +690,20 @@ structure Binary.Lawful (b : Binary) where
           subst hxx; subst hyy
           exact ⟨hv, hμ⟩
         · rintro ⟨hv, hμ⟩
-          exact ⟨⟨x, y, rfl, rfl, hv⟩, hμ⟩
-      show iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y⌝ ∗ Φ (b.res.inject (b.f x y))) ⊢ _
+          exact ⟨⟨x, y, rfl, rfl, hdom, hv⟩, hμ⟩
+      show iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ b.dom x y⌝ ∗
+        Φ (b.res.inject (b.f x y))) ⊢ _
       istart
       iintro ⟨%x, %y, %hab, HΦ⟩
-      obtain ⟨rfl, rfl⟩ := hab
-      iapply (wp.prim_pure (hred x y) ⟨_, rfl⟩)
+      obtain ⟨rfl, rfl, hdom⟩ := hab
+      iapply (wp.prim_pure (hred x y hdom) ⟨_, rfl⟩)
       iintro %v %hv
       subst hv
       iexact HΦ
   bridge := by
     intro _ σ Θ vs ρ Φ hρ
     simp only [Binary.instantiate_args, Binary.instantiate_retTy,
-      Spec.instantiate_pred, List.map_cons, List.map_nil]
+      Spec.instantiate_pred, Binary.spec_pred, List.map_cons, List.map_nil]
     show TinyML.ValsHaveTypes Θ vs [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ] ∗ _ ⊢ _
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -648,11 +722,17 @@ structure Binary.Lawful (b : Binary) where
       ipure Hv2eq
       obtain ⟨x, rfl⟩ := Hv1eq
       obtain ⟨y, rfl⟩ := Hv2eq
+      ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
+      icases Hsplit with ⟨%hpre, Hpost⟩
+      have hdom : b.dom x y := by
+        refine l.domSound ρ.env x y fun p hp => ?_
+        have h := hpre (p "a" "b") (by rw [hp]; rfl)
+        simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
       simp only [Binary.toIntrinsic, Intrinsic.toWp_two_of_arity]
       iexists x
       iexists y
-      isplitr [Hpred]
-      · ipureintro; exact ⟨rfl, rfl⟩
+      isplitr [Hpost]
+      · ipureintro; exact ⟨rfl, rfl, hdom⟩
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a") (.var .value "b"))).eval
             ((Spec.argsEnv ρ b.toIntrinsic.specArgs
@@ -704,7 +784,11 @@ its name/path, the argument and result embeddings, the carrier function `f`, and
 the SMT defining axiom. From this alone the `Intrinsic` and its FOL symbol are
 built (`toIntrinsic`). The proof obligations live in `Pure.Ternary.Lawful`. -/
 
-/-- The computational data of a pure ternary intrinsic. -/
+/-- The computational data of a pure ternary intrinsic. `dom` is the carrier-level
+    domain guarding `reduce`/`wp`; `pre` is the matching FOL precondition as a
+    function of the spec's argument names (the builder applies it at
+    `"a"`/`"b"`/`"c"`). For total intrinsics: `dom := fun _ _ _ => True`,
+    `pre := none`. -/
 structure Ternary where
   name     : String
   path     : Option (String × List String)
@@ -713,6 +797,8 @@ structure Ternary where
   arg₃     : Embedding
   res      : Embedding
   f        : arg₁.carrier → arg₂.carrier → arg₃.carrier → res.carrier
+  dom      : arg₁.carrier → arg₂.carrier → arg₃.carrier → Prop
+  pre      : Option (String → String → String → Formula)
   typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
@@ -743,14 +829,14 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
   path   := b.path
   reduce := Reduce.pure fun (a, c, d) v =>
     ∃ x y z, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z ∧
-      v = b.res.inject (b.f x y z)
+      b.dom x y z ∧ v = b.res.inject (b.f x y z)
   wp     := fun (a, c, d) Q =>
-    iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z⌝ ∗
-      Q (b.res.inject (b.f x y z)))
+    iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z ∧
+      b.dom x y z⌝ ∗ Q (b.res.inject (b.f x y z)))
   spec   :=
     { args  := [("a", b.arg₁.typ), ("b", b.arg₂.typ), ("c", b.arg₃.typ)]
       retTy := b.res.typ
-      pred  := .ret ("ret",
+      pred  := withPre (b.pre.map (· "a" "b" "c")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())) }
   typing := b.typing
@@ -759,13 +845,19 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
 
 @[simp] theorem Ternary.toWp_eq (b : Ternary) (a c d : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a, c, d] Q =
-      iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z⌝ ∗
-        Q (b.res.inject (b.f x y z))) := rfl
+      iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z ∧
+        b.dom x y z⌝ ∗ Q (b.res.inject (b.f x y z))) := rfl
 
 @[simp] theorem Ternary.toReduce_eq (b : Ternary) (a c d v : Runtime.Val) (μ μ' : TinyML.Heap) :
     b.toIntrinsic.toReduce [a, c, d] μ v μ' =
       ((∃ x y z, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z ∧
-        v = b.res.inject (b.f x y z)) ∧ μ' = μ) := rfl
+        b.dom x y z ∧ v = b.res.inject (b.f x y z)) ∧ μ' = μ) := rfl
+
+@[simp] theorem Ternary.spec_pred (b : Ternary) :
+    b.toIntrinsic.spec.pred = withPre (b.pre.map (· "a" "b" "c"))
+      (.ret ("ret",
+        .assert (.eq .value (.var .value "ret")
+          (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ()))) := rfl
 
 @[simp] theorem Ternary.instantiate_args (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
     (b.toIntrinsic.spec.instantiate σ).args
@@ -780,6 +872,12 @@ structure Ternary.Lawful (b : Ternary) where
   argL₂      : b.arg₂.Lawful
   argL₃      : b.arg₃.Lawful
   resL       : b.res.Lawful
+  domSound   : ∀ (ρ : Env) (x : b.arg₁.carrier) (y : b.arg₂.carrier) (z : b.arg₃.carrier),
+                 (∀ p, b.pre = some p →
+                   (p "a" "b" "c").eval (((ρ.updateConst .value "a"
+                     (b.arg₁.inject x)).updateConst .value "b"
+                     (b.arg₂.inject y)).updateConst .value "c" (b.arg₃.inject z))) →
+                 b.dom x y z
   specBaseWf : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
@@ -799,14 +897,14 @@ structure Ternary.Lawful (b : Ternary) where
     | [_, _] => exact false_elim
     | _ :: _ :: _ :: _ :: _ => exact false_elim
     | [a, c, d] =>
-      have hred : ∀ x y z μ v μ',
+      have hred : ∀ x y z, b.dom x y z → ∀ μ v μ',
           ctx b.toIntrinsic.name [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z] μ v μ'
             ↔ v = b.res.inject (b.f x y z) ∧ μ' = μ := by
-        intro x y z μ v μ'
+        intro x y z hdom μ v μ'
         rw [hctx]
         simp only [Ternary.toIntrinsic, Intrinsic.toReduce_three_of_arity, Reduce.pure]
         constructor
-        · rintro ⟨⟨x', y', z', hx, hy, hz, hv⟩, hμ⟩
+        · rintro ⟨⟨x', y', z', hx, hy, hz, _, hv⟩, hμ⟩
           have hxx : x = x' := by
             have := congrArg b.arg₁.project hx
             rwa [l.argL₁.project_inject, l.argL₁.project_inject] at this
@@ -819,20 +917,20 @@ structure Ternary.Lawful (b : Ternary) where
           subst hxx; subst hyy; subst hzz
           exact ⟨hv, hμ⟩
         · rintro ⟨hv, hμ⟩
-          exact ⟨⟨x, y, z, rfl, rfl, rfl, hv⟩, hμ⟩
-      show iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z⌝ ∗
-        Φ (b.res.inject (b.f x y z))) ⊢ _
+          exact ⟨⟨x, y, z, rfl, rfl, rfl, hdom, hv⟩, hμ⟩
+      show iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z ∧
+        b.dom x y z⌝ ∗ Φ (b.res.inject (b.f x y z))) ⊢ _
       istart
       iintro ⟨%x, %y, %z, %habc, HΦ⟩
-      obtain ⟨rfl, rfl, rfl⟩ := habc
-      iapply (wp.prim_pure (hred x y z) ⟨_, rfl⟩)
+      obtain ⟨rfl, rfl, rfl, hdom⟩ := habc
+      iapply (wp.prim_pure (hred x y z hdom) ⟨_, rfl⟩)
       iintro %v %hv
       subst hv
       iexact HΦ
   bridge := by
     intro _ σ Θ vs ρ Φ hρ
     simp only [Ternary.instantiate_args, Ternary.instantiate_retTy,
-      Spec.instantiate_pred, List.map_cons, List.map_nil]
+      Spec.instantiate_pred, Ternary.spec_pred, List.map_cons, List.map_nil]
     show TinyML.ValsHaveTypes Θ vs
       [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ, b.arg₃.typ.subst σ] ∗ _ ⊢ _
     match vs with
@@ -858,12 +956,18 @@ structure Ternary.Lawful (b : Ternary) where
       obtain ⟨x, rfl⟩ := Hv1eq
       obtain ⟨y, rfl⟩ := Hv2eq
       obtain ⟨z, rfl⟩ := Hv3eq
+      ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
+      icases Hsplit with ⟨%hpre, Hpost⟩
+      have hdom : b.dom x y z := by
+        refine l.domSound ρ.env x y z fun p hp => ?_
+        have h := hpre (p "a" "b" "c") (by rw [hp]; rfl)
+        simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
       simp only [Ternary.toIntrinsic, Intrinsic.toWp_three_of_arity]
       iexists x
       iexists y
       iexists z
-      isplitr [Hpred]
-      · ipureintro; exact ⟨rfl, rfl, rfl⟩
+      isplitr [Hpost]
+      · ipureintro; exact ⟨rfl, rfl, rfl, hdom⟩
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))).eval
             ((Spec.argsEnv ρ b.toIntrinsic.specArgs

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -1,4 +1,4 @@
--- SUMMARY: Embeddings and the pure-intrinsic builders (`Pure.Zero`/`Pure.Unary`/`Pure.Binary`/`Pure.Ternary`) that emit an intrinsic and its soundness instance, plus the shared helper lemmas their soundness proofs use.
+-- SUMMARY: Embeddings (with semantic type predicates for polymorphic types) and the pure-intrinsic builders (`Pure.Zero`/`Pure.Unary`/`Pure.Binary`/`Pure.Ternary`) that emit an intrinsic — optional precondition, generated type axiom — and its soundness instance.
 import Mica.Verifier.Intrinsic
 
 open Iris Iris.BI
@@ -123,14 +123,19 @@ predicate that recognizes the type at the value sort. The coherence laws
 live in `Embedding.Lawful`. -/
 
 /-- How a Lean carrier is represented as runtime values of a TinyML type: an
-    injection, its retracting projection, and the `is-of` value-sort predicate
-    recognizing the type. Pure data; see `Embedding.Lawful` for the laws. -/
+    injection, its retracting projection, the semantic type predicate
+    `typePred` — the resource left of a typing fact after peeling off the
+    injection (`emp` for the base types) — and an optional `is-of` value-sort
+    predicate recognizing the type (absent when the type is a variable).
+    Pure data; see `Embedding.Lawful` for the laws. -/
 structure Embedding where
-  typ     : TinyML.Typ
-  carrier : Type
-  inject  : carrier → Runtime.Val
-  project : Runtime.Val → carrier
-  isOf    : UnPred .value
+  typ      : TinyML.Typ
+  carrier  : Type
+  inject   : carrier → Runtime.Val
+  project  : Runtime.Val → carrier
+  typePred : ∀ [MicaGS.{0} HasLC.hasLC Sig],
+              (TinyML.TyVar → TinyML.Typ) → TinyML.TypeEnv → carrier → iProp
+  isOf     : Option (UnPred .value)
 
 /-- Integer projection of a runtime value, matching FOL's `toInt`. -/
 def valInt : Runtime.Val → Int
@@ -157,69 +162,135 @@ def valFloat : Runtime.Val → UInt64
   | .float b => b
   | _        => 0
 
+/-- Vector projection of a runtime value, matching FOL's `toVec`. -/
+def valVec : Runtime.Val → List Runtime.Val
+  | .vec l => l
+  | _      => []
+
 /-- Integers as `.int` values. -/
-def Embedding.int  : Embedding := ⟨.int,    Int,        .int,  valInt,  .isInt⟩
+def Embedding.int  : Embedding :=
+  ⟨.int, Int, .int, valInt, fun _ _ _ => iprop(emp), some .isInt⟩
 /-- Booleans as `.bool` values. -/
-def Embedding.bool : Embedding := ⟨.bool,   Bool,       .bool, valBool, .isBool⟩
+def Embedding.bool : Embedding :=
+  ⟨.bool, Bool, .bool, valBool, fun _ _ _ => iprop(emp), some .isBool⟩
 /-- Bytes as `.char` values. -/
-def Embedding.char : Embedding := ⟨.char, UInt8, .char, valChar, .isChar⟩
+def Embedding.char : Embedding :=
+  ⟨.char, UInt8, .char, valChar, fun _ _ _ => iprop(emp), some .isChar⟩
 /-- Byte strings as `.str` values. -/
-def Embedding.str  : Embedding := ⟨.string, List UInt8, .str,  valStr,  .isStr⟩
+def Embedding.str  : Embedding :=
+  ⟨.string, List UInt8, .str, valStr, fun _ _ _ => iprop(emp), some .isStr⟩
 /-- IEEE binary64 bit-patterns as `.float` values. -/
-def Embedding.float : Embedding := ⟨.float, UInt64, .float, valFloat, .isFloat⟩
+def Embedding.float : Embedding :=
+  ⟨.float, UInt64, .float, valFloat, fun _ _ _ => iprop(emp), some .isFloat⟩
+
+/-- A type variable `'a`: any runtime value, with its typing at the
+    instantiated type as the type predicate. No `is-of` recognizer, so no
+    type axiom. -/
+def Embedding.poly : Embedding :=
+  ⟨.tvar "a", Runtime.Val, id, id,
+    fun σ Θ v => TinyML.ValHasType Θ v (σ "a"), none⟩
+
+/-- Vectors `'a vec`: element lists, with the big-sep of element typings at
+    the instantiated element type as the type predicate. -/
+def Embedding.vec : Embedding :=
+  ⟨.vec (.tvar "a"), List Runtime.Val, .vec, valVec,
+    fun σ Θ l => iprop([∗list] w ∈ l, TinyML.ValHasType Θ w (σ "a")), some .isVec⟩
 
 /-- Coherence laws for an `Embedding`. The `member`/`intro` laws are stated at
     every instantiation `e.typ.subst σ` of the embedding's type. -/
 structure Embedding.Lawful (e : Embedding) where
   project_inject : ∀ x, e.project (e.inject x) = x
-  isOf_wf        : ∀ Δ, e.isOf.wfIn Δ
-  isOf_inject    : ∀ (ρ : Env) (x : e.carrier), UnPred.eval ρ e.isOf (e.inject x)
+  isOf_wf        : ∀ Δ p, e.isOf = some p → p.wfIn Δ
+  isOf_inject    : ∀ (ρ : Env) (x : e.carrier) p, e.isOf = some p →
+                     UnPred.eval ρ p (e.inject x)
   member         : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
                      (Θ : TinyML.TypeEnv) (w : Runtime.Val),
-                     TinyML.ValHasType Θ w (e.typ.subst σ) ⊣⊢ iprop(⌜∃ x, w = e.inject x⌝)
+                     TinyML.ValHasType Θ w (e.typ.subst σ) ⊣⊢
+                       iprop(∃ x, ⌜w = e.inject x⌝ ∗ e.typePred σ Θ x)
   intro          : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
                      (Θ : TinyML.TypeEnv) (x : e.carrier),
-                     ⊢ TinyML.ValHasType Θ (e.inject x) (e.typ.subst σ)
+                     e.typePred σ Θ x ⊢ TinyML.ValHasType Θ (e.inject x) (e.typ.subst σ)
+
+/-- Lift the pure membership fact of an embedding with trivial type predicate
+    to the predicate-carrying `member` shape (`∗ emp` under the existential). -/
+theorem pure_member [MicaGS HasLC.hasLC Sig] {P : iProp} {α : Type} {φ : α → Prop}
+    (h : P ⊣⊢ iprop(⌜∃ x, φ x⌝)) : P ⊣⊢ iprop(∃ x, ⌜φ x⌝ ∗ emp) :=
+  h.trans (pure_exists.symm.trans (exists_congr fun _ => sep_emp.symm))
 
 /-- Integers are a lawful embedding. -/
 def Embedding.lawfulInt : Embedding.int.Lawful where
   project_inject _ := rfl
-  isOf_wf _ := trivial
-  isOf_inject _ _ := by simp [Embedding.int]
-  member _ Θ w := by simpa [Embedding.int, TinyML.Typ.subst] using TinyML.ValHasType.int Θ w
+  isOf_wf _ _ h := by cases h; trivial
+  isOf_inject _ _ _ h := by cases h; simp [Embedding.int]
+  member _ Θ w := pure_member (φ := fun x => w = .int x)
+    (by simpa [Embedding.int, TinyML.Typ.subst] using TinyML.ValHasType.int Θ w)
   intro _ Θ x := by simpa [Embedding.int, TinyML.Typ.subst] using TinyML.ValHasType.int_intro Θ x
 
 /-- Booleans are a lawful embedding. -/
 def Embedding.lawfulBool : Embedding.bool.Lawful where
   project_inject _ := rfl
-  isOf_wf _ := trivial
-  isOf_inject _ _ := by simp [Embedding.bool]
-  member _ Θ w := by simpa [Embedding.bool, TinyML.Typ.subst] using TinyML.ValHasType.bool Θ w
+  isOf_wf _ _ h := by cases h; trivial
+  isOf_inject _ _ _ h := by cases h; simp [Embedding.bool]
+  member _ Θ w := pure_member (φ := fun x => w = .bool x)
+    (by simpa [Embedding.bool, TinyML.Typ.subst] using TinyML.ValHasType.bool Θ w)
   intro _ Θ x := by simpa [Embedding.bool, TinyML.Typ.subst] using TinyML.ValHasType.bool_intro Θ x
 
 /-- Characters are a lawful embedding. -/
 def Embedding.lawfulChar : Embedding.char.Lawful where
   project_inject _ := rfl
-  isOf_wf _ := trivial
-  isOf_inject _ _ := by simp [Embedding.char]
-  member _ Θ w := by simpa [Embedding.char, TinyML.Typ.subst] using TinyML.ValHasType.char Θ w
+  isOf_wf _ _ h := by cases h; trivial
+  isOf_inject _ _ _ h := by cases h; simp [Embedding.char]
+  member _ Θ w := pure_member (φ := fun x => w = .char x)
+    (by simpa [Embedding.char, TinyML.Typ.subst] using TinyML.ValHasType.char Θ w)
   intro _ Θ x := by simpa [Embedding.char, TinyML.Typ.subst] using TinyML.ValHasType.char_intro Θ x
 
 /-- Byte strings are a lawful embedding. -/
 def Embedding.lawfulStr : Embedding.str.Lawful where
   project_inject _ := rfl
-  isOf_wf _ := trivial
-  isOf_inject _ _ := by simp [Embedding.str]
-  member _ Θ w := by simpa [Embedding.str, TinyML.Typ.subst] using TinyML.ValHasType.string Θ w
+  isOf_wf _ _ h := by cases h; trivial
+  isOf_inject _ _ _ h := by cases h; simp [Embedding.str]
+  member _ Θ w := pure_member (φ := fun x => w = .str x)
+    (by simpa [Embedding.str, TinyML.Typ.subst] using TinyML.ValHasType.string Θ w)
   intro _ Θ x := by simpa [Embedding.str, TinyML.Typ.subst] using TinyML.ValHasType.string_intro Θ x
 
 /-- Floats are a lawful embedding. -/
 def Embedding.lawfulFloat : Embedding.float.Lawful where
   project_inject _ := rfl
-  isOf_wf _ := trivial
-  isOf_inject _ _ := by simp [Embedding.float]
-  member _ Θ w := by simpa [Embedding.float, TinyML.Typ.subst] using TinyML.ValHasType.float Θ w
+  isOf_wf _ _ h := by cases h; trivial
+  isOf_inject _ _ _ h := by cases h; simp [Embedding.float]
+  member _ Θ w := pure_member (φ := fun x => w = .float x)
+    (by simpa [Embedding.float, TinyML.Typ.subst] using TinyML.ValHasType.float Θ w)
   intro _ Θ x := by simpa [Embedding.float, TinyML.Typ.subst] using TinyML.ValHasType.float_intro Θ x
+
+/-- Type variables are a lawful embedding: the type predicate is the typing fact itself. -/
+def Embedding.lawfulPoly : Embedding.poly.Lawful where
+  project_inject _ := rfl
+  isOf_wf _ _ h := nomatch h
+  isOf_inject _ _ _ h := nomatch h
+  member σ Θ w := by
+    simp only [Embedding.poly, TinyML.Typ.subst]
+    constructor
+    · iintro H
+      iexists w
+      isplitl []
+      · ipureintro; rfl
+      · iexact H
+    · iintro ⟨%x, %hw, H⟩
+      obtain rfl := hw
+      iexact H
+  intro σ Θ x := by
+    simp only [Embedding.poly, TinyML.Typ.subst]
+    exact .rfl
+
+/-- Vectors are a lawful embedding: exactly the `ValHasType.vec` API. -/
+def Embedding.lawfulVec : Embedding.vec.Lawful where
+  project_inject _ := rfl
+  isOf_wf _ _ h := by cases h; trivial
+  isOf_inject _ _ _ h := by cases h; simp [Embedding.vec]
+  member σ Θ w := by
+    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec Θ w (σ "a")
+  intro σ Θ l := by
+    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec_intro Θ l (σ "a")
 
 /-! ## Name-based term builders -/
 
@@ -266,9 +337,9 @@ def Zero.sym (b : Zero) : FOL.Symbol .zero where
   name   := b.name
   interp := fun () => b.res.inject b.f
 
-/-- The result-typing axiom, generated from `res`. -/
-def Zero.typeAxiom (b : Zero) : Formula :=
-  .unpred b.res.isOf b.opTerm
+/-- The result-typing axiom, generated from `res` when it has a recognizer. -/
+def Zero.typeAxiom (b : Zero) : Option Formula :=
+  b.res.isOf.map fun p => .unpred p b.opTerm
 
 /-- The intrinsic built from `b`: a literal `Intrinsic.mk`. -/
 def Zero.toIntrinsic (b : Zero) : Intrinsic where
@@ -284,7 +355,7 @@ def Zero.toIntrinsic (b : Zero) : Intrinsic where
         .assert (.eq .value (.var .value "ret") b.opTerm) (.ret ())) }
   typing := b.typing
   folSym := some b.sym
-  axioms := [⟨b.defAxiom, .low⟩, ⟨b.typeAxiom, .low⟩]
+  axioms := ⟨b.defAxiom, .low⟩ :: (b.typeAxiom.map (⟨·, .low⟩)).toList
 
 @[simp] theorem Zero.toWp_eq (b : Zero) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [] Q = Q (b.res.inject b.f) := rfl
@@ -299,14 +370,16 @@ def Zero.toIntrinsic (b : Zero) : Intrinsic where
     keeps the generated constant symbol distinct from the spec's `"ret"`
     binder, since both live in the value-constant namespace. -/
 structure Zero.Lawful (b : Zero) where
-  resL       : b.res.Lawful
-  nameFresh  : b.name ≠ "ret"
-  specBaseWf : PredTrans.wfIn
+  resL         : b.res.Lawful
+  nameFresh    : b.name ≠ "ret"
+  semWellTyped : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
+                 (Θ : TinyML.TypeEnv), iprop(emp) ⊢ b.res.typePred σ Θ b.f
+  specBaseWf   : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
-  defWf      : b.defAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
-  typeWf     : b.typeAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
-  defEval    : ∀ ρ : Env, ρ.respects (some b.sym) → Formula.eval ρ b.defAxiom
+  defWf        : b.defAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
+  typeWf       : ∀ φ, b.typeAxiom = some φ → φ.wfIn (Intrinsic.sigOf [b.toIntrinsic])
+  defEval      : ∀ ρ : Env, ρ.respects (some b.sym) → Formula.eval ρ b.defAxiom
 
 /-- The `IntrinsicSound` instance for a pure zero-arity intrinsic. -/
 @[reducible] def Zero.Lawful.sound {b : Zero} (l : b.Lawful) :
@@ -348,26 +421,28 @@ structure Zero.Lawful (b : Zero) where
         simpa [Zero.opTerm, Term.eval, Const.denote] using hconst.symm
       · iintro Hwand
         iapply Hwand
-        exact l.resL.intro σ Θ b.f
+        exact (l.semWellTyped σ Θ).trans (l.resL.intro σ Θ b.f)
   axiomWf := by
     intro Δ hsub hwf a hφ
-    simp only [Zero.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
+    simp only [Zero.toIntrinsic, List.mem_cons, Option.mem_toList,
+      Option.map_eq_some_iff] at hφ
+    rcases hφ with rfl | ⟨φ, hφ, rfl⟩
     · exact Formula.wfIn_mono _ l.defWf hsub hwf
-    · exact Formula.wfIn_mono _ l.typeWf hsub hwf
+    · exact Formula.wfIn_mono _ (l.typeWf φ hφ) hsub hwf
   proof := by
     intro ρ hdeps a hφ
-    simp only [Zero.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
+    simp only [Zero.toIntrinsic, List.mem_cons, Option.mem_toList,
+      Option.map_eq_some_iff, Zero.typeAxiom] at hφ
     have hresp : ρ.respects (some b.sym) := by
       have h := hdeps b.toIntrinsic (by simp)
       simpa [Zero.toIntrinsic] using h
-    rcases hφ with rfl | rfl
+    rcases hφ with rfl | ⟨φ, ⟨p, hp, rfl⟩, rfl⟩
     · exact l.defEval ρ hresp
-    · simp only [Zero.typeAxiom, Formula.eval, Zero.opTerm, Term.eval, Const.denote]
+    · simp only [Formula.eval, Zero.opTerm, Term.eval, Const.denote]
       have hconst : ρ.consts .value b.name = b.res.inject b.f := by
         simpa [Env.respects, Env.lookupConst, Zero.sym] using hresp
       rw [hconst]
-      exact l.resL.isOf_inject _ _
+      exact l.resL.isOf_inject _ _ p hp
 
 /-! ## Builder for pure unary intrinsics
 
@@ -400,10 +475,11 @@ def Unary.sym (b : Unary) : FOL.Symbol .one where
   name   := b.name
   interp := fun a => b.res.inject (b.f (b.arg.project a))
 
-/-- The result-typing axiom, generated from `res`. -/
-def Unary.typeAxiom (b : Unary) : Formula :=
-  .forall_ "a" .value [.term (b.opTerm (.var .value "a"))] <|
-    .unpred b.res.isOf (b.opTerm (.var .value "a"))
+/-- The result-typing axiom, generated from `res` when it has a recognizer. -/
+def Unary.typeAxiom (b : Unary) : Option Formula :=
+  b.res.isOf.map fun p =>
+    .forall_ "a" .value [.term (b.opTerm (.var .value "a"))] <|
+      .unpred p (b.opTerm (.var .value "a"))
 
 /-- The intrinsic built from `b`: a literal `Intrinsic.mk`. -/
 def Unary.toIntrinsic (b : Unary) : Intrinsic where
@@ -421,7 +497,7 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
           (b.opTerm (.var .value "a"))) (.ret ())) }
   typing := b.typing
   folSym := some b.sym
-  axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
+  axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
 
 @[simp] theorem Unary.toWp_eq (b : Unary) (a : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a] Q
@@ -448,18 +524,21 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
     hypothesis is vacuous, so `dom` must hold unconditionally
     (`fun _ _ _ => trivial` for `dom := fun _ => True`). -/
 structure Unary.Lawful (b : Unary) where
-  argL       : b.arg.Lawful
-  resL       : b.res.Lawful
-  domSound   : ∀ (ρ : Env) (x : b.arg.carrier),
+  argL         : b.arg.Lawful
+  resL         : b.res.Lawful
+  domSound     : ∀ (ρ : Env) (x : b.arg.carrier),
                  (∀ p, b.pre = some p →
                    (p "a").eval (ρ.updateConst .value "a" (b.arg.inject x))) →
                  b.dom x
-  specBaseWf : PredTrans.wfIn
+  semWellTyped : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
+                 (Θ : TinyML.TypeEnv) (x : b.arg.carrier), b.dom x →
+                 b.arg.typePred σ Θ x ⊢ b.res.typePred σ Θ (b.f x)
+  specBaseWf   : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
-  defWf      : b.defAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
-  typeWf     : b.typeAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
-  defEval    : ∀ ρ : Env, ρ.respects (some b.sym) → Formula.eval ρ b.defAxiom
+  defWf        : b.defAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
+  typeWf       : ∀ φ, b.typeAxiom = some φ → φ.wfIn (Intrinsic.sigOf [b.toIntrinsic])
+  defEval      : ∀ ρ : Env, ρ.respects (some b.sym) → Formula.eval ρ b.defAxiom
 
 /-- The `IntrinsicSound` instance for a pure unary intrinsic. -/
 @[reducible] def Unary.Lawful.sound {b : Unary} (l : b.Lawful) :
@@ -507,17 +586,21 @@ structure Unary.Lawful (b : Unary) where
       ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v [] _ _).1 $$ Hvs
       icases Hcons with ⟨Hv, _⟩
       ihave Hveq := (l.argL.member σ Θ v).1 $$ Hv
-      ipure Hveq
-      obtain ⟨x, rfl⟩ := Hveq
+      icases Hveq with ⟨%x, %hw, Hrel⟩
+      obtain rfl := hw
       ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x := by
         refine l.domSound ρ.env x fun p hp => ?_
         have h := hpre (p "a") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
+      ihave Hty : iprop(TinyML.ValHasType Θ (b.res.inject (b.f x)) (b.res.typ.subst σ)) $$ [Hrel]
+      · iapply (l.resL.intro σ Θ (b.f x))
+        iapply (l.semWellTyped σ Θ x hdom)
+        iexact Hrel
       simp only [Unary.toIntrinsic, Intrinsic.toWp_one_of_arity]
       iexists x
-      isplitr [Hpost]
+      isplitr [Hpost Hty]
       · ipureintro; exact ⟨rfl, hdom⟩
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a"))).eval
@@ -531,32 +614,35 @@ structure Unary.Lawful (b : Unary) where
             (Spec.argsEnv ρ b.toIntrinsic.specArgs [b.arg.inject x]).env.unary
               .value .value b.name (b.arg.inject x)
           simp [hun, Unary.sym, l.argL.project_inject]
-        refine (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x)) hassert).trans ?_
-        iintro Hwand
+        refine (sep_mono_left
+          (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x)) hassert)).trans ?_
+        iintro ⟨Hwand, Hty⟩
         iapply Hwand
-        exact l.resL.intro σ Θ (b.f x)
+        iexact Hty
   axiomWf := by
     intro Δ hsub hwf a hφ
-    simp only [Unary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
+    simp only [Unary.toIntrinsic, List.mem_cons, Option.mem_toList,
+      Option.map_eq_some_iff] at hφ
+    rcases hφ with rfl | ⟨φ, hφ, rfl⟩
     · exact Formula.wfIn_mono _ l.defWf hsub hwf
-    · exact Formula.wfIn_mono _ l.typeWf hsub hwf
+    · exact Formula.wfIn_mono _ (l.typeWf φ hφ) hsub hwf
   proof := by
     intro ρ hdeps a hφ
-    simp only [Unary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
+    simp only [Unary.toIntrinsic, List.mem_cons, Option.mem_toList,
+      Option.map_eq_some_iff, Unary.typeAxiom] at hφ
     have hresp : ρ.respects (some b.sym) := by
       have h := hdeps b.toIntrinsic (by simp)
       simpa [Unary.toIntrinsic] using h
-    rcases hφ with rfl | rfl
+    rcases hφ with rfl | ⟨φ, ⟨p, hp, rfl⟩, rfl⟩
     · exact l.defEval ρ hresp
-    · simp only [Unary.typeAxiom, Formula.eval]
+    · simp only [Formula.eval]
       intro x
       have hu : (ρ.updateConst .value "a" x).unary .value .value b.name = b.sym.interp := by
         rw [Env.updateConst_unary]
         simpa [Unary.sym] using hresp
       simp only [Unary.opTerm, Term.eval, UnOp.eval, Env.lookupConst_updateConst_same,
         hu, Unary.sym]
-      exact l.resL.isOf_inject _ _
+      exact l.resL.isOf_inject _ _ p hp
 
 /-! ## Builder for pure binary intrinsics
 
@@ -591,12 +677,13 @@ def Binary.sym (b : Binary) : FOL.Symbol .two where
   name   := b.name
   interp := fun (a, c) => b.res.inject (b.f (b.arg₁.project a) (b.arg₂.project c))
 
-/-- The result-typing axiom, generated from `res`: the op result satisfies the
-    result embedding's `is-of` predicate. -/
-def Binary.typeAxiom (b : Binary) : Formula :=
-  .all "a" .value <| .forall_ "b" .value
-    [.term (b.opTerm (.var .value "a") (.var .value "b"))] <|
-    .unpred b.res.isOf (b.opTerm (.var .value "a") (.var .value "b"))
+/-- The result-typing axiom, generated from `res` when it has a recognizer: the
+    op result satisfies the result embedding's `is-of` predicate. -/
+def Binary.typeAxiom (b : Binary) : Option Formula :=
+  b.res.isOf.map fun p =>
+    .all "a" .value <| .forall_ "b" .value
+      [.term (b.opTerm (.var .value "a") (.var .value "b"))] <|
+      .unpred p (b.opTerm (.var .value "a") (.var .value "b"))
 
 /-- The intrinsic built from `b`: a literal `Intrinsic.mk` so the arity-unfolding
     lemmas (`toReduce_two_of_arity`, `toWp_two_of_arity`) keep firing by `rfl`. -/
@@ -617,7 +704,7 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
           (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())) }
   typing := b.typing
   folSym := some b.sym
-  axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
+  axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
 
 @[simp] theorem Binary.toWp_eq (b : Binary) (a c : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a, c] Q =
@@ -647,20 +734,24 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
     names), and validity of the defining axiom under the standard
     interpretation. -/
 structure Binary.Lawful (b : Binary) where
-  argL₁      : b.arg₁.Lawful
-  argL₂      : b.arg₂.Lawful
-  resL       : b.res.Lawful
-  domSound   : ∀ (ρ : Env) (x : b.arg₁.carrier) (y : b.arg₂.carrier),
+  argL₁        : b.arg₁.Lawful
+  argL₂        : b.arg₂.Lawful
+  resL         : b.res.Lawful
+  domSound     : ∀ (ρ : Env) (x : b.arg₁.carrier) (y : b.arg₂.carrier),
                  (∀ p, b.pre = some p →
                    (p "a" "b").eval ((ρ.updateConst .value "a" (b.arg₁.inject x)).updateConst
                      .value "b" (b.arg₂.inject y))) →
                  b.dom x y
-  specBaseWf : PredTrans.wfIn
+  semWellTyped : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
+                 (Θ : TinyML.TypeEnv) (x : b.arg₁.carrier) (y : b.arg₂.carrier),
+                 b.dom x y →
+                 b.arg₁.typePred σ Θ x ∗ b.arg₂.typePred σ Θ y ⊢ b.res.typePred σ Θ (b.f x y)
+  specBaseWf   : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
-  defWf      : b.defAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
-  typeWf     : b.typeAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
-  defEval    : ∀ ρ : Env, ρ.respects (some b.sym) → Formula.eval ρ b.defAxiom
+  defWf        : b.defAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
+  typeWf       : ∀ φ, b.typeAxiom = some φ → φ.wfIn (Intrinsic.sigOf [b.toIntrinsic])
+  defEval      : ∀ ρ : Env, ρ.respects (some b.sym) → Formula.eval ρ b.defAxiom
 
 /-- The whole `IntrinsicSound` instance for a pure binary intrinsic. -/
 @[reducible] def Binary.Lawful.sound {b : Binary} (l : b.Lawful) :
@@ -717,21 +808,28 @@ structure Binary.Lawful (b : Binary) where
       ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
       icases Hcons2 with ⟨Hv2, _⟩
       ihave Hv1eq := (l.argL₁.member σ Θ v1).1 $$ Hv1
-      ipure Hv1eq
+      icases Hv1eq with ⟨%x, %hw1, Hrel1⟩
+      obtain rfl := hw1
       ihave Hv2eq := (l.argL₂.member σ Θ v2).1 $$ Hv2
-      ipure Hv2eq
-      obtain ⟨x, rfl⟩ := Hv1eq
-      obtain ⟨y, rfl⟩ := Hv2eq
+      icases Hv2eq with ⟨%y, %hw2, Hrel2⟩
+      obtain rfl := hw2
       ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x y := by
         refine l.domSound ρ.env x y fun p hp => ?_
         have h := hpre (p "a" "b") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
+      ihave Hty : iprop(TinyML.ValHasType Θ (b.res.inject (b.f x y))
+          (b.res.typ.subst σ)) $$ [Hrel1 Hrel2]
+      · iapply (l.resL.intro σ Θ (b.f x y))
+        iapply (l.semWellTyped σ Θ x y hdom)
+        isplitl [Hrel1]
+        · iexact Hrel1
+        · iexact Hrel2
       simp only [Binary.toIntrinsic, Intrinsic.toWp_two_of_arity]
       iexists x
       iexists y
-      isplitr [Hpost]
+      isplitr [Hpost Hty]
       · ipureintro; exact ⟨rfl, rfl, hdom⟩
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a") (.var .value "b"))).eval
@@ -749,25 +847,28 @@ structure Binary.Lawful (b : Binary) where
               [b.arg₁.inject x, b.arg₂.inject y]).env.binary
               .value .value .value b.name (b.arg₁.inject x) (b.arg₂.inject y)
           simp [hbin, Binary.sym, l.argL₁.project_inject, l.argL₂.project_inject]
-        refine (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x y)) hassert).trans ?_
-        iintro Hwand
+        refine (sep_mono_left
+          (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x y)) hassert)).trans ?_
+        iintro ⟨Hwand, Hty⟩
         iapply Hwand
-        exact l.resL.intro σ Θ (b.f x y)
+        iexact Hty
   axiomWf := by
     intro Δ hsub hwf a hφ
-    simp only [Binary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
+    simp only [Binary.toIntrinsic, List.mem_cons, Option.mem_toList,
+      Option.map_eq_some_iff] at hφ
+    rcases hφ with rfl | ⟨φ, hφ, rfl⟩
     · exact Formula.wfIn_mono _ l.defWf hsub hwf
-    · exact Formula.wfIn_mono _ l.typeWf hsub hwf
+    · exact Formula.wfIn_mono _ (l.typeWf φ hφ) hsub hwf
   proof := by
     intro ρ hdeps a hφ
-    simp only [Binary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
+    simp only [Binary.toIntrinsic, List.mem_cons, Option.mem_toList,
+      Option.map_eq_some_iff, Binary.typeAxiom] at hφ
     have hresp : ρ.respects (some b.sym) := by
       have h := hdeps b.toIntrinsic (by simp)
       simpa [Binary.toIntrinsic] using h
-    rcases hφ with rfl | rfl
+    rcases hφ with rfl | ⟨φ, ⟨p, hp, rfl⟩, rfl⟩
     · exact l.defEval ρ hresp
-    · simp only [Binary.typeAxiom, Formula.all, Formula.eval]
+    · simp only [Formula.all, Formula.eval]
       intro x y
       have hb : ((ρ.updateConst .value "a" x).updateConst .value "b" y).binary
           .value .value .value b.name = fun a c => b.sym.interp (a, c) := by
@@ -775,7 +876,7 @@ structure Binary.Lawful (b : Binary) where
         simpa [Binary.sym] using hresp
       simp only [Binary.opTerm, Term.eval, BinOp.eval, Env.lookupConst_updateConst_same,
         Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), hb, Binary.sym]
-      exact l.resL.isOf_inject _ _
+      exact l.resL.isOf_inject _ _ p hp
 
 /-! ## Builder for pure ternary intrinsics
 
@@ -813,13 +914,13 @@ def Ternary.sym (b : Ternary) : FOL.Symbol .three where
   interp := fun (a, c, d) =>
     b.res.inject (b.f (b.arg₁.project a) (b.arg₂.project c) (b.arg₃.project d))
 
-/-- The result-typing axiom, generated from `res`: the op result satisfies the
-    result embedding's `is-of` predicate. -/
-def Ternary.typeAxiom (b : Ternary) : Formula :=
-  .all "a" .value <| .all "b" .value <| .forall_ "c" .value
-    [.term (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))] <|
-    .unpred b.res.isOf
-      (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))
+/-- The result-typing axiom, generated from `res` when it has a recognizer: the
+    op result satisfies the result embedding's `is-of` predicate. -/
+def Ternary.typeAxiom (b : Ternary) : Option Formula :=
+  b.res.isOf.map fun p =>
+    .all "a" .value <| .all "b" .value <| .forall_ "c" .value
+      [.term (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))] <|
+      .unpred p (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))
 
 /-- The intrinsic built from `b`: a literal `Intrinsic.mk` so the arity-unfolding
     lemmas (`toReduce_three_of_arity`, `toWp_three_of_arity`) keep firing by `rfl`. -/
@@ -841,7 +942,7 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
           (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())) }
   typing := b.typing
   folSym := some b.sym
-  axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
+  axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
 
 @[simp] theorem Ternary.toWp_eq (b : Ternary) (a c d : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a, c, d] Q =
@@ -868,22 +969,27 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
 
 /-- Proof obligations for a pure ternary intrinsic. -/
 structure Ternary.Lawful (b : Ternary) where
-  argL₁      : b.arg₁.Lawful
-  argL₂      : b.arg₂.Lawful
-  argL₃      : b.arg₃.Lawful
-  resL       : b.res.Lawful
-  domSound   : ∀ (ρ : Env) (x : b.arg₁.carrier) (y : b.arg₂.carrier) (z : b.arg₃.carrier),
+  argL₁        : b.arg₁.Lawful
+  argL₂        : b.arg₂.Lawful
+  argL₃        : b.arg₃.Lawful
+  resL         : b.res.Lawful
+  domSound     : ∀ (ρ : Env) (x : b.arg₁.carrier) (y : b.arg₂.carrier) (z : b.arg₃.carrier),
                  (∀ p, b.pre = some p →
                    (p "a" "b" "c").eval (((ρ.updateConst .value "a"
                      (b.arg₁.inject x)).updateConst .value "b"
                      (b.arg₂.inject y)).updateConst .value "c" (b.arg₃.inject z))) →
                  b.dom x y z
-  specBaseWf : PredTrans.wfIn
+  semWellTyped : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
+                 (Θ : TinyML.TypeEnv) (x : b.arg₁.carrier) (y : b.arg₂.carrier)
+                 (z : b.arg₃.carrier), b.dom x y z →
+                 b.arg₁.typePred σ Θ x ∗ b.arg₂.typePred σ Θ y ∗ b.arg₃.typePred σ Θ z ⊢
+                   b.res.typePred σ Θ (b.f x y z)
+  specBaseWf   : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
-  defWf      : b.defAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
-  typeWf     : b.typeAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
-  defEval    : ∀ ρ : Env, ρ.respects (some b.sym) → Formula.eval ρ b.defAxiom
+  defWf        : b.defAxiom.wfIn (Intrinsic.sigOf [b.toIntrinsic])
+  typeWf       : ∀ φ, b.typeAxiom = some φ → φ.wfIn (Intrinsic.sigOf [b.toIntrinsic])
+  defEval      : ∀ ρ : Env, ρ.respects (some b.sym) → Formula.eval ρ b.defAxiom
 
 /-- The whole `IntrinsicSound` instance for a pure ternary intrinsic. -/
 @[reducible] def Ternary.Lawful.sound {b : Ternary} (l : b.Lawful) :
@@ -948,25 +1054,34 @@ structure Ternary.Lawful (b : Ternary) where
       ihave Hcons3 := (TinyML.ValsHaveTypes.cons Θ v3 [] _ _).1 $$ Hvs3
       icases Hcons3 with ⟨Hv3, _⟩
       ihave Hv1eq := (l.argL₁.member σ Θ v1).1 $$ Hv1
-      ipure Hv1eq
+      icases Hv1eq with ⟨%x, %hw1, Hrel1⟩
+      obtain rfl := hw1
       ihave Hv2eq := (l.argL₂.member σ Θ v2).1 $$ Hv2
-      ipure Hv2eq
+      icases Hv2eq with ⟨%y, %hw2, Hrel2⟩
+      obtain rfl := hw2
       ihave Hv3eq := (l.argL₃.member σ Θ v3).1 $$ Hv3
-      ipure Hv3eq
-      obtain ⟨x, rfl⟩ := Hv1eq
-      obtain ⟨y, rfl⟩ := Hv2eq
-      obtain ⟨z, rfl⟩ := Hv3eq
+      icases Hv3eq with ⟨%z, %hw3, Hrel3⟩
+      obtain rfl := hw3
       ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x y z := by
         refine l.domSound ρ.env x y z fun p hp => ?_
         have h := hpre (p "a" "b" "c") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
+      ihave Hty : iprop(TinyML.ValHasType Θ (b.res.inject (b.f x y z))
+          (b.res.typ.subst σ)) $$ [Hrel1 Hrel2 Hrel3]
+      · iapply (l.resL.intro σ Θ (b.f x y z))
+        iapply (l.semWellTyped σ Θ x y z hdom)
+        isplitl [Hrel1]
+        · iexact Hrel1
+        · isplitl [Hrel2]
+          · iexact Hrel2
+          · iexact Hrel3
       simp only [Ternary.toIntrinsic, Intrinsic.toWp_three_of_arity]
       iexists x
       iexists y
       iexists z
-      isplitr [Hpost]
+      isplitr [Hpost Hty]
       · ipureintro; exact ⟨rfl, rfl, rfl, hdom⟩
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))).eval
@@ -987,25 +1102,28 @@ structure Ternary.Lawful (b : Ternary) where
               (b.arg₁.inject x) (b.arg₂.inject y) (b.arg₃.inject z)
           simp [hter, Ternary.sym, l.argL₁.project_inject, l.argL₂.project_inject,
             l.argL₃.project_inject]
-        refine (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x y z)) hassert).trans ?_
-        iintro Hwand
+        refine (sep_mono_left
+          (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x y z)) hassert)).trans ?_
+        iintro ⟨Hwand, Hty⟩
         iapply Hwand
-        exact l.resL.intro σ Θ (b.f x y z)
+        iexact Hty
   axiomWf := by
     intro Δ hsub hwf a hφ
-    simp only [Ternary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
+    simp only [Ternary.toIntrinsic, List.mem_cons, Option.mem_toList,
+      Option.map_eq_some_iff] at hφ
+    rcases hφ with rfl | ⟨φ, hφ, rfl⟩
     · exact Formula.wfIn_mono _ l.defWf hsub hwf
-    · exact Formula.wfIn_mono _ l.typeWf hsub hwf
+    · exact Formula.wfIn_mono _ (l.typeWf φ hφ) hsub hwf
   proof := by
     intro ρ hdeps a hφ
-    simp only [Ternary.toIntrinsic, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
+    simp only [Ternary.toIntrinsic, List.mem_cons, Option.mem_toList,
+      Option.map_eq_some_iff, Ternary.typeAxiom] at hφ
     have hresp : ρ.respects (some b.sym) := by
       have h := hdeps b.toIntrinsic (by simp)
       simpa [Ternary.toIntrinsic] using h
-    rcases hφ with rfl | rfl
+    rcases hφ with rfl | ⟨φ, ⟨p, hp, rfl⟩, rfl⟩
     · exact l.defEval ρ hresp
-    · simp only [Ternary.typeAxiom, Formula.all, Formula.eval]
+    · simp only [Formula.all, Formula.eval]
       intro x y z
       have ht : (((ρ.updateConst .value "a" x).updateConst .value "b" y).updateConst
             .value "c" z).ternary .value .value .value .value b.name =
@@ -1017,7 +1135,7 @@ structure Ternary.Lawful (b : Ternary) where
         Env.lookupConst_updateConst_ne (show "a" ≠ "c" by decide),
         Env.lookupConst_updateConst_ne (show "b" ≠ "c" by decide),
         ht, Ternary.sym]
-      exact l.resL.isOf_inject _ _
+      exact l.resL.isOf_inject _ _ p hp
 
 end Pure
 
@@ -1032,7 +1150,8 @@ macro_rules
     Env.lookupConst_updateConst_same, Pure.Zero.sym, Pure.Unary.sym, Pure.Binary.sym,
     Pure.Ternary.sym,
     Embedding.int, Embedding.bool, Embedding.char, Embedding.str, Embedding.float,
-     Const.denote, valInt, valBool, valChar, valStr, valFloat, $xs,*]))
+    Embedding.poly, Embedding.vec,
+     Const.denote, valInt, valBool, valChar, valStr, valFloat, valVec, $xs,*]))
 
 end Intrinsics
 end Stdlib

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -142,10 +142,7 @@ def Embedding.str  : Embedding := ⟨.string, List UInt8, .str,  valStr,  .isStr
 def Embedding.float : Embedding := ⟨.float, UInt64, .float, valFloat, .isFloat⟩
 
 /-- Coherence laws for an `Embedding`. The `member`/`intro` laws are stated at
-    every instantiation `e.typ.subst σ` of the embedding's type. For a concrete
-    embedding the type is closed, so the substitution reduces away; stating the
-    laws through `σ` lets the combinator soundness proofs face the *instantiated*
-    spec directly, without a closedness detour. -/
+    every instantiation `e.typ.subst σ` of the embedding's type. -/
 structure Embedding.Lawful (e : Embedding) where
   project_inject : ∀ x, e.project (e.inject x) = x
   isOf_wf        : ∀ Δ, e.isOf.wfIn Δ
@@ -230,6 +227,7 @@ structure Zero where
   path     : Option (String × List String)
   res      : Embedding
   f        : res.carrier
+  typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
 /-- The intrinsic's uninterpreted constant symbol as a value term. -/
@@ -257,7 +255,7 @@ def Zero.toIntrinsic (b : Zero) : Intrinsic where
       retTy := b.res.typ
       pred  := .ret ("ret",
         .assert (.eq .value (.var .value "ret") b.opTerm) (.ret ())) }
-  typing := monoTyping .zero
+  typing := b.typing
   folSym := some b.sym
   axioms := [⟨b.defAxiom, .low⟩, ⟨b.typeAxiom, .low⟩]
 
@@ -358,6 +356,7 @@ structure Unary where
   arg      : Embedding
   res      : Embedding
   f        : arg.carrier → res.carrier
+  typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
 /-- The intrinsic's uninterpreted unary symbol applied to a value term. -/
@@ -387,7 +386,7 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
       pred  := .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a"))) (.ret ())) }
-  typing := monoTyping .one
+  typing := b.typing
   folSym := some b.sym
   axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
 
@@ -516,9 +515,11 @@ built (`toIntrinsic`). The proof obligations live in `Pure.Binary.Lawful`. -/
 structure Binary where
   name     : String
   path     : Option (String × List String)
-  arg      : Embedding
+  arg₁     : Embedding
+  arg₂     : Embedding
   res      : Embedding
-  f        : arg.carrier → arg.carrier → res.carrier
+  f        : arg₁.carrier → arg₂.carrier → res.carrier
+  typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
 /-- The intrinsic's uninterpreted binary symbol applied to two value terms. -/
@@ -529,7 +530,7 @@ def Binary.opTerm (b : Binary) (x y : Term .value) : Term .value :=
     `f`, and injects the result. -/
 def Binary.sym (b : Binary) : FOL.Symbol .two where
   name   := b.name
-  interp := fun (a, c) => b.res.inject (b.f (b.arg.project a) (b.arg.project c))
+  interp := fun (a, c) => b.res.inject (b.f (b.arg₁.project a) (b.arg₂.project c))
 
 /-- The result-typing axiom, generated from `res`: the op result satisfies the
     result embedding's `is-of` predicate. -/
@@ -545,30 +546,30 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
   name   := b.name
   path   := b.path
   reduce := Reduce.pure fun (a, c) v =>
-    ∃ x y, a = b.arg.inject x ∧ c = b.arg.inject y ∧ v = b.res.inject (b.f x y)
+    ∃ x y, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ v = b.res.inject (b.f x y)
   wp     := fun (a, c) Q =>
-    iprop(∃ x y, ⌜a = b.arg.inject x ∧ c = b.arg.inject y⌝ ∗ Q (b.res.inject (b.f x y)))
+    iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y⌝ ∗ Q (b.res.inject (b.f x y)))
   spec   :=
-    { args  := [("a", b.arg.typ), ("b", b.arg.typ)]
+    { args  := [("a", b.arg₁.typ), ("b", b.arg₂.typ)]
       retTy := b.res.typ
       pred  := .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())) }
-  typing := monoTyping .two
+  typing := b.typing
   folSym := some b.sym
   axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
 
 @[simp] theorem Binary.toWp_eq (b : Binary) (a c : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a, c] Q =
-      iprop(∃ x y, ⌜a = b.arg.inject x ∧ c = b.arg.inject y⌝ ∗ Q (b.res.inject (b.f x y))) := rfl
+      iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y⌝ ∗ Q (b.res.inject (b.f x y))) := rfl
 
 @[simp] theorem Binary.toReduce_eq (b : Binary) (a c v : Runtime.Val) (μ μ' : TinyML.Heap) :
     b.toIntrinsic.toReduce [a, c] μ v μ' =
-      ((∃ x y, a = b.arg.inject x ∧ c = b.arg.inject y ∧ v = b.res.inject (b.f x y)) ∧ μ' = μ) := rfl
+      ((∃ x y, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ v = b.res.inject (b.f x y)) ∧ μ' = μ) := rfl
 
 @[simp] theorem Binary.instantiate_args (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
     (b.toIntrinsic.spec.instantiate σ).args
-      = [("a", b.arg.typ.subst σ), ("b", b.arg.typ.subst σ)] := rfl
+      = [("a", b.arg₁.typ.subst σ), ("b", b.arg₂.typ.subst σ)] := rfl
 
 @[simp] theorem Binary.instantiate_retTy (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
     (b.toIntrinsic.spec.instantiate σ).retTy = b.res.typ.subst σ := rfl
@@ -578,7 +579,8 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
     names), and validity of the defining axiom under the standard
     interpretation. -/
 structure Binary.Lawful (b : Binary) where
-  argL       : b.arg.Lawful
+  argL₁      : b.arg₁.Lawful
+  argL₂      : b.arg₂.Lawful
   resL       : b.res.Lawful
   specBaseWf : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
@@ -599,7 +601,7 @@ structure Binary.Lawful (b : Binary) where
     | _ :: _ :: _ :: _ => exact false_elim
     | [a, c] =>
       have hred : ∀ x y μ v μ',
-          ctx b.toIntrinsic.name [b.arg.inject x, b.arg.inject y] μ v μ'
+          ctx b.toIntrinsic.name [b.arg₁.inject x, b.arg₂.inject y] μ v μ'
             ↔ v = b.res.inject (b.f x y) ∧ μ' = μ := by
         intro x y μ v μ'
         rw [hctx]
@@ -607,16 +609,16 @@ structure Binary.Lawful (b : Binary) where
         constructor
         · rintro ⟨⟨x', y', hx, hy, hv⟩, hμ⟩
           have hxx : x = x' := by
-            have := congrArg b.arg.project hx
-            rwa [l.argL.project_inject, l.argL.project_inject] at this
+            have := congrArg b.arg₁.project hx
+            rwa [l.argL₁.project_inject, l.argL₁.project_inject] at this
           have hyy : y = y' := by
-            have := congrArg b.arg.project hy
-            rwa [l.argL.project_inject, l.argL.project_inject] at this
+            have := congrArg b.arg₂.project hy
+            rwa [l.argL₂.project_inject, l.argL₂.project_inject] at this
           subst hxx; subst hyy
           exact ⟨hv, hμ⟩
         · rintro ⟨hv, hμ⟩
           exact ⟨⟨x, y, rfl, rfl, hv⟩, hμ⟩
-      show iprop(∃ x y, ⌜a = b.arg.inject x ∧ c = b.arg.inject y⌝ ∗ Φ (b.res.inject (b.f x y))) ⊢ _
+      show iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y⌝ ∗ Φ (b.res.inject (b.f x y))) ⊢ _
       istart
       iintro ⟨%x, %y, %hab, HΦ⟩
       obtain ⟨rfl, rfl⟩ := hab
@@ -628,7 +630,7 @@ structure Binary.Lawful (b : Binary) where
     intro _ σ Θ vs ρ Φ hρ
     simp only [Binary.instantiate_args, Binary.instantiate_retTy,
       Spec.instantiate_pred, List.map_cons, List.map_nil]
-    show TinyML.ValsHaveTypes Θ vs [b.arg.typ.subst σ, b.arg.typ.subst σ] ∗ _ ⊢ _
+    show TinyML.ValsHaveTypes Θ vs [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ] ∗ _ ⊢ _
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -640,9 +642,9 @@ structure Binary.Lawful (b : Binary) where
       icases Hcons with ⟨Hv1, Hvs2⟩
       ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
       icases Hcons2 with ⟨Hv2, _⟩
-      ihave Hv1eq := (l.argL.member σ Θ v1).1 $$ Hv1
+      ihave Hv1eq := (l.argL₁.member σ Θ v1).1 $$ Hv1
       ipure Hv1eq
-      ihave Hv2eq := (l.argL.member σ Θ v2).1 $$ Hv2
+      ihave Hv2eq := (l.argL₂.member σ Θ v2).1 $$ Hv2
       ipure Hv2eq
       obtain ⟨x, rfl⟩ := Hv1eq
       obtain ⟨y, rfl⟩ := Hv2eq
@@ -654,19 +656,19 @@ structure Binary.Lawful (b : Binary) where
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a") (.var .value "b"))).eval
             ((Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg.inject x, b.arg.inject y]).updateConst
+              [b.arg₁.inject x, b.arg₂.inject y]).updateConst
               .value "ret" (b.res.inject (b.f x y))).env := by
           have hargs := respects_argsEnv_two b.toIntrinsic.specArgs
-            [b.arg.inject x, b.arg.inject y] hρ
+            [b.arg₁.inject x, b.arg₂.inject y] hρ
           have hbin : (Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg.inject x, b.arg.inject y]).env.binary .value .value .value b.name
+              [b.arg₁.inject x, b.arg₂.inject y]).env.binary .value .value .value b.name
               = fun a c => b.sym.interp (a, c) := by
             simpa [Env.respects, Binary.sym] using hargs
           show b.res.inject (b.f x y) =
             (Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg.inject x, b.arg.inject y]).env.binary
-              .value .value .value b.name (b.arg.inject x) (b.arg.inject y)
-          simp [hbin, Binary.sym, l.argL.project_inject]
+              [b.arg₁.inject x, b.arg₂.inject y]).env.binary
+              .value .value .value b.name (b.arg₁.inject x) (b.arg₂.inject y)
+          simp [hbin, Binary.sym, l.argL₁.project_inject, l.argL₂.project_inject]
         refine (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x y)) hassert).trans ?_
         iintro Hwand
         iapply Hwand
@@ -706,9 +708,12 @@ built (`toIntrinsic`). The proof obligations live in `Pure.Ternary.Lawful`. -/
 structure Ternary where
   name     : String
   path     : Option (String × List String)
-  arg      : Embedding
+  arg₁     : Embedding
+  arg₂     : Embedding
+  arg₃     : Embedding
   res      : Embedding
-  f        : arg.carrier → arg.carrier → arg.carrier → res.carrier
+  f        : arg₁.carrier → arg₂.carrier → arg₃.carrier → res.carrier
+  typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
 /-- The intrinsic's uninterpreted ternary symbol applied to three value terms. -/
@@ -720,7 +725,7 @@ def Ternary.opTerm (b : Ternary) (x y z : Term .value) : Term .value :=
 def Ternary.sym (b : Ternary) : FOL.Symbol .three where
   name   := b.name
   interp := fun (a, c, d) =>
-    b.res.inject (b.f (b.arg.project a) (b.arg.project c) (b.arg.project d))
+    b.res.inject (b.f (b.arg₁.project a) (b.arg₂.project c) (b.arg₃.project d))
 
 /-- The result-typing axiom, generated from `res`: the op result satisfies the
     result embedding's `is-of` predicate. -/
@@ -737,41 +742,43 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
   name   := b.name
   path   := b.path
   reduce := Reduce.pure fun (a, c, d) v =>
-    ∃ x y z, a = b.arg.inject x ∧ c = b.arg.inject y ∧ d = b.arg.inject z ∧
+    ∃ x y z, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z ∧
       v = b.res.inject (b.f x y z)
   wp     := fun (a, c, d) Q =>
-    iprop(∃ x y z, ⌜a = b.arg.inject x ∧ c = b.arg.inject y ∧ d = b.arg.inject z⌝ ∗
+    iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z⌝ ∗
       Q (b.res.inject (b.f x y z)))
   spec   :=
-    { args  := [("a", b.arg.typ), ("b", b.arg.typ), ("c", b.arg.typ)]
+    { args  := [("a", b.arg₁.typ), ("b", b.arg₂.typ), ("c", b.arg₃.typ)]
       retTy := b.res.typ
       pred  := .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())) }
-  typing := monoTyping .three
+  typing := b.typing
   folSym := some b.sym
   axioms := [⟨b.defAxiom, .high⟩, ⟨b.typeAxiom, .high⟩]
 
 @[simp] theorem Ternary.toWp_eq (b : Ternary) (a c d : Runtime.Val) (Q : Runtime.Val → iProp) :
     b.toIntrinsic.toWp [a, c, d] Q =
-      iprop(∃ x y z, ⌜a = b.arg.inject x ∧ c = b.arg.inject y ∧ d = b.arg.inject z⌝ ∗
+      iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z⌝ ∗
         Q (b.res.inject (b.f x y z))) := rfl
 
 @[simp] theorem Ternary.toReduce_eq (b : Ternary) (a c d v : Runtime.Val) (μ μ' : TinyML.Heap) :
     b.toIntrinsic.toReduce [a, c, d] μ v μ' =
-      ((∃ x y z, a = b.arg.inject x ∧ c = b.arg.inject y ∧ d = b.arg.inject z ∧
+      ((∃ x y z, a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z ∧
         v = b.res.inject (b.f x y z)) ∧ μ' = μ) := rfl
 
 @[simp] theorem Ternary.instantiate_args (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
     (b.toIntrinsic.spec.instantiate σ).args
-      = [("a", b.arg.typ.subst σ), ("b", b.arg.typ.subst σ), ("c", b.arg.typ.subst σ)] := rfl
+      = [("a", b.arg₁.typ.subst σ), ("b", b.arg₂.typ.subst σ), ("c", b.arg₃.typ.subst σ)] := rfl
 
 @[simp] theorem Ternary.instantiate_retTy (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
     (b.toIntrinsic.spec.instantiate σ).retTy = b.res.typ.subst σ := rfl
 
 /-- Proof obligations for a pure ternary intrinsic. -/
 structure Ternary.Lawful (b : Ternary) where
-  argL       : b.arg.Lawful
+  argL₁      : b.arg₁.Lawful
+  argL₂      : b.arg₂.Lawful
+  argL₃      : b.arg₃.Lawful
   resL       : b.res.Lawful
   specBaseWf : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
@@ -793,7 +800,7 @@ structure Ternary.Lawful (b : Ternary) where
     | _ :: _ :: _ :: _ :: _ => exact false_elim
     | [a, c, d] =>
       have hred : ∀ x y z μ v μ',
-          ctx b.toIntrinsic.name [b.arg.inject x, b.arg.inject y, b.arg.inject z] μ v μ'
+          ctx b.toIntrinsic.name [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z] μ v μ'
             ↔ v = b.res.inject (b.f x y z) ∧ μ' = μ := by
         intro x y z μ v μ'
         rw [hctx]
@@ -801,19 +808,19 @@ structure Ternary.Lawful (b : Ternary) where
         constructor
         · rintro ⟨⟨x', y', z', hx, hy, hz, hv⟩, hμ⟩
           have hxx : x = x' := by
-            have := congrArg b.arg.project hx
-            rwa [l.argL.project_inject, l.argL.project_inject] at this
+            have := congrArg b.arg₁.project hx
+            rwa [l.argL₁.project_inject, l.argL₁.project_inject] at this
           have hyy : y = y' := by
-            have := congrArg b.arg.project hy
-            rwa [l.argL.project_inject, l.argL.project_inject] at this
+            have := congrArg b.arg₂.project hy
+            rwa [l.argL₂.project_inject, l.argL₂.project_inject] at this
           have hzz : z = z' := by
-            have := congrArg b.arg.project hz
-            rwa [l.argL.project_inject, l.argL.project_inject] at this
+            have := congrArg b.arg₃.project hz
+            rwa [l.argL₃.project_inject, l.argL₃.project_inject] at this
           subst hxx; subst hyy; subst hzz
           exact ⟨hv, hμ⟩
         · rintro ⟨hv, hμ⟩
           exact ⟨⟨x, y, z, rfl, rfl, rfl, hv⟩, hμ⟩
-      show iprop(∃ x y z, ⌜a = b.arg.inject x ∧ c = b.arg.inject y ∧ d = b.arg.inject z⌝ ∗
+      show iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z⌝ ∗
         Φ (b.res.inject (b.f x y z))) ⊢ _
       istart
       iintro ⟨%x, %y, %z, %habc, HΦ⟩
@@ -827,7 +834,7 @@ structure Ternary.Lawful (b : Ternary) where
     simp only [Ternary.instantiate_args, Ternary.instantiate_retTy,
       Spec.instantiate_pred, List.map_cons, List.map_nil]
     show TinyML.ValsHaveTypes Θ vs
-      [b.arg.typ.subst σ, b.arg.typ.subst σ, b.arg.typ.subst σ] ∗ _ ⊢ _
+      [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ, b.arg₃.typ.subst σ] ∗ _ ⊢ _
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -842,11 +849,11 @@ structure Ternary.Lawful (b : Ternary) where
       icases Hcons2 with ⟨Hv2, Hvs3⟩
       ihave Hcons3 := (TinyML.ValsHaveTypes.cons Θ v3 [] _ _).1 $$ Hvs3
       icases Hcons3 with ⟨Hv3, _⟩
-      ihave Hv1eq := (l.argL.member σ Θ v1).1 $$ Hv1
+      ihave Hv1eq := (l.argL₁.member σ Θ v1).1 $$ Hv1
       ipure Hv1eq
-      ihave Hv2eq := (l.argL.member σ Θ v2).1 $$ Hv2
+      ihave Hv2eq := (l.argL₂.member σ Θ v2).1 $$ Hv2
       ipure Hv2eq
-      ihave Hv3eq := (l.argL.member σ Θ v3).1 $$ Hv3
+      ihave Hv3eq := (l.argL₃.member σ Θ v3).1 $$ Hv3
       ipure Hv3eq
       obtain ⟨x, rfl⟩ := Hv1eq
       obtain ⟨y, rfl⟩ := Hv2eq
@@ -860,21 +867,22 @@ structure Ternary.Lawful (b : Ternary) where
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))).eval
             ((Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg.inject x, b.arg.inject y, b.arg.inject z]).updateConst
+              [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z]).updateConst
               .value "ret" (b.res.inject (b.f x y z))).env := by
           have hargs := respects_argsEnv_three b.toIntrinsic.specArgs
-            [b.arg.inject x, b.arg.inject y, b.arg.inject z] hρ
+            [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z] hρ
           have hter : (Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg.inject x, b.arg.inject y, b.arg.inject z]).env.ternary
+              [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z]).env.ternary
               .value .value .value .value b.name
               = fun a c d => b.sym.interp (a, c, d) := by
             simpa [Env.respects, Ternary.sym] using hargs
           show b.res.inject (b.f x y z) =
             (Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg.inject x, b.arg.inject y, b.arg.inject z]).env.ternary
+              [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z]).env.ternary
               .value .value .value .value b.name
-              (b.arg.inject x) (b.arg.inject y) (b.arg.inject z)
-          simp [hter, Ternary.sym, l.argL.project_inject]
+              (b.arg₁.inject x) (b.arg₂.inject y) (b.arg₃.inject z)
+          simp [hter, Ternary.sym, l.argL₁.project_inject, l.argL₂.project_inject,
+            l.argL₃.project_inject]
         refine (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x y z)) hassert).trans ?_
         iintro Hwand
         iapply Hwand

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -1,4 +1,4 @@
--- SUMMARY: Embeddings (with semantic type predicates for polymorphic types) and the pure-intrinsic builders (`Pure.Zero`/`Pure.Unary`/`Pure.Binary`/`Pure.Ternary`) that emit an intrinsic — optional precondition, generated type axiom — and its soundness instance.
+-- SUMMARY: Embeddings and the pure-intrinsic builders (`Pure.Zero`/`Pure.Unary`/`Pure.Binary`/`Pure.Ternary`) that emit an intrinsic and its soundness instance.
 import Mica.Verifier.Intrinsic
 import Mica.TinyML.Printer
 

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -1,5 +1,6 @@
 -- SUMMARY: Embeddings (with semantic type predicates for polymorphic types) and the pure-intrinsic builders (`Pure.Zero`/`Pure.Unary`/`Pure.Binary`/`Pure.Ternary`) that emit an intrinsic — optional precondition, generated type axiom — and its soundness instance.
 import Mica.Verifier.Intrinsic
+import Mica.TinyML.Printer
 
 open Iris Iris.BI
 
@@ -183,18 +184,19 @@ def Embedding.str  : Embedding :=
 def Embedding.float : Embedding :=
   ⟨.float, UInt64, .float, valFloat, fun _ _ _ => iprop(emp), some .isFloat⟩
 
-/-- A type variable `'a`: any runtime value, with its typing at the
+/-- A type variable: any runtime value, with its typing at the
     instantiated type as the type predicate. No `is-of` recognizer, so no
     type axiom. -/
-def Embedding.poly : Embedding :=
-  ⟨.tvar "a", Runtime.Val, id, id,
-    fun σ Θ v => TinyML.ValHasType Θ v (σ "a"), none⟩
+def Embedding.poly (v : TinyML.TyVar) : Embedding :=
+  ⟨.tvar v, Runtime.Val, id, id,
+    fun σ Θ w => TinyML.ValHasType Θ w (σ v), none⟩
 
-/-- Vectors `'a vec`: element lists, with the big-sep of element typings at
-    the instantiated element type as the type predicate. -/
-def Embedding.vec : Embedding :=
-  ⟨.vec (.tvar "a"), List Runtime.Val, .vec, valVec,
-    fun σ Θ l => iprop([∗list] w ∈ l, TinyML.ValHasType Θ w (σ "a")), some .isVec⟩
+/-- Vectors of an arbitrary element scheme: element lists, with the big-sep of
+    instantiated element typings as the type predicate. -/
+def Embedding.vec (elem : TinyML.Typ) : Embedding :=
+  ⟨.vec elem, List Runtime.Val, .vec, valVec,
+    fun σ Θ l => iprop([∗list] w ∈ l, TinyML.ValHasType Θ w (elem.subst σ)),
+    some .isVec⟩
 
 /-- Coherence laws for an `Embedding`. The `member`/`intro` laws are stated at
     every instantiation `e.typ.subst σ` of the embedding's type. -/
@@ -263,7 +265,7 @@ def Embedding.lawfulFloat : Embedding.float.Lawful where
   intro _ Θ x := by simpa [Embedding.float, TinyML.Typ.subst] using TinyML.ValHasType.float_intro Θ x
 
 /-- Type variables are a lawful embedding: the type predicate is the typing fact itself. -/
-def Embedding.lawfulPoly : Embedding.poly.Lawful where
+def Embedding.lawfulPoly (v : TinyML.TyVar) : (Embedding.poly v).Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := nomatch h
   isOf_inject _ _ _ h := nomatch h
@@ -283,14 +285,63 @@ def Embedding.lawfulPoly : Embedding.poly.Lawful where
     exact .rfl
 
 /-- Vectors are a lawful embedding: exactly the `ValHasType.vec` API. -/
-def Embedding.lawfulVec : Embedding.vec.Lawful where
+def Embedding.lawfulVec (elem : TinyML.Typ) : (Embedding.vec elem).Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := by cases h; trivial
   isOf_inject _ _ _ h := by cases h; simp [Embedding.vec]
   member σ Θ w := by
-    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec Θ w (σ "a")
+    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec Θ w (elem.subst σ)
   intro σ Θ l := by
-    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec_intro Θ l (σ "a")
+    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec_intro Θ l (elem.subst σ)
+
+/-! ## Scheme matching -/
+
+/-- Render a list of types for intrinsic-instantiation diagnostics. -/
+private def printTypes (tys : List TinyML.Typ) : String :=
+  s!"[{", ".intercalate (tys.map TinyML.Typ.print)}]"
+
+/-- Match type variables occurring in a scheme type against an inferred type.
+    A variable is fixed by its first occurrence; later occurrences are checked
+    by the elaborator against the instantiated scheme, including subtyping. -/
+def matchType (inst : List (TinyML.TyVar × TinyML.Typ))
+    (pattern actual : TinyML.Typ) : Except String (List (TinyML.TyVar × TinyML.Typ)) :=
+  if pattern.closed then .ok inst
+  else
+    match pattern, actual with
+    | .tvar v, t => .ok (if inst.lookup v |>.isSome then inst else (v, t) :: inst)
+    | .sum ps, .sum ts => matchTypes inst ps ts
+    | .arrow p₁ p₂, .arrow t₁ t₂ => do
+        let inst ← matchType inst p₁ t₁
+        matchType inst p₂ t₂
+    | .ref p, .ref t | .array p, .array t | .vec p, .vec t | .owned p, .owned t =>
+        matchType inst p t
+    | .tuple ps, .tuple ts => matchTypes inst ps ts
+    | .named P ps, .named T ts =>
+        if P = T then matchTypes inst ps ts
+        else .error s!"expected {pattern.print}, got {actual.print}"
+    | _, _ => .error s!"expected {pattern.print}, got {actual.print}"
+where
+  matchTypes (inst : List (TinyML.TyVar × TinyML.Typ)) :
+      List TinyML.Typ → List TinyML.Typ →
+        Except String (List (TinyML.TyVar × TinyML.Typ))
+    | [], [] => .ok inst
+    | p :: ps, t :: ts => do
+        let inst ← matchType inst p t
+        matchTypes inst ps ts
+    | ps, ts => .error s!"expected type arguments {printTypes ps}, got {printTypes ts}"
+
+/-- Derive a primitive instantiation by structurally matching its argument
+    scheme against the inferred argument types. Arity and the instantiated
+    domains are rechecked by the elaborator. -/
+def schemeTyping (patterns : List TinyML.Typ) :
+    TinyML.TypeEnv → List TinyML.Typ →
+      Except String (List (TinyML.TyVar × TinyML.Typ)) :=
+  fun _ actuals =>
+    if patterns.length = actuals.length then
+      matchType.matchTypes [] patterns actuals
+    else
+      .error s!"expected {patterns.length} arguments {printTypes patterns}, got \
+        {actuals.length} arguments {printTypes actuals}"
 
 /-! ## Name-based term builders -/
 
@@ -325,7 +376,6 @@ structure Zero where
   path     : Option (String × List String)
   res      : Embedding
   f        : res.carrier
-  typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
 /-- The intrinsic's uninterpreted constant symbol as a value term. -/
@@ -353,7 +403,7 @@ def Zero.toIntrinsic (b : Zero) : Intrinsic where
       retTy := b.res.typ
       pred  := .ret ("ret",
         .assert (.eq .value (.var .value "ret") b.opTerm) (.ret ())) }
-  typing := b.typing
+  typing := schemeTyping []
   folSym := some b.sym
   axioms := ⟨b.defAxiom, .low⟩ :: (b.typeAxiom.map (⟨·, .low⟩)).toList
 
@@ -463,7 +513,6 @@ structure Unary where
   f        : arg.carrier → res.carrier
   dom      : arg.carrier → Prop
   pre      : Option (String → Formula)
-  typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
 /-- The intrinsic's uninterpreted unary symbol applied to a value term. -/
@@ -495,7 +544,7 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
       pred  := withPre (b.pre.map (· "a")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a"))) (.ret ())) }
-  typing := b.typing
+  typing := schemeTyping [b.arg.typ]
   folSym := some b.sym
   axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
 
@@ -664,7 +713,6 @@ structure Binary where
   f        : arg₁.carrier → arg₂.carrier → res.carrier
   dom      : arg₁.carrier → arg₂.carrier → Prop
   pre      : Option (String → String → Formula)
-  typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
 /-- The intrinsic's uninterpreted binary symbol applied to two value terms. -/
@@ -702,7 +750,7 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
       pred  := withPre (b.pre.map (· "a" "b")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())) }
-  typing := b.typing
+  typing := schemeTyping [b.arg₁.typ, b.arg₂.typ]
   folSym := some b.sym
   axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
 
@@ -900,7 +948,6 @@ structure Ternary where
   f        : arg₁.carrier → arg₂.carrier → arg₃.carrier → res.carrier
   dom      : arg₁.carrier → arg₂.carrier → arg₃.carrier → Prop
   pre      : Option (String → String → String → Formula)
-  typing   : TinyML.TypeEnv → List TinyML.Typ → Except String (List (TinyML.TyVar × TinyML.Typ))
   defAxiom : Formula
 
 /-- The intrinsic's uninterpreted ternary symbol applied to three value terms. -/
@@ -940,7 +987,7 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
       pred  := withPre (b.pre.map (· "a" "b" "c")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())) }
-  typing := b.typing
+  typing := schemeTyping [b.arg₁.typ, b.arg₂.typ, b.arg₃.typ]
   folSym := some b.sym
   axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
 

--- a/Mica/Stdlib/FloatStd.lean
+++ b/Mica/Stdlib/FloatStd.lean
@@ -117,7 +117,6 @@ def floatAbsB : Pure.Unary where
   f        := FloatBits.abs
   dom      := fun _ => True
   pre      := none
-  typing   := monoTyping .one
   defAxiom := floatAbsDefAxiom
 
 def floatAbs : Intrinsic := floatAbsB.toIntrinsic
@@ -150,7 +149,6 @@ def floatNegB : Pure.Unary where
   f        := FloatBits.neg
   dom      := fun _ => True
   pre      := none
-  typing   := monoTyping .one
   defAxiom := floatNegDefAxiom
 
 def floatNeg : Intrinsic := floatNegB.toIntrinsic
@@ -183,7 +181,6 @@ def floatSqrtB : Pure.Unary where
   f        := FloatBits.sqrt
   dom      := fun _ => True
   pre      := none
-  typing   := monoTyping .one
   defAxiom := floatSqrtDefAxiom
 
 def floatSqrt : Intrinsic := floatSqrtB.toIntrinsic
@@ -216,7 +213,6 @@ def floatIsNanB : Pure.Unary where
   f        := FloatBits.isNaN
   dom      := fun _ => True
   pre      := none
-  typing   := monoTyping .one
   defAxiom := floatIsNanDefAxiom
 
 def floatIsNan : Intrinsic := floatIsNanB.toIntrinsic
@@ -253,7 +249,6 @@ def floatIsFiniteB : Pure.Unary where
   f        := FloatBits.isFinite
   dom      := fun _ => True
   pre      := none
-  typing   := monoTyping .one
   defAxiom := floatIsFiniteDefAxiom
 
 def floatIsFinite : Intrinsic := floatIsFiniteB.toIntrinsic
@@ -286,7 +281,6 @@ def floatOfIntB : Pure.Unary where
   f        := FloatBits.ofInt
   dom      := fun _ => True
   pre      := none
-  typing   := monoTyping .one
   defAxiom := floatOfIntDefAxiom
 
 def floatOfInt : Intrinsic := floatOfIntB.toIntrinsic
@@ -321,7 +315,6 @@ def floatAddB : Pure.Binary where
   f        := FloatBits.add
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatAddSym .fpAdd
 
 def floatAdd : Intrinsic := floatAddB.toIntrinsic
@@ -351,7 +344,6 @@ def floatSubB : Pure.Binary where
   f        := FloatBits.sub
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatSubSym .fpSub
 
 def floatSub : Intrinsic := floatSubB.toIntrinsic
@@ -381,7 +373,6 @@ def floatMulB : Pure.Binary where
   f        := FloatBits.mul
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatMulSym .fpMul
 
 def floatMul : Intrinsic := floatMulB.toIntrinsic
@@ -411,7 +402,6 @@ def floatDivB : Pure.Binary where
   f        := FloatBits.div
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatDivSym .fpDiv
 
 def floatDiv : Intrinsic := floatDivB.toIntrinsic
@@ -454,7 +444,6 @@ def floatMinB : Pure.Binary where
   f        := FloatBits.min
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := floatMinDefAxiom
 
 def floatMin : Intrinsic := floatMinB.toIntrinsic
@@ -497,7 +486,6 @@ def floatMaxB : Pure.Binary where
   f        := FloatBits.max
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := floatMaxDefAxiom
 
 def floatMax : Intrinsic := floatMaxB.toIntrinsic
@@ -533,7 +521,6 @@ def floatEqualB : Pure.Binary where
   f        := FloatBits.eq
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatEqualSym .fpEq
 
 def floatEqual : Intrinsic := floatEqualB.toIntrinsic
@@ -563,7 +550,6 @@ def floatLtB : Pure.Binary where
   f        := FloatBits.lt
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatLtSym .fpLt
 
 def floatLt : Intrinsic := floatLtB.toIntrinsic
@@ -593,7 +579,6 @@ def floatLeB : Pure.Binary where
   f        := FloatBits.le
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatLeSym .fpLe
 
 def floatLe : Intrinsic := floatLeB.toIntrinsic
@@ -624,7 +609,6 @@ def floatNanB : Pure.Zero where
   path     := some ("Float", ["nan"])
   res      := .float
   f        := FloatBits.nan
-  typing   := monoTyping .zero
   defAxiom := zeroFloatDefAxiom floatNanSym .fpNaN
 
 def floatNan : Intrinsic := floatNanB.toIntrinsic
@@ -648,7 +632,6 @@ def floatInfinityB : Pure.Zero where
   path     := some ("Float", ["infinity"])
   res      := .float
   f        := FloatBits.posInf
-  typing   := monoTyping .zero
   defAxiom := zeroFloatDefAxiom floatInfinitySym .fpPosInf
 
 def floatInfinity : Intrinsic := floatInfinityB.toIntrinsic
@@ -672,7 +655,6 @@ def floatNegInfinityB : Pure.Zero where
   path     := some ("Float", ["neg_infinity"])
   res      := .float
   f        := FloatBits.negInf
-  typing   := monoTyping .zero
   defAxiom := zeroFloatDefAxiom floatNegInfinitySym .fpNegInf
 
 def floatNegInfinity : Intrinsic := floatNegInfinityB.toIntrinsic

--- a/Mica/Stdlib/FloatStd.lean
+++ b/Mica/Stdlib/FloatStd.lean
@@ -126,13 +126,14 @@ def floatAbs : Intrinsic := floatAbsB.toIntrinsic
 @[simp] theorem floatAbs_arity : floatAbs.arity = .one := rfl
 
 def floatAbsLawful : floatAbsB.Lawful where
-  argL       := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [unTerm, floatAbsB, floatAbsDefAxiom]; intros; rfl
+  argL         := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [unTerm, floatAbsB, floatAbsDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatAbs] floatAbs := floatAbsLawful.sound
 
@@ -158,13 +159,14 @@ def floatNeg : Intrinsic := floatNegB.toIntrinsic
 @[simp] theorem floatNeg_arity : floatNeg.arity = .one := rfl
 
 def floatNegLawful : floatNegB.Lawful where
-  argL       := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [unTerm, floatNegB, floatNegDefAxiom]; intros; rfl
+  argL         := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [unTerm, floatNegB, floatNegDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatNeg] floatNeg := floatNegLawful.sound
 
@@ -190,13 +192,14 @@ def floatSqrt : Intrinsic := floatSqrtB.toIntrinsic
 @[simp] theorem floatSqrt_arity : floatSqrt.arity = .one := rfl
 
 def floatSqrtLawful : floatSqrtB.Lawful where
-  argL       := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [unTerm, floatSqrtB, floatSqrtDefAxiom]; intros; rfl
+  argL         := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [unTerm, floatSqrtB, floatSqrtDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatSqrt] floatSqrt := floatSqrtLawful.sound
 
@@ -222,13 +225,14 @@ def floatIsNan : Intrinsic := floatIsNanB.toIntrinsic
 @[simp] theorem floatIsNan_arity : floatIsNan.arity = .one := rfl
 
 def floatIsNanLawful : floatIsNanB.Lawful where
-  argL       := Embedding.lawfulFloat
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [unTerm, floatIsNanB, floatIsNanDefAxiom]; intros; rfl
+  argL         := Embedding.lawfulFloat
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [unTerm, floatIsNanB, floatIsNanDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatIsNan] floatIsNan := floatIsNanLawful.sound
 
@@ -258,13 +262,14 @@ def floatIsFinite : Intrinsic := floatIsFiniteB.toIntrinsic
 @[simp] theorem floatIsFinite_arity : floatIsFinite.arity = .one := rfl
 
 def floatIsFiniteLawful : floatIsFiniteB.Lawful where
-  argL       := Embedding.lawfulFloat
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [unTerm, floatIsFiniteB, floatIsFiniteDefAxiom, FloatBits.isFinite]; intros; rfl
+  argL         := Embedding.lawfulFloat
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [unTerm, floatIsFiniteB, floatIsFiniteDefAxiom, FloatBits.isFinite]; intros; rfl
 
 instance : IntrinsicSound [floatIsFinite] floatIsFinite := floatIsFiniteLawful.sound
 
@@ -290,13 +295,14 @@ def floatOfInt : Intrinsic := floatOfIntB.toIntrinsic
 @[simp] theorem floatOfInt_arity : floatOfInt.arity = .one := rfl
 
 def floatOfIntLawful : floatOfIntB.Lawful where
-  argL       := Embedding.lawfulInt
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [unTerm, floatOfIntB, floatOfIntDefAxiom]; intros; rfl
+  argL         := Embedding.lawfulInt
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [unTerm, floatOfIntB, floatOfIntDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatOfInt] floatOfInt := floatOfIntLawful.sound
 
@@ -324,14 +330,15 @@ def floatAdd : Intrinsic := floatAddB.toIntrinsic
 @[simp] theorem floatAdd_arity : floatAdd.arity = .two := rfl
 
 def floatAddLawful : floatAddB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatAddB, floatAddSym, binFloatDefAxiom]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatAddB, floatAddSym, binFloatDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatAdd] floatAdd := floatAddLawful.sound
 
@@ -353,14 +360,15 @@ def floatSub : Intrinsic := floatSubB.toIntrinsic
 @[simp] theorem floatSub_arity : floatSub.arity = .two := rfl
 
 def floatSubLawful : floatSubB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatSubB, floatSubSym, binFloatDefAxiom]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatSubB, floatSubSym, binFloatDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatSub] floatSub := floatSubLawful.sound
 
@@ -382,14 +390,15 @@ def floatMul : Intrinsic := floatMulB.toIntrinsic
 @[simp] theorem floatMul_arity : floatMul.arity = .two := rfl
 
 def floatMulLawful : floatMulB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatMulB, floatMulSym, binFloatDefAxiom]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatMulB, floatMulSym, binFloatDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatMul] floatMul := floatMulLawful.sound
 
@@ -411,14 +420,15 @@ def floatDiv : Intrinsic := floatDivB.toIntrinsic
 @[simp] theorem floatDiv_arity : floatDiv.arity = .two := rfl
 
 def floatDivLawful : floatDivB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatDivB, floatDivSym, binFloatDefAxiom]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatDivB, floatDivSym, binFloatDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatDiv] floatDiv := floatDivLawful.sound
 
@@ -453,14 +463,15 @@ def floatMin : Intrinsic := floatMinB.toIntrinsic
 @[simp] theorem floatMin_arity : floatMin.arity = .two := rfl
 
 def floatMinLawful : floatMinB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatMinB, floatMinDefAxiom, FloatBits.min]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatMinB, floatMinDefAxiom, FloatBits.min]; intros; rfl
 
 instance : IntrinsicSound [floatMin] floatMin := floatMinLawful.sound
 
@@ -495,14 +506,15 @@ def floatMax : Intrinsic := floatMaxB.toIntrinsic
 @[simp] theorem floatMax_arity : floatMax.arity = .two := rfl
 
 def floatMaxLawful : floatMaxB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulFloat
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatMaxB, floatMaxDefAxiom, FloatBits.max]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulFloat
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatMaxB, floatMaxDefAxiom, FloatBits.max]; intros; rfl
 
 instance : IntrinsicSound [floatMax] floatMax := floatMaxLawful.sound
 
@@ -530,14 +542,15 @@ def floatEqual : Intrinsic := floatEqualB.toIntrinsic
 @[simp] theorem floatEqual_arity : floatEqual.arity = .two := rfl
 
 def floatEqualLawful : floatEqualB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatEqualB, floatEqualSym, binFloatBoolDefAxiom]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatEqualB, floatEqualSym, binFloatBoolDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatEqual] floatEqual := floatEqualLawful.sound
 
@@ -559,14 +572,15 @@ def floatLt : Intrinsic := floatLtB.toIntrinsic
 @[simp] theorem floatLt_arity : floatLt.arity = .two := rfl
 
 def floatLtLawful : floatLtB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatLtB, floatLtSym, binFloatBoolDefAxiom]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatLtB, floatLtSym, binFloatBoolDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatLt] floatLt := floatLtLawful.sound
 
@@ -588,14 +602,15 @@ def floatLe : Intrinsic := floatLeB.toIntrinsic
 @[simp] theorem floatLe_arity : floatLe.arity = .two := rfl
 
 def floatLeLawful : floatLeB.Lawful where
-  argL₁      := Embedding.lawfulFloat
-  argL₂      := Embedding.lawfulFloat
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, floatLeB, floatLeSym, binFloatBoolDefAxiom]; intros; rfl
+  argL₁        := Embedding.lawfulFloat
+  argL₂        := Embedding.lawfulFloat
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, floatLeB, floatLeSym, binFloatBoolDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [floatLe] floatLe := floatLeLawful.sound
 
@@ -618,12 +633,13 @@ def floatNan : Intrinsic := floatNanB.toIntrinsic
 @[simp] theorem floatNan_arity : floatNan.arity = .zero := rfl
 
 def floatNanLawful : floatNanB.Lawful where
-  resL       := Embedding.lawfulFloat
-  nameFresh  := by decide
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [constTerm, floatNanB, floatNanSym, zeroFloatDefAxiom]
+  resL         := Embedding.lawfulFloat
+  nameFresh    := by decide
+  semWellTyped := fun _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [constTerm, floatNanB, floatNanSym, zeroFloatDefAxiom]
 
 instance : IntrinsicSound [floatNan] floatNan := floatNanLawful.sound
 
@@ -641,12 +657,13 @@ def floatInfinity : Intrinsic := floatInfinityB.toIntrinsic
 @[simp] theorem floatInfinity_arity : floatInfinity.arity = .zero := rfl
 
 def floatInfinityLawful : floatInfinityB.Lawful where
-  resL       := Embedding.lawfulFloat
-  nameFresh  := by decide
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [constTerm, floatInfinityB, floatInfinitySym, zeroFloatDefAxiom]
+  resL         := Embedding.lawfulFloat
+  nameFresh    := by decide
+  semWellTyped := fun _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [constTerm, floatInfinityB, floatInfinitySym, zeroFloatDefAxiom]
 
 instance : IntrinsicSound [floatInfinity] floatInfinity := floatInfinityLawful.sound
 
@@ -665,12 +682,13 @@ def floatNegInfinity : Intrinsic := floatNegInfinityB.toIntrinsic
 @[simp] theorem floatNegInfinity_arity : floatNegInfinity.arity = .zero := rfl
 
 def floatNegInfinityLawful : floatNegInfinityB.Lawful where
-  resL       := Embedding.lawfulFloat
-  nameFresh  := by decide
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [constTerm, floatNegInfinityB, floatNegInfinitySym, zeroFloatDefAxiom]
+  resL         := Embedding.lawfulFloat
+  nameFresh    := by decide
+  semWellTyped := fun _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [constTerm, floatNegInfinityB, floatNegInfinitySym, zeroFloatDefAxiom]
 
 instance : IntrinsicSound [floatNegInfinity] floatNegInfinity := floatNegInfinityLawful.sound
 

--- a/Mica/Stdlib/FloatStd.lean
+++ b/Mica/Stdlib/FloatStd.lean
@@ -115,6 +115,8 @@ def floatAbsB : Pure.Unary where
   arg      := .float
   res      := .float
   f        := FloatBits.abs
+  dom      := fun _ => True
+  pre      := none
   typing   := monoTyping .one
   defAxiom := floatAbsDefAxiom
 
@@ -126,6 +128,7 @@ def floatAbs : Intrinsic := floatAbsB.toIntrinsic
 def floatAbsLawful : floatAbsB.Lawful where
   argL       := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -144,6 +147,8 @@ def floatNegB : Pure.Unary where
   arg      := .float
   res      := .float
   f        := FloatBits.neg
+  dom      := fun _ => True
+  pre      := none
   typing   := monoTyping .one
   defAxiom := floatNegDefAxiom
 
@@ -155,6 +160,7 @@ def floatNeg : Intrinsic := floatNegB.toIntrinsic
 def floatNegLawful : floatNegB.Lawful where
   argL       := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -173,6 +179,8 @@ def floatSqrtB : Pure.Unary where
   arg      := .float
   res      := .float
   f        := FloatBits.sqrt
+  dom      := fun _ => True
+  pre      := none
   typing   := monoTyping .one
   defAxiom := floatSqrtDefAxiom
 
@@ -184,6 +192,7 @@ def floatSqrt : Intrinsic := floatSqrtB.toIntrinsic
 def floatSqrtLawful : floatSqrtB.Lawful where
   argL       := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -202,6 +211,8 @@ def floatIsNanB : Pure.Unary where
   arg      := .float
   res      := .bool
   f        := FloatBits.isNaN
+  dom      := fun _ => True
+  pre      := none
   typing   := monoTyping .one
   defAxiom := floatIsNanDefAxiom
 
@@ -213,6 +224,7 @@ def floatIsNan : Intrinsic := floatIsNanB.toIntrinsic
 def floatIsNanLawful : floatIsNanB.Lawful where
   argL       := Embedding.lawfulFloat
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -235,6 +247,8 @@ def floatIsFiniteB : Pure.Unary where
   arg      := .float
   res      := .bool
   f        := FloatBits.isFinite
+  dom      := fun _ => True
+  pre      := none
   typing   := monoTyping .one
   defAxiom := floatIsFiniteDefAxiom
 
@@ -246,6 +260,7 @@ def floatIsFinite : Intrinsic := floatIsFiniteB.toIntrinsic
 def floatIsFiniteLawful : floatIsFiniteB.Lawful where
   argL       := Embedding.lawfulFloat
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -264,6 +279,8 @@ def floatOfIntB : Pure.Unary where
   arg      := .int
   res      := .float
   f        := FloatBits.ofInt
+  dom      := fun _ => True
+  pre      := none
   typing   := monoTyping .one
   defAxiom := floatOfIntDefAxiom
 
@@ -275,6 +292,7 @@ def floatOfInt : Intrinsic := floatOfIntB.toIntrinsic
 def floatOfIntLawful : floatOfIntB.Lawful where
   argL       := Embedding.lawfulInt
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -295,6 +313,8 @@ def floatAddB : Pure.Binary where
   arg₂     := .float
   res      := .float
   f        := FloatBits.add
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatAddSym .fpAdd
 
@@ -307,6 +327,7 @@ def floatAddLawful : floatAddB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -321,6 +342,8 @@ def floatSubB : Pure.Binary where
   arg₂     := .float
   res      := .float
   f        := FloatBits.sub
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatSubSym .fpSub
 
@@ -333,6 +356,7 @@ def floatSubLawful : floatSubB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -347,6 +371,8 @@ def floatMulB : Pure.Binary where
   arg₂     := .float
   res      := .float
   f        := FloatBits.mul
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatMulSym .fpMul
 
@@ -359,6 +385,7 @@ def floatMulLawful : floatMulB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -373,6 +400,8 @@ def floatDivB : Pure.Binary where
   arg₂     := .float
   res      := .float
   f        := FloatBits.div
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatDivSym .fpDiv
 
@@ -385,6 +414,7 @@ def floatDivLawful : floatDivB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -412,6 +442,8 @@ def floatMinB : Pure.Binary where
   arg₂     := .float
   res      := .float
   f        := FloatBits.min
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := floatMinDefAxiom
 
@@ -424,6 +456,7 @@ def floatMinLawful : floatMinB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -451,6 +484,8 @@ def floatMaxB : Pure.Binary where
   arg₂     := .float
   res      := .float
   f        := FloatBits.max
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := floatMaxDefAxiom
 
@@ -463,6 +498,7 @@ def floatMaxLawful : floatMaxB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -483,6 +519,8 @@ def floatEqualB : Pure.Binary where
   arg₂     := .float
   res      := .bool
   f        := FloatBits.eq
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatEqualSym .fpEq
 
@@ -495,6 +533,7 @@ def floatEqualLawful : floatEqualB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -509,6 +548,8 @@ def floatLtB : Pure.Binary where
   arg₂     := .float
   res      := .bool
   f        := FloatBits.lt
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatLtSym .fpLt
 
@@ -521,6 +562,7 @@ def floatLtLawful : floatLtB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -535,6 +577,8 @@ def floatLeB : Pure.Binary where
   arg₂     := .float
   res      := .bool
   f        := FloatBits.le
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatLeSym .fpLe
 
@@ -547,6 +591,7 @@ def floatLeLawful : floatLeB.Lawful where
   argL₁      := Embedding.lawfulFloat
   argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl

--- a/Mica/Stdlib/FloatStd.lean
+++ b/Mica/Stdlib/FloatStd.lean
@@ -115,6 +115,7 @@ def floatAbsB : Pure.Unary where
   arg      := .float
   res      := .float
   f        := FloatBits.abs
+  typing   := monoTyping .one
   defAxiom := floatAbsDefAxiom
 
 def floatAbs : Intrinsic := floatAbsB.toIntrinsic
@@ -143,6 +144,7 @@ def floatNegB : Pure.Unary where
   arg      := .float
   res      := .float
   f        := FloatBits.neg
+  typing   := monoTyping .one
   defAxiom := floatNegDefAxiom
 
 def floatNeg : Intrinsic := floatNegB.toIntrinsic
@@ -171,6 +173,7 @@ def floatSqrtB : Pure.Unary where
   arg      := .float
   res      := .float
   f        := FloatBits.sqrt
+  typing   := monoTyping .one
   defAxiom := floatSqrtDefAxiom
 
 def floatSqrt : Intrinsic := floatSqrtB.toIntrinsic
@@ -199,6 +202,7 @@ def floatIsNanB : Pure.Unary where
   arg      := .float
   res      := .bool
   f        := FloatBits.isNaN
+  typing   := monoTyping .one
   defAxiom := floatIsNanDefAxiom
 
 def floatIsNan : Intrinsic := floatIsNanB.toIntrinsic
@@ -231,6 +235,7 @@ def floatIsFiniteB : Pure.Unary where
   arg      := .float
   res      := .bool
   f        := FloatBits.isFinite
+  typing   := monoTyping .one
   defAxiom := floatIsFiniteDefAxiom
 
 def floatIsFinite : Intrinsic := floatIsFiniteB.toIntrinsic
@@ -259,6 +264,7 @@ def floatOfIntB : Pure.Unary where
   arg      := .int
   res      := .float
   f        := FloatBits.ofInt
+  typing   := monoTyping .one
   defAxiom := floatOfIntDefAxiom
 
 def floatOfInt : Intrinsic := floatOfIntB.toIntrinsic
@@ -285,9 +291,11 @@ private def binFloatDefAxiom (sym : FOL.Symbol .two) (op : BinOp .float .float .
 def floatAddB : Pure.Binary where
   name     := "float_add"
   path     := some ("Float", ["add"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .float
   f        := FloatBits.add
+  typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatAddSym .fpAdd
 
 def floatAdd : Intrinsic := floatAddB.toIntrinsic
@@ -296,7 +304,8 @@ def floatAdd : Intrinsic := floatAddB.toIntrinsic
 @[simp] theorem floatAdd_arity : floatAdd.arity = .two := rfl
 
 def floatAddLawful : floatAddB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -308,9 +317,11 @@ instance : IntrinsicSound [floatAdd] floatAdd := floatAddLawful.sound
 def floatSubB : Pure.Binary where
   name     := "float_sub"
   path     := some ("Float", ["sub"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .float
   f        := FloatBits.sub
+  typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatSubSym .fpSub
 
 def floatSub : Intrinsic := floatSubB.toIntrinsic
@@ -319,7 +330,8 @@ def floatSub : Intrinsic := floatSubB.toIntrinsic
 @[simp] theorem floatSub_arity : floatSub.arity = .two := rfl
 
 def floatSubLawful : floatSubB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -331,9 +343,11 @@ instance : IntrinsicSound [floatSub] floatSub := floatSubLawful.sound
 def floatMulB : Pure.Binary where
   name     := "float_mul"
   path     := some ("Float", ["mul"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .float
   f        := FloatBits.mul
+  typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatMulSym .fpMul
 
 def floatMul : Intrinsic := floatMulB.toIntrinsic
@@ -342,7 +356,8 @@ def floatMul : Intrinsic := floatMulB.toIntrinsic
 @[simp] theorem floatMul_arity : floatMul.arity = .two := rfl
 
 def floatMulLawful : floatMulB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -354,9 +369,11 @@ instance : IntrinsicSound [floatMul] floatMul := floatMulLawful.sound
 def floatDivB : Pure.Binary where
   name     := "float_div"
   path     := some ("Float", ["div"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .float
   f        := FloatBits.div
+  typing   := monoTyping .two
   defAxiom := binFloatDefAxiom floatDivSym .fpDiv
 
 def floatDiv : Intrinsic := floatDivB.toIntrinsic
@@ -365,7 +382,8 @@ def floatDiv : Intrinsic := floatDivB.toIntrinsic
 @[simp] theorem floatDiv_arity : floatDiv.arity = .two := rfl
 
 def floatDivLawful : floatDivB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -390,9 +408,11 @@ def floatMinDefAxiom : Formula :=
 def floatMinB : Pure.Binary where
   name     := "float_min"
   path     := some ("Float", ["min"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .float
   f        := FloatBits.min
+  typing   := monoTyping .two
   defAxiom := floatMinDefAxiom
 
 def floatMin : Intrinsic := floatMinB.toIntrinsic
@@ -401,7 +421,8 @@ def floatMin : Intrinsic := floatMinB.toIntrinsic
 @[simp] theorem floatMin_arity : floatMin.arity = .two := rfl
 
 def floatMinLawful : floatMinB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -426,9 +447,11 @@ def floatMaxDefAxiom : Formula :=
 def floatMaxB : Pure.Binary where
   name     := "float_max"
   path     := some ("Float", ["max"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .float
   f        := FloatBits.max
+  typing   := monoTyping .two
   defAxiom := floatMaxDefAxiom
 
 def floatMax : Intrinsic := floatMaxB.toIntrinsic
@@ -437,7 +460,8 @@ def floatMax : Intrinsic := floatMaxB.toIntrinsic
 @[simp] theorem floatMax_arity : floatMax.arity = .two := rfl
 
 def floatMaxLawful : floatMaxB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulFloat
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -455,9 +479,11 @@ private def binFloatBoolDefAxiom (sym : FOL.Symbol .two) (op : BinOp .float .flo
 def floatEqualB : Pure.Binary where
   name     := "float_equal"
   path     := some ("Float", ["equal"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .bool
   f        := FloatBits.eq
+  typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatEqualSym .fpEq
 
 def floatEqual : Intrinsic := floatEqualB.toIntrinsic
@@ -466,7 +492,8 @@ def floatEqual : Intrinsic := floatEqualB.toIntrinsic
 @[simp] theorem floatEqual_arity : floatEqual.arity = .two := rfl
 
 def floatEqualLawful : floatEqualB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulBool
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -478,9 +505,11 @@ instance : IntrinsicSound [floatEqual] floatEqual := floatEqualLawful.sound
 def floatLtB : Pure.Binary where
   name     := "float_lt"
   path     := some ("Float", ["lt"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .bool
   f        := FloatBits.lt
+  typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatLtSym .fpLt
 
 def floatLt : Intrinsic := floatLtB.toIntrinsic
@@ -489,7 +518,8 @@ def floatLt : Intrinsic := floatLtB.toIntrinsic
 @[simp] theorem floatLt_arity : floatLt.arity = .two := rfl
 
 def floatLtLawful : floatLtB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulBool
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -501,9 +531,11 @@ instance : IntrinsicSound [floatLt] floatLt := floatLtLawful.sound
 def floatLeB : Pure.Binary where
   name     := "float_le"
   path     := some ("Float", ["le"])
-  arg      := .float
+  arg₁     := .float
+  arg₂     := .float
   res      := .bool
   f        := FloatBits.le
+  typing   := monoTyping .two
   defAxiom := binFloatBoolDefAxiom floatLeSym .fpLe
 
 def floatLe : Intrinsic := floatLeB.toIntrinsic
@@ -512,7 +544,8 @@ def floatLe : Intrinsic := floatLeB.toIntrinsic
 @[simp] theorem floatLe_arity : floatLe.arity = .two := rfl
 
 def floatLeLawful : floatLeB.Lawful where
-  argL       := Embedding.lawfulFloat
+  argL₁      := Embedding.lawfulFloat
+  argL₂      := Embedding.lawfulFloat
   resL       := Embedding.lawfulBool
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -531,6 +564,7 @@ def floatNanB : Pure.Zero where
   path     := some ("Float", ["nan"])
   res      := .float
   f        := FloatBits.nan
+  typing   := monoTyping .zero
   defAxiom := zeroFloatDefAxiom floatNanSym .fpNaN
 
 def floatNan : Intrinsic := floatNanB.toIntrinsic
@@ -553,6 +587,7 @@ def floatInfinityB : Pure.Zero where
   path     := some ("Float", ["infinity"])
   res      := .float
   f        := FloatBits.posInf
+  typing   := monoTyping .zero
   defAxiom := zeroFloatDefAxiom floatInfinitySym .fpPosInf
 
 def floatInfinity : Intrinsic := floatInfinityB.toIntrinsic
@@ -575,6 +610,7 @@ def floatNegInfinityB : Pure.Zero where
   path     := some ("Float", ["neg_infinity"])
   res      := .float
   f        := FloatBits.negInf
+  typing   := monoTyping .zero
   defAxiom := zeroFloatDefAxiom floatNegInfinitySym .fpNegInf
 
 def floatNegInfinity : Intrinsic := floatNegInfinityB.toIntrinsic

--- a/Mica/Stdlib/FunStd.lean
+++ b/Mica/Stdlib/FunStd.lean
@@ -27,15 +27,11 @@ def funIdDefAxiom : Formula :=
 def funIdB : Pure.Unary where
   name     := "fun_id"
   path     := some ("Fun", ["id"])
-  arg      := .poly
-  res      := .poly
+  arg      := .poly "a"
+  res      := .poly "a"
   f        := (id : Runtime.Val → Runtime.Val)
   dom      := fun _ => True
   pre      := none
-  typing   := fun _ tys =>
-    match tys with
-    | [t] => .ok [("a", t)]
-    | _ => .error s!"expected 1 argument, got {tys.length}"
   defAxiom := funIdDefAxiom
 
 def funId : Intrinsic := funIdB.toIntrinsic
@@ -45,8 +41,8 @@ def funId : Intrinsic := funIdB.toIntrinsic
 @[simp] theorem funIdSym_name : funIdB.sym.name = "fun_id" := rfl
 
 def funIdLawful : funIdB.Lawful where
-  argL         := Embedding.lawfulPoly
-  resL         := Embedding.lawfulPoly
+  argL         := Embedding.lawfulPoly "a"
+  resL         := Embedding.lawfulPoly "a"
   domSound     := fun _ _ _ => True.intro
   semWellTyped := fun _ _ _ _ => .rfl
   specBaseWf   := by apply PredTrans.checkWf_ok; rfl

--- a/Mica/Stdlib/FunStd.lean
+++ b/Mica/Stdlib/FunStd.lean
@@ -19,91 +19,43 @@ namespace Intrinsics
 
 /-! ## `Fun.id` -/
 
+def funIdDefAxiom : Formula :=
+  .forall_ "x" .value [.term (unTerm "fun_id" (.var .value "x"))] <|
+    .eq .value (unTerm "fun_id" (.var .value "x")) (.var .value "x")
+
 /-- `Fun.id : 'a -> 'a`, the polymorphic identity. -/
-def funId : Intrinsic where
-  arity  := .one
-  name   := "fun_id"
-  path   := some ("Fun", ["id"])
-  reduce := Reduce.pure fun a v => v = a
-  wp     := fun a Q => Q a
-  spec   :=
-    { args  := [("x", .tvar "a")]
-      retTy := .tvar "a"
-      pred  := .ret ("ret",
-        .assert (.eq .value (.var .value "ret") (.var .value "x")) (.ret ())) }
-  typing := fun _ tys =>
+def funIdB : Pure.Unary where
+  name     := "fun_id"
+  path     := some ("Fun", ["id"])
+  arg      := .poly
+  res      := .poly
+  f        := (id : Runtime.Val → Runtime.Val)
+  dom      := fun _ => True
+  pre      := none
+  typing   := fun _ tys =>
     match tys with
     | [t] => .ok [("a", t)]
     | _ => .error s!"expected 1 argument, got {tys.length}"
-  folSym := none
-  axioms := []
+  defAxiom := funIdDefAxiom
 
-@[simp] theorem funId_folSym : funId.folSym = none := rfl
+def funId : Intrinsic := funIdB.toIntrinsic
 
-@[simp] theorem funId.toWp_eq (a : Runtime.Val) (Q : Runtime.Val → iProp) :
-    funId.toWp [a] Q = Q a := rfl
+@[simp] theorem funId_arity : funId.arity = .one := rfl
+@[simp] theorem funId_folSym : funId.folSym = some funIdB.sym := rfl
+@[simp] theorem funIdSym_name : funIdB.sym.name = "fun_id" := rfl
 
-@[simp] theorem funId.toReduce_eq (a v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    funId.toReduce [a] μ v μ' = (v = a ∧ μ' = μ) := rfl
+def funIdLawful : funIdB.Lawful where
+  argL         := Embedding.lawfulPoly
+  resL         := Embedding.lawfulPoly
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; exact nomatch h
+  defEval      := by
+    intrinsic_def_eval [unTerm, funIdB, funIdDefAxiom]
 
-@[simp] theorem funId.instantiate_args (σ : TinyML.TyVar → TinyML.Typ) :
-    (funId.spec.instantiate σ).args = [("x", σ "a")] := by
-  simp [funId, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem funId.instantiate_retTy (σ : TinyML.TyVar → TinyML.Typ) :
-    (funId.spec.instantiate σ).retTy = σ "a" := by
-  simp [funId, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem funId.spec_pred :
-    funId.spec.pred = .ret ("ret",
-      .assert (.eq .value (.var .value "ret") (.var .value "x")) (.ret ())) := rfl
-
-instance : IntrinsicSound [funId] funId where
-  specWf := fun _ hsub hwf =>
-    specWf_of_base (by apply PredTrans.checkWf_ok; rfl) hsub hwf
-  wp_sound := by
-    intro _ ctx hctx vs Φ
-    match vs with
-    | [] => exact false_elim
-    | _ :: _ :: _ => exact false_elim
-    | [a] =>
-      have hred : ∀ μ v μ', ctx funId.name [a] μ v μ' ↔ v = a ∧ μ' = μ := by
-        intro μ v μ'
-        rw [hctx]
-        simp only [funId.toReduce_eq]
-      show Φ a ⊢ _
-      istart
-      iintro HΦ
-      iapply (wp.prim_pure hred ⟨a, rfl⟩)
-      iintro %v %hv
-      subst hv
-      iexact HΦ
-  bridge := by
-    intro _ σ Θ vs ρ Φ _hρ
-    simp only [funId.instantiate_args, funId.instantiate_retTy,
-      Spec.instantiate_pred, funId.spec_pred, List.map_cons, List.map_nil]
-    match vs with
-    | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | _ :: _ :: _ =>
-        exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [v] =>
-      have hφ : (Formula.eq .value (.var .value "ret") (.var .value "x")).eval
-          ((Spec.argsEnv ρ [("x", σ "a")] [v]).updateConst .value "ret" v).env := by
-        simp [Spec.argsEnv, Formula.eval, Term.eval, VerifM.Env.updateConst_env,
-          Env.lookupConst_updateConst_same, Env.lookupConst_updateConst_ne]
-      iintro ⟨Hvals, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v [] _ _).1 $$ Hvals
-      icases Hcons with ⟨Hv, _⟩
-      ihave Hwand := (assert_ret_apply Θ _ "ret" _ _ v hφ) $$ Hpred
-      simp only [funId.toWp_eq]
-      iapply Hwand
-      iexact Hv
-  axiomWf := by
-    intro _ _ _ a ha
-    simp [funId] at ha
-  proof := by
-    intro ρ _ a ha
-    simp [funId] at ha
+instance : IntrinsicSound [funId] funId := funIdLawful.sound
 
 end Intrinsics
 

--- a/Mica/Stdlib/IntStd.lean
+++ b/Mica/Stdlib/IntStd.lean
@@ -68,7 +68,6 @@ def intMinB : Pure.Binary where
   f        := (min : Int → Int → Int)
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := intMinDefAxiom
 
 def intMin : Intrinsic := intMinB.toIntrinsic
@@ -104,7 +103,6 @@ def intMaxB : Pure.Binary where
   f        := (max : Int → Int → Int)
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := intMaxDefAxiom
 
 def intMax : Intrinsic := intMaxB.toIntrinsic

--- a/Mica/Stdlib/IntStd.lean
+++ b/Mica/Stdlib/IntStd.lean
@@ -77,14 +77,15 @@ def intMin : Intrinsic := intMinB.toIntrinsic
 @[simp] theorem intMin_arity : intMin.arity = .two := rfl
 
 def intMinLawful : intMinB.Lawful where
-  argL₁      := Embedding.lawfulInt
-  argL₂      := Embedding.lawfulInt
-  resL       := Embedding.lawfulInt
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  argL₁        := Embedding.lawfulInt
+  argL₂        := Embedding.lawfulInt
+  resL         := Embedding.lawfulInt
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     intrinsic_def_eval [binTerm, intMinB, intMinDefAxiom]
     intro x y
     rw [min_def, Bool.cond_decide]; congr 1
@@ -112,14 +113,15 @@ def intMax : Intrinsic := intMaxB.toIntrinsic
 @[simp] theorem intMax_arity : intMax.arity = .two := rfl
 
 def intMaxLawful : intMaxB.Lawful where
-  argL₁      := Embedding.lawfulInt
-  argL₂      := Embedding.lawfulInt
-  resL       := Embedding.lawfulInt
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  argL₁        := Embedding.lawfulInt
+  argL₂        := Embedding.lawfulInt
+  resL         := Embedding.lawfulInt
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     intrinsic_def_eval [binTerm, intMaxB, intMaxDefAxiom]
     intro x y
     rw [max_comm, max_def, Bool.cond_decide]; congr 1

--- a/Mica/Stdlib/IntStd.lean
+++ b/Mica/Stdlib/IntStd.lean
@@ -62,9 +62,11 @@ def intMaxDefAxiom : Formula :=
 def intMinB : Pure.Binary where
   name     := "int_min"
   path     := some ("Int", ["min"])
-  arg      := .int
+  arg₁     := .int
+  arg₂     := .int
   res      := .int
   f        := (min : Int → Int → Int)
+  typing   := monoTyping .two
   defAxiom := intMinDefAxiom
 
 def intMin : Intrinsic := intMinB.toIntrinsic
@@ -73,7 +75,8 @@ def intMin : Intrinsic := intMinB.toIntrinsic
 @[simp] theorem intMin_arity : intMin.arity = .two := rfl
 
 def intMinLawful : intMinB.Lawful where
-  argL       := Embedding.lawfulInt
+  argL₁      := Embedding.lawfulInt
+  argL₂      := Embedding.lawfulInt
   resL       := Embedding.lawfulInt
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -91,9 +94,11 @@ instance : IntrinsicSound [intMin] intMin := intMinLawful.sound
 def intMaxB : Pure.Binary where
   name     := "int_max"
   path     := some ("Int", ["max"])
-  arg      := .int
+  arg₁     := .int
+  arg₂     := .int
   res      := .int
   f        := (max : Int → Int → Int)
+  typing   := monoTyping .two
   defAxiom := intMaxDefAxiom
 
 def intMax : Intrinsic := intMaxB.toIntrinsic
@@ -102,7 +107,8 @@ def intMax : Intrinsic := intMaxB.toIntrinsic
 @[simp] theorem intMax_arity : intMax.arity = .two := rfl
 
 def intMaxLawful : intMaxB.Lawful where
-  argL       := Embedding.lawfulInt
+  argL₁      := Embedding.lawfulInt
+  argL₂      := Embedding.lawfulInt
   resL       := Embedding.lawfulInt
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl

--- a/Mica/Stdlib/IntStd.lean
+++ b/Mica/Stdlib/IntStd.lean
@@ -66,6 +66,8 @@ def intMinB : Pure.Binary where
   arg₂     := .int
   res      := .int
   f        := (min : Int → Int → Int)
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := intMinDefAxiom
 
@@ -78,6 +80,7 @@ def intMinLawful : intMinB.Lawful where
   argL₁      := Embedding.lawfulInt
   argL₂      := Embedding.lawfulInt
   resL       := Embedding.lawfulInt
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -98,6 +101,8 @@ def intMaxB : Pure.Binary where
   arg₂     := .int
   res      := .int
   f        := (max : Int → Int → Int)
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := intMaxDefAxiom
 
@@ -110,6 +115,7 @@ def intMaxLawful : intMaxB.Lawful where
   argL₁      := Embedding.lawfulInt
   argL₂      := Embedding.lawfulInt
   resL       := Embedding.lawfulInt
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl

--- a/Mica/Stdlib/OUTLINE.md
+++ b/Mica/Stdlib/OUTLINE.md
@@ -1,9 +1,9 @@
 **Mica/Stdlib**
 
 - `CharStd.lean` — Character intrinsics (`Char.code`, `Char.chr`, `Char.equal`) and their soundness instances.
-- `Combinators.lean` — Embeddings and the pure-intrinsic builders (`Pure.Zero`/`Pure.Unary`/`Pure.Binary`/`Pure.Ternary`) that emit an intrinsic and its soundness instance, plus the shared helper lemmas their soundness proofs use.
+- `Combinators.lean` — Embeddings and the pure-intrinsic builders (`Pure.Zero`/`Pure.Unary`/`Pure.Binary`/`Pure.Ternary`) that emit an intrinsic and its soundness instance.
 - `FloatStd.lean` — IEEE binary64 float intrinsics (`Float.abs`, `add`, `min`, `equal`, `nan`, …) and soundness instances.
 - `FunStd.lean` — `Fun.id`
 - `IntStd.lean` — Integer-arithmetic intrinsics (`Int.min`, `Int.max`) and their soundness instances.
 - `StringStd.lean` — Byte-string intrinsics (`String.length`, `get`, `sub`, `cat`, `equal`, `starts_with`, `ends_with`) and soundness instances.
-- `VecStd.lean` — Immutable-vector intrinsics (`Vec.length`, `Vec.get`, `Vec.set`, `Vec.make`) and their soundness instances.
+- `VecStd.lean` — Immutable-vector intrinsics (`Vec.length`, `Vec.get`, `Vec.set`, `Vec.make`).

--- a/Mica/Stdlib/StringStd.lean
+++ b/Mica/Stdlib/StringStd.lean
@@ -174,6 +174,7 @@ def stringLengthB : Pure.Unary where
   arg      := .str
   res      := .int
   f        := (fun s => (s.length : Int) : List UInt8 → Int)
+  typing   := monoTyping .one
   defAxiom := stringLengthDefAxiom
 
 def stringLength : Intrinsic := stringLengthB.toIntrinsic
@@ -197,9 +198,11 @@ instance : IntrinsicSound [stringLength] stringLength := stringLengthLawful.soun
 def stringCatB : Pure.Binary where
   name     := "string_cat"
   path     := some ("String", ["cat"])
-  arg      := .str
+  arg₁     := .str
+  arg₂     := .str
   res      := .str
   f        := (fun x y => x ++ y : List UInt8 → List UInt8 → List UInt8)
+  typing   := monoTyping .two
   defAxiom := stringCatDefAxiom
 
 def stringCat : Intrinsic := stringCatB.toIntrinsic
@@ -208,7 +211,8 @@ def stringCat : Intrinsic := stringCatB.toIntrinsic
 @[simp] theorem stringCat_folSym : stringCat.folSym = some stringCatSym := rfl
 
 def stringCatLawful : stringCatB.Lawful where
-  argL       := Embedding.lawfulStr
+  argL₁      := Embedding.lawfulStr
+  argL₂      := Embedding.lawfulStr
   resL       := Embedding.lawfulStr
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -615,9 +619,11 @@ instance : IntrinsicSound [stringSub] stringSub where
 def stringEqualB : Pure.Binary where
   name     := "string_equal"
   path     := some ("String", ["equal"])
-  arg      := .str
+  arg₁     := .str
+  arg₂     := .str
   res      := .bool
   f        := (fun x y => x == y : List UInt8 → List UInt8 → Bool)
+  typing   := monoTyping .two
   defAxiom := stringEqualDefAxiom
 
 def stringEqual : Intrinsic := stringEqualB.toIntrinsic
@@ -626,7 +632,8 @@ def stringEqual : Intrinsic := stringEqualB.toIntrinsic
 @[simp] theorem stringEqual_folSym : stringEqual.folSym = some stringEqualSym := rfl
 
 def stringEqualLawful : stringEqualB.Lawful where
-  argL       := Embedding.lawfulStr
+  argL₁      := Embedding.lawfulStr
+  argL₂      := Embedding.lawfulStr
   resL       := Embedding.lawfulBool
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -643,9 +650,11 @@ instance : IntrinsicSound [stringEqual] stringEqual := stringEqualLawful.sound
 def stringStartsWithB : Pure.Binary where
   name     := "string_starts_with"
   path     := some ("String", ["starts_with"])
-  arg      := .str
+  arg₁     := .str
+  arg₂     := .str
   res      := .bool
   f        := (fun x y => x.isPrefixOf y : List UInt8 → List UInt8 → Bool)
+  typing   := monoTyping .two
   defAxiom := stringStartsWithDefAxiom
 
 def stringStartsWith : Intrinsic := stringStartsWithB.toIntrinsic
@@ -655,7 +664,8 @@ def stringStartsWith : Intrinsic := stringStartsWithB.toIntrinsic
     stringStartsWith.folSym = some stringStartsWithSym := rfl
 
 def stringStartsWithLawful : stringStartsWithB.Lawful where
-  argL       := Embedding.lawfulStr
+  argL₁      := Embedding.lawfulStr
+  argL₂      := Embedding.lawfulStr
   resL       := Embedding.lawfulBool
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
@@ -671,9 +681,11 @@ instance : IntrinsicSound [stringStartsWith] stringStartsWith := stringStartsWit
 def stringEndsWithB : Pure.Binary where
   name     := "string_ends_with"
   path     := some ("String", ["ends_with"])
-  arg      := .str
+  arg₁     := .str
+  arg₂     := .str
   res      := .bool
   f        := (fun x y => x.isSuffixOf y : List UInt8 → List UInt8 → Bool)
+  typing   := monoTyping .two
   defAxiom := stringEndsWithDefAxiom
 
 def stringEndsWith : Intrinsic := stringEndsWithB.toIntrinsic
@@ -682,7 +694,8 @@ def stringEndsWith : Intrinsic := stringEndsWithB.toIntrinsic
 @[simp] theorem stringEndsWith_folSym : stringEndsWith.folSym = some stringEndsWithSym := rfl
 
 def stringEndsWithLawful : stringEndsWithB.Lawful where
-  argL       := Embedding.lawfulStr
+  argL₁      := Embedding.lawfulStr
+  argL₂      := Embedding.lawfulStr
   resL       := Embedding.lawfulBool
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl

--- a/Mica/Stdlib/StringStd.lean
+++ b/Mica/Stdlib/StringStd.lean
@@ -168,7 +168,6 @@ def stringLengthB : Pure.Unary where
   f        := (fun s => (s.length : Int) : List UInt8 → Int)
   dom      := fun _ => True
   pre      := none
-  typing   := monoTyping .one
   defAxiom := stringLengthDefAxiom
 
 def stringLength : Intrinsic := stringLengthB.toIntrinsic
@@ -200,7 +199,6 @@ def stringCatB : Pure.Binary where
   f        := (fun x y => x ++ y : List UInt8 → List UInt8 → List UInt8)
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := stringCatDefAxiom
 
 def stringCat : Intrinsic := stringCatB.toIntrinsic
@@ -233,7 +231,6 @@ def stringGetB : Pure.Binary where
   f        := stringGetByte
   dom      := (fun s i => 0 ≤ i ∧ i < (s.length : Int) : List UInt8 → Int → Prop)
   pre      := some stringGetPre
-  typing   := monoTyping .two
   defAxiom := stringGetDefAxiom
 
 def stringGet : Intrinsic := stringGetB.toIntrinsic
@@ -286,7 +283,6 @@ def stringSubB : Pure.Ternary where
   dom      := (fun s pos len => 0 ≤ pos ∧ 0 ≤ len ∧ pos + len ≤ (s.length : Int) :
                 List UInt8 → Int → Int → Prop)
   pre      := some stringSubPre
-  typing   := monoTyping .three
   defAxiom := stringSubDefAxiom
 
 def stringSub : Intrinsic := stringSubB.toIntrinsic
@@ -344,7 +340,6 @@ def stringEqualB : Pure.Binary where
   f        := (fun x y => x == y : List UInt8 → List UInt8 → Bool)
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := stringEqualDefAxiom
 
 def stringEqual : Intrinsic := stringEqualB.toIntrinsic
@@ -379,7 +374,6 @@ def stringStartsWithB : Pure.Binary where
   f        := (fun x y => x.isPrefixOf y : List UInt8 → List UInt8 → Bool)
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := stringStartsWithDefAxiom
 
 def stringStartsWith : Intrinsic := stringStartsWithB.toIntrinsic
@@ -414,7 +408,6 @@ def stringEndsWithB : Pure.Binary where
   f        := (fun x y => x.isSuffixOf y : List UInt8 → List UInt8 → Bool)
   dom      := fun _ _ => True
   pre      := none
-  typing   := monoTyping .two
   defAxiom := stringEndsWithDefAxiom
 
 def stringEndsWith : Intrinsic := stringEndsWithB.toIntrinsic

--- a/Mica/Stdlib/StringStd.lean
+++ b/Mica/Stdlib/StringStd.lean
@@ -177,13 +177,14 @@ def stringLength : Intrinsic := stringLengthB.toIntrinsic
 @[simp] theorem stringLength_folSym : stringLength.folSym = some stringLengthSym := rfl
 
 def stringLengthLawful : stringLengthB.Lawful where
-  argL       := Embedding.lawfulStr
-  resL       := Embedding.lawfulInt
-  domSound   := fun _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [unTerm, stringLengthB, stringLengthDefAxiom]; intros; rfl
+  argL         := Embedding.lawfulStr
+  resL         := Embedding.lawfulInt
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => .rfl
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [unTerm, stringLengthB, stringLengthDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [stringLength] stringLength := stringLengthLawful.sound
 
@@ -208,14 +209,15 @@ def stringCat : Intrinsic := stringCatB.toIntrinsic
 @[simp] theorem stringCat_folSym : stringCat.folSym = some stringCatSym := rfl
 
 def stringCatLawful : stringCatB.Lawful where
-  argL₁      := Embedding.lawfulStr
-  argL₂      := Embedding.lawfulStr
-  resL       := Embedding.lawfulStr
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by intrinsic_def_eval [binTerm, stringCatB, stringCatDefAxiom]; intros; rfl
+  argL₁        := Embedding.lawfulStr
+  argL₂        := Embedding.lawfulStr
+  resL         := Embedding.lawfulStr
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by intrinsic_def_eval [binTerm, stringCatB, stringCatDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [stringCat] stringCat := stringCatLawful.sound
 
@@ -240,19 +242,20 @@ def stringGet : Intrinsic := stringGetB.toIntrinsic
 @[simp] theorem stringGet_folSym : stringGet.folSym = some stringGetSym := rfl
 
 def stringGetLawful : stringGetB.Lawful where
-  argL₁      := Embedding.lawfulStr
-  argL₂      := Embedding.lawfulInt
-  resL       := Embedding.lawfulChar
-  domSound   := by
+  argL₁        := Embedding.lawfulStr
+  argL₂        := Embedding.lawfulInt
+  resL         := Embedding.lawfulChar
+  domSound     := by
     intro ρ s i h
     have hpre := h stringGetPre rfl
     simpa [stringGetB, stringGetPre, Embedding.str, Embedding.int, Formula.eval, Term.eval,
       Const.denote, Env.lookupConst_updateConst_same,
       Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), valStr, valInt] using hpre
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     have hsym : stringGetB.sym = stringGetSym := rfl
     intro ρ hresp
     rw [hsym] at hresp
@@ -292,11 +295,11 @@ def stringSub : Intrinsic := stringSubB.toIntrinsic
 @[simp] theorem stringSub_folSym : stringSub.folSym = some stringSubSym := rfl
 
 def stringSubLawful : stringSubB.Lawful where
-  argL₁      := Embedding.lawfulStr
-  argL₂      := Embedding.lawfulInt
-  argL₃      := Embedding.lawfulInt
-  resL       := Embedding.lawfulStr
-  domSound   := by
+  argL₁        := Embedding.lawfulStr
+  argL₂        := Embedding.lawfulInt
+  argL₃        := Embedding.lawfulInt
+  resL         := Embedding.lawfulStr
+  domSound     := by
     intro ρ s pos len h
     have hpre := h stringSubPre rfl
     simpa [stringSubB, stringSubPre, Embedding.str, Embedding.int, Formula.eval, Term.eval,
@@ -304,10 +307,11 @@ def stringSubLawful : stringSubB.Lawful where
       Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide),
       Env.lookupConst_updateConst_ne (show "a" ≠ "c" by decide),
       Env.lookupConst_updateConst_ne (show "b" ≠ "c" by decide), valStr, valInt] using hpre
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  semWellTyped := fun _ _ _ _ _ _ => emp_sep.1.trans emp_sep.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     have hsym : stringSubB.sym = stringSubSym := rfl
     intro ρ hresp
     rw [hsym] at hresp
@@ -349,14 +353,15 @@ def stringEqual : Intrinsic := stringEqualB.toIntrinsic
 @[simp] theorem stringEqual_folSym : stringEqual.folSym = some stringEqualSym := rfl
 
 def stringEqualLawful : stringEqualB.Lawful where
-  argL₁      := Embedding.lawfulStr
-  argL₂      := Embedding.lawfulStr
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  argL₁        := Embedding.lawfulStr
+  argL₂        := Embedding.lawfulStr
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     intrinsic_def_eval [binTerm, stringEqualB, stringEqualDefAxiom, Bool.beq_eq_decide_eq]
     intros; rfl
 
@@ -384,14 +389,15 @@ def stringStartsWith : Intrinsic := stringStartsWithB.toIntrinsic
     stringStartsWith.folSym = some stringStartsWithSym := rfl
 
 def stringStartsWithLawful : stringStartsWithB.Lawful where
-  argL₁      := Embedding.lawfulStr
-  argL₂      := Embedding.lawfulStr
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  argL₁        := Embedding.lawfulStr
+  argL₂        := Embedding.lawfulStr
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     intrinsic_def_eval [binTerm, stringStartsWithB, stringStartsWithDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [stringStartsWith] stringStartsWith := stringStartsWithLawful.sound
@@ -417,14 +423,15 @@ def stringEndsWith : Intrinsic := stringEndsWithB.toIntrinsic
 @[simp] theorem stringEndsWith_folSym : stringEndsWith.folSym = some stringEndsWithSym := rfl
 
 def stringEndsWithLawful : stringEndsWithB.Lawful where
-  argL₁      := Embedding.lawfulStr
-  argL₂      := Embedding.lawfulStr
-  resL       := Embedding.lawfulBool
-  domSound   := fun _ _ _ _ => True.intro
-  specBaseWf := by apply PredTrans.checkWf_ok; rfl
-  defWf      := by apply Formula.checkWf_ok; rfl
-  typeWf     := by apply Formula.checkWf_ok; rfl
-  defEval    := by
+  argL₁        := Embedding.lawfulStr
+  argL₂        := Embedding.lawfulStr
+  resL         := Embedding.lawfulBool
+  domSound     := fun _ _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ _ => sep_emp.1
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
     intrinsic_def_eval [binTerm, stringEndsWithB, stringEndsWithDefAxiom]; intros; rfl
 
 instance : IntrinsicSound [stringEndsWith] stringEndsWith := stringEndsWithLawful.sound

--- a/Mica/Stdlib/StringStd.lean
+++ b/Mica/Stdlib/StringStd.lean
@@ -85,12 +85,13 @@ def stringCatDefAxiom : Formula :=
       (.unop .toString (binTerm "string_cat" (.var .value "a") (.var .value "b")))
       (.binop .seqConcat (.unop .toString (.var .value "a")) (.unop .toString (.var .value "b")))
 
-def stringGetPre : Formula :=
-  let i := .unop .toInt (.var .value "i")
-  let len := .unop .seqLen (.unop .toString (.var .value "s"))
+/-- The FOL precondition of `String.get`, as a function of the argument names. -/
+def stringGetPre (s i : String) : Formula :=
+  let idx := .unop .toInt (.var .value i)
+  let len := .unop .seqLen (.unop .toString (.var .value s))
   .and
-    (.binpred .le (.const (.i 0)) i)
-    (.binpred .lt i len)
+    (.binpred .le (.const (.i 0)) idx)
+    (.binpred .lt idx len)
 
 /-- The value-level FOL term for `String.get s i`. -/
 def stringGetTerm (s i : Term .value) : Term .value :=
@@ -104,25 +105,21 @@ def stringGetByte (s : List UInt8) (i : Int) : UInt8 :=
 def stringGetDefAxiom : Formula :=
   .all "s" .value <| .forall_ "i" .value
     [.term (stringGetTerm (.var .value "s") (.var .value "i"))] <|
-    .implies stringGetPre <|
+    .implies (stringGetPre "s" "i") <|
       .eq .char
         (.unop .toChar (stringGetTerm (.var .value "s") (.var .value "i")))
         (.binop .seqNth (.unop .toString (.var .value "s")) (.unop .toInt (.var .value "i")))
 
-def stringGetTypeAxiom : Formula :=
-  .all "s" .value <| .forall_ "i" .value
-    [.term (stringGetTerm (.var .value "s") (.var .value "i"))] <|
-    .unpred .isChar (stringGetTerm (.var .value "s") (.var .value "i"))
-
-def stringSubPre : Formula :=
-  let pos := .unop .toInt (.var .value "pos")
-  let len := .unop .toInt (.var .value "len")
-  let strlen := .unop .seqLen (.unop .toString (.var .value "s"))
+/-- The FOL precondition of `String.sub`, as a function of the argument names. -/
+def stringSubPre (s pos len : String) : Formula :=
+  let p := .unop .toInt (.var .value pos)
+  let l := .unop .toInt (.var .value len)
+  let strlen := .unop .seqLen (.unop .toString (.var .value s))
   .and
-    (.binpred .le (.const (.i 0)) pos)
+    (.binpred .le (.const (.i 0)) p)
     (.and
-      (.binpred .le (.const (.i 0)) len)
-      (.binpred .le (.binop .add pos len) strlen))
+      (.binpred .le (.const (.i 0)) l)
+      (.binpred .le (.binop .add p l) strlen))
 
 /-- The value-level FOL term for `String.sub s pos len`. -/
 def stringSubTerm (s pos len : Term .value) : Term .value :=
@@ -131,18 +128,13 @@ def stringSubTerm (s pos len : Term .value) : Term .value :=
 def stringSubDefAxiom : Formula :=
   .all "s" .value <| .all "pos" .value <| .forall_ "len" .value
     [.term (stringSubTerm (.var .value "s") (.var .value "pos") (.var .value "len"))] <|
-    .implies stringSubPre <|
+    .implies (stringSubPre "s" "pos" "len") <|
       .eq .string
         (.unop .toString (stringSubTerm (.var .value "s") (.var .value "pos") (.var .value "len")))
         (.terop .seqExtract
           (.unop .toString (.var .value "s"))
           (.unop .toInt (.var .value "pos"))
           (.unop .toInt (.var .value "len")))
-
-def stringSubTypeAxiom : Formula :=
-  .all "s" .value <| .all "pos" .value <| .forall_ "len" .value
-    [.term (stringSubTerm (.var .value "s") (.var .value "pos") (.var .value "len"))] <|
-    .unpred .isStr (stringSubTerm (.var .value "s") (.var .value "pos") (.var .value "len"))
 
 def stringEqualDefAxiom : Formula :=
   .all "a" .value <| .forall_ "b" .value
@@ -174,6 +166,8 @@ def stringLengthB : Pure.Unary where
   arg      := .str
   res      := .int
   f        := (fun s => (s.length : Int) : List UInt8 → Int)
+  dom      := fun _ => True
+  pre      := none
   typing   := monoTyping .one
   defAxiom := stringLengthDefAxiom
 
@@ -185,6 +179,7 @@ def stringLength : Intrinsic := stringLengthB.toIntrinsic
 def stringLengthLawful : stringLengthB.Lawful where
   argL       := Embedding.lawfulStr
   resL       := Embedding.lawfulInt
+  domSound   := fun _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -202,6 +197,8 @@ def stringCatB : Pure.Binary where
   arg₂     := .str
   res      := .str
   f        := (fun x y => x ++ y : List UInt8 → List UInt8 → List UInt8)
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := stringCatDefAxiom
 
@@ -214,6 +211,7 @@ def stringCatLawful : stringCatB.Lawful where
   argL₁      := Embedding.lawfulStr
   argL₂      := Embedding.lawfulStr
   resL       := Embedding.lawfulStr
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -223,395 +221,112 @@ instance : IntrinsicSound [stringCat] stringCat := stringCatLawful.sound
 
 /-! ## `String.get` -/
 
-private theorem string_respects_argsEnv_two {s : FOL.Symbol .two} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
-  | [], _, _, h => h
-  | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
-      simp only [Spec.argsEnv]
-      refine string_respects_argsEnv_two rest vs ?_
-      rw [VerifM.Env.updateConst_env]
-      simpa only [Env.respects, Env.updateConst_binary] using h
-
 /-- `String.get`: byte lookup, with OCaml's in-bounds precondition. -/
-def stringGet : Intrinsic where
-  arity  := .two
-  name   := "string_get"
-  path   := some ("String", ["get"])
-  reduce := Reduce.pure fun (s, i) v =>
-    ∃ bytes n, s = .str bytes ∧ i = .int n ∧ 0 ≤ n ∧ n < (bytes.length : Int) ∧
-      v = .char (stringGetByte bytes n)
-  wp     := fun (s, i) Q =>
-    iprop(∃ bytes n,
-      ⌜s = .str bytes ∧ i = .int n ∧ 0 ≤ n ∧ n < (bytes.length : Int)⌝ ∗
-      Q (.char (stringGetByte bytes n)))
-  spec   :=
-    { args  := [("s", .string), ("i", .int)]
-      retTy := .char
-      pred  := .assert stringGetPre <|
-        .ret ("ret",
-          .assert (.eq .value (.var .value "ret")
-            (stringGetTerm (.var .value "s") (.var .value "i")))
-            (.ret ())) }
-  typing := monoTyping .two
-  folSym := some stringGetSym
-  axioms := [⟨stringGetDefAxiom, .high⟩, ⟨stringGetTypeAxiom, .high⟩]
+def stringGetB : Pure.Binary where
+  name     := "string_get"
+  path     := some ("String", ["get"])
+  arg₁     := .str
+  arg₂     := .int
+  res      := .char
+  f        := stringGetByte
+  dom      := (fun s i => 0 ≤ i ∧ i < (s.length : Int) : List UInt8 → Int → Prop)
+  pre      := some stringGetPre
+  typing   := monoTyping .two
+  defAxiom := stringGetDefAxiom
+
+def stringGet : Intrinsic := stringGetB.toIntrinsic
 
 @[simp] theorem stringGet_arity : stringGet.arity = .two := rfl
 @[simp] theorem stringGet_folSym : stringGet.folSym = some stringGetSym := rfl
 
-@[simp] theorem stringGet.toWp_eq (s i : Runtime.Val) (Q : Runtime.Val → iProp) :
-    stringGet.toWp [s, i] Q =
-      iprop(∃ bytes n,
-        ⌜s = .str bytes ∧ i = .int n ∧ 0 ≤ n ∧ n < (bytes.length : Int)⌝ ∗
-        Q (.char (stringGetByte bytes n))) := rfl
+def stringGetLawful : stringGetB.Lawful where
+  argL₁      := Embedding.lawfulStr
+  argL₂      := Embedding.lawfulInt
+  resL       := Embedding.lawfulChar
+  domSound   := by
+    intro ρ s i h
+    have hpre := h stringGetPre rfl
+    simpa [stringGetB, stringGetPre, Embedding.str, Embedding.int, Formula.eval, Term.eval,
+      Const.denote, Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), valStr, valInt] using hpre
+  specBaseWf := by apply PredTrans.checkWf_ok; rfl
+  defWf      := by apply Formula.checkWf_ok; rfl
+  typeWf     := by apply Formula.checkWf_ok; rfl
+  defEval    := by
+    have hsym : stringGetB.sym = stringGetSym := rfl
+    intro ρ hresp
+    rw [hsym] at hresp
+    simp only [stringGetB, stringGetDefAxiom, Formula.all, Formula.eval]
+    intro s i hpre
+    have hbin : (((ρ.updateConst .value "s" s).updateConst .value "i" i).binary
+        .value .value .value "string_get") = fun a b => stringGetSym.interp (a, b) := by
+      rw [Env.updateConst_binary, Env.updateConst_binary]
+      simpa [Env.respects, stringGetSym] using hresp
+    simp [stringGetTerm, binTerm, stringGetSym, hbin,
+      Term.eval, Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "s" ≠ "i" by decide), valStr, valInt]
+    rfl
 
-@[simp] theorem stringGet.toReduce_eq (s i v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    stringGet.toReduce [s, i] μ v μ' =
-      ((∃ bytes n, s = .str bytes ∧ i = .int n ∧ 0 ≤ n ∧
-        n < (bytes.length : Int) ∧ v = .char (stringGetByte bytes n)) ∧ μ' = μ) := rfl
-
-@[simp] theorem stringGet.instantiate_args (σ : TinyML.TyVar → TinyML.Typ) :
-    (stringGet.spec.instantiate σ).args = [("s", .string), ("i", .int)] := by
-  simp [stringGet, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem stringGet.instantiate_retTy (σ : TinyML.TyVar → TinyML.Typ) :
-    (stringGet.spec.instantiate σ).retTy = .char := by
-  simp [stringGet, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem stringGet.spec_pred :
-    stringGet.spec.pred = .assert stringGetPre
-      (.ret ("ret",
-        .assert (.eq .value (.var .value "ret")
-          (stringGetTerm (.var .value "s") (.var .value "i")))
-          (.ret ()))) := rfl
-
-instance : IntrinsicSound [stringGet] stringGet where
-  specWf := fun _ hsub hwf =>
-    specWf_of_base (by apply PredTrans.checkWf_ok; rfl) hsub hwf
-  wp_sound := by
-    intro _ ctx hctx vs Φ
-    match vs with
-    | [] => exact false_elim
-    | [_] => exact false_elim
-    | _ :: _ :: _ :: _ => exact false_elim
-    | [s, i] =>
-      have hred : ∀ bytes n μ v μ',
-          ctx stringGet.name [.str bytes, .int n] μ v μ'
-            ↔ (0 ≤ n ∧ n < (bytes.length : Int) ∧ v = .char (stringGetByte bytes n)) ∧
-              μ' = μ := by
-        intro bytes n μ v μ'
-        rw [hctx]
-        simp only [stringGet.toReduce_eq]
-        constructor
-        · rintro ⟨⟨bytes', n', hs, hi, hlo, hhi, hv⟩, hμ⟩
-          cases hs
-          cases hi
-          exact ⟨⟨hlo, hhi, hv⟩, hμ⟩
-        · rintro ⟨⟨hlo, hhi, hv⟩, hμ⟩
-          exact ⟨⟨bytes, n, rfl, rfl, hlo, hhi, hv⟩, hμ⟩
-      show iprop(∃ bytes n,
-        ⌜s = .str bytes ∧ i = .int n ∧ 0 ≤ n ∧ n < (bytes.length : Int)⌝ ∗
-        Φ (.char (stringGetByte bytes n))) ⊢ _
-      istart
-      iintro ⟨%bytes, %n, %ha, HΦ⟩
-      obtain ⟨rfl, rfl, hlo, hhi⟩ := ha
-      iapply (wp.prim_pure (hred bytes n) ⟨.char (stringGetByte bytes n), hlo, hhi, rfl⟩)
-      iintro %v %hv
-      obtain ⟨_, _, rfl⟩ := hv
-      iexact HΦ
-  bridge := by
-    intro _ σ Θ vs ρ Φ hρ
-    simp only [stringGet.instantiate_args, stringGet.instantiate_retTy,
-      Spec.instantiate_pred, stringGet.spec_pred, List.map_cons, List.map_nil]
-    match vs with
-    | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | _ :: _ :: _ :: _ =>
-        exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [s, i] =>
-      simp only [PredTrans.apply, Assertion.pre]
-      iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ s [i] _ _).1 $$ Hvs
-      icases Hcons with ⟨Hs, Hrest⟩
-      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ i [] _ _).1 $$ Hrest
-      icases Hcons2 with ⟨Hi, _⟩
-      ihave Hseq := (TinyML.ValHasType.string Θ s).1 $$ Hs
-      ipure Hseq
-      obtain ⟨bytes, rfl⟩ := Hseq
-      ihave Hieq := (TinyML.ValHasType.int Θ i).1 $$ Hi
-      ipure Hieq
-      obtain ⟨n, rfl⟩ := Hieq
-      icases Hpred with ⟨%hpre, Hpost⟩
-      have hbounds : 0 ≤ n ∧ n < (bytes.length : Int) := by
-        simpa [stringGetPre, Spec.argsEnv, Formula.eval, Term.eval, Const.denote,
-          VerifM.Env.updateConst_env, Env.lookupConst_updateConst_same,
-          Env.lookupConst_updateConst_ne (show "s" ≠ "i" by decide)] using hpre
-      simp only [stringGet.toWp_eq]
-      iexists bytes
-      iexists n
-      isplitr [Hpost]
-      · ipureintro
-        exact ⟨rfl, rfl, hbounds.1, hbounds.2⟩
-      · have hassert : (Formula.eq .value (.var .value "ret")
-            (stringGetTerm (.var .value "s") (.var .value "i"))).eval
-            ((Spec.argsEnv ρ stringGet.specArgs [.str bytes, .int n]).updateConst
-              .value "ret" (.char (stringGetByte bytes n))).env := by
-          have hargs := string_respects_argsEnv_two stringGet.specArgs [.str bytes, .int n] hρ
-          have hbin : (Spec.argsEnv ρ stringGet.specArgs [.str bytes, .int n]).env.binary
-              .value .value .value "string_get" = fun a b => stringGetSym.interp (a, b) := by
-            simpa [Env.respects, stringGetSym] using hargs
-          show .char (stringGetByte bytes n) =
-            (Spec.argsEnv ρ stringGet.specArgs [.str bytes, .int n]).env.binary
-              .value .value .value "string_get" (.str bytes) (.int n)
-          simp [stringGetByte, stringGetSym, hbin, valStr, valInt]
-        refine (assert_ret_apply Θ _ "ret" _ _ (.char (stringGetByte bytes n)) hassert).trans ?_
-        iintro Hwand
-        iapply Hwand
-        exact TinyML.ValHasType.char_intro Θ (stringGetByte bytes n)
-  axiomWf := by
-    intro Δ hsub hwf a hφ
-    simp only [stringGet, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-  proof := by
-    intro ρ hdeps a hφ
-    simp only [stringGet, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    have hresp : ρ.respects (some stringGetSym) := by
-      have h := hdeps stringGet (by simp)
-      simpa [stringGet] using h
-    rcases hφ with rfl | rfl
-    · simp only [stringGetDefAxiom, Formula.all, Formula.eval]
-      intro s i hpre
-      have hbin : (((ρ.updateConst .value "s" s).updateConst .value "i" i).binary
-          .value .value .value "string_get") = fun a b => stringGetSym.interp (a, b) := by
-        rw [Env.updateConst_binary, Env.updateConst_binary]
-        simpa [Env.respects, stringGetSym] using hresp
-      simp [stringGetTerm, binTerm, stringGetSym, hbin,
-        Term.eval, Env.lookupConst_updateConst_same,
-        Env.lookupConst_updateConst_ne (show "s" ≠ "i" by decide), valStr, valInt]
-      rfl
-    · simp only [stringGetTypeAxiom, Formula.all, Formula.eval]
-      intro s i
-      have hbin : (((ρ.updateConst .value "s" s).updateConst .value "i" i).binary
-          .value .value .value "string_get") = fun a b => stringGetSym.interp (a, b) := by
-        rw [Env.updateConst_binary, Env.updateConst_binary]
-        simpa [Env.respects, stringGetSym] using hresp
-      simp [stringGetTerm, binTerm, stringGetSym, hbin, Term.eval,
-        Env.lookupConst_updateConst_same,
-        Env.lookupConst_updateConst_ne (show "s" ≠ "i" by decide), valStr, valInt]
+instance : IntrinsicSound [stringGet] stringGet := stringGetLawful.sound
 
 /-! ## `String.sub` -/
 
-private theorem string_respects_argsEnv_three {s : FOL.Symbol .three} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
-  | [], _, _, h => h
-  | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
-      simp only [Spec.argsEnv]
-      refine string_respects_argsEnv_three rest vs ?_
-      rw [VerifM.Env.updateConst_env]
-      simpa only [Env.respects, Env.updateConst_ternary] using h
-
 /-- `String.sub`: byte-string slicing, with OCaml's bounds precondition. -/
-def stringSub : Intrinsic where
-  arity  := .three
-  name   := "string_sub"
-  path   := some ("String", ["sub"])
-  reduce := Reduce.pure fun (s, pos, len) v =>
-    ∃ bytes p n, s = .str bytes ∧ pos = .int p ∧ len = .int n ∧
-      0 ≤ p ∧ 0 ≤ n ∧ p + n ≤ (bytes.length : Int) ∧
-      v = .str (stringSubBytes bytes p n)
-  wp     := fun (s, pos, len) Q =>
-    iprop(∃ bytes p n,
-      ⌜s = .str bytes ∧ pos = .int p ∧ len = .int n ∧
-        0 ≤ p ∧ 0 ≤ n ∧ p + n ≤ (bytes.length : Int)⌝ ∗
-      Q (.str (stringSubBytes bytes p n)))
-  spec   :=
-    { args  := [("s", .string), ("pos", .int), ("len", .int)]
-      retTy := .string
-      pred  := .assert stringSubPre <|
-        .ret ("ret",
-          .assert (.eq .value (.var .value "ret")
-            (stringSubTerm (.var .value "s") (.var .value "pos") (.var .value "len")))
-            (.ret ())) }
-  typing := monoTyping .three
-  folSym := some stringSubSym
-  axioms := [⟨stringSubDefAxiom, .high⟩, ⟨stringSubTypeAxiom, .high⟩]
+def stringSubB : Pure.Ternary where
+  name     := "string_sub"
+  path     := some ("String", ["sub"])
+  arg₁     := .str
+  arg₂     := .int
+  arg₃     := .int
+  res      := .str
+  f        := stringSubBytes
+  dom      := (fun s pos len => 0 ≤ pos ∧ 0 ≤ len ∧ pos + len ≤ (s.length : Int) :
+                List UInt8 → Int → Int → Prop)
+  pre      := some stringSubPre
+  typing   := monoTyping .three
+  defAxiom := stringSubDefAxiom
+
+def stringSub : Intrinsic := stringSubB.toIntrinsic
 
 @[simp] theorem stringSub_arity : stringSub.arity = .three := rfl
 @[simp] theorem stringSub_folSym : stringSub.folSym = some stringSubSym := rfl
 
-@[simp] theorem stringSub.toWp_eq (s pos len : Runtime.Val) (Q : Runtime.Val → iProp) :
-    stringSub.toWp [s, pos, len] Q =
-      iprop(∃ bytes p n,
-        ⌜s = .str bytes ∧ pos = .int p ∧ len = .int n ∧
-          0 ≤ p ∧ 0 ≤ n ∧ p + n ≤ (bytes.length : Int)⌝ ∗
-        Q (.str (stringSubBytes bytes p n))) := rfl
+def stringSubLawful : stringSubB.Lawful where
+  argL₁      := Embedding.lawfulStr
+  argL₂      := Embedding.lawfulInt
+  argL₃      := Embedding.lawfulInt
+  resL       := Embedding.lawfulStr
+  domSound   := by
+    intro ρ s pos len h
+    have hpre := h stringSubPre rfl
+    simpa [stringSubB, stringSubPre, Embedding.str, Embedding.int, Formula.eval, Term.eval,
+      Const.denote, Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide),
+      Env.lookupConst_updateConst_ne (show "a" ≠ "c" by decide),
+      Env.lookupConst_updateConst_ne (show "b" ≠ "c" by decide), valStr, valInt] using hpre
+  specBaseWf := by apply PredTrans.checkWf_ok; rfl
+  defWf      := by apply Formula.checkWf_ok; rfl
+  typeWf     := by apply Formula.checkWf_ok; rfl
+  defEval    := by
+    have hsym : stringSubB.sym = stringSubSym := rfl
+    intro ρ hresp
+    rw [hsym] at hresp
+    simp only [stringSubB, stringSubDefAxiom, Formula.all, Formula.eval]
+    intro s pos len hpre
+    have hter : ((((ρ.updateConst .value "s" s).updateConst .value "pos" pos).updateConst
+          .value "len" len).ternary .value .value .value .value "string_sub") =
+        fun a b c => stringSubSym.interp (a, b, c) := by
+      rw [Env.updateConst_ternary, Env.updateConst_ternary, Env.updateConst_ternary]
+      simpa [Env.respects, stringSubSym] using hresp
+    simp [stringSubTerm, terTerm, stringSubSym, stringSubBytes, hter, Term.eval,
+      Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "s" ≠ "pos" by decide),
+      Env.lookupConst_updateConst_ne (show "s" ≠ "len" by decide),
+      Env.lookupConst_updateConst_ne (show "pos" ≠ "len" by decide),
+      valStr, valInt]
+    rfl
 
-@[simp] theorem stringSub.toReduce_eq
-    (s pos len v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    stringSub.toReduce [s, pos, len] μ v μ' =
-      ((∃ bytes p n, s = .str bytes ∧ pos = .int p ∧ len = .int n ∧
-        0 ≤ p ∧ 0 ≤ n ∧ p + n ≤ (bytes.length : Int) ∧
-        v = .str (stringSubBytes bytes p n)) ∧ μ' = μ) := rfl
-
-@[simp] theorem stringSub.instantiate_args (σ : TinyML.TyVar → TinyML.Typ) :
-    (stringSub.spec.instantiate σ).args = [("s", .string), ("pos", .int), ("len", .int)] := by
-  simp [stringSub, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem stringSub.instantiate_retTy (σ : TinyML.TyVar → TinyML.Typ) :
-    (stringSub.spec.instantiate σ).retTy = .string := by
-  simp [stringSub, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem stringSub.spec_pred :
-    stringSub.spec.pred = .assert stringSubPre
-      (.ret ("ret",
-        .assert (.eq .value (.var .value "ret")
-          (stringSubTerm (.var .value "s") (.var .value "pos") (.var .value "len")))
-          (.ret ()))) := rfl
-
-instance : IntrinsicSound [stringSub] stringSub where
-  specWf := fun _ hsub hwf =>
-    specWf_of_base (by apply PredTrans.checkWf_ok; rfl) hsub hwf
-  wp_sound := by
-    intro _ ctx hctx vs Φ
-    match vs with
-    | [] => exact false_elim
-    | [_] => exact false_elim
-    | [_, _] => exact false_elim
-    | _ :: _ :: _ :: _ :: _ => exact false_elim
-    | [s, pos, len] =>
-      have hred : ∀ bytes p n μ v μ',
-          ctx stringSub.name [.str bytes, .int p, .int n] μ v μ'
-            ↔ (0 ≤ p ∧ 0 ≤ n ∧ p + n ≤ (bytes.length : Int) ∧
-              v = .str (stringSubBytes bytes p n)) ∧ μ' = μ := by
-        intro bytes p n μ v μ'
-        rw [hctx]
-        simp only [stringSub.toReduce_eq]
-        constructor
-        · rintro ⟨⟨bytes', p', n', hs, hp, hn, hp0, hn0, hbound, hv⟩, hμ⟩
-          cases hs
-          cases hp
-          cases hn
-          exact ⟨⟨hp0, hn0, hbound, hv⟩, hμ⟩
-        · rintro ⟨⟨hp0, hn0, hbound, hv⟩, hμ⟩
-          exact ⟨⟨bytes, p, n, rfl, rfl, rfl, hp0, hn0, hbound, hv⟩, hμ⟩
-      show iprop(∃ bytes p n,
-        ⌜s = .str bytes ∧ pos = .int p ∧ len = .int n ∧
-          0 ≤ p ∧ 0 ≤ n ∧ p + n ≤ (bytes.length : Int)⌝ ∗
-        Φ (.str (stringSubBytes bytes p n))) ⊢ _
-      istart
-      iintro ⟨%bytes, %p, %n, %ha, HΦ⟩
-      obtain ⟨rfl, rfl, rfl, hp0, hn0, hbound⟩ := ha
-      iapply (wp.prim_pure (hred bytes p n)
-        ⟨.str (stringSubBytes bytes p n), hp0, hn0, hbound, rfl⟩)
-      iintro %v %hv
-      obtain ⟨_, _, _, rfl⟩ := hv
-      iexact HΦ
-  bridge := by
-    intro _ σ Θ vs ρ Φ hρ
-    simp only [stringSub.instantiate_args, stringSub.instantiate_retTy,
-      Spec.instantiate_pred, stringSub.spec_pred, List.map_cons, List.map_nil]
-    match vs with
-    | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [_, _] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | _ :: _ :: _ :: _ :: _ =>
-        exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [s, pos, len] =>
-      simp only [PredTrans.apply, Assertion.pre]
-      iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ s [pos, len] _ _).1 $$ Hvs
-      icases Hcons with ⟨Hs, Hrest⟩
-      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ pos [len] _ _).1 $$ Hrest
-      icases Hcons2 with ⟨Hpos, Hrest2⟩
-      ihave Hcons3 := (TinyML.ValsHaveTypes.cons Θ len [] _ _).1 $$ Hrest2
-      icases Hcons3 with ⟨Hlen, _⟩
-      ihave Hseq := (TinyML.ValHasType.string Θ s).1 $$ Hs
-      ipure Hseq
-      obtain ⟨bytes, rfl⟩ := Hseq
-      ihave Hposeq := (TinyML.ValHasType.int Θ pos).1 $$ Hpos
-      ipure Hposeq
-      obtain ⟨p, rfl⟩ := Hposeq
-      ihave Hleneq := (TinyML.ValHasType.int Θ len).1 $$ Hlen
-      ipure Hleneq
-      obtain ⟨n, rfl⟩ := Hleneq
-      icases Hpred with ⟨%hpre, Hpost⟩
-      have hbounds : 0 ≤ p ∧ 0 ≤ n ∧ p + n ≤ (bytes.length : Int) := by
-        simpa [stringSubPre, Spec.argsEnv, Formula.eval, Term.eval, Const.denote,
-          VerifM.Env.updateConst_env, Env.lookupConst_updateConst_same,
-          Env.lookupConst_updateConst_ne (show "s" ≠ "pos" by decide),
-          Env.lookupConst_updateConst_ne (show "s" ≠ "len" by decide),
-          Env.lookupConst_updateConst_ne (show "pos" ≠ "len" by decide)] using hpre
-      simp only [stringSub.toWp_eq]
-      iexists bytes
-      iexists p
-      iexists n
-      isplitr [Hpost]
-      · ipureintro
-        exact ⟨rfl, rfl, rfl, hbounds.1, hbounds.2.1, hbounds.2.2⟩
-      · have hassert : (Formula.eq .value (.var .value "ret")
-            (stringSubTerm (.var .value "s") (.var .value "pos") (.var .value "len"))).eval
-            ((Spec.argsEnv ρ stringSub.specArgs [.str bytes, .int p, .int n]).updateConst
-              .value "ret" (.str (stringSubBytes bytes p n))).env := by
-          have hargs := string_respects_argsEnv_three stringSub.specArgs
-            [.str bytes, .int p, .int n] hρ
-          have hter : (Spec.argsEnv ρ stringSub.specArgs [.str bytes, .int p, .int n]).env.ternary
-              .value .value .value .value "string_sub" =
-                fun a b c => stringSubSym.interp (a, b, c) := by
-            simpa [Env.respects, stringSubSym] using hargs
-          show .str (stringSubBytes bytes p n) =
-            (Spec.argsEnv ρ stringSub.specArgs [.str bytes, .int p, .int n]).env.ternary
-              .value .value .value .value "string_sub" (.str bytes) (.int p) (.int n)
-          simp [stringSubBytes, stringSubSym, hter, valStr, valInt]
-        refine (assert_ret_apply Θ _ "ret" _ _ (.str (stringSubBytes bytes p n)) hassert).trans ?_
-        iintro Hwand
-        iapply Hwand
-        exact TinyML.ValHasType.string_intro Θ (stringSubBytes bytes p n)
-  axiomWf := by
-    intro Δ hsub hwf a hφ
-    simp only [stringSub, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-  proof := by
-    intro ρ hdeps a hφ
-    simp only [stringSub, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    have hresp : ρ.respects (some stringSubSym) := by
-      have h := hdeps stringSub (by simp)
-      simpa [stringSub] using h
-    rcases hφ with rfl | rfl
-    · simp only [stringSubDefAxiom, Formula.all, Formula.eval]
-      intro s pos len hpre
-      have hter : ((((ρ.updateConst .value "s" s).updateConst .value "pos" pos).updateConst
-            .value "len" len).ternary .value .value .value .value "string_sub") =
-          fun a b c => stringSubSym.interp (a, b, c) := by
-        rw [Env.updateConst_ternary, Env.updateConst_ternary, Env.updateConst_ternary]
-        simpa [Env.respects, stringSubSym] using hresp
-      simp [stringSubTerm, terTerm, stringSubSym, stringSubBytes, hter, Term.eval,
-        Env.lookupConst_updateConst_same,
-        Env.lookupConst_updateConst_ne (show "s" ≠ "pos" by decide),
-        Env.lookupConst_updateConst_ne (show "s" ≠ "len" by decide),
-        Env.lookupConst_updateConst_ne (show "pos" ≠ "len" by decide),
-        valStr, valInt]
-      rfl
-    · simp only [stringSubTypeAxiom, Formula.all, Formula.eval]
-      intro s pos len
-      have hter : ((((ρ.updateConst .value "s" s).updateConst .value "pos" pos).updateConst
-            .value "len" len).ternary .value .value .value .value "string_sub") =
-          fun a b c => stringSubSym.interp (a, b, c) := by
-        rw [Env.updateConst_ternary, Env.updateConst_ternary, Env.updateConst_ternary]
-        simpa [Env.respects, stringSubSym] using hresp
-      simp [stringSubTerm, terTerm, stringSubSym, stringSubBytes, hter, Term.eval,
-        Env.lookupConst_updateConst_same,
-        Env.lookupConst_updateConst_ne (show "s" ≠ "pos" by decide),
-        Env.lookupConst_updateConst_ne (show "s" ≠ "len" by decide),
-        Env.lookupConst_updateConst_ne (show "pos" ≠ "len" by decide),
-        valStr, valInt]
+instance : IntrinsicSound [stringSub] stringSub := stringSubLawful.sound
 
 /-! ## `String.equal` -/
 
@@ -623,6 +338,8 @@ def stringEqualB : Pure.Binary where
   arg₂     := .str
   res      := .bool
   f        := (fun x y => x == y : List UInt8 → List UInt8 → Bool)
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := stringEqualDefAxiom
 
@@ -635,6 +352,7 @@ def stringEqualLawful : stringEqualB.Lawful where
   argL₁      := Embedding.lawfulStr
   argL₂      := Embedding.lawfulStr
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -654,6 +372,8 @@ def stringStartsWithB : Pure.Binary where
   arg₂     := .str
   res      := .bool
   f        := (fun x y => x.isPrefixOf y : List UInt8 → List UInt8 → Bool)
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := stringStartsWithDefAxiom
 
@@ -667,6 +387,7 @@ def stringStartsWithLawful : stringStartsWithB.Lawful where
   argL₁      := Embedding.lawfulStr
   argL₂      := Embedding.lawfulStr
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl
@@ -685,6 +406,8 @@ def stringEndsWithB : Pure.Binary where
   arg₂     := .str
   res      := .bool
   f        := (fun x y => x.isSuffixOf y : List UInt8 → List UInt8 → Bool)
+  dom      := fun _ _ => True
+  pre      := none
   typing   := monoTyping .two
   defAxiom := stringEndsWithDefAxiom
 
@@ -697,6 +420,7 @@ def stringEndsWithLawful : stringEndsWithB.Lawful where
   argL₁      := Embedding.lawfulStr
   argL₂      := Embedding.lawfulStr
   resL       := Embedding.lawfulBool
+  domSound   := fun _ _ _ _ => True.intro
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf      := by apply Formula.checkWf_ok; rfl
   typeWf     := by apply Formula.checkWf_ok; rfl

--- a/Mica/Stdlib/VecStd.lean
+++ b/Mica/Stdlib/VecStd.lean
@@ -1,4 +1,4 @@
--- SUMMARY: Immutable-vector intrinsics (`Vec.length`, `Vec.get`, `Vec.set`, `Vec.make`) and their soundness instances.
+-- SUMMARY: Immutable-vector intrinsics (`Vec.length`, `Vec.get`, `Vec.set`, `Vec.make`) as builder instances over the vec/poly embeddings.
 import Mica.Stdlib.Combinators
 
 open Iris Iris.BI
@@ -19,10 +19,12 @@ standard interpretations agree with them everywhere, not only in bounds.
 The SMT preamble only constrains the underlying vector operations on their
 intrinsic domains; their out-of-domain SMT values remain unspecified.
 
-`get`/`set` are partial: their `reduce` relations demand an in-bounds index, so
-an out-of-bounds call is stuck, and the `spec.pred` precondition is what makes
-the weakest precondition provable at a call site. `make` demands a nonnegative
-length.
+`get`/`set` are partial: their `dom` demands an in-bounds index, so an
+out-of-bounds call is stuck, and the `pre` precondition is what makes the
+weakest precondition provable at a call site. `make` demands a nonnegative
+length. Polymorphism is carried by the `Embedding.vec`/`Embedding.poly`
+embeddings, whose type predicates (big-sep of element typings, resp. the
+typing fact itself) feed the `semWellTyped` obligations.
 -/
 
 namespace Stdlib
@@ -30,78 +32,6 @@ namespace Stdlib
 open Verifier
 
 namespace Intrinsics
-
-/-- Vector projection of a runtime value, matching FOL's `toVec`. -/
-def valVec : Runtime.Val → List Runtime.Val
-  | .vec l => l
-  | _      => []
-
-private theorem vec_respects_argsEnv_one {s : FOL.Symbol .one} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
-  | [], _, _, h => h
-  | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
-      simp only [Spec.argsEnv]
-      refine vec_respects_argsEnv_one rest vs ?_
-      rw [VerifM.Env.updateConst_env]
-      simpa only [Env.respects, Env.updateConst_unary] using h
-
-private theorem vec_respects_argsEnv_two {s : FOL.Symbol .two} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
-  | [], _, _, h => h
-  | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
-      simp only [Spec.argsEnv]
-      refine vec_respects_argsEnv_two rest vs ?_
-      rw [VerifM.Env.updateConst_env]
-      simpa only [Env.respects, Env.updateConst_binary] using h
-
-private theorem vec_respects_argsEnv_three {s : FOL.Symbol .three} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
-  | [], _, _, h => h
-  | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
-      simp only [Spec.argsEnv]
-      refine vec_respects_argsEnv_three rest vs ?_
-      rw [VerifM.Env.updateConst_env]
-      simpa only [Env.respects, Env.updateConst_ternary] using h
-
-/-! ## FOL symbols
-
-Value-sorted counterparts of the `Vec`-sorted operations. Each standard
-interpretation projects its arguments (`valVec`/`valInt`, matching FOL's
-`toVec`/`toInt`) and injects the result. Negative indices and lengths have
-explicit totalized behavior matching the interpreted FOL operations. -/
-
-def vecLengthSym : FOL.Symbol .one where
-  name   := "val_vec_length"
-  interp := fun v => .int (valVec v).length
-
-def vecGetSym : FOL.Symbol .two where
-  name   := "val_vec_get"
-  interp := fun (v, i) =>
-    let n := valInt i
-    if 0 ≤ n then ((valVec v)[n.toNat]?).getD .unit else .unit
-
-def vecSetSym : FOL.Symbol .three where
-  name   := "val_vec_set"
-  interp := fun (v, i, x) =>
-    let n := valInt i
-    .vec (if 0 ≤ n then (valVec v).set n.toNat x else valVec v)
-
-def vecMakeSym : FOL.Symbol .two where
-  name   := "val_vec_make"
-  interp := fun (n, x) =>
-    let len := valInt n
-    .vec (if 0 ≤ len then List.replicate len.toNat x else [])
-
-@[simp] theorem vecLengthSym_name : vecLengthSym.name = "val_vec_length" := rfl
-@[simp] theorem vecGetSym_name : vecGetSym.name = "val_vec_get" := rfl
-@[simp] theorem vecSetSym_name : vecSetSym.name = "val_vec_set" := rfl
-@[simp] theorem vecMakeSym_name : vecMakeSym.name = "val_vec_make" := rfl
 
 /-! ## Shared term abbreviations -/
 
@@ -128,10 +58,6 @@ def vecLengthDefAxiom : Formula :=
       (.unop .toInt (unTerm "val_vec_length" (.var .value "v")))
       (.unop .vecLen (vecOf "v"))
 
-def vecLengthTypeAxiom : Formula :=
-  .forall_ "v" .value [.term (unTerm "val_vec_length" (.var .value "v"))] <|
-    .unpred .isInt (unTerm "val_vec_length" (.var .value "v"))
-
 def vecGetDefAxiom : Formula :=
   .all "v" .value <| .forall_ "i" .value
     [.term (binTerm "val_vec_get" (.var .value "v") (.var .value "i"))] <|
@@ -146,11 +72,6 @@ def vecSetDefAxiom : Formula :=
       (terTerm "val_vec_set" (.var .value "v") (.var .value "i") (.var .value "x"))
       (.unop .ofVec (.terop .vecSet (vecOf "v") (intOf "i") (.var .value "x")))
 
-def vecSetTypeAxiom : Formula :=
-  .all "v" .value <| .all "i" .value <| .forall_ "x" .value
-    [.term (terTerm "val_vec_set" (.var .value "v") (.var .value "i") (.var .value "x"))] <|
-    .unpred .isVec (terTerm "val_vec_set" (.var .value "v") (.var .value "i") (.var .value "x"))
-
 def vecMakeDefAxiom : Formula :=
   .all "n" .value <| .forall_ "x" .value
     [.term (binTerm "val_vec_make" (.var .value "n") (.var .value "x"))] <|
@@ -158,680 +79,219 @@ def vecMakeDefAxiom : Formula :=
       (binTerm "val_vec_make" (.var .value "n") (.var .value "x"))
       (.unop .ofVec (.binop .vecMake (intOf "n") (.var .value "x")))
 
-def vecMakeTypeAxiom : Formula :=
-  .all "n" .value <| .forall_ "x" .value
-    [.term (binTerm "val_vec_make" (.var .value "n") (.var .value "x"))] <|
-    .unpred .isVec (binTerm "val_vec_make" (.var .value "n") (.var .value "x"))
-
 /-! ## `Vec.length` -/
 
 /-- `Vec.length : 'a vec -> int`. Total. -/
-def vecLength : Intrinsic where
-  arity  := .one
-  name   := "val_vec_length"
-  path   := some ("Vec", ["length"])
-  reduce := Reduce.pure fun v r => ∃ l, v = .vec l ∧ r = .int l.length
-  wp     := fun v Q => iprop(∃ l, ⌜v = .vec l⌝ ∗ Q (.int l.length))
-  spec   :=
-    { args  := [("v", .vec (.tvar "a"))]
-      retTy := .int
-      pred  := .ret ("ret",
-        .assert (.eq .value (.var .value "ret")
-          (unTerm "val_vec_length" (.var .value "v"))) (.ret ())) }
-  typing := fun _ tys =>
+def vecLengthB : Pure.Unary where
+  name     := "val_vec_length"
+  path     := some ("Vec", ["length"])
+  arg      := .vec
+  res      := .int
+  f        := (fun l => (l.length : Int) : List Runtime.Val → Int)
+  dom      := fun _ => True
+  pre      := none
+  typing   := fun _ tys =>
     match tys with
     | [.vec t] => .ok [("a", t)]
     | [_] => .error "Vec.length expects a vector argument"
     | _ => .error s!"expected 1 argument, got {tys.length}"
-  folSym := some vecLengthSym
-  axioms := [⟨vecLengthDefAxiom, .high⟩, ⟨vecLengthTypeAxiom, .high⟩]
+  defAxiom := vecLengthDefAxiom
+
+def vecLength : Intrinsic := vecLengthB.toIntrinsic
 
 @[simp] theorem vecLength_arity : vecLength.arity = .one := rfl
-@[simp] theorem vecLength_folSym : vecLength.folSym = some vecLengthSym := rfl
+@[simp] theorem vecLength_folSym : vecLength.folSym = some vecLengthB.sym := rfl
+@[simp] theorem vecLengthSym_name : vecLengthB.sym.name = "val_vec_length" := rfl
 
-@[simp] theorem vecLength.toWp_eq (v : Runtime.Val) (Q : Runtime.Val → iProp) :
-    vecLength.toWp [v] Q = iprop(∃ l, ⌜v = .vec l⌝ ∗ Q (.int l.length)) := rfl
+def vecLengthLawful : vecLengthB.Lawful where
+  argL         := Embedding.lawfulVec
+  resL         := Embedding.lawfulInt
+  domSound     := fun _ _ _ => True.intro
+  semWellTyped := fun _ _ _ _ => affine
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
+    intrinsic_def_eval [unTerm, vecOf, UnOp.eval, vecLengthB, vecLengthDefAxiom]
+    intro v
+    rfl
 
-@[simp] theorem vecLength.toReduce_eq (v r : Runtime.Val) (μ μ' : TinyML.Heap) :
-    vecLength.toReduce [v] μ r μ' =
-      ((∃ l, v = .vec l ∧ r = .int l.length) ∧ μ' = μ) := rfl
-
-@[simp] theorem vecLength.instantiate_args (σ : TinyML.TyVar → TinyML.Typ) :
-    (vecLength.spec.instantiate σ).args = [("v", .vec (σ "a"))] := by
-  simp [vecLength, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem vecLength.instantiate_retTy (σ : TinyML.TyVar → TinyML.Typ) :
-    (vecLength.spec.instantiate σ).retTy = .int := by
-  simp [vecLength, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem vecLength.spec_pred :
-    vecLength.spec.pred = .ret ("ret",
-      .assert (.eq .value (.var .value "ret")
-        (unTerm "val_vec_length" (.var .value "v"))) (.ret ())) := rfl
-
-instance : IntrinsicSound [vecLength] vecLength where
-  specWf := fun _ hsub hwf =>
-    specWf_of_base (by apply PredTrans.checkWf_ok; rfl) hsub hwf
-  wp_sound := by
-    intro _ ctx hctx vs Φ
-    match vs with
-    | [] => exact false_elim
-    | _ :: _ :: _ => exact false_elim
-    | [v] =>
-      have hred : ∀ l μ r μ',
-          ctx vecLength.name [.vec l] μ r μ' ↔ r = .int l.length ∧ μ' = μ := by
-        intro l μ r μ'
-        rw [hctx]
-        simp only [vecLength.toReduce_eq]
-        constructor
-        · rintro ⟨⟨l', hv, hr⟩, hμ⟩
-          cases hv
-          exact ⟨hr, hμ⟩
-        · rintro ⟨hr, hμ⟩
-          exact ⟨⟨l, rfl, hr⟩, hμ⟩
-      show iprop(∃ l, ⌜v = .vec l⌝ ∗ Φ (.int l.length)) ⊢ _
-      istart
-      iintro ⟨%l, %hv, HΦ⟩
-      obtain rfl := hv
-      iapply (wp.prim_pure (hred l) ⟨_, rfl⟩)
-      iintro %r %hr
-      subst hr
-      iexact HΦ
-  bridge := by
-    intro _ σ Θ vs ρ Φ hρ
-    simp only [vecLength.instantiate_args, vecLength.instantiate_retTy,
-      Spec.instantiate_pred, vecLength.spec_pred, List.map_cons, List.map_nil]
-    match vs with
-    | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | _ :: _ :: _ =>
-        exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [v] =>
-      iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v [] _ _).1 $$ Hvs
-      icases Hcons with ⟨Hv, _⟩
-      ihave Hvec := (TinyML.ValHasType.vec Θ v (σ "a")).1 $$ Hv
-      icases Hvec with ⟨%l, %hv, _⟩
-      obtain rfl := hv
-      simp only [vecLength.toWp_eq]
-      iexists l
-      isplitr [Hpred]
-      · ipureintro; rfl
-      · have hassert : (Formula.eq .value (.var .value "ret")
-            (unTerm "val_vec_length" (.var .value "v"))).eval
-            ((Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a"))] [.vec l]).updateConst
-              .value "ret" (.int l.length)).env := by
-          have hargs := vec_respects_argsEnv_one
-            [("v", TinyML.Typ.vec (σ "a"))] [Runtime.Val.vec l] hρ
-          have hun : (Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a"))] [.vec l]).env.unary
-              .value .value "val_vec_length" = vecLengthSym.interp := by
-            simpa [Env.respects, vecLengthSym] using hargs
-          show Runtime.Val.int l.length =
-            (Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a"))] [.vec l]).env.unary
-              .value .value "val_vec_length" (.vec l)
-          rw [hun]
-          simp [vecLengthSym, valVec]
-        refine (assert_ret_apply Θ _ "ret" _ _ (.int l.length) hassert).trans ?_
-        iintro Hwand
-        iapply Hwand
-        exact TinyML.ValHasType.int_intro Θ l.length
-  axiomWf := by
-    intro Δ hsub hwf a hφ
-    simp only [vecLength, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-  proof := by
-    intro ρ hdeps a hφ
-    simp only [vecLength, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    have hresp : ρ.respects (some vecLengthSym) := by
-      have h := hdeps vecLength (by simp)
-      simpa [vecLength] using h
-    have hun : ∀ v : Runtime.Val,
-        (ρ.updateConst .value "v" v).unary .value .value "val_vec_length" = vecLengthSym.interp := by
-      intro v
-      rw [Env.updateConst_unary]
-      simpa [Env.respects, vecLengthSym] using hresp
-    rcases hφ with rfl | rfl
-    · simp only [vecLengthDefAxiom, Formula.eval]
-      intro v
-      simp only [unTerm, vecOf, vecLengthSym, hun v, Term.eval, UnOp.eval,
-        Env.lookupConst_updateConst_same, valVec]
-      rfl
-    · simp only [vecLengthTypeAxiom, Formula.eval]
-      intro v
-      simp [unTerm, vecLengthSym, hun v, Term.eval, Env.lookupConst_updateConst_same]
+instance : IntrinsicSound [vecLength] vecLength := vecLengthLawful.sound
 
 /-! ## `Vec.get` -/
 
 /-- `Vec.get : 'a vec -> int -> 'a`. Partial: the index must be in bounds. -/
-def vecGet : Intrinsic where
-  arity  := .two
-  name   := "val_vec_get"
-  path   := some ("Vec", ["get"])
-  reduce := Reduce.pure fun (v, i) r =>
-    ∃ l n, v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int) ∧
-      r = (l[n.toNat]?).getD .unit
-  wp     := fun (v, i) Q =>
-    iprop(∃ l n, ⌜v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int)⌝ ∗
-      Q ((l[n.toNat]?).getD .unit))
-  spec   :=
-    { args  := [("v", .vec (.tvar "a")), ("i", .int)]
-      retTy := .tvar "a"
-      pred  := .assert (vecBoundsPre "v" "i") <|
-        .ret ("ret",
-          .assert (.eq .value (.var .value "ret")
-            (binTerm "val_vec_get" (.var .value "v") (.var .value "i"))) (.ret ())) }
-  typing := fun _ tys =>
+def vecGetB : Pure.Binary where
+  name     := "val_vec_get"
+  path     := some ("Vec", ["get"])
+  arg₁     := .vec
+  arg₂     := .int
+  res      := .poly
+  f        := fun (l : List Runtime.Val) (i : Int) =>
+    if 0 ≤ i then (l[i.toNat]?).getD .unit else .unit
+  dom      := (fun l n => 0 ≤ n ∧ n < (l.length : Int) : List Runtime.Val → Int → Prop)
+  pre      := some vecBoundsPre
+  typing   := fun _ tys =>
     match tys with
     | [.vec t, _] => .ok [("a", t)]
     | [_, _] => .error "Vec.get expects a vector as its first argument"
     | _ => .error s!"expected 2 arguments, got {tys.length}"
-  folSym := some vecGetSym
-  axioms := [⟨vecGetDefAxiom, .high⟩]
+  defAxiom := vecGetDefAxiom
+
+def vecGet : Intrinsic := vecGetB.toIntrinsic
 
 @[simp] theorem vecGet_arity : vecGet.arity = .two := rfl
-@[simp] theorem vecGet_folSym : vecGet.folSym = some vecGetSym := rfl
+@[simp] theorem vecGet_folSym : vecGet.folSym = some vecGetB.sym := rfl
+@[simp] theorem vecGetSym_name : vecGetB.sym.name = "val_vec_get" := rfl
 
-@[simp] theorem vecGet.toWp_eq (v i : Runtime.Val) (Q : Runtime.Val → iProp) :
-    vecGet.toWp [v, i] Q =
-      iprop(∃ l n, ⌜v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int)⌝ ∗
-        Q ((l[n.toNat]?).getD .unit)) := rfl
-
-@[simp] theorem vecGet.toReduce_eq (v i r : Runtime.Val) (μ μ' : TinyML.Heap) :
-    vecGet.toReduce [v, i] μ r μ' =
-      ((∃ l n, v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int) ∧
-        r = (l[n.toNat]?).getD .unit) ∧ μ' = μ) := rfl
-
-@[simp] theorem vecGet.instantiate_args (σ : TinyML.TyVar → TinyML.Typ) :
-    (vecGet.spec.instantiate σ).args = [("v", .vec (σ "a")), ("i", .int)] := by
-  simp [vecGet, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem vecGet.instantiate_retTy (σ : TinyML.TyVar → TinyML.Typ) :
-    (vecGet.spec.instantiate σ).retTy = σ "a" := by
-  simp [vecGet, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem vecGet.spec_pred :
-    vecGet.spec.pred = .assert (vecBoundsPre "v" "i")
-      (.ret ("ret",
-        .assert (.eq .value (.var .value "ret")
-          (binTerm "val_vec_get" (.var .value "v") (.var .value "i"))) (.ret ()))) := rfl
-
-instance : IntrinsicSound [vecGet] vecGet where
-  specWf := fun _ hsub hwf =>
-    specWf_of_base (by apply PredTrans.checkWf_ok; rfl) hsub hwf
-  wp_sound := by
-    intro _ ctx hctx vs Φ
-    match vs with
-    | [] => exact false_elim
-    | [_] => exact false_elim
-    | _ :: _ :: _ :: _ => exact false_elim
-    | [v, i] =>
-      have hred : ∀ l n μ r μ',
-          ctx vecGet.name [.vec l, .int n] μ r μ'
-            ↔ (0 ≤ n ∧ n < (l.length : Int) ∧ r = (l[n.toNat]?).getD .unit) ∧ μ' = μ := by
-        intro l n μ r μ'
-        rw [hctx]
-        simp only [vecGet.toReduce_eq]
-        constructor
-        · rintro ⟨⟨l', n', hv, hi, hlo, hhi, hr⟩, hμ⟩
-          cases hv
-          cases hi
-          exact ⟨⟨hlo, hhi, hr⟩, hμ⟩
-        · rintro ⟨⟨hlo, hhi, hr⟩, hμ⟩
-          exact ⟨⟨l, n, rfl, rfl, hlo, hhi, hr⟩, hμ⟩
-      show iprop(∃ l n, ⌜v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int)⌝ ∗
-        Φ ((l[n.toNat]?).getD .unit)) ⊢ _
-      istart
-      iintro ⟨%l, %n, %ha, HΦ⟩
-      obtain ⟨rfl, rfl, hlo, hhi⟩ := ha
-      iapply (wp.prim_pure (hred l n) ⟨_, hlo, hhi, rfl⟩)
-      iintro %r %hr
-      obtain ⟨_, _, rfl⟩ := hr
-      iexact HΦ
-  bridge := by
-    intro _ σ Θ vs ρ Φ hρ
-    simp only [vecGet.instantiate_args, vecGet.instantiate_retTy,
-      Spec.instantiate_pred, vecGet.spec_pred, List.map_cons, List.map_nil]
-    match vs with
-    | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | _ :: _ :: _ :: _ =>
-        exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [v, i] =>
-      simp only [PredTrans.apply, Assertion.pre]
-      iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v [i] _ _).1 $$ Hvs
-      icases Hcons with ⟨Hv, Hrest⟩
-      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ i [] _ _).1 $$ Hrest
-      icases Hcons2 with ⟨Hi, _⟩
-      ihave Hvec := (TinyML.ValHasType.vec Θ v (σ "a")).1 $$ Hv
-      icases Hvec with ⟨%l, %hv, Helems⟩
-      obtain rfl := hv
-      ihave Hieq := (TinyML.ValHasType.int Θ i).1 $$ Hi
-      ipure Hieq
-      obtain ⟨n, rfl⟩ := Hieq
-      icases Hpred with ⟨%hpre, Hpost⟩
-      have hbounds : 0 ≤ n ∧ n < (l.length : Int) := by
-        simpa [vecBoundsPre, vecOf, intOf, Spec.argsEnv, Formula.eval, Term.eval,
-          VerifM.Env.updateConst_env, Env.lookupConst_updateConst_same,
-          Env.lookupConst_updateConst_ne (show "v" ≠ "i" by decide)] using hpre
-      have hlt : n.toNat < l.length := by omega
-      have hget : l[n.toNat]? = some l[n.toNat] := List.getElem?_eq_getElem hlt
-      simp only [vecGet.toWp_eq]
-      iexists l
-      iexists n
-      isplitr [Hpost Helems]
-      · ipureintro
-        exact ⟨rfl, rfl, hbounds.1, hbounds.2⟩
-      · have hassert : (Formula.eq .value (.var .value "ret")
-            (binTerm "val_vec_get" (.var .value "v") (.var .value "i"))).eval
-            ((Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a")), ("i", TinyML.Typ.int)]
-              [.vec l, .int n]).updateConst .value "ret" ((l[n.toNat]?).getD .unit)).env := by
-          have hargs := vec_respects_argsEnv_two
-            [("v", TinyML.Typ.vec (σ "a")), ("i", TinyML.Typ.int)]
-            [Runtime.Val.vec l, Runtime.Val.int n] hρ
-          have hbin : (Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a")), ("i", TinyML.Typ.int)]
-              [.vec l, .int n]).env.binary .value .value .value "val_vec_get"
-                = fun a b => vecGetSym.interp (a, b) := by
-            simpa [Env.respects, vecGetSym] using hargs
-          show (l[n.toNat]?).getD .unit =
-            (Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a")), ("i", TinyML.Typ.int)]
-              [.vec l, .int n]).env.binary .value .value .value "val_vec_get"
-                (.vec l) (.int n)
-          rw [hbin]
-          simp [vecGetSym, valVec, valInt, hbounds.1]
-        refine (sep_mono_right
-          (assert_ret_apply Θ _ "ret" _ _ ((l[n.toNat]?).getD .unit) hassert)).trans ?_
-        iintro ⟨Helems, Hwand⟩
-        iapply Hwand
-        simp only [hget, Option.getD_some]
-        iapply (BigSepL.bigSepL_lookup
-          (Φ := fun _ w => TinyML.ValHasType Θ w (σ "a")) hget)
-        iexact Helems
-  axiomWf := by
-    intro Δ hsub hwf a hφ
-    simp only [vecGet, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    subst hφ
-    exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-  proof := by
-    intro ρ hdeps a hφ
-    simp only [vecGet, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    have hresp : ρ.respects (some vecGetSym) := by
-      have h := hdeps vecGet (by simp)
-      simpa [vecGet] using h
-    subst hφ
-    simp only [vecGetDefAxiom, Formula.all, Formula.eval]
-    intro v i
-    have hbin : (((ρ.updateConst .value "v" v).updateConst .value "i" i).binary
-        .value .value .value "val_vec_get") = fun a b => vecGetSym.interp (a, b) := by
-      rw [Env.updateConst_binary, Env.updateConst_binary]
-      simpa [Env.respects, vecGetSym] using hresp
-    simp only [binTerm, vecOf, intOf, vecGetSym, hbin, Term.eval, UnOp.eval, BinOp.eval,
-      Env.lookupConst_updateConst_same,
-      Env.lookupConst_updateConst_ne (show "v" ≠ "i" by decide), valVec, valInt]
+def vecGetLawful : vecGetB.Lawful where
+  argL₁        := Embedding.lawfulVec
+  argL₂        := Embedding.lawfulInt
+  resL         := Embedding.lawfulPoly
+  domSound     := by
+    intro ρ l n h
+    have hpre := h vecBoundsPre rfl
+    simpa [vecGetB, vecBoundsPre, vecOf, intOf, Embedding.vec, Embedding.int,
+      Formula.eval, Term.eval, Const.denote, Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), valVec, valInt] using hpre
+  semWellTyped := by
+    refine fun σ Θ (l : List Runtime.Val) (n : Int) hdom => ?_
+    obtain ⟨h0, hlen⟩ := hdom
+    have hlt : n.toNat < l.length := by omega
+    have hget : l[n.toNat]? = some l[n.toNat] := List.getElem?_eq_getElem hlt
+    simp only [Embedding.vec, Embedding.int, Embedding.poly, vecGetB, if_pos h0,
+      hget, Option.getD_some]
+    refine sep_emp.1.trans ?_
+    exact BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType Θ w (σ "a")) hget
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; exact nomatch h
+  defEval      := by
+    intrinsic_def_eval [binTerm, vecOf, intOf, UnOp.eval, BinOp.eval, vecGetB, vecGetDefAxiom]
+    intros
     rfl
+
+instance : IntrinsicSound [vecGet] vecGet := vecGetLawful.sound
 
 /-! ## `Vec.set` -/
 
 /-- `Vec.set : 'a vec -> int -> 'a -> 'a vec`, the copying functional update.
     Partial: the index must be in bounds. -/
-def vecSet : Intrinsic where
-  arity  := .three
-  name   := "val_vec_set"
-  path   := some ("Vec", ["set"])
-  reduce := Reduce.pure fun (v, i, x) r =>
-    ∃ l n, v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int) ∧
-      r = .vec (l.set n.toNat x)
-  wp     := fun (v, i, x) Q =>
-    iprop(∃ l n, ⌜v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int)⌝ ∗
-      Q (.vec (l.set n.toNat x)))
-  spec   :=
-    { args  := [("v", .vec (.tvar "a")), ("i", .int), ("x", .tvar "a")]
-      retTy := .vec (.tvar "a")
-      pred  := .assert (vecBoundsPre "v" "i") <|
-        .ret ("ret",
-          .assert (.eq .value (.var .value "ret")
-            (terTerm "val_vec_set" (.var .value "v") (.var .value "i") (.var .value "x")))
-            (.ret ())) }
-  typing := fun _ tys =>
+def vecSetB : Pure.Ternary where
+  name     := "val_vec_set"
+  path     := some ("Vec", ["set"])
+  arg₁     := .vec
+  arg₂     := .int
+  arg₃     := .poly
+  res      := .vec
+  f        := fun (l : List Runtime.Val) (i : Int) (x : Runtime.Val) =>
+    if 0 ≤ i then l.set i.toNat x else l
+  dom      := (fun l n _ => 0 ≤ n ∧ n < (l.length : Int) :
+                List Runtime.Val → Int → Runtime.Val → Prop)
+  pre      := some fun v i _ => vecBoundsPre v i
+  typing   := fun _ tys =>
     match tys with
     | [.vec t, _, _] => .ok [("a", t)]
     | [_, _, _] => .error "Vec.set expects a vector as its first argument"
     | _ => .error s!"expected 3 arguments, got {tys.length}"
-  folSym := some vecSetSym
-  axioms := [⟨vecSetDefAxiom, .high⟩, ⟨vecSetTypeAxiom, .high⟩]
+  defAxiom := vecSetDefAxiom
+
+def vecSet : Intrinsic := vecSetB.toIntrinsic
 
 @[simp] theorem vecSet_arity : vecSet.arity = .three := rfl
-@[simp] theorem vecSet_folSym : vecSet.folSym = some vecSetSym := rfl
+@[simp] theorem vecSet_folSym : vecSet.folSym = some vecSetB.sym := rfl
+@[simp] theorem vecSetSym_name : vecSetB.sym.name = "val_vec_set" := rfl
 
-@[simp] theorem vecSet.toWp_eq (v i x : Runtime.Val) (Q : Runtime.Val → iProp) :
-    vecSet.toWp [v, i, x] Q =
-      iprop(∃ l n, ⌜v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int)⌝ ∗
-        Q (.vec (l.set n.toNat x))) := rfl
+def vecSetLawful : vecSetB.Lawful where
+  argL₁        := Embedding.lawfulVec
+  argL₂        := Embedding.lawfulInt
+  argL₃        := Embedding.lawfulPoly
+  resL         := Embedding.lawfulVec
+  domSound     := by
+    intro ρ l n x h
+    have hpre := h _ rfl
+    simpa [vecSetB, vecBoundsPre, vecOf, intOf, Embedding.vec, Embedding.int, Embedding.poly,
+      Formula.eval, Term.eval, Const.denote, Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide),
+      Env.lookupConst_updateConst_ne (show "a" ≠ "c" by decide),
+      Env.lookupConst_updateConst_ne (show "b" ≠ "c" by decide), valVec, valInt] using hpre
+  semWellTyped := by
+    refine fun σ Θ (l : List Runtime.Val) (n : Int) (x : Runtime.Val) hdom => ?_
+    obtain ⟨h0, hlen⟩ := hdom
+    have hlt : n.toNat < l.length := by omega
+    have hget : l[n.toNat]? = some l[n.toNat] := List.getElem?_eq_getElem hlt
+    simp only [Embedding.vec, Embedding.int, Embedding.poly, vecSetB, if_pos h0]
+    refine (sep_mono_right emp_sep.1).trans ?_
+    refine (sep_mono_left (BigSepL.bigSepL_insert_acc
+      (Φ := fun _ w => TinyML.ValHasType Θ w (σ "a")) hget)).trans ?_
+    refine (sep_mono_left sep_elim_right).trans ?_
+    exact (sep_mono_left (forall_elim x)).trans wand_elim_left
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
+    intrinsic_def_eval [terTerm, vecOf, intOf, UnOp.eval, TerOp.eval, vecSetB, vecSetDefAxiom]
+    intros
+    rfl
 
-@[simp] theorem vecSet.toReduce_eq (v i x r : Runtime.Val) (μ μ' : TinyML.Heap) :
-    vecSet.toReduce [v, i, x] μ r μ' =
-      ((∃ l n, v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int) ∧
-        r = .vec (l.set n.toNat x)) ∧ μ' = μ) := rfl
-
-@[simp] theorem vecSet.instantiate_args (σ : TinyML.TyVar → TinyML.Typ) :
-    (vecSet.spec.instantiate σ).args
-      = [("v", .vec (σ "a")), ("i", .int), ("x", σ "a")] := by
-  simp [vecSet, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem vecSet.instantiate_retTy (σ : TinyML.TyVar → TinyML.Typ) :
-    (vecSet.spec.instantiate σ).retTy = .vec (σ "a") := by
-  simp [vecSet, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem vecSet.spec_pred :
-    vecSet.spec.pred = .assert (vecBoundsPre "v" "i")
-      (.ret ("ret",
-        .assert (.eq .value (.var .value "ret")
-          (terTerm "val_vec_set" (.var .value "v") (.var .value "i") (.var .value "x")))
-          (.ret ()))) := rfl
-
-instance : IntrinsicSound [vecSet] vecSet where
-  specWf := fun _ hsub hwf =>
-    specWf_of_base (by apply PredTrans.checkWf_ok; rfl) hsub hwf
-  wp_sound := by
-    intro _ ctx hctx vs Φ
-    match vs with
-    | [] => exact false_elim
-    | [_] => exact false_elim
-    | [_, _] => exact false_elim
-    | _ :: _ :: _ :: _ :: _ => exact false_elim
-    | [v, i, x] =>
-      have hred : ∀ l n μ r μ',
-          ctx vecSet.name [.vec l, .int n, x] μ r μ'
-            ↔ (0 ≤ n ∧ n < (l.length : Int) ∧ r = .vec (l.set n.toNat x)) ∧ μ' = μ := by
-        intro l n μ r μ'
-        rw [hctx]
-        simp only [vecSet.toReduce_eq]
-        constructor
-        · rintro ⟨⟨l', n', hv, hi, hlo, hhi, hr⟩, hμ⟩
-          cases hv
-          cases hi
-          exact ⟨⟨hlo, hhi, hr⟩, hμ⟩
-        · rintro ⟨⟨hlo, hhi, hr⟩, hμ⟩
-          exact ⟨⟨l, n, rfl, rfl, hlo, hhi, hr⟩, hμ⟩
-      show iprop(∃ l n, ⌜v = .vec l ∧ i = .int n ∧ 0 ≤ n ∧ n < (l.length : Int)⌝ ∗
-        Φ (.vec (l.set n.toNat x))) ⊢ _
-      istart
-      iintro ⟨%l, %n, %ha, HΦ⟩
-      obtain ⟨rfl, rfl, hlo, hhi⟩ := ha
-      iapply (wp.prim_pure (hred l n) ⟨_, hlo, hhi, rfl⟩)
-      iintro %r %hr
-      obtain ⟨_, _, rfl⟩ := hr
-      iexact HΦ
-  bridge := by
-    intro _ σ Θ vs ρ Φ hρ
-    simp only [vecSet.instantiate_args, vecSet.instantiate_retTy,
-      Spec.instantiate_pred, vecSet.spec_pred, List.map_cons, List.map_nil]
-    match vs with
-    | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [_, _] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | _ :: _ :: _ :: _ :: _ =>
-        exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [v, i, x] =>
-      simp only [PredTrans.apply, Assertion.pre]
-      iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v [i, x] _ _).1 $$ Hvs
-      icases Hcons with ⟨Hv, Hrest⟩
-      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ i [x] _ _).1 $$ Hrest
-      icases Hcons2 with ⟨Hi, Hrest2⟩
-      ihave Hcons3 := (TinyML.ValsHaveTypes.cons Θ x [] _ _).1 $$ Hrest2
-      icases Hcons3 with ⟨Hx, _⟩
-      ihave Hvec := (TinyML.ValHasType.vec Θ v (σ "a")).1 $$ Hv
-      icases Hvec with ⟨%l, %hv, Helems⟩
-      obtain rfl := hv
-      ihave Hieq := (TinyML.ValHasType.int Θ i).1 $$ Hi
-      ipure Hieq
-      obtain ⟨n, rfl⟩ := Hieq
-      icases Hpred with ⟨%hpre, Hpost⟩
-      have hbounds : 0 ≤ n ∧ n < (l.length : Int) := by
-        simpa [vecBoundsPre, vecOf, intOf, Spec.argsEnv, Formula.eval, Term.eval,
-          VerifM.Env.updateConst_env, Env.lookupConst_updateConst_same,
-          Env.lookupConst_updateConst_ne (show "v" ≠ "i" by decide),
-          Env.lookupConst_updateConst_ne (show "v" ≠ "x" by decide),
-          Env.lookupConst_updateConst_ne (show "i" ≠ "x" by decide)] using hpre
-      have hlt : n.toNat < l.length := by omega
-      have hget : l[n.toNat]? = some l[n.toNat] := List.getElem?_eq_getElem hlt
-      ihave Hty : iprop(TinyML.ValHasType Θ (Runtime.Val.vec (l.set n.toNat x))
-          ((σ "a").vec)) $$ [Helems Hx]
-      · iapply (TinyML.ValHasType.vec_set Θ hget)
-        isplitl [Helems]
-        · iexact Helems
-        · iexact Hx
-      simp only [vecSet.toWp_eq]
-      iexists l
-      iexists n
-      isplitr [Hpost Hty]
-      · ipureintro
-        exact ⟨rfl, rfl, hbounds.1, hbounds.2⟩
-      · have hassert : (Formula.eq .value (.var .value "ret")
-            (terTerm "val_vec_set" (.var .value "v") (.var .value "i") (.var .value "x"))).eval
-            ((Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a")), ("i", TinyML.Typ.int),
-                ("x", σ "a")] [.vec l, .int n, x]).updateConst
-              .value "ret" (.vec (l.set n.toNat x))).env := by
-          have hargs := vec_respects_argsEnv_three
-            [("v", TinyML.Typ.vec (σ "a")), ("i", TinyML.Typ.int), ("x", σ "a")]
-            [Runtime.Val.vec l, Runtime.Val.int n, x] hρ
-          have hter : (Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a")), ("i", TinyML.Typ.int),
-              ("x", σ "a")] [.vec l, .int n, x]).env.ternary
-                .value .value .value .value "val_vec_set"
-                = fun a b c => vecSetSym.interp (a, b, c) := by
-            simpa [Env.respects, vecSetSym] using hargs
-          show Runtime.Val.vec (l.set n.toNat x) =
-            (Spec.argsEnv ρ [("v", TinyML.Typ.vec (σ "a")), ("i", TinyML.Typ.int),
-              ("x", σ "a")] [.vec l, .int n, x]).env.ternary
-                .value .value .value .value "val_vec_set" (.vec l) (.int n) x
-          rw [hter]
-          simp [vecSetSym, valVec, valInt, hbounds.1]
-        refine (sep_mono_left
-          (assert_ret_apply Θ _ "ret" _ _ (.vec (l.set n.toNat x)) hassert)).trans ?_
-        iintro ⟨Hwand, Hty⟩
-        iapply Hwand
-        iexact Hty
-  axiomWf := by
-    intro Δ hsub hwf a hφ
-    simp only [vecSet, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-  proof := by
-    intro ρ hdeps a hφ
-    simp only [vecSet, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    have hresp : ρ.respects (some vecSetSym) := by
-      have h := hdeps vecSet (by simp)
-      simpa [vecSet] using h
-    have hter : ∀ v i x : Runtime.Val,
-        ((((ρ.updateConst .value "v" v).updateConst .value "i" i).updateConst
-          .value "x" x).ternary .value .value .value .value "val_vec_set")
-            = fun a b c => vecSetSym.interp (a, b, c) := by
-      intro v i x
-      rw [Env.updateConst_ternary, Env.updateConst_ternary, Env.updateConst_ternary]
-      simpa [Env.respects, vecSetSym] using hresp
-    rcases hφ with rfl | rfl
-    · simp only [vecSetDefAxiom, Formula.all, Formula.eval]
-      intro v i x
-      simp only [terTerm, vecOf, intOf, vecSetSym, hter v i x, Term.eval, UnOp.eval, TerOp.eval,
-        Env.lookupConst_updateConst_same,
-        Env.lookupConst_updateConst_ne (show "v" ≠ "i" by decide),
-        Env.lookupConst_updateConst_ne (show "v" ≠ "x" by decide),
-        Env.lookupConst_updateConst_ne (show "i" ≠ "x" by decide), valVec, valInt]
-      rfl
-    · simp only [vecSetTypeAxiom, Formula.all, Formula.eval]
-      intro v i x
-      simp [terTerm, vecSetSym, hter v i x, Term.eval,
-        Env.lookupConst_updateConst_same,
-        Env.lookupConst_updateConst_ne (show "v" ≠ "i" by decide),
-        Env.lookupConst_updateConst_ne (show "v" ≠ "x" by decide),
-        Env.lookupConst_updateConst_ne (show "i" ≠ "x" by decide)]
+instance : IntrinsicSound [vecSet] vecSet := vecSetLawful.sound
 
 /-! ## `Vec.make` -/
 
 /-- `Vec.make : int -> 'a -> 'a vec`. Partial: the length must be nonnegative. -/
-def vecMake : Intrinsic where
-  arity  := .two
-  name   := "val_vec_make"
-  path   := some ("Vec", ["make"])
-  reduce := Reduce.pure fun (n, x) r =>
-    ∃ m, n = .int m ∧ 0 ≤ m ∧ r = .vec (List.replicate m.toNat x)
-  wp     := fun (n, x) Q =>
-    iprop(∃ m, ⌜n = .int m ∧ 0 ≤ m⌝ ∗ Q (.vec (List.replicate m.toNat x)))
-  spec   :=
-    { args  := [("n", .int), ("x", .tvar "a")]
-      retTy := .vec (.tvar "a")
-      pred  := .assert (.binpred .le (.const (.i 0)) (intOf "n")) <|
-        .ret ("ret",
-          .assert (.eq .value (.var .value "ret")
-            (binTerm "val_vec_make" (.var .value "n") (.var .value "x"))) (.ret ())) }
-  typing := fun _ tys =>
+def vecMakeB : Pure.Binary where
+  name     := "val_vec_make"
+  path     := some ("Vec", ["make"])
+  arg₁     := .int
+  arg₂     := .poly
+  res      := .vec
+  f        := fun (m : Int) (x : Runtime.Val) =>
+    let len := m
+    if 0 ≤ len then List.replicate len.toNat x else []
+  dom      := (fun m _ => 0 ≤ m : Int → Runtime.Val → Prop)
+  pre      := some fun n _ => .binpred .le (.const (.i 0)) (intOf n)
+  typing   := fun _ tys =>
     match tys with
     | [_, t] => .ok [("a", t)]
     | _ => .error s!"expected 2 arguments, got {tys.length}"
-  folSym := some vecMakeSym
-  axioms := [⟨vecMakeDefAxiom, .high⟩, ⟨vecMakeTypeAxiom, .high⟩]
+  defAxiom := vecMakeDefAxiom
+
+def vecMake : Intrinsic := vecMakeB.toIntrinsic
 
 @[simp] theorem vecMake_arity : vecMake.arity = .two := rfl
-@[simp] theorem vecMake_folSym : vecMake.folSym = some vecMakeSym := rfl
+@[simp] theorem vecMake_folSym : vecMake.folSym = some vecMakeB.sym := rfl
+@[simp] theorem vecMakeSym_name : vecMakeB.sym.name = "val_vec_make" := rfl
 
-@[simp] theorem vecMake.toWp_eq (n x : Runtime.Val) (Q : Runtime.Val → iProp) :
-    vecMake.toWp [n, x] Q =
-      iprop(∃ m, ⌜n = .int m ∧ 0 ≤ m⌝ ∗ Q (.vec (List.replicate m.toNat x))) := rfl
+def vecMakeLawful : vecMakeB.Lawful where
+  argL₁        := Embedding.lawfulInt
+  argL₂        := Embedding.lawfulPoly
+  resL         := Embedding.lawfulVec
+  domSound     := by
+    intro ρ m x h
+    have hpre := h _ rfl
+    simpa [vecMakeB, intOf, Embedding.int, Embedding.poly, Formula.eval, Term.eval,
+      Const.denote, Env.lookupConst_updateConst_same,
+      Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), valInt] using hpre
+  semWellTyped := by
+    refine fun σ Θ (m : Int) (x : Runtime.Val) hdom => ?_
+    have hnonneg : 0 ≤ m := hdom
+    simp only [Embedding.vec, Embedding.int, Embedding.poly, vecMakeB, if_pos hnonneg]
+    refine emp_sep.1.trans ?_
+    refine (TinyML.ValHasType.vec_replicate Θ m.toNat x (σ "a")).trans ?_
+    refine (TinyML.ValHasType.vec Θ _ (σ "a")).1.trans ?_
+    istart
+    iintro ⟨%vs, %hv, Hs⟩
+    obtain rfl : List.replicate m.toNat x = vs := by injection hv
+    iexact Hs
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := by intro φ h; injection h with h; subst h; apply Formula.checkWf_ok; rfl
+  defEval      := by
+    intrinsic_def_eval [binTerm, vecOf, intOf, UnOp.eval, BinOp.eval, vecMakeB, vecMakeDefAxiom]
+    intros
+    rfl
 
-@[simp] theorem vecMake.toReduce_eq (n x r : Runtime.Val) (μ μ' : TinyML.Heap) :
-    vecMake.toReduce [n, x] μ r μ' =
-      ((∃ m, n = .int m ∧ 0 ≤ m ∧ r = .vec (List.replicate m.toNat x)) ∧ μ' = μ) := rfl
-
-@[simp] theorem vecMake.instantiate_args (σ : TinyML.TyVar → TinyML.Typ) :
-    (vecMake.spec.instantiate σ).args = [("n", .int), ("x", σ "a")] := by
-  simp [vecMake, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem vecMake.instantiate_retTy (σ : TinyML.TyVar → TinyML.Typ) :
-    (vecMake.spec.instantiate σ).retTy = .vec (σ "a") := by
-  simp [vecMake, Spec.instantiate, TinyML.Typ.subst]
-
-@[simp] theorem vecMake.spec_pred :
-    vecMake.spec.pred = .assert (.binpred .le (.const (.i 0)) (intOf "n"))
-      (.ret ("ret",
-        .assert (.eq .value (.var .value "ret")
-          (binTerm "val_vec_make" (.var .value "n") (.var .value "x"))) (.ret ()))) := rfl
-
-instance : IntrinsicSound [vecMake] vecMake where
-  specWf := fun _ hsub hwf =>
-    specWf_of_base (by apply PredTrans.checkWf_ok; rfl) hsub hwf
-  wp_sound := by
-    intro _ ctx hctx vs Φ
-    match vs with
-    | [] => exact false_elim
-    | [_] => exact false_elim
-    | _ :: _ :: _ :: _ => exact false_elim
-    | [n, x] =>
-      have hred : ∀ m μ r μ',
-          ctx vecMake.name [.int m, x] μ r μ'
-            ↔ (0 ≤ m ∧ r = .vec (List.replicate m.toNat x)) ∧ μ' = μ := by
-        intro m μ r μ'
-        rw [hctx]
-        simp only [vecMake.toReduce_eq]
-        constructor
-        · rintro ⟨⟨m', hn, hlo, hr⟩, hμ⟩
-          cases hn
-          exact ⟨⟨hlo, hr⟩, hμ⟩
-        · rintro ⟨⟨hlo, hr⟩, hμ⟩
-          exact ⟨⟨m, rfl, hlo, hr⟩, hμ⟩
-      show iprop(∃ m, ⌜n = .int m ∧ 0 ≤ m⌝ ∗ Φ (.vec (List.replicate m.toNat x))) ⊢ _
-      istart
-      iintro ⟨%m, %ha, HΦ⟩
-      obtain ⟨rfl, hlo⟩ := ha
-      iapply (wp.prim_pure (hred m) ⟨_, hlo, rfl⟩)
-      iintro %r %hr
-      obtain ⟨_, rfl⟩ := hr
-      iexact HΦ
-  bridge := by
-    intro _ σ Θ vs ρ Φ hρ
-    simp only [vecMake.instantiate_args, vecMake.instantiate_retTy,
-      Spec.instantiate_pred, vecMake.spec_pred, List.map_cons, List.map_nil]
-    match vs with
-    | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | _ :: _ :: _ :: _ =>
-        exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
-    | [n, x] =>
-      simp only [PredTrans.apply, Assertion.pre]
-      iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ n [x] _ _).1 $$ Hvs
-      icases Hcons with ⟨Hn, Hrest⟩
-      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ x [] _ _).1 $$ Hrest
-      icases Hcons2 with ⟨Hx, _⟩
-      ihave Hneq := (TinyML.ValHasType.int Θ n).1 $$ Hn
-      ipure Hneq
-      obtain ⟨m, rfl⟩ := Hneq
-      icases Hpred with ⟨%hpre, Hpost⟩
-      have hlo : 0 ≤ m := by
-        simpa [intOf, Spec.argsEnv, Formula.eval, Term.eval,
-          VerifM.Env.updateConst_env, Env.lookupConst_updateConst_same,
-          Env.lookupConst_updateConst_ne (show "n" ≠ "x" by decide)] using hpre
-      ihave Hty : iprop(TinyML.ValHasType Θ (Runtime.Val.vec (List.replicate m.toNat x))
-          ((σ "a").vec)) $$ [Hx]
-      · iapply (TinyML.ValHasType.vec_replicate Θ m.toNat x (σ "a"))
-        iexact Hx
-      simp only [vecMake.toWp_eq]
-      iexists m
-      isplitr [Hpost Hty]
-      · ipureintro
-        exact ⟨rfl, hlo⟩
-      · have hassert : (Formula.eq .value (.var .value "ret")
-            (binTerm "val_vec_make" (.var .value "n") (.var .value "x"))).eval
-            ((Spec.argsEnv ρ [("n", TinyML.Typ.int), ("x", σ "a")] [.int m, x]).updateConst
-              .value "ret" (.vec (List.replicate m.toNat x))).env := by
-          have hargs := vec_respects_argsEnv_two
-            [("n", TinyML.Typ.int), ("x", σ "a")] [Runtime.Val.int m, x] hρ
-          have hbin : (Spec.argsEnv ρ [("n", TinyML.Typ.int), ("x", σ "a")]
-              [.int m, x]).env.binary .value .value .value "val_vec_make"
-                = fun a b => vecMakeSym.interp (a, b) := by
-            simpa [Env.respects, vecMakeSym] using hargs
-          show Runtime.Val.vec (List.replicate m.toNat x) =
-            (Spec.argsEnv ρ [("n", TinyML.Typ.int), ("x", σ "a")]
-              [.int m, x]).env.binary .value .value .value "val_vec_make" (.int m) x
-          rw [hbin]
-          simp [vecMakeSym, valInt, hlo]
-        refine (sep_mono_left
-          (assert_ret_apply Θ _ "ret" _ _ (.vec (List.replicate m.toNat x)) hassert)).trans ?_
-        iintro ⟨Hwand, Hty⟩
-        iapply Hwand
-        iexact Hty
-  axiomWf := by
-    intro Δ hsub hwf a hφ
-    simp only [vecMake, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    rcases hφ with rfl | rfl
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-    · exact Formula.wfIn_mono _ (by apply Formula.checkWf_ok; rfl) hsub hwf
-  proof := by
-    intro ρ hdeps a hφ
-    simp only [vecMake, List.mem_cons, List.not_mem_nil, _root_.or_false] at hφ
-    have hresp : ρ.respects (some vecMakeSym) := by
-      have h := hdeps vecMake (by simp)
-      simpa [vecMake] using h
-    have hbin : ∀ n x : Runtime.Val,
-        (((ρ.updateConst .value "n" n).updateConst .value "x" x).binary
-          .value .value .value "val_vec_make") = fun a b => vecMakeSym.interp (a, b) := by
-      intro n x
-      rw [Env.updateConst_binary, Env.updateConst_binary]
-      simpa [Env.respects, vecMakeSym] using hresp
-    rcases hφ with rfl | rfl
-    · simp only [vecMakeDefAxiom, Formula.all, Formula.eval]
-      intro n x
-      simp only [binTerm, intOf, vecMakeSym, hbin n x, Term.eval, UnOp.eval, BinOp.eval,
-        Env.lookupConst_updateConst_same,
-        Env.lookupConst_updateConst_ne (show "n" ≠ "x" by decide), valInt]
-      rfl
-    · simp only [vecMakeTypeAxiom, Formula.all, Formula.eval]
-      intro n x
-      simp [binTerm, vecMakeSym, hbin n x, Term.eval,
-        Env.lookupConst_updateConst_same,
-        Env.lookupConst_updateConst_ne (show "n" ≠ "x" by decide)]
+instance : IntrinsicSound [vecMake] vecMake := vecMakeLawful.sound
 
 end Intrinsics
 

--- a/Mica/Stdlib/VecStd.lean
+++ b/Mica/Stdlib/VecStd.lean
@@ -1,4 +1,4 @@
--- SUMMARY: Immutable-vector intrinsics (`Vec.length`, `Vec.get`, `Vec.set`, `Vec.make`) as builder instances over the vec/poly embeddings.
+-- SUMMARY: Immutable-vector intrinsics (`Vec.length`, `Vec.get`, `Vec.set`, `Vec.make`).
 import Mica.Stdlib.Combinators
 
 open Iris Iris.BI

--- a/Mica/Stdlib/VecStd.lean
+++ b/Mica/Stdlib/VecStd.lean
@@ -85,16 +85,11 @@ def vecMakeDefAxiom : Formula :=
 def vecLengthB : Pure.Unary where
   name     := "val_vec_length"
   path     := some ("Vec", ["length"])
-  arg      := .vec
+  arg      := .vec (.tvar "a")
   res      := .int
   f        := (fun l => (l.length : Int) : List Runtime.Val → Int)
   dom      := fun _ => True
   pre      := none
-  typing   := fun _ tys =>
-    match tys with
-    | [.vec t] => .ok [("a", t)]
-    | [_] => .error "Vec.length expects a vector argument"
-    | _ => .error s!"expected 1 argument, got {tys.length}"
   defAxiom := vecLengthDefAxiom
 
 def vecLength : Intrinsic := vecLengthB.toIntrinsic
@@ -104,7 +99,7 @@ def vecLength : Intrinsic := vecLengthB.toIntrinsic
 @[simp] theorem vecLengthSym_name : vecLengthB.sym.name = "val_vec_length" := rfl
 
 def vecLengthLawful : vecLengthB.Lawful where
-  argL         := Embedding.lawfulVec
+  argL         := Embedding.lawfulVec (.tvar "a")
   resL         := Embedding.lawfulInt
   domSound     := fun _ _ _ => True.intro
   semWellTyped := fun _ _ _ _ => affine
@@ -124,18 +119,13 @@ instance : IntrinsicSound [vecLength] vecLength := vecLengthLawful.sound
 def vecGetB : Pure.Binary where
   name     := "val_vec_get"
   path     := some ("Vec", ["get"])
-  arg₁     := .vec
+  arg₁     := .vec (.tvar "a")
   arg₂     := .int
-  res      := .poly
+  res      := .poly "a"
   f        := fun (l : List Runtime.Val) (i : Int) =>
     if 0 ≤ i then (l[i.toNat]?).getD .unit else .unit
   dom      := (fun l n => 0 ≤ n ∧ n < (l.length : Int) : List Runtime.Val → Int → Prop)
   pre      := some vecBoundsPre
-  typing   := fun _ tys =>
-    match tys with
-    | [.vec t, _] => .ok [("a", t)]
-    | [_, _] => .error "Vec.get expects a vector as its first argument"
-    | _ => .error s!"expected 2 arguments, got {tys.length}"
   defAxiom := vecGetDefAxiom
 
 def vecGet : Intrinsic := vecGetB.toIntrinsic
@@ -145,9 +135,9 @@ def vecGet : Intrinsic := vecGetB.toIntrinsic
 @[simp] theorem vecGetSym_name : vecGetB.sym.name = "val_vec_get" := rfl
 
 def vecGetLawful : vecGetB.Lawful where
-  argL₁        := Embedding.lawfulVec
+  argL₁        := Embedding.lawfulVec (.tvar "a")
   argL₂        := Embedding.lawfulInt
-  resL         := Embedding.lawfulPoly
+  resL         := Embedding.lawfulPoly "a"
   domSound     := by
     intro ρ l n h
     have hpre := h vecBoundsPre rfl
@@ -159,7 +149,8 @@ def vecGetLawful : vecGetB.Lawful where
     obtain ⟨h0, hlen⟩ := hdom
     have hlt : n.toNat < l.length := by omega
     have hget : l[n.toNat]? = some l[n.toNat] := List.getElem?_eq_getElem hlt
-    simp only [Embedding.vec, Embedding.int, Embedding.poly, vecGetB, if_pos h0,
+    simp only [Embedding.vec, Embedding.int, Embedding.poly, TinyML.Typ.subst,
+      vecGetB, if_pos h0,
       hget, Option.getD_some]
     refine sep_emp.1.trans ?_
     exact BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType Θ w (σ "a")) hget
@@ -180,20 +171,15 @@ instance : IntrinsicSound [vecGet] vecGet := vecGetLawful.sound
 def vecSetB : Pure.Ternary where
   name     := "val_vec_set"
   path     := some ("Vec", ["set"])
-  arg₁     := .vec
+  arg₁     := .vec (.tvar "a")
   arg₂     := .int
-  arg₃     := .poly
-  res      := .vec
+  arg₃     := .poly "a"
+  res      := .vec (.tvar "a")
   f        := fun (l : List Runtime.Val) (i : Int) (x : Runtime.Val) =>
     if 0 ≤ i then l.set i.toNat x else l
   dom      := (fun l n _ => 0 ≤ n ∧ n < (l.length : Int) :
                 List Runtime.Val → Int → Runtime.Val → Prop)
   pre      := some fun v i _ => vecBoundsPre v i
-  typing   := fun _ tys =>
-    match tys with
-    | [.vec t, _, _] => .ok [("a", t)]
-    | [_, _, _] => .error "Vec.set expects a vector as its first argument"
-    | _ => .error s!"expected 3 arguments, got {tys.length}"
   defAxiom := vecSetDefAxiom
 
 def vecSet : Intrinsic := vecSetB.toIntrinsic
@@ -203,10 +189,10 @@ def vecSet : Intrinsic := vecSetB.toIntrinsic
 @[simp] theorem vecSetSym_name : vecSetB.sym.name = "val_vec_set" := rfl
 
 def vecSetLawful : vecSetB.Lawful where
-  argL₁        := Embedding.lawfulVec
+  argL₁        := Embedding.lawfulVec (.tvar "a")
   argL₂        := Embedding.lawfulInt
-  argL₃        := Embedding.lawfulPoly
-  resL         := Embedding.lawfulVec
+  argL₃        := Embedding.lawfulPoly "a"
+  resL         := Embedding.lawfulVec (.tvar "a")
   domSound     := by
     intro ρ l n x h
     have hpre := h _ rfl
@@ -220,7 +206,8 @@ def vecSetLawful : vecSetB.Lawful where
     obtain ⟨h0, hlen⟩ := hdom
     have hlt : n.toNat < l.length := by omega
     have hget : l[n.toNat]? = some l[n.toNat] := List.getElem?_eq_getElem hlt
-    simp only [Embedding.vec, Embedding.int, Embedding.poly, vecSetB, if_pos h0]
+    simp only [Embedding.vec, Embedding.int, Embedding.poly, TinyML.Typ.subst,
+      vecSetB, if_pos h0]
     refine (sep_mono_right emp_sep.1).trans ?_
     refine (sep_mono_left (BigSepL.bigSepL_insert_acc
       (Φ := fun _ w => TinyML.ValHasType Θ w (σ "a")) hget)).trans ?_
@@ -243,17 +230,13 @@ def vecMakeB : Pure.Binary where
   name     := "val_vec_make"
   path     := some ("Vec", ["make"])
   arg₁     := .int
-  arg₂     := .poly
-  res      := .vec
+  arg₂     := .poly "a"
+  res      := .vec (.tvar "a")
   f        := fun (m : Int) (x : Runtime.Val) =>
     let len := m
     if 0 ≤ len then List.replicate len.toNat x else []
   dom      := (fun m _ => 0 ≤ m : Int → Runtime.Val → Prop)
   pre      := some fun n _ => .binpred .le (.const (.i 0)) (intOf n)
-  typing   := fun _ tys =>
-    match tys with
-    | [_, t] => .ok [("a", t)]
-    | _ => .error s!"expected 2 arguments, got {tys.length}"
   defAxiom := vecMakeDefAxiom
 
 def vecMake : Intrinsic := vecMakeB.toIntrinsic
@@ -264,8 +247,8 @@ def vecMake : Intrinsic := vecMakeB.toIntrinsic
 
 def vecMakeLawful : vecMakeB.Lawful where
   argL₁        := Embedding.lawfulInt
-  argL₂        := Embedding.lawfulPoly
-  resL         := Embedding.lawfulVec
+  argL₂        := Embedding.lawfulPoly "a"
+  resL         := Embedding.lawfulVec (.tvar "a")
   domSound     := by
     intro ρ m x h
     have hpre := h _ rfl
@@ -275,7 +258,8 @@ def vecMakeLawful : vecMakeB.Lawful where
   semWellTyped := by
     refine fun σ Θ (m : Int) (x : Runtime.Val) hdom => ?_
     have hnonneg : 0 ≤ m := hdom
-    simp only [Embedding.vec, Embedding.int, Embedding.poly, vecMakeB, if_pos hnonneg]
+    simp only [Embedding.vec, Embedding.int, Embedding.poly, TinyML.Typ.subst,
+      vecMakeB, if_pos hnonneg]
     refine emp_sep.1.trans ?_
     refine (TinyML.ValHasType.vec_replicate Θ m.toNat x (σ "a")).trans ?_
     refine (TinyML.ValHasType.vec Θ _ (σ "a")).1.trans ?_


### PR DESCRIPTION
This PR generalises the intrinsic builder combinators to support preconditions and different types. This allows us to use them for more intrinsics in the codebase like `Vec.get`.