### PR TITLE
Support for bounded quantifiers

### DIFF
--- a/Examples/range_find.ml
+++ b/Examples/range_find.ml
@@ -1,0 +1,30 @@
+open Mica
+
+(* Binary search over a sorted array, returning the index of the key in the
+   window [lo, hi) or [-1] if it does not occur there.  The postcondition is
+   exact in both directions: a returned index is in the window and stores the
+   key, while [-1] means that the key is absent from the whole window.
+
+   This example lives separately from the smaller bounded-range examples so
+   their unrelated quantified axioms do not compete for the solver's fixed
+   time budget. *)
+let rec find (a : int array [@owned]) (key : int) (lo : int) (hi : int) : int =
+  if lo >= hi then -1
+  else
+    let mid = lo + (hi - lo) / 2 in
+    let m = a.(mid) in
+    if m = key then mid
+    else if m < key then find a key (mid + 1) hi
+    else find a key lo mid
+[@@spec fun a key lo hi ->
+  bind (arr a) @@ fun (v : int vec) ->
+  assert (0 <= lo && lo <= hi && hi <= Vec.length v);
+  assert (Range.all 0 (Vec.length v) (fun (i : int) : bool ->
+            Range.all 0 (Vec.length v) (fun (j : int) : bool ->
+              if i <= j then Vec.get v i <= Vec.get v j else true)));
+  ret (fun r ->
+    bind (arr a) @@ fun (w : int vec) ->
+    if r >= 0 then
+      assert (lo <= r && r < hi && Vec.get v r = key)
+    else
+      assert (Range.all lo hi (fun (i : int) : bool -> not (Vec.get v i = key))))];;

--- a/Examples/ranges.ml
+++ b/Examples/ranges.ml
@@ -1,0 +1,48 @@
+open Mica
+
+(* Bounded quantifiers in specifications.
+
+   [Range.all a b (fun i -> p i)] means [forall i, a <= i < b -> p i], and is
+   vacuously true when [b <= a]; [Range.exists] is the dual.  They may appear
+   only in specifications: the verifier lambda-lifts each occurrence into an
+   uninterpreted function with defining axioms. The registry operations have a
+   false precondition, so any occurrence that survives into ordinary
+   verification fails like any other unprovable call.
+
+   Both directions are usable: a universally quantified range is proved by
+   instantiating the hypotheses' axioms at the goal's (skolemized) index, and an
+   existentially quantified one by supplying a witness. *)
+
+(* Empty ranges: [all] holds, [exists] does not, whatever the body says. *)
+let vacuous (n : int) : int =
+  n
+[@@spec fun n ->
+  ret (fun v ->
+    assert (Range.all 0 0 (fun (i : int) : bool -> i < 0));
+    assert (not (Range.exists 0 0 (fun (i : int) : bool -> i >= 0))))];;
+
+(* Nested ranges with a captured vector: pairwise sortedness, instantiated at
+   the two indices of interest. *)
+let get_sorted (a : int array [@owned]) (i : int) (j : int) : int =
+  a.(i)
+[@@spec fun a i j ->
+  bind (arr a) @@ fun (v : int vec) ->
+  assert (Range.all 0 (Vec.length v) (fun (x : int) : bool ->
+            Range.all x (Vec.length v) (fun (y : int) : bool -> Vec.get v x <= Vec.get v y)));
+  assert (0 <= i);
+  assert (i <= j);
+  assert (j < Vec.length v);
+  ret (fun r ->
+    bind (arr a) @@ fun (w : int vec) ->
+    assert (Vec.get w i <= Vec.get w j))];;
+
+(* A [Range.exists] postcondition: after the write, the key occurs in the
+   array. *)
+let plant (a : int array [@owned]) (x : int) : unit =
+  a.(0) <- x
+[@@spec fun a x ->
+  assert (Array.length a > 0);
+  bind (arr a) @@ fun (before : int vec) ->
+  ret (fun r ->
+    bind (arr a) @@ fun (v : int vec) ->
+    assert (Range.exists 0 (Vec.length v) (fun (i : int) : bool -> Vec.get v i = x)))];;

--- a/Mica/Engine/Driver.lean
+++ b/Mica/Engine/Driver.lean
@@ -28,11 +28,15 @@ namespace Session
 -- Z3's default eager instantiation easily falls into a matching loop. It even
 -- does so _before_ a check-sat is reached when entering a new scope.
 -- To avoid a severe performance penalty, we lower the default from 10.0 to 5.0.
+-- The verifier's quantified axioms are designed for E-matching (with explicit
+-- or Z3-inferred triggers), so model-based quantifier instantiation adds a
+-- second, less predictable search path without being needed by the examples.
 def preamble : String := s!"
 ;; preamble
 (set-logic ALL)
 {String.intercalate "\n" (List.map Options.Settable.toSMTLIB Options.Settable.initial)}
 (set-option :smt.qi.eager_threshold 5.0)
+(set-option :smt.mbqi false)
 
 (declare-sort Other 0)
 (declare-sort Loc 0)

--- a/Mica/FOL/Formulas.lean
+++ b/Mica/FOL/Formulas.lean
@@ -50,6 +50,21 @@ inductive Formula where
 def Formula.all (x : String) (τ : Srt) (body : Formula) : Formula :=
   .forall_ x τ [] body
 
+/-- Bi-implication, encoded as the two implications. -/
+@[simp]
+def Formula.iff (φ ψ : Formula) : Formula :=
+  .and (.implies φ ψ) (.implies ψ φ)
+
+/-- The value-sorted term is the encoded boolean `true`. -/
+@[simp]
+def Term.isTrue (t : Term .value) : Formula :=
+  .eq .value t (.unop .ofBool (.const (.b true)))
+
+/-- The value-sorted term is the encoded boolean `false`. -/
+@[simp]
+def Term.isFalse (t : Term .value) : Formula :=
+  .eq .value t (.unop .ofBool (.const (.b false)))
+
 def Pattern.freeVars : Pattern → List Var
   | .term t => t.freeVars
   | .unpred _ t => t.freeVars

--- a/Mica/Stdlib.lean
+++ b/Mica/Stdlib.lean
@@ -1,5 +1,6 @@
 -- SUMMARY: The concrete stdlib: the intrinsic registry, its soundness aggregate, and the prelude resolver.
 import Mica.Verifier.Intrinsic
+import Mica.Verifier.BoundedQuantifier
 import Mica.Stdlib.IntStd
 import Mica.Stdlib.CharStd
 import Mica.Stdlib.StringStd
@@ -15,6 +16,8 @@ namespace Stdlib
 open Verifier
 
 def registry : Registry := [
+  Verifier.BoundedQuantifier.allIntrinsic,
+  Verifier.BoundedQuantifier.existsIntrinsic,
   Intrinsics.vecMake,
   Intrinsics.vecSet,
   Intrinsics.vecGet,

--- a/Mica/Verifier.lean
+++ b/Mica/Verifier.lean
@@ -6,6 +6,7 @@ import Mica.Verifier.Bindings
 import Mica.Verifier.Utils
 import Mica.Verifier.Assertions
 import Mica.Verifier.Intrinsic
+import Mica.Verifier.BoundedQuantifier
 import Mica.Verifier.Expressions
 import Mica.Verifier.RelationalEncoding
 import Mica.Verifier.Functions

--- a/Mica/Verifier/BoundedQuantifier.lean
+++ b/Mica/Verifier/BoundedQuantifier.lean
@@ -1,0 +1,922 @@
+-- SUMMARY: Lambda lifting of spec-level bounded quantifiers (Range.all/Range.exists) into axiomatized function symbols.
+import Mica.TinyML.Typing
+import Mica.TinyML.Spec
+import Mica.Verifier.RelationalEncoding.Variables
+import Mica.Verifier.Guard
+import Mica.Verifier.Intrinsic
+import Mica.Verifier.RelationalEncoding.Axioms
+
+open Iris Iris.BI
+
+/-!
+# Bounded quantifiers
+
+`Range.all lo hi (fun i -> body)` in a specification means
+`∀ i, lo ≤ i < hi → body` (vacuously true on an empty range);
+`Range.exists` is the dual. The surface forms elaborate to ordinary
+applications of the primitives `range-all`/`range-exists`
+(`allName`/`existsName`). Their registry entries have false operational and
+specification semantics: a rewrite pass lambda-lifts every legitimate spec
+occurrence into calls to freshly axiomatized function symbols, while any
+occurrence that survives the pass fails verification normally.
+-/
+
+/-! ## Declaring a spec-function symbol triple
+
+Generic infrastructure, shared with relation assembly in `Programs.lean`:
+declaring the three solver symbols of a spec function whose relation
+interpretation is the graph of its value function on its definedness domain,
+and assuming its valid defining axioms, preserves the relation-assembly
+invariants. -/
+
+namespace Verifier.RelationalEncoding.SpecFn
+
+/-- Declare the solver-facing triple of `L` and assume its defining axioms. -/
+def declare (L : SpecFn) (axs : List Axiom) : VerifM Unit := do
+  VerifM.declBinaryRelExact (SpecFn.rel L)
+  VerifM.declUnaryExact (SpecFn.func L)
+  VerifM.declUnaryRelExact (SpecFn.defined L)
+  VerifM.assumeAxioms axs
+
+/-- Declaring the triple of a fresh symbol `L` — with interpretations whose
+relation is the graph of the value function on the definedness domain, and
+defining axioms that are well-formed and valid in the extended
+signature/environment — preserves the relation-assembly invariants and
+extends the function context by `(f, L)`. -/
+theorem declare_correct (L : SpecFn) (f : TinyML.Var) (axs : List Axiom)
+    (R : Srt.value.denote → Srt.value.denote → Prop)
+    (F : Srt.value.denote → Srt.value.denote)
+    (D : Srt.value.denote → Prop)
+    (Δ : Signature) (Γ : FunCtx) (st : TransState) (ρ : VerifM.Env)
+    {Q : Unit → TransState → VerifM.Env → Prop}
+    (hrelFresh : relName L ∉ Δ.allNames)
+    (hfunFresh : funcName L ∉ Δ.allNames)
+    (hdefFresh : defName L ∉ Δ.allNames)
+    (hgraph : ∀ a b, R a b ↔ D a ∧ F a = b)
+    (hdecls : st.decls = Δ) (howns : st.owns = []) (hvars : st.decls.vars = [])
+    (hwfext : (((Δ.addBinaryRel (rel L)).addUnary (func L)).addUnaryRel (defined L)).wf)
+    (hΓwf : FunCtx.wfIn Γ Δ)
+    (hsplit : FunCtx.splitCompatible Γ ρ.env)
+    (hdet : Relation.BinaryRelDet Γ ρ.env ρ.env)
+    (haxwf : ∀ ax ∈ axs, ax.formula.wfIn
+      (((Δ.addBinaryRel (rel L)).addUnary (func L)).addUnaryRel (defined L)))
+    (haxeval : ∀ ax ∈ axs, ax.formula.eval (Skolemize.relSplitEnv ρ.env L R D F))
+    (heval : VerifM.eval (declare L axs) st ρ Q) :
+    ∃ st' ρ',
+      st'.decls = ((Δ.addBinaryRel (rel L)).addUnary (func L)).addUnaryRel (defined L) ∧
+      st'.owns = [] ∧ st'.decls.vars = [] ∧ st'.decls.wf ∧
+      st.decls.Subset st'.decls ∧
+      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      FunCtx.wfIn (Γ ++ [(f, L)]) st'.decls ∧
+      FunCtx.splitCompatible (Γ ++ [(f, L)]) ρ'.env ∧
+      Relation.BinaryRelDet (Γ ++ [(f, L)]) ρ'.env ρ'.env ∧
+      Q () st' ρ' := by
+  simp only [declare] at heval
+  obtain ⟨_, h1⟩ := VerifM.eval_declBinaryRelExact (VerifM.eval_bind heval)
+  obtain ⟨_, h2⟩ := VerifM.eval_declUnaryExact (VerifM.eval_bind (h1 R))
+  obtain ⟨_, h3⟩ := VerifM.eval_declUnaryRelExact (VerifM.eval_bind (h2 F))
+  have h4 := h3 D
+  set Δext : Signature :=
+    ((Δ.addBinaryRel (rel L)).addUnary (func L)).addUnaryRel (defined L)
+  set st3 : TransState :=
+    { st with decls := ((st.decls.addBinaryRel (rel L)).addUnary
+        (func L)).addUnaryRel (defined L) }
+  set ρ3 : VerifM.Env :=
+    ((ρ.updateBinaryRel .value .value (relName L) R).updateUnary
+        .value .value (funcName L) F).updateUnaryRel
+      .value (defName L) D
+  have hst3 : st3.decls = Δext := by
+    simp only [st3, Δext, hdecls]
+  have hρ3 : ρ3.env = Skolemize.relSplitEnv ρ.env L R D F := by
+    simp only [ρ3, VerifM.Env.updateUnaryRel_env, VerifM.Env.updateUnary_env,
+      VerifM.Env.updateBinaryRel_env, Skolemize.relSplitEnv]
+  have hsub : Δ.Subset Δext :=
+    ((Signature.Subset.subset_addBinaryRel _ _).trans
+      (Signature.Subset.subset_addUnary _ _)).trans
+      (Signature.Subset.subset_addUnaryRel _ _)
+  obtain ⟨st4, hst4, howns4, _, hQ4⟩ :=
+    VerifM.eval_assumeAxioms h4 (fun ax hax => hst3 ▸ haxwf ax hax)
+      (fun ax hax => hρ3 ▸ haxeval ax hax)
+  have howns4' : st4.owns = [] := by rw [howns4]; exact howns
+  have hvars4 : st4.decls.vars = [] := by
+    rw [hst4, hst3]
+    show Δ.vars = []
+    rw [← hdecls]
+    exact hvars
+  have hwf4 : st4.decls.wf := by rw [hst4, hst3]; exact hwfext
+  have hagree : Env.agreeOn Δ ρ.env ρ3.env := by
+    rw [hρ3]
+    exact Skolemize.relSplitEnv_agreeOn hrelFresh hfunFresh hdefFresh
+  have hΓwf' : FunCtx.wfIn (Γ ++ [(f, L)]) st4.decls := by
+    rw [hst4, hst3]
+    refine ⟨?_, ?_⟩
+    · intro x rel hxr
+      rcases List.mem_append.mp hxr with hold | hnew
+      · exact hsub.binaryRel _ (hΓwf.rel x rel hold)
+      · simp at hnew; obtain ⟨_, rfl⟩ := hnew
+        exact List.Mem.head _
+    · intro x rel hxr
+      rcases List.mem_append.mp hxr with hold | hnew
+      · obtain ⟨hu, hr⟩ := hΓwf.split x rel hold
+        exact ⟨hsub.unary _ hu, hsub.unaryRel _ hr⟩
+      · simp at hnew; obtain ⟨_, rfl⟩ := hnew
+        exact ⟨List.Mem.head _, List.Mem.head _⟩
+  have hsplit' : FunCtx.splitCompatible (Γ ++ [(f, L)]) ρ3.env := by
+    intro g rel hgr x y
+    rcases List.mem_append.mp hgr with hold | hnew
+    · obtain ⟨hu, hr⟩ := hΓwf.split g rel hold
+      obtain ⟨her, hec, hed⟩ := SpecFn.agreeOn hagree (hΓwf.rel g rel hold) hu hr
+      rw [← her, ← hec, ← hed]
+      exact hsplit g rel hold x y
+    · simp at hnew; obtain ⟨_, rfl⟩ := hnew
+      rw [hρ3]
+      exact Skolemize.relSplitEnv_graph rel ρ.env hgraph x y
+  have hdet' : Relation.BinaryRelDet (Γ ++ [(f, L)]) ρ3.env ρ3.env := by
+    intro g rel hgr x y₁ y₂ hy₁ hy₂
+    rcases List.mem_append.mp hgr with hold | hnew
+    · obtain ⟨hu, hr⟩ := hΓwf.split g rel hold
+      obtain ⟨her, _, _⟩ := SpecFn.agreeOn hagree (hΓwf.rel g rel hold) hu hr
+      rw [← her] at hy₁ hy₂
+      exact hdet g rel hold x y₁ y₂ hy₁ hy₂
+    · simp at hnew; obtain ⟨_, rfl⟩ := hnew
+      rw [hρ3] at hy₁ hy₂
+      obtain ⟨_, heq₁⟩ := (Skolemize.relSplitEnv_graph rel ρ.env hgraph x y₁).mp hy₁
+      obtain ⟨_, heq₂⟩ := (Skolemize.relSplitEnv_graph rel ρ.env hgraph x y₂).mp hy₂
+      exact heq₁.symm.trans heq₂
+  have hsub4 : st.decls.Subset st4.decls := by
+    rw [hst4, hst3, hdecls]
+    exact hsub
+  have hagree4 : VerifM.Env.agreeOn st.decls ρ ρ3 := by
+    rw [hdecls]
+    exact hagree
+  exact ⟨st4, ρ3, by rw [hst4, hst3], howns4', hvars4, hwf4, hsub4,
+    hagree4, hΓwf', hsplit', hdet', hQ4⟩
+
+end Verifier.RelationalEncoding.SpecFn
+
+namespace Verifier.BoundedQuantifier
+
+/-- Internal primitive name for `Range.all`. -/
+def allName : String := "range-all"
+
+/-- Internal primitive name for `Range.exists`. -/
+def existsName : String := "range-exists"
+
+/-- Whether `n` is one of the bounded-quantifier primitives. -/
+def isPrim (n : String) : Bool :=
+  n = allName || n = existsName
+
+/-! ## Registry entries
+
+The quantifier operations are real intrinsics so the ordinary registry is the
+single source of surface resolution and typing. Their operational relation,
+weakest precondition, and specification precondition are all false: legitimate
+specification occurrences are eliminated by this pass, while any occurrence
+that survives cannot verify. No FOL symbol or axiom is required. -/
+
+/-- A spec-only bounded-quantifier intrinsic. -/
+def intrinsic (name : String) (path : String) : Verifier.Intrinsic where
+  arity := .three
+  name := name
+  path := some ("Range", [path])
+  reduce := fun _ _ _ _ => False
+  wp := fun _ _ => iprop(False)
+  spec :=
+    { args := [("lo", .int), ("hi", .int), ("body", .arrow .int .bool)]
+      retTy := .bool
+      pred := .assert .false_ (.ret ("ret", .ret ())) }
+  typing := Verifier.monoTyping .three
+  folSym := none
+  axioms := []
+
+/-- Registry entry for `Range.all`. -/
+def allIntrinsic : Verifier.Intrinsic := intrinsic allName "all"
+
+/-- Registry entry for `Range.exists`. -/
+def existsIntrinsic : Verifier.Intrinsic := intrinsic existsName "exists"
+
+@[simp] theorem allIntrinsic_arity : allIntrinsic.arity = .three := rfl
+@[simp] theorem existsIntrinsic_arity : existsIntrinsic.arity = .three := rfl
+@[simp] theorem allIntrinsic_folSym : allIntrinsic.folSym = none := rfl
+@[simp] theorem existsIntrinsic_folSym : existsIntrinsic.folSym = none := rfl
+
+/-- A forbidden intrinsic is sound: its specification and weakest precondition
+are both false, and it contributes no solver symbols or axioms. -/
+@[reducible] def intrinsicSound (name path : String) :
+    Verifier.IntrinsicSound [] (intrinsic name path) where
+  specWf := by
+    intro Δ _ _
+    simp [intrinsic, Verifier.Intrinsic.specArgs, PredTrans.wfIn, Assertion.wfIn]
+    trivial
+  bridge := by
+    intro _ σ Θ vs ρ Φ _
+    simp only [intrinsic, Spec.instantiate, PredTrans.apply, Assertion.pre]
+    iintro H
+    icases H with ⟨_, %hfalse, _⟩
+    exact hfalse.elim
+  wp_sound := by
+    intro _ _ _ vs _
+    match vs with
+    | [] => exact false_elim
+    | [_] => exact false_elim
+    | [_, _] => exact false_elim
+    | [_, _, _] => exact false_elim
+    | _ :: _ :: _ :: _ :: _ => exact false_elim
+  axiomWf := by
+    intro _ _ _ a ha
+    cases ha
+  proof := by
+    intro _ _ a ha
+    cases ha
+
+instance : Verifier.IntrinsicSound [] allIntrinsic := intrinsicSound _ _
+
+instance : Verifier.IntrinsicSound [] existsIntrinsic := intrinsicSound _ _
+
+/-! ## The rewrite pass
+
+Runs on the typed program before relation assembly. Each occurrence
+`Range.all lo hi (fun i -> body)` in a spec leaf is replaced by a plain call
+`L (lo, hi, x̄)` of a fresh symbol `L = "<decl>-range-<k>"` over the packed
+bounds and captured variables `x̄`; the closure is recorded as a lifted
+function body `let (x̄, i) = arg in body` to be axiomatized during assembly.
+Only the spec leaves change — declaration bodies (hence the program's runtime
+erasure) are untouched.
+
+The rewrite itself is `partial` and unverified: no proof depends on its
+equations. Rewritten specs are re-checked from scratch by spec translation,
+name freshness is validated operationally during assembly, and `run_runtime`
+only needs that declaration bodies are untouched. -/
+
+/-- One lifted occurrence of a bounded quantifier: the quantifier symbol's base
+name, the quantifier kind, the captured spec variables (first-occurrence
+order), and the lifted closure's packed argument name and body. -/
+structure Lifting where
+  name : String
+  all : Bool
+  captured : List TinyML.Var
+  arg : String
+  body : Typed.Expr
+
+/-- State of the per-declaration rewrite: the occurrence counter and the
+lifted symbols in dependency order (inner occurrences precede outer ones). -/
+structure LiftState where
+  count : Nat := 0
+  syms : List Lifting := []
+
+abbrev LiftM := StateT LiftState (Except String)
+
+mutual
+  /-- Free program variables of a typed expression, in first-occurrence order.
+  A named unary call head is resolved through the function context and is not
+  captured as a value variable. -/
+  private def freeVars : Typed.Expr → List TinyML.Var
+    | .const _ => []
+    | .var x _ => [x]
+    | .prim .. => []
+    | .unop _ e _ => freeVars e
+    | .binop _ l r _ => freeVars l ++ freeVars r
+    | .fix self args _ body =>
+        (freeVars body).filter fun v =>
+          self.name != some v && !args.any (·.name == some v)
+    | .app (.var _ _) [arg] _ => freeVars arg
+    | .app fn args _ => freeVars fn ++ args.flatMap freeVars
+    | .ifThenElse c t e _ => freeVars c ++ freeVars t ++ freeVars e
+    | .letIn b bound body =>
+        freeVars bound ++ (freeVars body).filter (fun v => b.name != some v)
+    | .letProd bs bound body =>
+        freeVars bound ++ (freeVars body).filter (fun v => !bs.any (·.name == some v))
+    | .ref _ e => freeVars e
+    | .deref e _ => freeVars e
+    | .store loc val => freeVars loc ++ freeVars val
+    | .arrayMake _ len init => freeVars len ++ freeVars init
+    | .arrayLen arr => freeVars arr
+    | .arrayGet arr idx _ => freeVars arr ++ freeVars idx
+    | .arraySet arr idx val => freeVars arr ++ freeVars idx ++ freeVars val
+    | .assert e => freeVars e
+    | .tuple es => es.flatMap freeVars
+    | .inj _ _ payload => freeVars payload
+    | .match_ scrut branches _ => freeVars scrut ++ branchFreeVars branches
+    | .cast e _ => freeVars e
+
+  private def branchFreeVars : List (Typed.Binder × Typed.Expr) → List TinyML.Var
+    | [] => []
+    | (b, body) :: rest =>
+        (freeVars body).filter (fun v => b.name != some v) ++ branchFreeVars rest
+end
+
+/-- Lift one occurrence: allocate the quantifier symbol, record the lifted closure
+`let (x̄, i) = arg in body`, and return the plain call replacing the
+occurrence — the quantifier symbol applied to the packed `(lo, hi, x̄)` tuple. -/
+private def lift (decl : Option String) (all : Bool) (binder : Typed.Binder)
+    (body lo hi : Typed.Expr) : LiftM Typed.Expr := do
+  let some decl := decl
+    | throw "Range.all/Range.exists in a specification require a named declaration"
+  let st ← get
+  let name := s!"{decl}-range-{st.count}"
+  let captured := ((freeVars body).filter (fun v => binder.name != some v)).eraseDups
+  let gBody := Typed.Expr.letProd
+    (captured.map (fun x => ⟨some x, .value⟩) ++ [binder]) (.var (name ++ "-x") .value) body
+  set ({ count := st.count + 1,
+         syms := st.syms ++ [{ name, all, captured, arg := name ++ "-x", body := gBody }] } : LiftState)
+  pure (.app (.var name (.arrow .value .bool))
+    [.tuple (lo :: hi :: captured.map (fun x => Typed.Expr.var x .value))] .bool)
+
+/-- Rewrite every bounded-quantifier occurrence in a spec leaf, bottom-up:
+bounds and closure bodies are rewritten first, so inner occurrences are
+lifted before — and their calls captured by — outer ones. -/
+private partial def rewrite (decl : Option String) : Typed.Expr → LiftM Typed.Expr
+  | .app (.prim n inst pty) args ty => do
+      if isPrim n then
+        match args with
+        | [lo, hi, .fix _ [binder] _ body] => do
+            let lo' ← rewrite decl lo
+            let hi' ← rewrite decl hi
+            let body' ← rewrite decl body
+            lift decl (n = allName) binder body' lo' hi'
+        | _ => throw "Range.all/Range.exists expect a literal single-argument function"
+      else do
+        pure (.app (.prim n inst pty) (← args.mapM (rewrite decl)) ty)
+  | .const c => pure (.const c)
+  | .var x ty => pure (.var x ty)
+  | .prim n inst ty => pure (.prim n inst ty)
+  | .unop op e ty => do pure (.unop op (← rewrite decl e) ty)
+  | .binop op l r ty => do pure (.binop op (← rewrite decl l) (← rewrite decl r) ty)
+  | .fix self args retTy body => do pure (.fix self args retTy (← rewrite decl body))
+  | .app fn args ty => do
+      pure (.app (← rewrite decl fn) (← args.mapM (rewrite decl)) ty)
+  | .ifThenElse c t e ty => do
+      pure (.ifThenElse (← rewrite decl c) (← rewrite decl t) (← rewrite decl e) ty)
+  | .letIn b bound body => do pure (.letIn b (← rewrite decl bound) (← rewrite decl body))
+  | .letProd bs bound body => do
+      pure (.letProd bs (← rewrite decl bound) (← rewrite decl body))
+  | .ref owned e => do pure (.ref owned (← rewrite decl e))
+  | .deref e ty => do pure (.deref (← rewrite decl e) ty)
+  | .store loc val => do pure (.store (← rewrite decl loc) (← rewrite decl val))
+  | .arrayMake owned len init => do
+      pure (.arrayMake owned (← rewrite decl len) (← rewrite decl init))
+  | .arrayLen arr => do pure (.arrayLen (← rewrite decl arr))
+  | .arrayGet arr idx ty => do pure (.arrayGet (← rewrite decl arr) (← rewrite decl idx) ty)
+  | .arraySet arr idx val => do
+      pure (.arraySet (← rewrite decl arr) (← rewrite decl idx) (← rewrite decl val))
+  | .assert e => do pure (.assert (← rewrite decl e))
+  | .tuple es => do pure (.tuple (← es.mapM (rewrite decl)))
+  | .inj tag arity payload => do pure (.inj tag arity (← rewrite decl payload))
+  | .match_ scrut branches ty => do
+      pure (.match_ (← rewrite decl scrut)
+        (← branches.mapM fun (b, body) => do pure (b, ← rewrite decl body)) ty)
+  | .cast e ty => do pure (.cast (← rewrite decl e) ty)
+
+/-- Rewrite the leaves of a spec assertion; `f` handles the return payload. -/
+private def rewriteAssert {α β : Type} (decl : Option String) (f : α → LiftM β) :
+    Spec.Assert Typed.Expr α → LiftM (Spec.Assert Typed.Expr β)
+  | .ret v => .ret <$> f v
+  | .assert c rest => do pure (.assert (← rewrite decl c) (← rewriteAssert decl f rest))
+  | .let_ x v rest => do pure (.let_ x (← rewrite decl v) (← rewriteAssert decl f rest))
+  | .bind p x ty rest => do pure (.bind p x ty (← rewriteAssert decl f rest))
+  | .ite c t e => do
+      pure (.ite (← rewrite decl c) (← rewriteAssert decl f t) (← rewriteAssert decl f e))
+
+/-- Rewrite all spec leaves of a spec body. -/
+private def rewriteBody (decl : Option String) (body : Spec.Body Typed.Expr) :
+    LiftM (Spec.Body Typed.Expr) := do
+  let pre ← rewriteAssert decl
+    (fun (r, post) => do pure (r, ← rewriteAssert decl pure post)) body.2
+  pure (body.1, pre)
+
+/-- Rewrite one declaration's spec, pairing it with the lifted symbols. -/
+def runDecl (d : Typed.ValDecl (Spec.Body Typed.Expr)) :
+    Except String (Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting) :=
+  match d.declMeta.spec with
+  | none => .ok (d, [])
+  | some body =>
+      match (rewriteBody d.name.name body).run {} with
+      | .error err => .error err
+      | .ok (body', st) =>
+          .ok ({ d with declMeta := { d.declMeta with spec := some body' } }, st.syms)
+
+/-- Run the bounded-quantifier pass over a typed program: rewrite every spec's
+bounded-quantifier occurrences and pair each declaration with its lifted
+symbols in dependency order. Declaration bodies are untouched, so the
+program's runtime erasure is preserved (`run_runtime`). -/
+def run : Typed.Program (Spec.Body Typed.Expr) →
+    Except String (List (Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting))
+  | [] => .ok []
+  | d :: ds =>
+      match runDecl d with
+      | .error err => .error err
+      | .ok p =>
+          match run ds with
+          | .error err => .error err
+          | .ok ps => .ok (p :: ps)
+
+/-- The pass leaves a declaration's name and body untouched. -/
+theorem runDecl_runtime {d : Typed.ValDecl (Spec.Body Typed.Expr)}
+    {p : Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting}
+    (h : runDecl d = .ok p) : p.1.runtime = d.runtime := by
+  unfold runDecl at h
+  split at h
+  · cases h; rfl
+  · split at h
+    · cases h
+    · cases h; rfl
+
+/-- The pass preserves the program's runtime erasure: only spec metadata
+changes. -/
+theorem run_runtime {prog : Typed.Program (Spec.Body Typed.Expr)}
+    {pairs : List (Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting)}
+    (h : run prog = .ok pairs) :
+    Typed.Program.runtime (pairs.map Prod.fst) = prog.runtime := by
+  induction prog generalizing pairs with
+  | nil =>
+    simp only [run, Except.ok.injEq] at h
+    subst h
+    rfl
+  | cons d ds ih =>
+    rw [run] at h
+    split at h
+    · cases h
+    · rename_i p hd
+      split at h
+      · cases h
+      · rename_i ps hds
+        cases h
+        simp only [List.map_cons, Typed.Program.runtime, List.map]
+        rw [show p.1.runtime = d.runtime from runDecl_runtime hd]
+        have := ih hds
+        simp only [Typed.Program.runtime] at this
+        rw [this]
+
+/-! ## Lifted closures -/
+
+open Verifier.RelationalEncoding
+
+namespace Lifting
+
+/-- The lifted closure's spec-function base name. -/
+def fn (s : Lifting) : SpecFn := s.name ++ "-fn"
+
+end Lifting
+
+/-- The lifted closure as a synthetic relation-marked declaration. It is used
+only while assembling solver symbols and has no runtime counterpart. -/
+def Lifting.closureDecl (s : Lifting) :
+    Typed.ValDecl (Spec.Body Typed.Expr) :=
+  { name := ⟨some s.fn, .value⟩,
+    body := .fix ⟨none, .value⟩ [⟨some s.arg, .value⟩] .bool s.body,
+    declMeta := { spec := none, relation := some s.fn } }
+
+/-! ## Solver-facing symbols and defining axioms
+
+Each lifted occurrence contributes two `SpecFn`-shaped symbol triples:
+
+* the lifted closure `g = "<L>-fn"`, whose body is a plain TinyML expression
+  and is axiomatized by the standard `Skolemize.bundle` machinery during
+  relation assembly (it is registered as a synthetic relation-marked
+  declaration there);
+* the quantifier symbol `L` itself, defined by the two hand-built axioms below in
+  terms of `g`'s solver-facing symbols. The axioms mention only projections,
+  integer comparisons, and the two symbol triples — never a translated
+  expression — so their well-formedness is generic.
+
+The canonical interpretations of `L`'s symbols are the evaluations of the
+axioms' right-hand sides, so validity is by construction (no fixpoint: `g`'s
+interpretations are fixed before `L`'s). -/
+
+open Verifier.RelationalEncoding
+
+namespace Lifting
+
+/-- Bound index variable of the defining axioms. -/
+def idx (s : Lifting) : String := s.name ++ "-i"
+
+/-- Facts required to declare a quantifier symbol: freshness of all derived
+names and availability of its closure's symbols. Established operationally by
+`validate`. -/
+structure Valid (s : Lifting) (Δ : Signature) : Prop where
+  relFresh : SpecFn.relName s.name ∉ Δ.allNames
+  funFresh : SpecFn.funcName s.name ∉ Δ.allNames
+  defFresh : SpecFn.defName s.name ∉ Δ.allNames
+  argFresh : s.arg ∉ Δ.allNames
+  idxFresh : s.idx ∉ Δ.allNames
+  idxNeArg : s.idx ≠ s.arg
+  argNeRel : s.arg ≠ SpecFn.relName s.name
+  argNeFun : s.arg ≠ SpecFn.funcName s.name
+  argNeDef : s.arg ≠ SpecFn.defName s.name
+  idxNeRel : s.idx ≠ SpecFn.relName s.name
+  idxNeFun : s.idx ≠ SpecFn.funcName s.name
+  idxNeDef : s.idx ≠ SpecFn.defName s.name
+  closureFun : SpecFn.func s.fn ∈ Δ.unary
+  closureDef : SpecFn.defined s.fn ∈ Δ.unaryRel
+
+/-- Run one decidable validation check, or fail with `msg`. -/
+private def check (p : Prop) [Decidable p] (msg : String) : Except String (PLift p) :=
+  if h : p then .ok ⟨h⟩ else .error msg
+
+/-- Validate the fresh names and closure dependencies required to declare the
+solver-facing quantifier symbol over `Δ`. A successful run returns the
+`Valid` evidence directly. -/
+def validate (s : Lifting) (Δ : Signature) : Except String (PLift (Valid s Δ)) := do
+  let L := s.name
+  let ⟨relFresh⟩ ← check (SpecFn.relName L ∉ Δ.allNames)
+    s!"derived relation name '{SpecFn.relName L}' for a bounded quantifier conflicts with an existing symbol"
+  let ⟨funFresh⟩ ← check (SpecFn.funcName L ∉ Δ.allNames)
+    s!"derived value-function name '{SpecFn.funcName L}' for a bounded quantifier conflicts with an existing symbol"
+  let ⟨defFresh⟩ ← check (SpecFn.defName L ∉ Δ.allNames)
+    s!"derived definedness name '{SpecFn.defName L}' for a bounded quantifier conflicts with an existing symbol"
+  let ⟨argFresh⟩ ← check (s.arg ∉ Δ.allNames)
+    s!"bounded quantifier argument name '{s.arg}' conflicts with a global symbol"
+  let ⟨idxFresh⟩ ← check (s.idx ∉ Δ.allNames)
+    s!"bounded quantifier index name '{s.idx}' conflicts with a global symbol"
+  let ⟨idxNeArg⟩ ← check (s.idx ≠ s.arg)
+    s!"bounded quantifier index name '{s.idx}' clashes with its argument name"
+  let ⟨argNeRel⟩ ← check (s.arg ≠ SpecFn.relName L)
+    s!"bounded quantifier argument name '{s.arg}' clashes with derived relation name '{SpecFn.relName L}'"
+  let ⟨argNeFun⟩ ← check (s.arg ≠ SpecFn.funcName L)
+    s!"bounded quantifier argument name '{s.arg}' clashes with derived value-function name '{SpecFn.funcName L}'"
+  let ⟨argNeDef⟩ ← check (s.arg ≠ SpecFn.defName L)
+    s!"bounded quantifier argument name '{s.arg}' clashes with derived definedness name '{SpecFn.defName L}'"
+  let ⟨idxNeRel⟩ ← check (s.idx ≠ SpecFn.relName L)
+    s!"bounded quantifier index name '{s.idx}' clashes with derived relation name '{SpecFn.relName L}'"
+  let ⟨idxNeFun⟩ ← check (s.idx ≠ SpecFn.funcName L)
+    s!"bounded quantifier index name '{s.idx}' clashes with derived value-function name '{SpecFn.funcName L}'"
+  let ⟨idxNeDef⟩ ← check (s.idx ≠ SpecFn.defName L)
+    s!"bounded quantifier index name '{s.idx}' clashes with derived definedness name '{SpecFn.defName L}'"
+  let ⟨closureFun⟩ ← check (SpecFn.func s.fn ∈ Δ.unary)
+    s!"internal error: quantifier symbol '{L}' declared before its closure's value symbol"
+  let ⟨closureDef⟩ ← check (SpecFn.defined s.fn ∈ Δ.unaryRel)
+    s!"internal error: quantifier symbol '{L}' declared before its closure's definedness symbol"
+  .ok ⟨⟨relFresh, funFresh, defFresh, argFresh, idxFresh, idxNeArg, argNeRel,
+    argNeFun, argNeDef, idxNeRel, idxNeFun, idxNeDef, closureFun, closureDef⟩⟩
+
+/-- The packed axiom variable (also the lifted closure's argument name). -/
+private def pvar (s : Lifting) : Term .value := .var .value s.arg
+
+private def ivar (s : Lifting) : Term .int := .var .int s.idx
+
+/-- Lower bound: the packed tuple's first component. -/
+private def lo (s : Lifting) : Term .int := .unop .toInt (VarEnv.prodProj s.pvar 0)
+
+/-- Upper bound: the packed tuple's second component. -/
+private def hi (s : Lifting) : Term .int := .unop .toInt (VarEnv.prodProj s.pvar 1)
+
+/-- The bounds premise `lo ≤ i ∧ i < hi`. -/
+private def bounds (s : Lifting) : Formula :=
+  .and (.binpred .le s.lo s.ivar) (.binpred .lt s.ivar s.hi)
+
+/-- The lifted closure's packed argument: the captured components of `p`
+(positions `2..`) followed by the index. Matches the destructuring order of
+the closure's `letProd`. -/
+private def gpack (s : Lifting) : Term .value :=
+  .unop .ofValList (Terms.toValList
+    ((List.range s.captured.length).map (fun k => VarEnv.prodProj s.pvar (k + 2))
+      ++ [.unop .ofInt s.ivar]))
+
+/-- Truth of the lifted closure at the packed axiom argument. -/
+private def holds (s : Lifting) : Formula :=
+  (SpecFn.call s.fn s.gpack).isTrue
+
+/-- Matrix of the value axiom: the bounded quantifier over the lifted
+closure's truth. -/
+def matrix (s : Lifting) : Formula :=
+  if s.all then .forall_ s.idx .int [] (.implies s.bounds s.holds)
+  else .exists_ s.idx .int (.and s.bounds s.holds)
+
+/-- Matrix of the definedness axiom: the lifted closure is defined on the
+whole range (vacuously on an empty range, giving the vacuity semantics). -/
+def defMatrix (s : Lifting) : Formula :=
+  .forall_ s.idx .int [] (.implies s.bounds (SpecFn.isDefined s.fn s.gpack))
+
+/-- Defining definedness axiom: `L-def(p)` iff the closure is defined on the
+whole range. Triggered only by the `L-def` application. -/
+def defAxiom (s : Lifting) : Formula :=
+  .forall_ s.arg .value
+    [.unpred (.uninterpreted (SpecFn.defName s.name) .value) s.pvar]
+    (.iff (SpecFn.isDefined s.name s.pvar) s.defMatrix)
+
+/-- Defining value axiom: `L-func(p)` is the boolean truth value of the
+bounded quantifier. Stated as the two directions so the solver also learns
+booleanness of the result. Triggered only by the `L-func` application. -/
+def valAxiom (s : Lifting) : Formula :=
+  .forall_ s.arg .value
+    [.term (SpecFn.call s.name s.pvar)]
+    (.and (.implies s.matrix (SpecFn.call s.name s.pvar).isTrue)
+          (.implies (.not s.matrix) (SpecFn.call s.name s.pvar).isFalse))
+
+/-- The axioms defining a quantifier symbol; both quantified, hence guarded. -/
+def axioms (s : Lifting) : List Axiom :=
+  [⟨s.defAxiom, .high⟩, ⟨s.valAxiom, .high⟩]
+
+/-- Signature after declaring the quantifier relation, value function, and
+definedness predicate. -/
+def extendSignature (s : Lifting) (Δ : Signature) : Signature :=
+  ((Δ.addBinaryRel (SpecFn.rel s.name)).addUnary
+    (SpecFn.func s.name)).addUnaryRel (SpecFn.defined s.name)
+
+/-- Declare and axiomatize one validated quantifier symbol. -/
+def declare (s : Lifting) : VerifM Unit :=
+  SpecFn.declare s.name s.axioms
+
+/-- Canonical interpretation of the quantifier symbol's definedness predicate:
+the evaluation of the definedness axiom's right-hand side. -/
+noncomputable def definterp (s : Lifting) (ρ : Env) : Srt.value.denote → Prop :=
+  fun v => s.defMatrix.eval (ρ.updateConst .value s.arg v)
+
+open Classical in
+/-- Canonical interpretation of the quantifier symbol's value function: the
+boolean truth value of the value axiom's matrix. -/
+noncomputable def funcinterp (s : Lifting) (ρ : Env) :
+    Srt.value.denote → Srt.value.denote :=
+  fun v =>
+    if s.matrix.eval (ρ.updateConst .value s.arg v)
+    then Runtime.Val.bool true else Runtime.Val.bool false
+
+/-- Canonical interpretation of the quantifier symbol's relation: the graph of the
+value function on the definedness domain (deterministic and split-compatible
+by construction). -/
+noncomputable def relinterp (s : Lifting) (ρ : Env) :
+    Srt.value.denote → Srt.value.denote → Prop :=
+  fun a b => s.definterp ρ a ∧ s.funcinterp ρ a = b
+
+/-! ### Well-formedness of the defining axioms -/
+
+private theorem var_wfIn {Δ : Signature} {x : String} {τ : Srt}
+    (hΔ : Δ.wf) (hmem : (⟨x, τ⟩ : Var) ∈ Δ.vars) : (Term.var τ x).wfIn Δ :=
+  ⟨hmem, fun _ hc => Signature.wf_no_const_of_var hΔ hmem hc,
+   fun _ hv => Signature.wf_unique_var hΔ hmem hv⟩
+
+variable {s : Lifting} {Δ : Signature}
+
+private theorem prodProj_wfIn {x : String} (k : Nat)
+    (hΔ : Δ.wf) (hmem : (⟨x, .value⟩ : Var) ∈ Δ.vars) :
+    (VarEnv.prodProj (.var .value x) k).wfIn Δ :=
+  show UnOp.wfIn .vhead Δ ∧ (vtailN (.unop .toValList (.var .value x)) k).wfIn Δ from
+    ⟨trivial, vtailN_wfIn (t := .unop .toValList (.var .value x))
+      ⟨trivial, var_wfIn hΔ hmem⟩ k⟩
+
+private theorem gpack_wfIn (hΔ : Δ.wf)
+    (hp : (⟨s.arg, .value⟩ : Var) ∈ Δ.vars) (hi : (⟨s.idx, .int⟩ : Var) ∈ Δ.vars) :
+    s.gpack.wfIn Δ := by
+  refine show UnOp.wfIn .ofValList Δ ∧ (Terms.toValList _).wfIn Δ from
+    ⟨trivial, Terms.toValList_wfIn ?_⟩
+  intro t ht
+  rcases List.mem_append.mp ht with hmem | hmem
+  · obtain ⟨k, _, rfl⟩ := List.mem_map.mp hmem
+    exact prodProj_wfIn _ hΔ hp
+  · simp only [List.mem_singleton] at hmem
+    subst hmem
+    exact show UnOp.wfIn .ofInt Δ ∧ (Term.var .int s.idx).wfIn Δ from
+      ⟨trivial, var_wfIn hΔ hi⟩
+
+private theorem bounds_wfIn (hΔ : Δ.wf)
+    (hp : (⟨s.arg, .value⟩ : Var) ∈ Δ.vars) (hi : (⟨s.idx, .int⟩ : Var) ∈ Δ.vars) :
+    s.bounds.wfIn Δ := by
+  have hproj : ∀ k, (VarEnv.prodProj s.pvar k).wfIn Δ := fun k => prodProj_wfIn k hΔ hp
+  have hlo : s.lo.wfIn Δ :=
+    show UnOp.wfIn .toInt Δ ∧ (VarEnv.prodProj s.pvar 0).wfIn Δ from ⟨trivial, hproj 0⟩
+  have hhi : s.hi.wfIn Δ :=
+    show UnOp.wfIn .toInt Δ ∧ (VarEnv.prodProj s.pvar 1).wfIn Δ from ⟨trivial, hproj 1⟩
+  have hiv : s.ivar.wfIn Δ := var_wfIn hΔ hi
+  exact ⟨⟨trivial, hlo, hiv⟩, ⟨trivial, hiv, hhi⟩⟩
+
+/-- The index variable is fresh for the signature extended by the packed
+variable, so the nested `declVar` is an extension. -/
+private theorem idx_fresh_declVar (harg : s.arg ∉ Δ.allNames)
+    (hidx : s.idx ∉ Δ.allNames) (hai : s.idx ≠ s.arg) :
+    s.idx ∉ (Δ.declVar ⟨s.arg, .value⟩).allNames := by
+  rw [Signature.allNames_declVar_of_not_in harg]
+  intro hmem
+  rcases List.mem_cons.mp hmem with h | h
+  · exact hai h
+  · exact hidx h
+
+/-- Well-formedness of the value-axiom matrix at the packed-variable
+signature. Everything is interpreted except the lifted closure's value
+function. -/
+theorem matrix_wfIn (hΔ : Δ.wf) (hgfun : SpecFn.func s.fn ∈ Δ.unary)
+    (harg : s.arg ∉ Δ.allNames) (hidx : s.idx ∉ Δ.allNames) (hai : s.idx ≠ s.arg) :
+    s.matrix.wfIn (Δ.declVar ⟨s.arg, .value⟩) := by
+  set Δp := Δ.declVar ⟨s.arg, .value⟩ with hΔp_def
+  set Δpi := Δp.declVar ⟨s.idx, .int⟩ with hΔpi_def
+  have hΔp : Δp.wf := Signature.wf_declVar hΔ
+  have hΔpi : Δpi.wf := Signature.wf_declVar hΔp
+  have hsubpi : Δp.Subset Δpi :=
+    Signature.subset_declVar_of_fresh (idx_fresh_declVar harg hidx hai)
+  have hpvars : (⟨s.arg, .value⟩ : Var) ∈ Δpi.vars :=
+    hsubpi.vars _ (Signature.var_mem_declVar Δ ⟨s.arg, .value⟩)
+  have hivars : (⟨s.idx, .int⟩ : Var) ∈ Δpi.vars :=
+    Signature.var_mem_declVar Δp ⟨s.idx, .int⟩
+  have hgfun_pi : SpecFn.func s.fn ∈ Δpi.unary :=
+    hsubpi.unary _ ((Signature.subset_declVar_of_fresh harg).unary _ hgfun)
+  have hholds : s.holds.wfIn Δpi :=
+    ⟨SpecFn.call_wfIn hgfun_pi hΔpi (gpack_wfIn hΔpi hpvars hivars),
+     trivial, trivial⟩
+  unfold matrix
+  split
+  · exact ⟨fun _ h => (List.not_mem_nil h).elim,
+      bounds_wfIn hΔpi hpvars hivars, hholds⟩
+  · exact ⟨bounds_wfIn hΔpi hpvars hivars, hholds⟩
+
+/-- Well-formedness of the definedness-axiom matrix at the packed-variable
+signature. -/
+theorem defMatrix_wfIn (hΔ : Δ.wf) (hgdef : SpecFn.defined s.fn ∈ Δ.unaryRel)
+    (harg : s.arg ∉ Δ.allNames) (hidx : s.idx ∉ Δ.allNames) (hai : s.idx ≠ s.arg) :
+    s.defMatrix.wfIn (Δ.declVar ⟨s.arg, .value⟩) := by
+  set Δp := Δ.declVar ⟨s.arg, .value⟩ with hΔp_def
+  set Δpi := Δp.declVar ⟨s.idx, .int⟩ with hΔpi_def
+  have hΔp : Δp.wf := Signature.wf_declVar hΔ
+  have hΔpi : Δpi.wf := Signature.wf_declVar hΔp
+  have hsubpi : Δp.Subset Δpi :=
+    Signature.subset_declVar_of_fresh (idx_fresh_declVar harg hidx hai)
+  have hpvars : (⟨s.arg, .value⟩ : Var) ∈ Δpi.vars :=
+    hsubpi.vars _ (Signature.var_mem_declVar Δ ⟨s.arg, .value⟩)
+  have hivars : (⟨s.idx, .int⟩ : Var) ∈ Δpi.vars :=
+    Signature.var_mem_declVar Δp ⟨s.idx, .int⟩
+  have hgdef_pi : SpecFn.defined s.fn ∈ Δpi.unaryRel :=
+    hsubpi.unaryRel _ ((Signature.subset_declVar_of_fresh harg).unaryRel _ hgdef)
+  exact ⟨fun _ h => (List.not_mem_nil h).elim,
+    bounds_wfIn hΔpi hpvars hivars,
+    SpecFn.isDefined_wfIn hgdef_pi hΔpi (gpack_wfIn hΔpi hpvars hivars)⟩
+
+/-- Well-formedness of the defining axioms. All hypotheses are discharged
+operationally by the assembly step (symbol declarations and name checks). -/
+theorem axioms_wfIn (hΔ : Δ.wf)
+    (hgfun : SpecFn.func s.fn ∈ Δ.unary) (hgdef : SpecFn.defined s.fn ∈ Δ.unaryRel)
+    (hlfun : SpecFn.func s.name ∈ Δ.unary) (hldef : SpecFn.defined s.name ∈ Δ.unaryRel)
+    (harg : s.arg ∉ Δ.allNames) (hidx : s.idx ∉ Δ.allNames) (hai : s.idx ≠ s.arg) :
+    ∀ ax ∈ s.axioms, ax.formula.wfIn Δ := by
+  intro ax hmem
+  have hΔp : (Δ.declVar ⟨s.arg, .value⟩).wf := Signature.wf_declVar hΔ
+  have hsubp : Δ.Subset (Δ.declVar ⟨s.arg, .value⟩) :=
+    Signature.subset_declVar_of_fresh harg
+  have hpwf : (Term.var .value s.arg).wfIn (Δ.declVar ⟨s.arg, .value⟩) :=
+    var_wfIn hΔp (Signature.var_mem_declVar Δ ⟨s.arg, .value⟩)
+  have hlfun_p : SpecFn.func s.name ∈ (Δ.declVar ⟨s.arg, .value⟩).unary :=
+    hsubp.unary _ hlfun
+  have hldef_p : SpecFn.defined s.name ∈ (Δ.declVar ⟨s.arg, .value⟩).unaryRel :=
+    hsubp.unaryRel _ hldef
+  simp only [axioms, List.mem_cons, List.not_mem_nil, or_false] at hmem
+  rcases hmem with rfl | rfl
+  · -- defAxiom
+    refine ⟨?_, ?_⟩
+    · intro p hp
+      simp only [List.mem_singleton] at hp
+      subst hp
+      exact SpecFn.isDefined_wfIn hldef_p hΔp hpwf
+    · exact ⟨⟨SpecFn.isDefined_wfIn hldef_p hΔp hpwf,
+        defMatrix_wfIn hΔ hgdef harg hidx hai⟩,
+        ⟨defMatrix_wfIn hΔ hgdef harg hidx hai,
+        SpecFn.isDefined_wfIn hldef_p hΔp hpwf⟩⟩
+  · -- valAxiom
+    refine ⟨?_, ?_⟩
+    · intro p hp
+      simp only [List.mem_singleton] at hp
+      subst hp
+      exact SpecFn.call_wfIn hlfun_p hΔp hpwf
+    · exact ⟨⟨matrix_wfIn hΔ hgfun harg hidx hai,
+        SpecFn.call_wfIn hlfun_p hΔp hpwf, trivial, trivial⟩,
+        ⟨matrix_wfIn hΔ hgfun harg hidx hai,
+        SpecFn.call_wfIn hlfun_p hΔp hpwf, trivial, trivial⟩⟩
+
+/-! ### Validity of the defining axioms under the canonical interpretations -/
+
+/-- The environment carrying the quantifier symbol's canonical interpretations. -/
+noncomputable def extend (s : Lifting) (ρ : Env) : Env :=
+  ((ρ.updateBinaryRel .value .value (SpecFn.relName s.name) (s.relinterp ρ)).updateUnary
+      .value .value (SpecFn.funcName s.name) (s.funcinterp ρ)).updateUnaryRel
+    .value (SpecFn.defName s.name) (s.definterp ρ)
+
+/-- The extension only touches the quantifier symbol's three fresh names. -/
+theorem extend_agreeOn {ρ : Env}
+    (hrel : SpecFn.relName s.name ∉ Δ.allNames)
+    (hfun : SpecFn.funcName s.name ∉ Δ.allNames)
+    (hdef : SpecFn.defName s.name ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (s.extend ρ) :=
+  Env.agreeOn_trans
+    (Env.agreeOn_update_fresh_binaryRel (b := SpecFn.rel s.name)
+      (f := s.relinterp ρ) hrel)
+    (Env.agreeOn_trans
+      (Env.agreeOn_update_fresh_unary (u := SpecFn.func s.name)
+        (f := s.funcinterp ρ) hfun)
+      (Env.agreeOn_update_fresh_unaryRel (u := SpecFn.defined s.name)
+        (f := s.definterp ρ) hdef))
+
+@[simp] theorem extend_evalDefined (ρ : Env) (v : Srt.value.denote) :
+    SpecFn.evalDefined s.name (s.extend ρ) v ↔ s.definterp ρ v := by
+  simp [extend, SpecFn.evalDefined, SpecFn.defined, SpecFn.defName,
+    Env.updateUnaryRel, Env.updateUnary, Env.updateBinaryRel]
+
+@[simp] theorem extend_evalCall (ρ : Env) (v : Srt.value.denote) :
+    SpecFn.evalCall s.name (s.extend ρ) v = s.funcinterp ρ v := by
+  simp [extend, SpecFn.evalCall, SpecFn.func, SpecFn.funcName,
+    Env.updateUnaryRel, Env.updateUnary, Env.updateBinaryRel]
+
+@[simp] theorem extend_evalRelates (ρ : Env) (a b : Srt.value.denote) :
+    SpecFn.evalRelates s.name (s.extend ρ) a b ↔ s.relinterp ρ a b := by
+  simp [extend, SpecFn.evalRelates, SpecFn.rel, SpecFn.relName,
+    Env.updateUnaryRel, Env.updateUnary, Env.updateBinaryRel]
+
+/-- The defining axioms hold in the extended environment. The matrix
+well-formedness hypotheses (over any signature the environments agree on that
+declares the lifted closure's symbols) let the interpretation's evaluation be
+transported past the extension. -/
+theorem axioms_eval {ρ : Env}
+    (hmat : s.matrix.wfIn (Δ.declVar ⟨s.arg, .value⟩))
+    (hdefmat : s.defMatrix.wfIn (Δ.declVar ⟨s.arg, .value⟩))
+    (hrel : SpecFn.relName s.name ∉ Δ.allNames)
+    (hfun : SpecFn.funcName s.name ∉ Δ.allNames)
+    (hdef : SpecFn.defName s.name ∉ Δ.allNames) :
+    ∀ ax ∈ s.axioms, ax.formula.eval (s.extend ρ) := by
+  have hagree : Env.agreeOn Δ ρ (s.extend ρ) := extend_agreeOn hrel hfun hdef
+  have htrans : ∀ (φ : Formula), φ.wfIn (Δ.declVar ⟨s.arg, .value⟩) →
+      ∀ v, φ.eval ((s.extend ρ).updateConst .value s.arg v) ↔
+        φ.eval (ρ.updateConst .value s.arg v) :=
+    fun φ hwf v => (Formula.eval_env_agree hwf (Env.agreeOn_declVar hagree)).symm
+  intro ax hmem
+  simp only [axioms, List.mem_cons, List.not_mem_nil, or_false] at hmem
+  rcases hmem with rfl | rfl
+  · -- defAxiom
+    simp only [defAxiom, Formula.iff, Formula.eval]
+    intro v
+    have hA : (SpecFn.isDefined s.name s.pvar).eval
+        ((s.extend ρ).updateConst .value s.arg v) ↔ s.definterp ρ v := by
+      simp [pvar, Term.eval]
+    have hB := htrans s.defMatrix hdefmat v
+    exact ⟨fun h => hB.mpr (hA.mp h), fun h => hA.mpr (hB.mp h)⟩
+  · -- valAxiom
+    simp only [valAxiom, Term.isTrue, Term.isFalse, Formula.eval]
+    intro v
+    have hM := htrans s.matrix hmat v
+    have hcall : Term.eval ((s.extend ρ).updateConst .value s.arg v)
+        (SpecFn.call s.name s.pvar) = s.funcinterp ρ v := by
+      simp [pvar, Term.eval]
+    constructor
+    · intro h
+      rw [hcall]
+      simp only [funcinterp]
+      rw [if_pos (hM.mp h)]
+      simp [Term.eval]
+    · intro h
+      rw [hcall]
+      simp only [funcinterp]
+      rw [if_neg (fun hm => h (hM.mpr hm))]
+      simp [Term.eval]
+
+/-- Declaring a validated quantifier symbol preserves the global
+relation-assembly invariants: the generic triple declaration
+(`SpecFn.declare_correct`) instantiated with the canonical interpretations,
+whose graph shape holds by construction. -/
+theorem declare_correct (s : Lifting) (Δ : Signature) (Γ : FunCtx)
+    (st : TransState) (ρ : VerifM.Env) {Q : Unit → TransState → VerifM.Env → Prop}
+    (hv : Valid s Δ)
+    (hdecls : st.decls = Δ) (howns : st.owns = []) (hvars : st.decls.vars = [])
+    (hwf : Δ.wf) (hΓwf : FunCtx.wfIn Γ Δ)
+    (hsplit : FunCtx.splitCompatible Γ ρ.env)
+    (hdet : Relation.BinaryRelDet Γ ρ.env ρ.env)
+    (heval : VerifM.eval s.declare st ρ Q) :
+    ∃ st' ρ',
+      st'.decls = s.extendSignature Δ ∧ st'.owns = [] ∧ st'.decls.vars = [] ∧
+      st'.decls.wf ∧ st.decls.Subset st'.decls ∧
+      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      FunCtx.wfIn (Γ ++ [(s.name, s.name)]) st'.decls ∧
+      FunCtx.splitCompatible (Γ ++ [(s.name, s.name)]) ρ'.env ∧
+      Relation.BinaryRelDet (Γ ++ [(s.name, s.name)]) ρ'.env ρ'.env ∧
+      Q () st' ρ' := by
+  have hf : Skolemize.InfoFresh Δ s.name s.arg :=
+    { relFresh := hv.relFresh, funFresh := hv.funFresh, defFresh := hv.defFresh,
+      argFresh := hv.argFresh, argNeRel := hv.argNeRel,
+      argNeFun := hv.argNeFun, argNeDef := hv.argNeDef }
+  have hh : Skolemize.HeadFresh Δ s.name s.arg s.idx :=
+    Skolemize.headFresh_of_fresh hf hv.idxFresh hv.idxNeRel hv.idxNeFun
+      hv.idxNeDef hv.idxNeArg
+  have hwfext : (s.extendSignature Δ).wf := hf.wf_addSplit hwf
+  have hsub : Δ.Subset (s.extendSignature Δ) :=
+    ((Signature.Subset.subset_addBinaryRel _ _).trans
+      (Signature.Subset.subset_addUnary _ _)).trans
+      (Signature.Subset.subset_addUnaryRel _ _)
+  have hargext : s.arg ∉ (s.extendSignature Δ).allNames := hh.argFresh
+  have hidxext : s.idx ∉ (s.extendSignature Δ).allNames := by
+    intro hmem
+    apply hh.resFresh
+    show s.idx ∈ ((s.extendSignature Δ).declVar ⟨s.arg, .value⟩).allNames
+    rw [Signature.allNames_declVar_of_not_in hargext]
+    exact List.mem_cons_of_mem _ hmem
+  have haxwf : ∀ ax ∈ s.axioms, ax.formula.wfIn (s.extendSignature Δ) :=
+    s.axioms_wfIn hwfext (hsub.unary _ hv.closureFun)
+      (hsub.unaryRel _ hv.closureDef) (List.Mem.head _) (List.Mem.head _)
+      hargext hidxext hv.idxNeArg
+  have haxeval : ∀ ax ∈ s.axioms,
+      ax.formula.eval (Skolemize.relSplitEnv ρ.env s.name
+        (s.relinterp ρ.env) (s.definterp ρ.env) (s.funcinterp ρ.env)) :=
+    s.axioms_eval (Δ := Δ)
+      (s.matrix_wfIn hwf hv.closureFun hv.argFresh hv.idxFresh hv.idxNeArg)
+      (s.defMatrix_wfIn hwf hv.closureDef hv.argFresh hv.idxFresh hv.idxNeArg)
+      hv.relFresh hv.funFresh hv.defFresh
+  exact SpecFn.declare_correct s.name s.name s.axioms
+    (s.relinterp ρ.env) (s.funcinterp ρ.env) (s.definterp ρ.env) Δ Γ st ρ
+    hv.relFresh hv.funFresh hv.defFresh (fun _ _ => Iff.rfl)
+    hdecls howns hvars hwfext hΓwf hsplit hdet haxwf haxeval heval
+
+end Lifting
+
+end Verifier.BoundedQuantifier

--- a/Mica/Verifier/BoundedQuantifier.lean
+++ b/Mica/Verifier/BoundedQuantifier.lean
@@ -258,9 +258,11 @@ structure Lifting where
   arg : String
   body : Typed.Expr
 
-/-- State of the per-declaration rewrite: the occurrence counter and the
-lifted symbols in dependency order (inner occurrences precede outer ones). -/
+/-- State of the per-declaration rewrite: its program index, the occurrence
+counter, and the lifted symbols in dependency order (inner occurrences precede
+outer ones). -/
 structure LiftState where
+  declIdx : Nat := 0
   count : Nat := 0
   syms : List Lifting := []
 
@@ -313,11 +315,12 @@ private def lift (decl : Option String) (all : Bool) (binder : Typed.Binder)
   let some decl := decl
     | throw "Range.all/Range.exists in a specification require a named declaration"
   let st ← get
-  let name := s!"{decl}-range-{st.count}"
+  let name := s!"{decl}-range-{st.declIdx}-{st.count}"
   let captured := ((freeVars body).filter (fun v => binder.name != some v)).eraseDups
   let gBody := Typed.Expr.letProd
     (captured.map (fun x => ⟨some x, .value⟩) ++ [binder]) (.var (name ++ "-x") .value) body
-  set ({ count := st.count + 1,
+  set ({ declIdx := st.declIdx,
+         count := st.count + 1,
          syms := st.syms ++ [{ name, all, captured, arg := name ++ "-x", body := gBody }] } : LiftState)
   pure (.app (.var name (.arrow .value .bool))
     [.tuple (lo :: hi :: captured.map (fun x => Typed.Expr.var x .value))] .bool)
@@ -384,13 +387,14 @@ private def rewriteBody (decl : Option String) (body : Spec.Body Typed.Expr) :
     (fun (r, post) => do pure (r, ← rewriteAssert decl pure post)) body.2
   pure (body.1, pre)
 
-/-- Rewrite one declaration's spec, pairing it with the lifted symbols. -/
-def runDecl (d : Typed.ValDecl (Spec.Body Typed.Expr)) :
+/-- Rewrite one declaration's spec at its program index, pairing it with the
+lifted symbols. -/
+def runDecl (declIdx : Nat) (d : Typed.ValDecl (Spec.Body Typed.Expr)) :
     Except String (Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting) :=
   match d.declMeta.spec with
   | none => .ok (d, [])
   | some body =>
-      match (rewriteBody d.name.name body).run {} with
+      match (rewriteBody d.name.name body).run { declIdx := declIdx } with
       | .error err => .error err
       | .ok (body', st) =>
           .ok ({ d with declMeta := { d.declMeta with spec := some body' } }, st.syms)
@@ -399,21 +403,28 @@ def runDecl (d : Typed.ValDecl (Spec.Body Typed.Expr)) :
 bounded-quantifier occurrences and pair each declaration with its lifted
 symbols in dependency order. Declaration bodies are untouched, so the
 program's runtime erasure is preserved (`run_runtime`). -/
-def run : Typed.Program (Spec.Body Typed.Expr) →
+private def runFrom : Nat → Typed.Program (Spec.Body Typed.Expr) →
     Except String (List (Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting))
-  | [] => .ok []
-  | d :: ds =>
-      match runDecl d with
+  | _, [] => .ok []
+  | declIdx, d :: ds =>
+      match runDecl declIdx d with
       | .error err => .error err
       | .ok p =>
-          match run ds with
+          match runFrom (declIdx + 1) ds with
           | .error err => .error err
           | .ok ps => .ok (p :: ps)
 
+/-- Run the bounded-quantifier pass over a typed program. The declaration
+index makes generated symbol names unique even when top-level names are
+shadowed. -/
+def run (prog : Typed.Program (Spec.Body Typed.Expr)) :
+    Except String (List (Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting)) :=
+  runFrom 0 prog
+
 /-- The pass leaves a declaration's name and body untouched. -/
-theorem runDecl_runtime {d : Typed.ValDecl (Spec.Body Typed.Expr)}
+theorem runDecl_runtime {declIdx : Nat} {d : Typed.ValDecl (Spec.Body Typed.Expr)}
     {p : Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting}
-    (h : runDecl d = .ok p) : p.1.runtime = d.runtime := by
+    (h : runDecl declIdx d = .ok p) : p.1.runtime = d.runtime := by
   unfold runDecl at h
   split at h
   · cases h; rfl
@@ -423,17 +434,17 @@ theorem runDecl_runtime {d : Typed.ValDecl (Spec.Body Typed.Expr)}
 
 /-- The pass preserves the program's runtime erasure: only spec metadata
 changes. -/
-theorem run_runtime {prog : Typed.Program (Spec.Body Typed.Expr)}
+private theorem runFrom_runtime {declIdx : Nat} {prog : Typed.Program (Spec.Body Typed.Expr)}
     {pairs : List (Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting)}
-    (h : run prog = .ok pairs) :
+    (h : runFrom declIdx prog = .ok pairs) :
     Typed.Program.runtime (pairs.map Prod.fst) = prog.runtime := by
-  induction prog generalizing pairs with
+  induction prog generalizing declIdx pairs with
   | nil =>
-    simp only [run, Except.ok.injEq] at h
+    simp only [runFrom, Except.ok.injEq] at h
     subst h
     rfl
   | cons d ds ih =>
-    rw [run] at h
+    rw [runFrom] at h
     split at h
     · cases h
     · rename_i p hd
@@ -446,6 +457,14 @@ theorem run_runtime {prog : Typed.Program (Spec.Body Typed.Expr)}
         have := ih hds
         simp only [Typed.Program.runtime] at this
         rw [this]
+
+/-- The pass preserves the program's runtime erasure: only spec metadata
+changes. -/
+theorem run_runtime {prog : Typed.Program (Spec.Body Typed.Expr)}
+    {pairs : List (Typed.ValDecl (Spec.Body Typed.Expr) × List Lifting)}
+    (h : run prog = .ok pairs) :
+    Typed.Program.runtime (pairs.map Prod.fst) = prog.runtime := by
+  exact runFrom_runtime h
 
 /-! ## Lifted closures -/
 

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -266,10 +266,10 @@ mutual
         VerifM.expectEq "if branch type annotation mismatch" els.ty ty
         let branch ← VerifM.all [true, false]
         if branch then do
-          VerifM.assume (.pure (.not (.eq .value sc (.unop .ofBool (.const (.b false))))))
+          VerifM.assume (.pure (.not sc.isFalse))
           compile reg Θ Δ_spec S B Γ thn
         else do
-          VerifM.assume (.pure (.eq .value sc (.unop .ofBool (.const (.b false)))))
+          VerifM.assume (.pure sc.isFalse)
           compile reg Θ Δ_spec S B Γ els
     | .app (.var f fty) args aty => do
         let spec ← VerifM.expectSome s!"no spec for function {f}" (S.lookup f)
@@ -2757,15 +2757,15 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
   have hall := VerifM.eval_all heval_branches
   have htrue := hall true (by simp)
   have hfalse := hall false (by simp)
-  have hwf_ne : (Formula.not (Formula.eq .value sc (.unop .ofBool (.const (.b false))))).wfIn st₁.decls := by
-    simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]
+  have hwf_ne : (Formula.not sc.isFalse).wfIn st₁.decls := by
+    simp only [Term.isFalse, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]
     exact hsc_wf
-  have hwf_eq : (Formula.eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))).wfIn st₁.decls := by
-    simp only [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]
+  have hwf_eq : sc.isFalse.wfIn st₁.decls := by
+    simp only [Term.isFalse, Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, _root_.and_true]
     exact hsc_wf
   have htrue_cont := VerifM.eval_assumePure (VerifM.eval_bind htrue)
   have hfalse_cont := VerifM.eval_assumePure (VerifM.eval_bind hfalse)
-  let φ_eq : Formula := .eq .value sc (.unop .ofBool (.const (.b false) : Term .bool))
+  let φ_eq : Formula := sc.isFalse
   let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
   let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
   have hbool_cases_bool :
@@ -2799,7 +2799,7 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
   · subst hfalse_val
     have heval_els : (compile reg Θ Δ_spec S B Γ els).eval st_els ρ_c Ψ :=
       hfalse_cont hwf_eq (by
-        simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
+        simp only [Term.isFalse, Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_c)
     have hwp :
         st_els.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
@@ -2827,7 +2827,7 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
       simp
     have heval_thn : (compile reg Θ Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
       htrue_cont hwf_ne (by
-        simp only [Formula.eval, Term.eval, UnOp.eval, Const.denote]
+        simp only [Term.isFalse, Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_ne)
     have hwp :
         st_thn.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢

--- a/Mica/Verifier/OUTLINE.md
+++ b/Mica/Verifier/OUTLINE.md
@@ -3,6 +3,7 @@
 - `Assertions.lean` — Assertion language for specifications, together with its semantics, well-formedness conditions, and verifier operations.
 - `Atoms.lean` — Verifier atoms for pure and spatial facts, together with their interpretations, resolution procedures, and correctness lemmas.
 - `Bindings.lean` — Verifier variable-to-constant bindings, their semantic linkage to runtime substitutions, and typing/lookup lemmas.
+- `BoundedQuantifier.lean` — Lambda lifting of spec-level bounded quantifiers (Range.all/Range.exists) into axiomatized function symbols.
 - `Expressions.lean` — Compilation of typed TinyML expressions into verifier terms, with weakest-precondition correctness proofs.
 - `Functions.lean` — Verification of function bodies against specifications, including the soundness of specification checking.
 - `Guard.lean` — The guard constant deactivating quantified axioms in low-effort checks, effort levels, and guarded axioms.

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -11,6 +11,7 @@ import Mica.Verifier.PredicateTransformers
 import Mica.Verifier.Specifications
 import Mica.Engine.Driver
 import Mica.Verifier.Intrinsic
+import Mica.Verifier.BoundedQuantifier
 
 open Iris Iris.BI
 
@@ -122,12 +123,6 @@ private def extend (acc : RelationSpec) (d : Typed.ValDecl (Spec.Body Typed.Expr
                                   (SpecFn.func rel)).addUnaryRel (SpecFn.defined rel) }
         .ok { spec, res, axs, f, rel, arg, body, bv }
 
-private def addDecl (acc : RelationSpec) (d : Typed.ValDecl (Spec.Body Typed.Expr)) :
-    Except String RelationSpec := do
-  match d.declMeta.relation with
-  | none => .ok acc
-  | some _ => return (← extend acc d).spec
-
 private def declareAndAssume (acc : RelationSpec) (d : Typed.ValDecl (Spec.Body Typed.Expr)) :
     VerifM RelationSpec := do
   match d.declMeta.relation with
@@ -136,11 +131,23 @@ private def declareAndAssume (acc : RelationSpec) (d : Typed.ValDecl (Spec.Body 
       match extend acc d with
       | .error msg => VerifM.fatal msg
       | .ok info => do
-          VerifM.declBinaryRelExact (SpecFn.rel rel)
-          VerifM.declUnaryExact (SpecFn.func rel)
-          VerifM.declUnaryRelExact (SpecFn.defined rel)
-          VerifM.assumeAxioms info.axs
+          SpecFn.declare rel info.axs
           pure info.spec
+
+/-- Declare a bounded quantifier's solver-facing triple and its defining
+axioms on top of the accumulated relation spec. All freshness and membership
+conditions needed by the soundness proof are checked operationally by
+`validate`. -/
+private def declareLifting (acc : RelationSpec) (s : Verifier.BoundedQuantifier.Lifting) :
+    VerifM RelationSpec :=
+  match s.validate acc.delta with
+  | .error msg => VerifM.fatal msg
+  | .ok _ => do
+      s.declare
+      pure { symbols := acc.symbols ++ [SpecFn.rel s.name],
+             axioms := acc.axioms ++ s.axioms,
+             functionMap := acc.functionMap ++ [(s.name, s.name)],
+             delta := s.extendSignature acc.delta }
 
 private def assembleFrom : RelationSpec → Typed.Program (Spec.Body Typed.Expr) → VerifM RelationSpec
   | acc, [] => pure acc
@@ -148,209 +155,223 @@ private def assembleFrom : RelationSpec → Typed.Program (Spec.Body Typed.Expr)
       let acc' ← declareAndAssume acc d
       assembleFrom acc' ds
 
-/-- Assemble the global relation signature and function-name map for a typed program. -/
-def assemble (prog : Typed.Program (Spec.Body Typed.Expr)) : VerifM RelationSpec := do
+/-- Declare the lifted bounded quantifiers in lift order: each closure is
+axiomatized as a synthetic relation declaration, then its quantifier symbol
+is defined on top of it. -/
+private def assembleLiftings : RelationSpec → List Verifier.BoundedQuantifier.Lifting → VerifM RelationSpec
+  | acc, [] => pure acc
+  | acc, s :: ss => do
+      let acc' ← declareAndAssume acc s.closureDecl
+      let acc'' ← declareLifting acc' s
+      assembleLiftings acc'' ss
+
+/-- Assemble the global relation signature and function-name map for a typed
+program paired with its lifted bounded quantifiers. Quantifier symbols are
+declared after all program declarations: assembly never consults specs, and
+the only cross-references between lifted closures — inner occurrences
+captured by outer ones — respect the lift order, which `flatMap` preserves. -/
+def assemble (pairs : List (Typed.ValDecl (Spec.Body Typed.Expr) × List Verifier.BoundedQuantifier.Lifting)) :
+    VerifM RelationSpec := do
   let Δ ← VerifM.ctx (fun st => (st.decls, st.owns))
-  assembleFrom { RelationSpec.empty with delta := Δ } prog
+  let acc ← assembleFrom { RelationSpec.empty with delta := Δ } (pairs.map Prod.fst)
+  assembleLiftings acc (pairs.flatMap Prod.snd)
+
+/-- The invariant pack threaded through relation assembly: the accumulated
+delta mirrors the declared signature, the state is spec-level (no owned
+locations, no variables), and the accumulated function map is well-formed
+with deterministic, split-compatible interpretations. -/
+private structure Inv (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env) : Prop where
+  delta : acc.delta = st.decls
+  owns : st.owns = []
+  vars : st.decls.vars = []
+  wf : st.decls.wf
+  Γwf : FunCtx.wfIn acc.functionMap st.decls
+  split : FunCtx.splitCompatible acc.functionMap ρ.env
+  det : Relation.BinaryRelDet acc.functionMap ρ.env ρ.env
+
+omit [MicaGS HasLC.hasLC Sig] in
+/-- Declaring one relation-marked declaration preserves the assembly
+invariants; the signature only grows and the environment is only extended
+with fresh interpretations. -/
+private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec.Body Typed.Expr))
+    (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
+    {Q : RelationSpec → TransState → VerifM.Env → Prop}
+    (hinv : Inv acc st ρ)
+    (heval : VerifM.eval (declareAndAssume acc d) st ρ Q) :
+    ∃ acc' st' ρ', Inv acc' st' ρ' ∧
+      st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      Q acc' st' ρ' := by
+  obtain ⟨hacc, howns, hvars, hwf, hΓwf, hsplit, hdet⟩ := hinv
+  simp only [declareAndAssume] at heval
+  cases hrel : d.declMeta.relation with
+  | none =>
+    simp only [hrel] at heval
+    exact ⟨acc, st, ρ, ⟨hacc, howns, hvars, hwf, hΓwf, hsplit, hdet⟩,
+      Signature.Subset.refl _, VerifM.Env.agreeOn_refl, VerifM.eval_ret heval⟩
+  | some rel_name =>
+    simp only [hrel] at heval
+    cases hext : extend acc d with
+    | error msg => simp only [hext] at heval; exact (VerifM.eval_fatal heval).elim
+    | ok info =>
+      simp only [hext] at heval
+      -- Unfold `extend` once to expose its construction facts about `info`.
+      obtain ⟨hf, hspec_delta, hspec_fm, hinfoEq⟩ :
+          Skolemize.InfoFresh acc.delta rel_name info.arg ∧
+          info.spec.delta = ((acc.delta.addBinaryRel (SpecFn.rel rel_name)).addUnary
+              (SpecFn.func rel_name)).addUnaryRel (SpecFn.defined rel_name) ∧
+          info.spec.functionMap = acc.functionMap ++ [(info.f, rel_name)] ∧
+          Skolemize.bundle acc.functionMap acc.delta info.f rel_name info.arg info.body
+            = .ok (info.res, info.bv, info.axs) := by
+        unfold extend at hext
+        simp only [hrel, bind, Except.bind] at hext
+        split at hext
+        · cases hext
+        rename_i validated _
+        obtain ⟨f, arg, body⟩ := validated
+        split_ifs at hext with
+          hrel_in hfun_in hdef_in harg_in harg_eq_rel harg_eq_fun harg_eq_def
+        case neg =>
+          split at hext
+          · cases hext
+          rename_i tup hinfoTuple
+          obtain ⟨res, bv, axs⟩ := tup
+          cases hext
+          exact ⟨{ relFresh := hrel_in, funFresh := hfun_in, defFresh := hdef_in,
+                   argFresh := harg_in, argNeRel := harg_eq_rel,
+                   argNeFun := harg_eq_fun, argNeDef := harg_eq_def }, rfl, rfl, hinfoTuple⟩
+      have hΓwf_acc : FunCtx.wfIn acc.functionMap acc.delta := hacc ▸ hΓwf
+      have hΔwf_acc : acc.delta.wf := hacc ▸ hwf
+      -- The chosen interpretations: the ground-truth relation and its split.
+      set R : Relation.ValRel :=
+        Relation.semrel acc.functionMap acc.delta ρ.env
+          info.f rel_name info.arg info.res info.body
+      set F := Skolemize.semFunc R
+      set D : Srt.value.denote → Prop :=
+        Skolemize.semdef acc.functionMap acc.delta ρ.env
+          info.f rel_name info.arg info.res info.body info.bv
+      have hgraph : ∀ a b, R a b ↔ D a ∧ F a = b := fun a b =>
+        Skolemize.bundle_semrel_compatible hinfoEq hsplit hΓwf_acc hΔwf_acc hf hdet a b
+      have henv : Skolemize.relSplitEnv ρ.env rel_name R D F
+          = (Skolemize.defInterpEnv acc.functionMap acc.delta ρ.env
+              info.f rel_name info.arg info.res info.body info.bv).updateBinaryRel
+            .value .value (SpecFn.relName rel_name) R := by
+        simp only [Skolemize.relSplitEnv, Skolemize.defInterpEnv, Skolemize.splitEnv]
+        apply Env.ext <;> rfl
+      have haxeval : ∀ ax ∈ info.axs,
+          ax.formula.eval (Skolemize.relSplitEnv ρ.env rel_name R D F) := by
+        rw [henv]
+        exact Skolemize.bundle_eval_updateBinaryRel
+          hinfoEq hsplit hΓwf_acc hΔwf_acc hf hdet R
+      obtain ⟨st4, ρ4, hst4_decls, howns4, hvars4, hwf4, hsub4, hagree4,
+        hΓwf4, hsplit4, hdet4, hcont⟩ :=
+        SpecFn.declare_correct rel_name info.f info.axs R F D acc.delta acc.functionMap st ρ
+          hf.relFresh hf.funFresh hf.defFresh hgraph hacc.symm howns hvars
+          (hf.wf_addSplit hΔwf_acc) hΓwf_acc hsplit hdet
+          (Skolemize.bundle_wfIn hinfoEq hΔwf_acc hΓwf_acc hf) haxeval
+          (VerifM.eval_bind heval)
+      have hdelta4 : info.spec.delta = st4.decls := by rw [hspec_delta, hst4_decls]
+      have hΓwf4' : FunCtx.wfIn info.spec.functionMap st4.decls := by
+        rw [hspec_fm]; exact hΓwf4
+      have hsplit4' : FunCtx.splitCompatible info.spec.functionMap ρ4.env := by
+        rw [hspec_fm]; exact hsplit4
+      have hdet4' : Relation.BinaryRelDet info.spec.functionMap ρ4.env ρ4.env := by
+        rw [hspec_fm]; exact hdet4
+      exact ⟨info.spec, st4, ρ4,
+        ⟨hdelta4, howns4, hvars4, hwf4, hΓwf4', hsplit4', hdet4'⟩,
+        hsub4, hagree4, VerifM.eval_ret hcont⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
 private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr)) :
     ∀ (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
       {Q : RelationSpec → TransState → VerifM.Env → Prop},
-      acc.delta = st.decls →
-      st.owns = [] →
-      st.decls.vars = [] →
-      st.decls.wf →
-      FunCtx.wfIn acc.functionMap st.decls →
-      FunCtx.splitCompatible acc.functionMap ρ.env →
-      Relation.BinaryRelDet acc.functionMap ρ.env ρ.env →
+      Inv acc st ρ →
       VerifM.eval (assembleFrom acc prog) st ρ Q →
-      ∃ result stRel ρRel,
-        stRel.decls.vars = [] ∧ stRel.owns = [] ∧
+      ∃ result stRel ρRel, Inv result stRel ρRel ∧
         st.decls.Subset stRel.decls ∧ VerifM.Env.agreeOn st.decls ρ ρRel ∧
-        result.delta = stRel.decls ∧ Q result stRel ρRel := by
+        Q result stRel ρRel := by
   induction prog with
   | nil =>
-    intro acc st ρ Q hacc howns hvars _ _ _ _ heval
+    intro acc st ρ Q hinv heval
     simp only [assembleFrom] at heval
-    exact ⟨acc, st, ρ, hvars, howns, Signature.Subset.refl _, VerifM.Env.agreeOn_refl,
-      hacc, VerifM.eval_ret heval⟩
+    exact ⟨acc, st, ρ, hinv, Signature.Subset.refl _, VerifM.Env.agreeOn_refl,
+      VerifM.eval_ret heval⟩
   | cons d ds ih =>
-    intro acc st ρ Q hacc howns hvars hwf hΓwf hsplit hdet heval
+    intro acc st ρ Q hinv heval
     simp only [assembleFrom] at heval
-    have hbind := VerifM.eval_bind heval
-    simp only [declareAndAssume] at hbind
-    cases hrel : d.declMeta.relation with
-    | none =>
-      simp only [hrel] at hbind
-      exact ih acc st ρ hacc howns hvars hwf hΓwf hsplit hdet (VerifM.eval_ret hbind)
-    | some rel_name =>
-      simp only [hrel] at hbind
-      cases hext : extend acc d with
-      | error msg => simp only [hext] at hbind; exact (VerifM.eval_fatal hbind).elim
-      | ok info =>
-        simp only [hext] at hbind
-        -- Unfold `extend` once to expose its construction facts about `info`.
-        obtain ⟨hf, hspec_delta, hspec_fm, hinfoEq⟩ :
-            Skolemize.InfoFresh acc.delta rel_name info.arg ∧
-            info.spec.delta = ((acc.delta.addBinaryRel (SpecFn.rel rel_name)).addUnary
-                (SpecFn.func rel_name)).addUnaryRel (SpecFn.defined rel_name) ∧
-            info.spec.functionMap = acc.functionMap ++ [(info.f, rel_name)] ∧
-            Skolemize.bundle acc.functionMap acc.delta info.f rel_name info.arg info.body
-              = .ok (info.res, info.bv, info.axs) := by
-          unfold extend at hext
-          simp only [hrel, bind, Except.bind] at hext
-          split at hext
-          · cases hext
-          rename_i validated _
-          obtain ⟨f, arg, body⟩ := validated
-          split_ifs at hext with
-            hrel_in hfun_in hdef_in harg_in harg_eq_rel harg_eq_fun harg_eq_def
-          case neg =>
-            split at hext
-            · cases hext
-            rename_i tup hinfoTuple
-            obtain ⟨res, bv, axs⟩ := tup
-            cases hext
-            exact ⟨{ relFresh := hrel_in, funFresh := hfun_in, defFresh := hdef_in,
-                     argFresh := harg_in, argNeRel := harg_eq_rel,
-                     argNeFun := harg_eq_fun, argNeDef := harg_eq_def }, rfl, rfl, hinfoTuple⟩
-        have hΓwf_acc : FunCtx.wfIn acc.functionMap acc.delta := hacc ▸ hΓwf
-        have hΔwf_acc : acc.delta.wf := hacc ▸ hwf
-        -- Three declaration steps; introduce the chosen interpretations.
-        set R : Relation.ValRel :=
-          Relation.semrel acc.functionMap acc.delta ρ.env
-            info.f rel_name info.arg info.res info.body
-        set F := Skolemize.semFunc R
-        set D : Srt.value.denote → Prop :=
-          Skolemize.semdef acc.functionMap acc.delta ρ.env
-            info.f rel_name info.arg info.res info.body info.bv
-        obtain ⟨_, hbcont⟩ := VerifM.eval_declBinaryRelExact (VerifM.eval_bind hbind)
-        obtain ⟨_, hbcont3⟩ := VerifM.eval_declUnaryExact (VerifM.eval_bind (hbcont R))
-        obtain ⟨_, hbcont5⟩ := VerifM.eval_declUnaryRelExact (VerifM.eval_bind (hbcont3 F))
-        have hbind7 := VerifM.eval_bind (hbcont5 D)
-        -- Δ after the three declarations.
-        set Δext : Signature :=
-          ((acc.delta.addBinaryRel (SpecFn.rel rel_name)).addUnary
-            (SpecFn.func rel_name)).addUnaryRel (SpecFn.defined rel_name)
-        set st3 : TransState :=
-          { st with decls := ((st.decls.addBinaryRel (SpecFn.rel rel_name)).addUnary
-              (SpecFn.func rel_name)).addUnaryRel (SpecFn.defined rel_name) }
-        set ρ3 : VerifM.Env :=
-          ((ρ.updateBinaryRel .value .value (SpecFn.relName rel_name) R).updateUnary
-              .value .value (SpecFn.funcName rel_name) F).updateUnaryRel
-            .value (SpecFn.defName rel_name) D
-        have hst3_decls : st3.decls = Δext := by simp only [st3, Δext, hacc]
-        -- Axiom well-formedness via bundle_wfIn.
-        have hax_wf_acc := Skolemize.bundle_wfIn hinfoEq hΔwf_acc hΓwf_acc hf
-        have hax_wf : ∀ ax ∈ info.axs, ax.formula.wfIn st3.decls :=
-          fun ax hmem => hst3_decls ▸ hax_wf_acc ax hmem
-        -- ρ3.env vs (defInterpEnv ...).updateBinaryRel R.
-        have hρ3_env_eq :
-            ρ3.env = (Skolemize.defInterpEnv acc.functionMap acc.delta ρ.env
-                info.f rel_name info.arg info.res info.body info.bv).updateBinaryRel
-                  .value .value (SpecFn.relName rel_name) R := by
-          simp only [ρ3, VerifM.Env.updateUnaryRel_env, VerifM.Env.updateUnary_env,
-            VerifM.Env.updateBinaryRel_env, Skolemize.defInterpEnv, Skolemize.splitEnv]
-          apply Env.ext <;> rfl
-        have hax_eval : ∀ ax ∈ info.axs, ax.formula.eval ρ3.env := fun ax hmem => by
-          rw [hρ3_env_eq]
-          exact Skolemize.bundle_eval_updateBinaryRel
-            hinfoEq hsplit hΓwf_acc hΔwf_acc hf hdet R ax hmem
-        obtain ⟨st4, hst4_decls, hst4_owns, _, hpure_pre⟩ :=
-          VerifM.eval_assumeAxioms hbind7 hax_wf hax_eval
-        -- Reestablish invariants and apply IH.
-        have hst4_owns_eq : st4.owns = [] := by rw [hst4_owns]; exact howns
-        have hst4_vars : st4.decls.vars = [] := by
-          rw [hst4_decls, hst3_decls]; show acc.delta.vars = []; rw [hacc]; exact hvars
-        have hst4_wf : st4.decls.wf := by
-          rw [hst4_decls, hst3_decls]; exact hf.wf_addSplit hΔwf_acc
-        have hnewAcc_delta : info.spec.delta = st4.decls := by
-          rw [hspec_delta, hst4_decls, hst3_decls]
-        -- Agreement on acc.delta: the three new symbols are fresh.
-        have hagree_old : Env.agreeOn acc.delta ρ.env ρ3.env := by
-          rw [hρ3_env_eq]
-          unfold Skolemize.defInterpEnv Skolemize.splitEnv
-          refine Env.agreeOn_trans
-            (Env.agreeOn_update_fresh_unary (ρ := ρ.env) (u := SpecFn.func rel_name)
-              (f := F) hf.funFresh) ?_
-          refine Env.agreeOn_trans
-            (Env.agreeOn_update_fresh_unaryRel (u := SpecFn.defined rel_name)
-              (f := D) hf.defFresh) ?_
-          exact Env.agreeOn_update_fresh_binaryRel (b := SpecFn.rel rel_name) (f := R) hf.relFresh
-        have hΔext_sub : acc.delta.Subset Δext :=
-          ((Signature.Subset.subset_addBinaryRel _ _).trans
-            (Signature.Subset.subset_addUnary _ _)).trans
-            (Signature.Subset.subset_addUnaryRel _ _)
-        -- FunCtx.wfIn on the extended map.
-        have hnewΓwf : FunCtx.wfIn info.spec.functionMap st4.decls := by
-          rw [hst4_decls, hst3_decls, hspec_fm]
-          refine ⟨?_, ?_⟩
-          · intro x rel hxr
-            rcases List.mem_append.mp hxr with hold | hnew
-            · exact hΔext_sub.binaryRel _ (hΓwf_acc.rel x rel hold)
-            · simp at hnew; obtain ⟨_, rfl⟩ := hnew
-              show SpecFn.rel rel ∈ Δext.binaryRel
-              exact List.Mem.head _
-          · intro x rel hxr
-            rcases List.mem_append.mp hxr with hold | hnew
-            · obtain ⟨hu, hr⟩ := hΓwf_acc.split x rel hold
-              exact ⟨hΔext_sub.unary _ hu, hΔext_sub.unaryRel _ hr⟩
-            · simp at hnew; obtain ⟨_, rfl⟩ := hnew
-              exact ⟨List.Mem.head _, List.Mem.head _⟩
-        -- New invariants on ρ3.
-        have hsplit_new : FunCtx.splitCompatible info.spec.functionMap ρ3.env := by
-          rw [hspec_fm]
-          intro f rel hxr x y
-          rcases List.mem_append.mp hxr with hold | hnew
-          · obtain ⟨hu_mem, hr_mem⟩ := hΓwf_acc.split f rel hold
-            obtain ⟨her, hec, hed⟩ :=
-              SpecFn.agreeOn hagree_old (hΓwf_acc.rel f rel hold) hu_mem hr_mem
-            rw [← her, ← hec, ← hed]; exact hsplit f rel hold x y
-          · simp at hnew; obtain ⟨_, rfl⟩ := hnew
-            rw [hρ3_env_eq]
-            have hgraph := Skolemize.bundle_semrel_compatible
-              hinfoEq hsplit hΓwf_acc hΔwf_acc hf hdet x y
-            simp only [SpecFn.evalRelates, SpecFn.evalCall, SpecFn.evalDefined,
-              SpecFn.rel, SpecFn.func, SpecFn.defined,
-              Skolemize.defInterpEnv, Skolemize.splitEnv,
-              Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
-            exact hgraph
-        have hdet_new : Relation.BinaryRelDet info.spec.functionMap ρ3.env ρ3.env := by
-          rw [hspec_fm]
-          intro f rel hxr vin y₁ y₂ h₁ h₂
-          rcases List.mem_append.mp hxr with hold | hnew
-          · obtain ⟨hu_mem, hr_mem⟩ := hΓwf_acc.split f rel hold
-            obtain ⟨her, _, _⟩ :=
-              SpecFn.agreeOn hagree_old (hΓwf_acc.rel f rel hold) hu_mem hr_mem
-            rw [← her] at h₁ h₂
-            exact hdet f rel hold vin y₁ y₂ h₁ h₂
-          · simp at hnew; obtain ⟨_, rfl⟩ := hnew
-            rw [hρ3_env_eq] at h₁ h₂
-            simp only [SpecFn.evalRelates, SpecFn.rel, Env.updateBinaryRel] at h₁ h₂
-            exact Skolemize.bundle_semrel_functional
-              hinfoEq hΓwf_acc hΔwf_acc hf ρ.env hdet vin y₁ y₂ h₁ h₂
-        obtain ⟨result, stRel, ρRel, hvarsRel, hownsRel, hsubRel, hagRel, hresD, hQ⟩ :=
-          ih info.spec st4 ρ3 hnewAcc_delta hst4_owns_eq hst4_vars hst4_wf
-          hnewΓwf hsplit_new hdet_new (VerifM.eval_ret hpure_pre)
-        have hsub_old : st.decls.Subset st4.decls := by
-          rw [hst4_decls, hst3_decls, ← hacc]
-          exact hΔext_sub
-        have hag_old : VerifM.Env.agreeOn st.decls ρ ρ3 := by
-          rw [← hacc]
-          exact hagree_old
-        exact ⟨result, stRel, ρRel, hvarsRel, hownsRel, hsub_old.trans hsubRel,
-          VerifM.Env.agreeOn_trans hag_old (VerifM.Env.agreeOn_mono hsub_old hagRel),
-          hresD, hQ⟩
+    obtain ⟨acc', st', ρ', hinv', hsub', hag', hcont⟩ :=
+      declareAndAssume_correct d acc st ρ hinv (VerifM.eval_bind heval)
+    obtain ⟨result, stRel, ρRel, hinvRel, hsubRel, hagRel, hQ⟩ := ih acc' st' ρ' hinv' hcont
+    exact ⟨result, stRel, ρRel, hinvRel, hsub'.trans hsubRel,
+      VerifM.Env.agreeOn_trans hag' (VerifM.Env.agreeOn_mono hsub' hagRel), hQ⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem assemble_correct (typed : Typed.Program (Spec.Body Typed.Expr))
+/-- Declaring one lifted bounded quantifier preserves the assembly
+invariants; its closure's symbols must already be declared (checked by
+`validate`). -/
+private theorem declareLifting_correct (s : Verifier.BoundedQuantifier.Lifting)
+    (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
+    {Q : RelationSpec → TransState → VerifM.Env → Prop}
+    (hinv : Inv acc st ρ)
+    (heval : VerifM.eval (declareLifting acc s) st ρ Q) :
+    ∃ acc' st' ρ', Inv acc' st' ρ' ∧
+      st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      Q acc' st' ρ' := by
+  obtain ⟨hacc, howns, hvars, hwf, hΓwf, hsplit, hdet⟩ := hinv
+  simp only [declareLifting] at heval
+  cases hvalid : s.validate acc.delta with
+  | error msg =>
+    simp only [hvalid] at heval
+    exact (VerifM.eval_fatal heval).elim
+  | ok v =>
+    simp only [hvalid] at heval
+    obtain ⟨st4, ρ4, hdelta, howns4, hvars4, hwf4, hsub4, hagree4,
+      hΓwf4, hsplit4, hdet4, hcont⟩ :=
+      Verifier.BoundedQuantifier.Lifting.declare_correct s acc.delta acc.functionMap st ρ
+        v.down hacc.symm howns hvars
+        (hacc ▸ hwf) (hacc ▸ hΓwf) hsplit hdet (VerifM.eval_bind heval)
+    exact ⟨{ symbols := acc.symbols ++ [SpecFn.rel s.name],
+             axioms := acc.axioms ++ s.axioms,
+             functionMap := acc.functionMap ++ [(s.name, s.name)],
+             delta := s.extendSignature acc.delta }, st4, ρ4,
+      ⟨hdelta.symm, howns4, hvars4, hwf4, hΓwf4, hsplit4, hdet4⟩,
+      hsub4, hagree4, VerifM.eval_ret hcont⟩
+
+omit [MicaGS HasLC.hasLC Sig] in
+private theorem assembleLiftings_correct (ss : List Verifier.BoundedQuantifier.Lifting) :
+    ∀ (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
+      {Q : RelationSpec → TransState → VerifM.Env → Prop},
+      Inv acc st ρ →
+      VerifM.eval (assembleLiftings acc ss) st ρ Q →
+      ∃ result stRel ρRel, Inv result stRel ρRel ∧
+        st.decls.Subset stRel.decls ∧ VerifM.Env.agreeOn st.decls ρ ρRel ∧
+        Q result stRel ρRel := by
+  induction ss with
+  | nil =>
+    intro acc st ρ Q hinv heval
+    simp only [assembleLiftings] at heval
+    exact ⟨acc, st, ρ, hinv, Signature.Subset.refl _, VerifM.Env.agreeOn_refl,
+      VerifM.eval_ret heval⟩
+  | cons s ss ih =>
+    intro acc st ρ Q hinv heval
+    simp only [assembleLiftings] at heval
+    obtain ⟨acc1, st1, ρ1, hinv1, hsub1, hag1, hcont1⟩ :=
+      declareAndAssume_correct s.closureDecl acc st ρ hinv (VerifM.eval_bind heval)
+    obtain ⟨acc2, st2, ρ2, hinv2, hsub2, hag2, hcont2⟩ :=
+      declareLifting_correct s acc1 st1 ρ1 hinv1 (VerifM.eval_bind hcont1)
+    obtain ⟨result, stRel, ρRel, hinvRel, hsubRel, hagRel, hQ⟩ := ih acc2 st2 ρ2 hinv2 hcont2
+    exact ⟨result, stRel, ρRel, hinvRel, (hsub1.trans hsub2).trans hsubRel,
+      VerifM.Env.agreeOn_trans hag1 (VerifM.Env.agreeOn_mono hsub1
+        (VerifM.Env.agreeOn_trans hag2 (VerifM.Env.agreeOn_mono hsub2 hagRel))), hQ⟩
+
+omit [MicaGS HasLC.hasLC Sig] in
+theorem assemble_correct
+    (pairs : List (Typed.ValDecl (Spec.Body Typed.Expr) × List Verifier.BoundedQuantifier.Lifting))
     {st : TransState} {ρ : VerifM.Env}
     {Q : RelationSpec → TransState → VerifM.Env → Prop}
     (hvars0 : st.decls.vars = [])
     (howns0 : st.owns = [])
     (hwf0 : st.decls.wf)
-    (heval : VerifM.eval (RelationSpec.assemble typed) st ρ Q) :
+    (heval : VerifM.eval (RelationSpec.assemble pairs) st ρ Q) :
     ∃ spec0 : RelationSpec, ∃ stRel ρRel,
       stRel.decls.vars = [] ∧
       stRel.owns = [] ∧
@@ -368,10 +389,15 @@ theorem assemble_correct (typed : Typed.Program (Spec.Body Typed.Expr))
   have hempty_det : Relation.BinaryRelDet
       empty.functionMap ρ.env ρ.env :=
     fun _ _ h => (List.not_mem_nil h).elim
-  obtain ⟨result, stRel, ρRel, hvars, howns, hsub, hag, hresD, hQ⟩ :=
-    assembleFrom_correct typed { empty with delta := st.decls } st ρ
-      rfl howns0 hvars0 hwf0 hempty_Γwf hempty_split hempty_det hrest
-  refine ⟨result, stRel, ρRel, hvars, howns, hsub, hag, ?_⟩
+  obtain ⟨acc, st1, ρ1, hinv1, hsub1, hag1, hcont⟩ :=
+    assembleFrom_correct (pairs.map Prod.fst) { empty with delta := st.decls } st ρ
+      ⟨rfl, howns0, hvars0, hwf0, hempty_Γwf, hempty_split, hempty_det⟩
+      (VerifM.eval_bind hrest)
+  obtain ⟨result, stRel, ρRel, hinvRel, hsubRel, hagRel, hQ⟩ :=
+    assembleLiftings_correct (pairs.flatMap Prod.snd) acc st1 ρ1 hinv1 hcont
+  refine ⟨result, stRel, ρRel, hinvRel.vars, hinvRel.owns, hsub1.trans hsubRel,
+    VerifM.Env.agreeOn_trans hag1 (VerifM.Env.agreeOn_mono hsub1 hagRel), ?_⟩
+  have hresD := hinvRel.delta
   obtain ⟨_, _, _, _⟩ := result
   simp only at hresD; subst hresD
   exact hQ
@@ -435,9 +461,12 @@ def ρ_spec : VerifM.Env := VerifM.Env.empty
 def Program.verify (reg : Verifier.Registry) (prog : Untyped.Program (Spec.Body Untyped.Expr)) : Smt.Strategy Smt.Strategy.Outcome :=
   VerifM.strategy do
     let (Θ, typed) ← Program.prepare reg.sigs prog
-    Verifier.Registry.introduceRegistry reg
-    let relations ← RelationSpec.assemble typed
-    Program.check reg Θ relations.delta relations.functionMap ∅ typed
+    match Verifier.BoundedQuantifier.run typed with
+    | .error msg => VerifM.fatal msg
+    | .ok pairs => do
+        Verifier.Registry.introduceRegistry reg
+        let relations ← RelationSpec.assemble pairs
+        Program.check reg Θ relations.delta relations.functionMap ∅ (pairs.map Prod.fst)
 
 /-! ## Correctness -/
 
@@ -727,15 +756,30 @@ theorem Program.verify_correct (reg : Verifier.Registry)
     have hverifM := VerifM.eval_of_translate
                       (do
                         let (Θ, typed) ← Program.prepare reg.sigs p
-                        Verifier.Registry.introduceRegistry reg
-                        let relations ← RelationSpec.assemble typed
-                        Program.check reg Θ relations.delta relations.functionMap ∅ typed)
+                        match Verifier.BoundedQuantifier.run typed with
+                        | .error msg => VerifM.fatal msg
+                        | .ok pairs => do
+                            Verifier.Registry.introduceRegistry reg
+                            let relations ← RelationSpec.assemble pairs
+                            Program.check reg Θ relations.delta relations.functionMap ∅
+                              (pairs.map Prod.fst))
                       TransState.init VerifM.Env.init ctx_mid
                       (ScopedM.eval_declareConst hverif)
                       TransState.init_holdsFor TransState.init_wf
     have hbind := VerifM.eval_bind hverifM
     obtain ⟨Θ, typed, hrt, hrest⟩ :=
       Program.prepare_correct reg.sigs p TransState.init VerifM.Env.init hbind
+    -- Peel the bounded-quantifier pass: a rewrite failure is fatal, and a success
+    -- leaves the program's runtime erasure unchanged.
+    dsimp only at hrest
+    cases hrun : Verifier.BoundedQuantifier.run typed with
+    | error msg =>
+      rw [hrun] at hrest
+      exact (VerifM.eval_fatal hrest).elim
+    | ok pairs =>
+    rw [hrun] at hrest
+    have hrt : Typed.Program.runtime (pairs.map Prod.fst) = Untyped.Program.runtime p :=
+      (Verifier.BoundedQuantifier.run_runtime hrun).trans hrt
     -- Peel the registry setup from the continuation generically.
     have hsetup_bind := VerifM.eval_bind hrest
     obtain ⟨st_setup, ρ_setup, _hΔsub, hdep_setup, hvars_setup_eq, howns_setup,
@@ -746,7 +790,7 @@ theorem Program.verify_correct (reg : Verifier.Registry)
       rw [hvars_setup_eq]
       rfl
     obtain ⟨spec0, stRel, ρRel, hvars, howns, hsub_setup_rel, hag_setup_rel, hcheck_eval⟩ :=
-      RelationSpec.assemble_correct typed hvars_setup howns_setup hcheck_eval.1.namesDisjoint hassemble
+      RelationSpec.assemble_correct pairs hvars_setup howns_setup hcheck_eval.1.namesDisjoint hassemble
     have hΔreg : Verifier.Registry.symSubset reg stRel.decls := by
       intro i hi
       exact (Verifier.Registry.extendWithSym_subset_sigOf_of_mem hi).trans
@@ -755,7 +799,7 @@ theorem Program.verify_correct (reg : Verifier.Registry)
       intro i hi
       exact hstable_setup ρRel hag_setup_rel i hi
     have hcorrect := Program.check_correct reg hSound Θ stRel.decls spec0.functionMap ρRel
-                       ∅ typed Runtime.Subst.id
+                       ∅ (pairs.map Prod.fst) Runtime.Subst.id
                        (SpecMap.empty_wfIn _)
                        hcheck_eval.1.namesDisjoint
                        hvars

--- a/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
+++ b/Mica/Verifier/RelationalEncoding/SkolemizeCommon.lean
@@ -496,6 +496,56 @@ def relSplitEnv (ρ : Env) (fn : SpecFn)
   ((ρ.updateBinaryRel .value .value fn.relName R).updateUnary .value .value (fn.funcName) F)
     |>.updateUnaryRel .value (fn.defName) D
 
+/-- Interpreting the triple's three fresh names leaves `Δ`-agreement intact. -/
+theorem relSplitEnv_agreeOn {Δ : Signature} {fn : SpecFn} {ρ : Env}
+    {R : Srt.value.denote → Srt.value.denote → Prop}
+    {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
+    (hrel : fn.relName ∉ Δ.allNames)
+    (hfun : fn.funcName ∉ Δ.allNames)
+    (hdef : fn.defName ∉ Δ.allNames) :
+    Env.agreeOn Δ ρ (relSplitEnv ρ fn R D F) :=
+  Env.agreeOn_trans
+    (Env.agreeOn_update_fresh_binaryRel (b := fn.rel) (f := R) hrel)
+    (Env.agreeOn_trans
+      (Env.agreeOn_update_fresh_unary (u := fn.func) (f := F) hfun)
+      (Env.agreeOn_update_fresh_unaryRel (u := fn.defined) (f := D) hdef))
+
+theorem relSplitEnv_evalDefined (fn : SpecFn) (ρ : Env)
+    {R : Srt.value.denote → Srt.value.denote → Prop}
+    {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
+    (v : Srt.value.denote) :
+    SpecFn.evalDefined fn (relSplitEnv ρ fn R D F) v ↔ D v := by
+  simp [relSplitEnv, SpecFn.evalDefined, SpecFn.defined, SpecFn.defName,
+    Env.updateUnaryRel, Env.updateUnary, Env.updateBinaryRel]
+
+theorem relSplitEnv_evalCall (fn : SpecFn) (ρ : Env)
+    {R : Srt.value.denote → Srt.value.denote → Prop}
+    {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
+    (v : Srt.value.denote) :
+    SpecFn.evalCall fn (relSplitEnv ρ fn R D F) v = F v := by
+  simp [relSplitEnv, SpecFn.evalCall, SpecFn.func, SpecFn.funcName,
+    Env.updateUnaryRel, Env.updateUnary, Env.updateBinaryRel]
+
+theorem relSplitEnv_evalRelates (fn : SpecFn) (ρ : Env)
+    {R : Srt.value.denote → Srt.value.denote → Prop}
+    {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
+    (a b : Srt.value.denote) :
+    SpecFn.evalRelates fn (relSplitEnv ρ fn R D F) a b ↔ R a b := by
+  simp [relSplitEnv, SpecFn.evalRelates, SpecFn.rel, SpecFn.relName,
+    Env.updateUnaryRel, Env.updateUnary, Env.updateBinaryRel]
+
+/-- With graph-shaped interpretations, the interpreted environment presents
+the relation as the graph of the value function on the definedness domain. -/
+theorem relSplitEnv_graph (fn : SpecFn) (ρ : Env)
+    {R : Srt.value.denote → Srt.value.denote → Prop}
+    {D : Srt.value.denote → Prop} {F : Srt.value.denote → Srt.value.denote}
+    (hgraph : ∀ a b, R a b ↔ D a ∧ F a = b) (a b : Srt.value.denote) :
+    SpecFn.evalRelates fn (relSplitEnv ρ fn R D F) a b ↔
+      SpecFn.evalDefined fn (relSplitEnv ρ fn R D F) a ∧
+        SpecFn.evalCall fn (relSplitEnv ρ fn R D F) a = b := by
+  simp only [relSplitEnv_evalRelates, relSplitEnv_evalDefined, relSplitEnv_evalCall]
+  exact hgraph a b
+
 /-- Environment for evaluating a split encoded body at input `vin`, with
 recursive calls interpreted by `D` and `F`. -/
 def defEnv (ρ : Env) (fn : SpecFn) (x : String)
@@ -688,12 +738,8 @@ theorem splitSound_cons_relSplitEnv
   cases hmem with
   | head =>
       have hsplit' : D x ∧ F x = y := by
-        simpa [SpecFn.evalDefined, SpecFn.evalCall, SpecFn.defined, SpecFn.func,
-          relSplitEnv, Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
-          using hsplit
-      simpa [SpecFn.evalRelates, SpecFn.rel, relSplitEnv,
-        Env.updateBinaryRel, Env.updateUnary, Env.updateUnaryRel]
-        using hRF x y hsplit'
+        simpa [relSplitEnv_evalDefined, relSplitEnv_evalCall] using hsplit
+      simpa [relSplitEnv_evalRelates] using hRF x y hsplit'
   | tail _ htail =>
       have hnames := hfresh g fn' htail
       have hsplit' : fn'.evalDefined ρ x ∧ fn'.evalCall ρ x = y := by

--- a/mica.ml
+++ b/mica.ml
@@ -61,3 +61,8 @@ end
 
 type 'a vec = 'a iarray
 module Vec = Iarray
+
+module Range = struct
+  let rec all a b f = a >= b || (f a && all (a + 1) b f)
+  let rec exists a b f = a < b && (f a || exists (a + 1) b f)
+end


### PR DESCRIPTION
This PR adds support for bounded quantifiers via `Range.all low high (fun (i : int) : bool -> ...)` and analogously `Range.exists`. The PR does _not_ implement general support for lambdas. Instead, the implementation lambda-lifts specifically `Range.all low high (fun ...)` and `Range.exists low high (fun ...)` into `forall i, low <= i < high -> ...` and analogously for exists. 