### PR TITLE
Error handling operations for the stdlib

### DIFF
--- a/Examples/checked_access.ml
+++ b/Examples/checked_access.ml
@@ -1,0 +1,30 @@
+open Mica
+
+(* Guarded error paths.
+
+   [failwith] and [invalid_arg] have precondition [False]: a call verifies
+   only in a contradictory context.  Each function below guards its raise
+   with a check that the spec's precondition rules out, so the verifier
+   proves every raise dead while the compiled code keeps its runtime
+   protection. *)
+
+(* First element, guarded against the empty vector. *)
+let first (v : int vec) : int =
+  if Vec.length v = 0 then failwith "empty vector"
+  else Vec.get v 0
+[@@spec fun v ->
+  assert (Vec.length v > 0);
+  ret (fun r -> assert (r = Vec.get v 0))];;
+
+(* Bounds-checked access with distinct error messages per failure mode. *)
+let checked_get (v : int vec) (i : int) : int =
+  if i < 0 then invalid_arg "negative index"
+  else if i >= Vec.length v then invalid_arg "index past the end"
+  else Vec.get v i
+[@@spec fun v i ->
+  assert (0 <= i && i < Vec.length v);
+  ret (fun r -> assert (r = Vec.get v i))];;
+
+let _ = assert (first (Vec.make 3 7) = 7)
+
+let _ = assert (checked_get (Vec.set (Vec.make 3 0) 2 9) 2 = 9)

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -406,7 +406,13 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
       | _ =>
         match List.lookup name env.ctors with
         | some (tag, arity, _) => .ok (.inj tag arity (.const .unit))
-        | none => .ok (.var name)
+        | none =>
+          -- Bare stdlib primitives (`failwith`, `invalid_arg`): resolved like
+          -- their qualified counterparts; anything else is a local variable.
+          match env.resolver.value path with
+          | some (.primitive n .function) => .ok (.prim n)
+          | some (.primitive n .nullary) => .ok (.app (.prim n) [])
+          | _ => .ok (.var name)
 
   | .ctor path =>
     if path.isQualified then

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -79,6 +79,7 @@ structure ElabEnv where
   ctors    : List (Constructor × (Nat × Nat × TinyML.Typ))   := []
   fields   : List (FieldName × (TypeConstructor × Nat))      := []
   records  : List (TypeConstructor × List (FieldName × TinyML.Typ)) := []
+  locals   : List Var                                        := []
   resolver : Resolver
 
 -- ---------------------------------------------------------------------------
@@ -88,6 +89,40 @@ private abbrev ElabM := Except ElaborateError
 
 private def err (loc : Location) (kind : ElaborateErrorKind) : ElabM α :=
   .error { loc, kind }
+
+private def Pattern.binderName? (pat : Pattern) : Option Var :=
+  match pat.kind with
+  | .binder (some name) _ => some name
+  | _ => none
+
+private def Pattern.productBoundNames (pat : Pattern) : List Var :=
+  match pat.kind with
+  | .tuple pats => pats.filterMap Pattern.binderName?
+  | .record fields => fields.filterMap (fun (_, field) => field.binderName?)
+  | _ => []
+
+private def Pattern.boundNames (pat : Pattern) : List Var :=
+  match pat.kind with
+  | .binder (some name) _ => [name]
+  | .ctor _ (some payload) =>
+      match payload.binderName? with
+      | some name => [name]
+      | none => payload.productBoundNames
+  | .tuple _ | .record _ => pat.productBoundNames
+  | _ => []
+
+private def ElabEnv.bindPattern (env : ElabEnv) (pat : Pattern) : ElabEnv :=
+  { env with locals := pat.boundNames ++ env.locals }
+
+private def ElabEnv.bindPatterns (env : ElabEnv) (pats : List Pattern) : ElabEnv :=
+  { env with locals := pats.flatMap Pattern.boundNames ++ env.locals }
+
+private def ElabEnv.bindBinder (env : ElabEnv) : Untyped.Binder → ElabEnv
+  | .none => env
+  | .named name _ => { env with locals := name :: env.locals }
+
+private def ElabEnv.isLocal (env : ElabEnv) (name : Var) : Bool :=
+  env.locals.elem name
 
 -- ---------------------------------------------------------------------------
 -- Type elaboration
@@ -401,18 +436,21 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
       | none => err loc (.unsupportedPath path)
     else
       let name := path.head
-      match name with
-      | "ref" | "not" => err loc (.bareSpecialIdentifier name)
-      | _ =>
-        match List.lookup name env.ctors with
-        | some (tag, arity, _) => .ok (.inj tag arity (.const .unit))
-        | none =>
-          -- Bare stdlib primitives (`failwith`, `invalid_arg`): resolved like
-          -- their qualified counterparts; anything else is a local variable.
-          match env.resolver.value path with
-          | some (.primitive n .function) => .ok (.prim n)
-          | some (.primitive n .nullary) => .ok (.app (.prim n) [])
-          | _ => .ok (.var name)
+      if env.isLocal name then
+        .ok (.var name)
+      else
+        match name with
+        | "ref" | "not" => err loc (.bareSpecialIdentifier name)
+        | _ =>
+          match List.lookup name env.ctors with
+          | some (tag, arity, _) => .ok (.inj tag arity (.const .unit))
+          | none =>
+            -- Bare prelude values resolve only when no lexical binder shadows
+            -- them; qualified paths always resolve through the resolver.
+            match env.resolver.value path with
+            | some (.primitive n .function) => .ok (.prim n)
+            | some (.primitive n .nullary) => .ok (.app (.prim n) [])
+            | _ => .ok (.var name)
 
   | .ctor path =>
     if path.isQualified then
@@ -425,13 +463,13 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
   | .app fn args =>
     match fn.kind with
     | .var path =>
-      if !path.isQualified && path.head == "not" then
+      if !path.isQualified && !env.isLocal path.head && path.head == "not" then
         match args with
         | [arg] => do
           let arg' ← Expr.elaborate env arg
           .ok (.unop .not arg')
         | _ => err loc (.arityMismatch 1 args.length)
-      else if !path.isQualified && path.head == "ref" then
+      else if !path.isQualified && !env.isLocal path.head && path.head == "ref" then
         match args with
         | [arg] => do
           let arg' ← Expr.elaborate env arg
@@ -584,10 +622,10 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     | [] => err loc (.unsupportedFeature "let with no binders")
     | [pat] => do
       let bound' ← Expr.elaborate env bound
-      let body' ← Expr.elaborate env body
       if isRec then
         err loc (.unsupportedFeature "let rec requires function arguments")
       else
+        let body' ← Expr.elaborate (env.bindPattern pat) body
         if isProductPattern pat then
           let names ← patternToProductBinders env pat
           .ok (.letProd names bound' body')
@@ -597,14 +635,16 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
     | pat :: args => do
       let name ← patternToBinder pat
       let self := if isRec then name else .none
-      let bound' ← Expr.elaborate env bound
+      let boundEnv := env.bindPatterns args
+      let boundEnv := if isRec then boundEnv.bindPattern pat else boundEnv
+      let bound' ← Expr.elaborate boundEnv bound
       let (args', bound'') ← elaborateFunctionArgs env "$param" 0 args bound'
-      let body' ← Expr.elaborate env body
+      let body' ← Expr.elaborate (env.bindPattern pat) body
       .ok (.letIn name (.fix self args' none bound'') body')
 
   | .fun_ args retTy body => do
     let retTy' ← elaborateOptTyp env retTy
-    let body' ← Expr.elaborate env body
+    let body' ← Expr.elaborate (env.bindPatterns args) body
     let (args', body'') ← elaborateFunctionArgs env "$param" 0 args body'
     .ok (.fix .none args' retTy' body'')
 
@@ -657,7 +697,6 @@ def MatchArm.elaborateList (env : ElabEnv)
     : List MatchArm → ElabM (List (Constructor × Option Untyped.Binder × Untyped.Expr))
   | [] => .ok []
   | ⟨pat, body⟩ :: arms => do
-    let body' ← Expr.elaborate env body
     let (ctorName, binder, body'') ← match pat.kind with
       | .ctor path payload => do
         let name ← if path.isQualified then
@@ -670,6 +709,7 @@ def MatchArm.elaborateList (env : ElabEnv)
           | none => err pat.loc (.unknownConstructor name)
         let (binder, body'') ← match payload with
           | some p =>
+            let body' ← Expr.elaborate (env.bindPattern p) body
             match payloadTy with
             | .tuple _ =>
                 if isProductPattern p then do
@@ -686,6 +726,7 @@ def MatchArm.elaborateList (env : ElabEnv)
                   let b ← patternToBinder p
                   pure (some b, body')
           | none =>
+            let body' ← Expr.elaborate env body
             match payloadTy with
             | .prim .unit => pure (none, body')
             | _ => err pat.loc (.unsupportedPattern "constructor payload must be matched")
@@ -792,7 +833,9 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
     let name ← patternToBinder pat
     let self := if isRec then name else .none
     let retTy' ← elaborateOptTyp env retTy
-    let body' ← Expr.elaborate env body
+    let bodyEnv := env.bindPatterns args
+    let bodyEnv := if isRec then bodyEnv.bindPattern pat else bodyEnv
+    let body' ← Expr.elaborate bodyEnv body
     let (args', body'') ← elaborateFunctionArgs env "$param" 0 args body'
     .ok { name, body := .fix self args' retTy' body'', declMeta := md }
 
@@ -845,7 +888,7 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
       | .named x _ => .ok (some x)
       | .none => err decl.loc (.unsupportedFeature "[@@fn] requires a named declaration")
     else .ok none
-    .ok (env, some (.val_ { d with declMeta := { d.declMeta with relation } }))
+    .ok (env.bindBinder d.name, some (.val_ { d with declMeta := { d.declMeta with relation } }))
 
 private def elaborateDecls (env : ElabEnv) :
     List Decl → ElabM (List (Untyped.Decl (Spec.Body Untyped.Expr)))

--- a/Mica/Stdlib.lean
+++ b/Mica/Stdlib.lean
@@ -7,6 +7,7 @@ import Mica.Stdlib.StringStd
 import Mica.Stdlib.FloatStd
 import Mica.Stdlib.FunStd
 import Mica.Stdlib.VecStd
+import Mica.Stdlib.ErrorStd
 import Mica.Frontend.Resolver
 
 open Iris Iris.BI
@@ -18,6 +19,8 @@ open Verifier
 def registry : Registry := [
   Verifier.BoundedQuantifier.allIntrinsic,
   Verifier.BoundedQuantifier.existsIntrinsic,
+  Intrinsics.failwith,
+  Intrinsics.invalidArg,
   Intrinsics.vecMake,
   Intrinsics.vecSet,
   Intrinsics.vecGet,

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -191,6 +191,12 @@ def Embedding.poly (v : TinyML.TyVar) : Embedding :=
   ⟨.tvar v, Runtime.Val, id, id,
     fun σ Θ w => TinyML.ValHasType Θ w (σ v), none⟩
 
+/-- The empty type: no closed values inhabit it. Trivial `Unit` carrier with a
+    `False` type predicate, so only an intrinsic with an unsatisfiable domain
+    can use it as a result. No `is-of` recognizer, so no type axiom. -/
+def Embedding.empty : Embedding :=
+  ⟨.empty, Unit, fun _ => .unit, fun _ => (), fun _ _ _ => iprop(False), none⟩
+
 /-- Vectors of an arbitrary element scheme: element lists, with the big-sep of
     instantiated element typings as the type predicate. -/
 def Embedding.vec (elem : TinyML.Typ) : Embedding :=
@@ -283,6 +289,23 @@ def Embedding.lawfulPoly (v : TinyML.TyVar) : (Embedding.poly v).Lawful where
   intro σ Θ x := by
     simp only [Embedding.poly, TinyML.Typ.subst]
     exact .rfl
+
+/-- The empty embedding is lawful: `ValHasType` at `.empty` is `False`, so both
+    typing directions are vacuous. -/
+def Embedding.lawfulEmpty : Embedding.empty.Lawful where
+  project_inject _ := rfl
+  isOf_wf _ _ h := nomatch h
+  isOf_inject _ _ _ h := nomatch h
+  member σ Θ w := by
+    simp only [Embedding.empty, TinyML.Typ.subst]
+    refine (TinyML.ValHasType.empty Θ w).trans ?_
+    constructor
+    · exact false_elim
+    · iintro ⟨%x, %hw, H⟩
+      iexact H
+  intro σ Θ x := by
+    simp only [Embedding.empty, TinyML.Typ.subst]
+    exact false_elim
 
 /-- Vectors are a lawful embedding: exactly the `ValHasType.vec` API. -/
 def Embedding.lawfulVec (elem : TinyML.Typ) : (Embedding.vec elem).Lawful where

--- a/Mica/Stdlib/ErrorStd.lean
+++ b/Mica/Stdlib/ErrorStd.lean
@@ -1,0 +1,95 @@
+-- SUMMARY: Error intrinsics (`failwith`, `invalid_arg`): precondition `False`, so the verifier must prove every raise unreachable.
+import Mica.Stdlib.Combinators
+
+open Iris Iris.BI
+
+namespace Stdlib
+
+open Verifier
+
+namespace Intrinsics
+
+/-! ## FOL symbols
+
+Both symbols are uninterpreted and never constrained: the `False` precondition
+means no verified program reaches a call, so no defining axiom is needed. -/
+
+/-- FOL symbol for `failwith`; uninterpreted, never constrained. -/
+def failwithSym : FOL.Symbol .one where
+  name   := "failwith"
+  interp := fun _ => .unit
+
+/-- FOL symbol for `invalid_arg`; uninterpreted, never constrained. -/
+def invalidArgSym : FOL.Symbol .one where
+  name   := "invalid_arg"
+  interp := fun _ => .unit
+
+@[simp] theorem failwithSym_name : failwithSym.name = "failwith" := rfl
+@[simp] theorem invalidArgSym_name : invalidArgSym.name = "invalid_arg" := rfl
+
+/-! ## `failwith` -/
+
+/-- `failwith : string -> empty` with precondition `False`: the call is only
+    verifiable in a contradictory context, i.e. on a dead path. At runtime the
+    reduce relation is empty (real OCaml raises). -/
+def failwithB : Pure.Unary where
+  name     := "failwith"
+  path     := some ("failwith", [])
+  arg      := .str
+  res      := .empty
+  f        := fun _ => ()
+  dom      := fun _ => False
+  pre      := some fun _ => .false_
+  defAxiom := .true_
+
+def failwith : Intrinsic := failwithB.toIntrinsic
+
+@[simp] theorem failwith_arity : failwith.arity = .one := rfl
+@[simp] theorem failwith_folSym : failwith.folSym = some failwithSym := rfl
+
+def failwithLawful : failwithB.Lawful where
+  argL         := Embedding.lawfulStr
+  resL         := Embedding.lawfulEmpty
+  domSound     := fun _ _ h => (h _ rfl).elim
+  semWellTyped := fun _ _ _ hdom => hdom.elim
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := fun _ h => nomatch h
+  defEval      := fun _ _ => trivial
+
+instance : IntrinsicSound [failwith] failwith := failwithLawful.sound
+
+/-! ## `invalid_arg` -/
+
+/-- `invalid_arg : string -> empty` with precondition `False`; identical to
+    `failwith` except for the exception it raises in real OCaml, which the
+    verifier never observes. -/
+def invalidArgB : Pure.Unary where
+  name     := "invalid_arg"
+  path     := some ("invalid_arg", [])
+  arg      := .str
+  res      := .empty
+  f        := fun _ => ()
+  dom      := fun _ => False
+  pre      := some fun _ => .false_
+  defAxiom := .true_
+
+def invalidArg : Intrinsic := invalidArgB.toIntrinsic
+
+@[simp] theorem invalidArg_arity : invalidArg.arity = .one := rfl
+@[simp] theorem invalidArg_folSym : invalidArg.folSym = some invalidArgSym := rfl
+
+def invalidArgLawful : invalidArgB.Lawful where
+  argL         := Embedding.lawfulStr
+  resL         := Embedding.lawfulEmpty
+  domSound     := fun _ _ h => (h _ rfl).elim
+  semWellTyped := fun _ _ _ hdom => hdom.elim
+  specBaseWf   := by apply PredTrans.checkWf_ok; rfl
+  defWf        := by apply Formula.checkWf_ok; rfl
+  typeWf       := fun _ h => nomatch h
+  defEval      := fun _ _ => trivial
+
+instance : IntrinsicSound [invalidArg] invalidArg := invalidArgLawful.sound
+
+end Intrinsics
+end Stdlib

--- a/Mica/Stdlib/OUTLINE.md
+++ b/Mica/Stdlib/OUTLINE.md
@@ -2,6 +2,7 @@
 
 - `CharStd.lean` — Character intrinsics (`Char.code`, `Char.chr`, `Char.equal`) and their soundness instances.
 - `Combinators.lean` — Embeddings and the pure-intrinsic builders (`Pure.Zero`/`Pure.Unary`/`Pure.Binary`/`Pure.Ternary`) that emit an intrinsic and its soundness instance.
+- `ErrorStd.lean` — Error intrinsics (`failwith`, `invalid_arg`): precondition `False`, so the verifier must prove every raise unreachable.
 - `FloatStd.lean` — IEEE binary64 float intrinsics (`Float.abs`, `add`, `min`, `equal`, `nan`, …) and soundness instances.
 - `FunStd.lean` — `Fun.id`
 - `IntStd.lean` — Integer-arithmetic intrinsics (`Int.min`, `Int.max`) and their soundness instances.

--- a/Tests/arith/smt_script.out
+++ b/Tests/arith/smt_script.out
@@ -65,6 +65,8 @@
 
 ;; verification
 (declare-const guard! Bool)
+(declare-fun failwith (Value) Value)
+(declare-fun invalid_arg (Value) Value)
 (declare-fun val_vec_make (Value Value) Value)
 (declare-fun val_vec_set (Value Value Value) Value)
 (declare-fun val_vec_get (Value Value) Value)
@@ -100,6 +102,8 @@
 (declare-fun char_code (Value) Value)
 (declare-fun int_max (Value Value) Value)
 (declare-fun int_min (Value Value) Value)
+(assert (=> (= guard! true) true))
+(assert (=> (= guard! true) true))
 (assert (forall ((n Value)) (forall ((x Value)) (! (=> (= guard! true) (= (val_vec_make n x) (of_vec (vec_make (to_int n) x)))) :pattern ((val_vec_make n x))))))
 (assert (forall ((a Value)) (forall ((b Value)) (! (=> (= guard! true) (is-of_vec (val_vec_make a b))) :pattern ((val_vec_make a b))))))
 (assert (forall ((v Value)) (forall ((i Value)) (forall ((x Value)) (! (=> (= guard! true) (= (val_vec_set v i x) (of_vec (vec_set (to_vec v) (to_int i) x)))) :pattern ((val_vec_set v i x)))))))

--- a/Tests/errors/errors.ml
+++ b/Tests/errors/errors.ml
@@ -17,3 +17,33 @@ let checked_sub (a : int) (b : int) : int =
 let _ = assert (checked_pos 5 = 5)
 
 let _ = assert (checked_sub 7 2 = 5)
+
+(* Local bindings shadow bare prelude primitives. *)
+let shadow_failwith (n : int) : int =
+  let failwith = n + 1 in
+  failwith
+[@@spec fun n ->
+  ret (fun v ->
+    assert (v = n + 1))];;
+
+let shadow_argument (failwith : int) : int = failwith
+[@@spec fun failwith ->
+  ret (fun v ->
+    assert (v = failwith))];;
+
+(* Top-level bindings shadow the opened prelude in later declarations. *)
+let invalid_arg (x : int) : int = x + 2
+[@@spec fun x ->
+  ret (fun v ->
+    assert (v = x + 2))];;
+
+let shadow_invalid_arg (n : int) : int = invalid_arg n
+[@@spec fun n ->
+  ret (fun v ->
+    assert (v = n + 2))];;
+
+let _ = assert (shadow_failwith 4 = 5)
+
+let _ = assert (shadow_argument 4 = 4)
+
+let _ = assert (shadow_invalid_arg 4 = 6)

--- a/Tests/errors/errors.ml
+++ b/Tests/errors/errors.ml
@@ -1,0 +1,19 @@
+open Mica
+
+let checked_pos (n : int) : int =
+  if n > 0 then n else failwith "expected a positive number"
+[@@spec fun n ->
+  assert (n > 0);
+  ret (fun v ->
+    assert (v = n))];;
+
+let checked_sub (a : int) (b : int) : int =
+  if a < b then invalid_arg "underflow" else a - b
+[@@spec fun a b ->
+  assert (b <= a);
+  ret (fun v ->
+    assert (v = a - b))];;
+
+let _ = assert (checked_pos 5 = 5)
+
+let _ = assert (checked_sub 7 2 = 5)

--- a/mica.ml
+++ b/mica.ml
@@ -1,3 +1,6 @@
+let failwith = Stdlib.failwith
+let invalid_arg = Stdlib.invalid_arg
+
 module String = struct
   let length = Stdlib.String.length
   let get = Stdlib.String.get


### PR DESCRIPTION
This PR adds two error operations to the stdlib, `invalid_argument` and `failwith`. 