### PR TITLE
Add missing type constraint for references

### DIFF
--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -325,6 +325,7 @@ mutual
         let l ← VerifM.decl none .value
         let sl := Term.const (.uninterpreted l.name .value)
         VerifM.assume (.spatial (.pointsTo sl v e.ty))
+        VerifM.assumeAll (TinyML.typeConstraints (.owned e.ty) sl)
         pure sl
     | .deref e ty => do
         match e.ty with
@@ -992,9 +993,19 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
       Term.wfIn_mono se hse_wf (Signature.Subset.subset_addConst _ _)
         (TransState.freshConst.wf _ hwf_st₁).namesDisjoint
     have hatom_wf : (SpatialAtom.pointsTo sl se e.ty).wfIn st₂.decls := ⟨hsl_wf, hse_wf₂⟩
-    have hret := VerifM.eval_ret (VerifM.eval_assumeSpatial (VerifM.eval_bind hdecl_loc) hatom_wf)
+    have hassumed := VerifM.eval_assumeSpatial (VerifM.eval_bind hdecl_loc) hatom_wf
     have hsl_eval : sl.eval ρ₂.env = .loc loc := by
       simp [sl, ρ₂, c, Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
+    have htyped : ∀ φ ∈ TinyML.typeConstraints (.owned e.ty) sl, φ.eval ρ₂.env := by
+      intro φ hφ
+      simp only [TinyML.typeConstraints, List.mem_singleton] at hφ
+      subst hφ
+      simp [Formula.eval, hsl_eval]
+    obtain ⟨st₃, hdecls₃, howns₃, _hasserts₃, hq₃⟩ :=
+      VerifM.eval_assumeAll (VerifM.eval_bind hassumed)
+        (fun φ hφ => TinyML.typeConstraints_wfIn hsl_wf φ hφ) htyped
+    have hret := VerifM.eval_ret hq₃
+    have hsl_wf₃ : sl.wfIn st₃.decls := by rw [hdecls₃]; exact hsl_wf
     have hlocTy : ⊢ TinyML.ValHasType Θ (.loc loc) (.owned e.ty) := by
       refine Entails.trans ?_ (TinyML.ValHasType.owned Θ (.loc loc) e.ty).2
       istart
@@ -1004,10 +1015,9 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
       rfl
     istart
     iintro ⟨Hsl, HR⟩
-    iapply (hpost (.loc loc) ρ₂ { st₂ with owns := .pointsTo sl se e.ty :: st₁.owns }
-      sl hret hsl_wf hsl_eval)
+    iapply (hpost (.loc loc) ρ₂ st₃ sl hret hsl_wf₃ hsl_eval)
     isplitl [Hsl]
-    · simp [TransState.sl_eq, st₂, SpatialContext.insert]
+    · simp [TransState.sl_eq, howns₃, SpatialContext.insert]
       rw [show ρ₂.env = ρ_e.env.updateConst .value c.name (.loc loc) by rfl]
       iexact Hsl
     · isplitl []

--- a/Tests/ownership/spec_let_own.ml
+++ b/Tests/ownership/spec_let_own.ml
@@ -1,0 +1,63 @@
+open Mica
+
+(* Post-side [own] and [arr] binders over spec-level let aliases.
+
+   The location a binder resolves flows through a spec-level [let] — for a
+   returned owned ref or mutable array directly and for owned locations stored
+   in returned record fields.  Regression test: the spec-level [let] asserts
+   the bound expression's type constraints ([isLoc] for owned locations), so
+   allocation must assume them; without that, a post-side ownership binder over
+   an alias of a freshly allocated location fails. *)
+
+type box = { data : int array [@owned]; size : int ref [@owned] }
+
+let alloc (x : int) : int ref [@owned] =
+  ref x [@owned]
+[@@spec fun x ->
+  ret (fun r ->
+    let s = r in
+    bind (own s) @@ fun (v : int) ->
+    assert (v = x))];;
+
+let alloc_array (n : int) : int array [@owned] =
+  Array.make n 0 [@owned]
+[@@spec fun n ->
+  assert (0 <= n);
+  ret (fun r ->
+    let a = r in
+    bind (arr a) @@ fun (w : int vec) ->
+    assert (Vec.length w = n))];;
+
+let make (n : int) : box =
+  { data = (Array.make n 0 [@owned]); size = (ref 7 [@owned]) }
+[@@spec fun n ->
+  assert (0 <= n);
+  ret (fun d ->
+    let a = d.data in
+    bind (arr a) @@ fun (w : int vec) ->
+    let s = d.size in
+    bind (own s) @@ fun (m : int) ->
+    assert (Vec.length w = n);
+    assert (m = 7))];;
+
+(* Mutate through the projected field; the caller observes it across the
+   call boundary. *)
+let bump (d : box) : unit =
+  let s = d.size in
+  let n = !s in
+  s := n + 1
+[@@spec fun d ->
+  let s = d.size in
+  bind (own s) @@ fun (n : int) ->
+  ret (fun r ->
+    let s2 = d.size in
+    bind (own s2) @@ fun (m : int) ->
+    assert (m = n + 1))];;
+
+let drive (unused : int) : int =
+  let d = make 3 in
+  bump d;
+  let s = d.size in
+  !s
+[@@spec fun unused ->
+  ret (fun r -> assert (r = 8))];;


### PR DESCRIPTION
This PR adds missing type constraints for reference allocation and a new test.