### PR TITLE
Miscellaneous structural improvements

### DIFF
--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -191,7 +191,9 @@ def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyM
   | .arrow dom cod => do
     let dom' ← Typ.elaborate env dom
     let cod' ← Typ.elaborate env cod
-    .ok (.arrow dom' cod')
+    match cod' with
+    | .arrow args ret => .ok (.arrow (dom' :: args) ret)
+    | _ => .ok (.arrow [dom'] cod')
   | .tuple ts => do
     let ts' ← Typ.elaborateList env ts
     .ok (.tuple ts')
@@ -671,6 +673,8 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
       let body' ← Expr.elaborate (env.bindPattern pat) body
       .ok (.letIn name (.fix self args' none bound'') body')
 
+  | .fun_ [] _ _ =>
+    err loc (.unsupportedFeature "function expressions require at least one argument")
   | .fun_ args retTy body => do
     let retTy' ← elaborateOptTyp env retTy
     let body' ← Expr.elaborate (env.bindPatterns args) body

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -19,6 +19,7 @@ inductive ParseErrorKind where
   | invalidRecordField
   | nonPositiveProjIndex
   | letRecNoArgs
+  | funNoArgs
   | nonFinalLowercaseSegment (segment : String)
   | expectedArrayElementAssignTarget
   deriving Repr, Inhabited
@@ -36,6 +37,7 @@ def ParseError.toString (e : ParseError) : String :=
   | .invalidRecordField => s!"{loc}: expected field name (identifier) before '=' in record literal"
   | .nonPositiveProjIndex => s!"{loc}: projection index must be at least 1 (projections are 1-based)"
   | .letRecNoArgs => s!"{loc}: let rec without arguments is not supported"
+  | .funNoArgs => s!"{loc}: function expressions require at least one argument"
   | .nonFinalLowercaseSegment seg => s!"{loc}: qualified path segment '{seg}' is lowercase, but only the final component of a module path may be lowercase"
   | .expectedArrayElementAssignTarget => s!"{loc}: `<-` expects an array element `a.(i)` on the left"
 
@@ -794,6 +796,8 @@ where
     let p := peekLoc st
     let st ← expect .kw_fun st
     let (args, st) ← parseFunArgs st
+    if args.isEmpty then
+      .error { loc := p, kind := .funNoArgs }
     let (retTy, st) ← parseOptRetTy st
     let st ← expect .arrow st
     let (body, st) ← parseExpr st

--- a/Mica/SeparationLogic/Interpretations.lean
+++ b/Mica/SeparationLogic/Interpretations.lean
@@ -18,9 +18,9 @@ namespace SpatialAtom
 
 /-- Interpreting a well-formed atom only depends on the environment values of
     symbols in the ambient signature. -/
-theorem interp_env_agree (Θ : TinyML.TypeEnv) {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
+theorem interp_env_agree (W : TinyML.World) {a : SpatialAtom} {Δ : Signature} {ρ ρ' : Env}
     (hwf : a.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    interp Θ ρ a ⊣⊢ interp Θ ρ' a := by
+    interp W ρ a ⊣⊢ interp W ρ' a := by
   cases a with
   | pointsTo l v ty =>
     simp only [interp, Term.eval_env_agree hwf.1 hagree, Term.eval_env_agree hwf.2 hagree]
@@ -32,11 +32,11 @@ theorem interp_env_agree (Θ : TinyML.TypeEnv) {a : SpatialAtom} {Δ : Signature
 /-- If a points-to atom's location term evaluates to `loc`, its interpretation
     is equivalent to the raw heap ownership together with the bundled value
     typing fact. -/
-theorem interp_pointsTo (Θ : TinyML.TypeEnv) {ρ : Env} {lt vt : Term .value}
+theorem interp_pointsTo (W : TinyML.World) {ρ : Env} {lt vt : Term .value}
     {ty : TinyML.Typ} {loc : Runtime.Location}
     (hloc : Term.eval ρ lt = .loc loc) :
-    interp Θ ρ (.pointsTo lt vt ty) ⊣⊢
-      loc ↦ [Term.eval ρ vt] ∗ TinyML.ValHasType Θ (Term.eval ρ vt) ty := by
+    interp W ρ (.pointsTo lt vt ty) ⊣⊢
+      loc ↦ [Term.eval ρ vt] ∗ TinyML.ValHasType W (Term.eval ρ vt) ty := by
   constructor
   · simp only [interp]
     istart
@@ -60,12 +60,12 @@ theorem interp_pointsTo (Θ : TinyML.TypeEnv) {ρ : Env} {lt vt : Term .value}
 /-- If an owned-array atom's array and snapshot terms evaluate to the same
     runtime block, its interpretation exposes ownership of that whole block
     together with the element-typing fact carried by the vector snapshot. -/
-theorem interp_arrayPointsTo (Θ : TinyML.TypeEnv) {ρ : Env} {arrt vt : Term .value}
+theorem interp_arrayPointsTo (W : TinyML.World) {ρ : Env} {arrt vt : Term .value}
     {ty : TinyML.Typ} {loc : Runtime.Location} {vs : List Runtime.Val}
     (harr : Term.eval ρ arrt = .array vs.length loc)
     (hvec : Term.eval ρ vt = .vec vs) :
-    interp Θ ρ (.arrayPointsTo arrt vt ty) ⊣⊢
-      loc ↦ vs ∗ TinyML.ValHasType Θ (.vec vs) (.vec ty) := by
+    interp W ρ (.arrayPointsTo arrt vt ty) ⊣⊢
+      loc ↦ vs ∗ TinyML.ValHasType W (.vec vs) (.vec ty) := by
   constructor
   · simp only [interp]
     istart
@@ -95,23 +95,23 @@ theorem interp_arrayPointsTo (Θ : TinyML.TypeEnv) {ρ : Env} {arrt vt : Term .v
 /-- Destruct an owned-array atom at an in-bounds index: expose the underlying
 block, the integer index witness, and the persistent element typing of the
 snapshot. -/
-theorem interp_arrayPointsTo_lookup (Θ : TinyML.TypeEnv) {ρ : Env}
+theorem interp_arrayPointsTo_lookup (W : TinyML.World) {ρ : Env}
     {arr contents idx : Term .value} {elemTy : TinyML.Typ} {vidx : Runtime.Val}
     (hidx : Term.eval ρ idx = vidx)
     (hi : 0 ≤ Term.eval ρ (.unop .toInt idx))
     (hlt : Term.eval ρ (.unop .toInt idx) < Term.eval ρ (.unop .arrayLengthOf arr)) :
-    SpatialAtom.interp Θ ρ (.arrayPointsTo arr contents elemTy) ⊢
-      TinyML.ValHasType Θ vidx .int -∗
+    SpatialAtom.interp W ρ (.arrayPointsTo arr contents elemTy) ⊢
+      TinyML.ValHasType W vidx .int -∗
       ∃ (loc : Runtime.Location) (vs : List Runtime.Val) (i : Int),
         ⌜Term.eval ρ arr = .array vs.length loc⌝ ∗ ⌜Term.eval ρ contents = .vec vs⌝ ∗
         ⌜vidx = .int i⌝ ∗ ⌜0 ≤ i⌝ ∗ ⌜i.toNat < vs.length⌝ ∗
-        loc ↦ vs ∗ □ TinyML.ValHasType Θ (.vec vs) (.vec elemTy) := by
+        loc ↦ vs ∗ □ TinyML.ValHasType W (.vec vs) (.vec elemTy) := by
   simp only [SpatialAtom.interp]
   istart
   iintro Hatom
   iintro HidxTy
   icases Hatom with ⟨%loc, %vs, %ha, %hv, Hpt, #HvecTy⟩
-  ihave Hidx' := (TinyML.ValHasType.int Θ vidx).1 $$ HidxTy
+  ihave Hidx' := (TinyML.ValHasType.int W vidx).1 $$ HidxTy
   icases Hidx' with ⟨%i, %hvidx⟩
   have hi' : 0 ≤ i := by simpa [Term.eval, UnOp.eval, hidx, hvidx] using hi
   have hlt' : i.toNat < vs.length := by
@@ -140,8 +140,8 @@ theorem interp_arrayPointsTo_lookup (Θ : TinyML.TypeEnv) {ρ : Env}
               iexact HvecTy
 
 /-- An atom's interpretation implies its pure facts. -/
-theorem interp_facts (Θ : TinyML.TypeEnv) {ρ : Env} (a : SpatialAtom) :
-    interp Θ ρ a ⊢ ⌜∀ φ ∈ a.facts, φ.eval ρ⌝ ∗ interp Θ ρ a := by
+theorem interp_facts (W : TinyML.World) {ρ : Env} (a : SpatialAtom) :
+    interp W ρ a ⊢ ⌜∀ φ ∈ a.facts, φ.eval ρ⌝ ∗ interp W ρ a := by
   cases a with
   | pointsTo l v ty =>
     istart
@@ -179,31 +179,31 @@ end SpatialAtom
 namespace SpatialContext
 
 /-- Iris interpretation of a spatial context: the separating conjunction of all items. -/
-def interp (Θ : TinyML.TypeEnv) (ρ : Env) : SpatialContext → iProp
+def interp (W : TinyML.World) (ρ : Env) : SpatialContext → iProp
   | []     => emp
-  | a :: Γ => a.interp Θ ρ ∗ interp Θ ρ Γ
+  | a :: Γ => a.interp W ρ ∗ interp W ρ Γ
 
 /-- Interpreting a well-formed context only depends on the environment values of
     symbols in the ambient signature. -/
-theorem interp_env_agree (Θ : TinyML.TypeEnv) {ctx : SpatialContext} {Δ : Signature} {ρ ρ' : Env}
+theorem interp_env_agree (W : TinyML.World) {ctx : SpatialContext} {Δ : Signature} {ρ ρ' : Env}
     (hwf : wfIn ctx Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    interp Θ ρ ctx ⊣⊢ interp Θ ρ' ctx := by
+    interp W ρ ctx ⊣⊢ interp W ρ' ctx := by
   induction ctx with
   | nil => simp [interp]
   | cons a ctx ih =>
-    have ha : SpatialAtom.interp Θ ρ a ⊣⊢ SpatialAtom.interp Θ ρ' a :=
-      SpatialAtom.interp_env_agree Θ (hwf a (by simp)) hagree
+    have ha : SpatialAtom.interp W ρ a ⊣⊢ SpatialAtom.interp W ρ' a :=
+      SpatialAtom.interp_env_agree W (hwf a (by simp)) hagree
     have htail : wfIn ctx Δ := (wfIn_cons a ctx Δ).1 hwf |>.2
-    have hctx : interp Θ ρ ctx ⊣⊢ interp Θ ρ' ctx := ih htail
+    have hctx : interp W ρ ctx ⊣⊢ interp W ρ' ctx := ih htail
     simp only [interp]
     exact ⟨sep_mono ha.1 hctx.1, sep_mono ha.2 hctx.2⟩
 
-@[simp] theorem interp_nil (Θ : TinyML.TypeEnv) (ρ : Env) : interp Θ ρ [] = emp := rfl
-@[simp] theorem interp_cons (Θ : TinyML.TypeEnv) (ρ : Env) (a : SpatialAtom) (Γ : SpatialContext) :
-    interp Θ ρ (a :: Γ) = (a.interp Θ ρ ∗ interp Θ ρ Γ) := rfl
+@[simp] theorem interp_nil (W : TinyML.World) (ρ : Env) : interp W ρ [] = emp := rfl
+@[simp] theorem interp_cons (W : TinyML.World) (ρ : Env) (a : SpatialAtom) (Γ : SpatialContext) :
+    interp W ρ (a :: Γ) = (a.interp W ρ ∗ interp W ρ Γ) := rfl
 
-@[simp] theorem interp_insert (Θ : TinyML.TypeEnv) (ρ : Env) (a : SpatialAtom) (ctx : SpatialContext) :
-    interp Θ ρ (insert a ctx) = (a.interp Θ ρ ∗ interp Θ ρ ctx) := rfl
+@[simp] theorem interp_insert (W : TinyML.World) (ρ : Env) (a : SpatialAtom) (ctx : SpatialContext) :
+    interp W ρ (insert a ctx) = (a.interp W ρ ∗ interp W ρ ctx) := rfl
 
 omit [MicaGS HasLC.hasLC Sig] in
 private theorem sep_comm3 {A B C : iProp} : A ∗ (B ∗ C) ⊣⊢ B ∗ (A ∗ C) :=
@@ -211,10 +211,10 @@ private theorem sep_comm3 {A B C : iProp} : A ∗ (B ∗ C) ⊣⊢ B ∗ (A ∗ 
    sep_assoc.2 |>.trans (sep_mono_left sep_comm.2) |>.trans sep_assoc.1⟩
 
 /-- The interpretation of a context is equivalent to splitting off the atom at index `n`. -/
-theorem interp_remove (Θ : TinyML.TypeEnv) (ρ : Env) (ctx : SpatialContext) (n : Nat)
+theorem interp_remove (W : TinyML.World) (ρ : Env) (ctx : SpatialContext) (n : Nat)
     (a : SpatialAtom) (rest : SpatialContext)
     (h : remove ctx n = some (a, rest)) :
-    interp Θ ρ ctx ⊣⊢ a.interp Θ ρ ∗ interp Θ ρ rest := by
+    interp W ρ ctx ⊣⊢ a.interp W ρ ∗ interp W ρ rest := by
   induction ctx generalizing n a rest with
   | nil => simp at h
   | cons x xs ih =>

--- a/Mica/SeparationLogic/LogicalRelation.lean
+++ b/Mica/SeparationLogic/LogicalRelation.lean
@@ -6,6 +6,7 @@ import Mica.TinyML.OpSem
 import Mica.FOL.Formulas
 import Mica.Base.Fresh
 import Mica.SeparationLogic.Wp
+import Mica.SeparationLogic.World
 import Iris.BI.Lib.Fixpoint
 
 open Iris Iris.BI Iris.OFE
@@ -258,22 +259,22 @@ private instance ValRelBody.contractive (k : RecCont) (v : Runtime.Val) (t : Typ
   distLater_dist hR := ValRelBody.dist hR Dist.rfl t v
 
 /-- One unfolding of the inner recursive type interpretation. -/
-private def ValRelIndF (Θ : TypeEnv) (R : ValShape) (Φ : RecIdx → iProp) (x : RecIdx) : iProp :=
+private def ValRelIndF (W : World) (R : ValShape) (Φ : RecIdx → iProp) (x : RecIdx) : iProp :=
   match x with
   | ⟨(v, T, args)⟩ =>
-      iprop(∃ ty, ⌜TypeName.unfold Θ T args = some ty⌝ ∗
+      iprop(∃ ty, ⌜TypeName.unfold W.Θ T args = some ty⌝ ∗
         ValRelBody R v ty (RecCont.ofPred Φ))
 
-private instance (Θ : TypeEnv) (R : ValShape) (Φ : RecIdx → iProp) :
-    NonExpansive (ValRelIndF Θ R Φ) where
+private instance (W : World) (R : ValShape) (Φ : RecIdx → iProp) :
+    NonExpansive (ValRelIndF W R Φ) where
   ne {_ x y} h := by
     obtain ⟨x⟩ := x
     obtain ⟨y⟩ := y
     cases LeibnizO.dist_inj h
     exact Dist.of_eq rfl
 
-private theorem ValRelIndF.contractive (Θ : TypeEnv) (Φ : RecIdx → iProp) (x : RecIdx) :
-    Contractive (fun R : ValShape => ValRelIndF Θ R Φ x) where
+private theorem ValRelIndF.contractive (W : World) (Φ : RecIdx → iProp) (x : RecIdx) :
+    Contractive (fun R : ValShape => ValRelIndF W R Φ x) where
   distLater_dist {n R S} hR := by
     obtain ⟨v, T, args⟩ := x
     simp only [ValRelIndF]
@@ -282,7 +283,7 @@ private theorem ValRelIndF.contractive (Θ : TypeEnv) (Φ : RecIdx → iProp) (x
     exact Contractive.distLater_dist
       (f := fun R : ValShape => ValRelBody R v ty (RecCont.ofPred Φ)) hR
 
-private instance (Θ : TypeEnv) (R : ValShape) : BIMonoPred (ValRelIndF Θ R) where
+private instance (W : World) (R : ValShape) : BIMonoPred (ValRelIndF W R) where
   mono_pred := by
     intro Φ Ψ _ _
     iintro #HΦΨ %x HF
@@ -306,20 +307,20 @@ private instance (Θ : TypeEnv) (R : ValShape) : BIMonoPred (ValRelIndF Θ R) wh
     exact Dist.of_eq rfl
 
 /-- The inner least fixpoint for named types, with the outer approximation fixed. -/
-private def ValRelInd (Θ : TypeEnv) (R : ValShape) : RecCont :=
-  fun v T args => Iris.bi_least_fixpoint (ValRelIndF Θ R) ⟨(v, T, args)⟩
+private def ValRelInd (W : World) (R : ValShape) : RecCont :=
+  fun v T args => Iris.bi_least_fixpoint (ValRelIndF W R) ⟨(v, T, args)⟩
 
-private theorem ValRelInd.unfold {Θ : TypeEnv} {R : ValShape}
+private theorem ValRelInd.unfold {W : World} {R : ValShape}
     {v : Runtime.Val} {T : TypeName} {args : List Typ} :
-    ValRelInd Θ R v T args ⊣⊢
-      iprop(∃ ty, ⌜TypeName.unfold Θ T args = some ty⌝ ∗
-        ValRelBody R v ty (ValRelInd Θ R)) := by
-  have h := Iris.least_fixpoint_unfold (ValRelIndF Θ R) (x := ⟨(v, T, args)⟩)
+    ValRelInd W R v T args ⊣⊢
+      iprop(∃ ty, ⌜TypeName.unfold W.Θ T args = some ty⌝ ∗
+        ValRelBody R v ty (ValRelInd W R)) := by
+  have h := Iris.least_fixpoint_unfold (ValRelIndF W R) (x := ⟨(v, T, args)⟩)
   simp only [ValRelIndF] at h
   exact equiv_iff.mp h
 
-private instance ValRelInd.contractive (Θ : TypeEnv) :
-    Contractive (fun R : ValShape => ValRelInd Θ R) where
+private instance ValRelInd.contractive (W : World) :
+    Contractive (fun R : ValShape => ValRelInd W R) where
   distLater_dist {n R S} hR v T args := by
     unfold ValRelInd Iris.bi_least_fixpoint
     refine forall_ne fun Φ => ?_
@@ -327,36 +328,36 @@ private instance ValRelInd.contractive (Θ : TypeEnv) :
     refine intuitionistically_ne.ne ?_
     refine forall_ne fun x => ?_
     refine wand_ne.ne ?_ (.of_eq rfl)
-    exact (ValRelIndF.contractive Θ (fun x => Φ x) x).distLater_dist hR
+    exact (ValRelIndF.contractive W (fun x => Φ x) x).distLater_dist hR
 
 /-- The outer functional. It closes the named-type continuation using `ValRelInd`. -/
-private def ValRelF (Θ : TypeEnv) (R : ValShape) : ValShape :=
-  fun v t => ValRelBody R v t (ValRelInd Θ R)
+private def ValRelF (W : World) (R : ValShape) : ValShape :=
+  fun v t => ValRelBody R v t (ValRelInd W R)
 
-private instance ValRelF.contractive (Θ : TypeEnv) : Contractive (ValRelF Θ) where
+private instance ValRelF.contractive (W : World) : Contractive (ValRelF W) where
   distLater_dist {n R S} hR v t := by
     unfold ValRelF
-    have hk : ValRelInd Θ R ≡{n}≡ ValRelInd Θ S :=
-      Contractive.distLater_dist (f := fun R : ValShape => ValRelInd Θ R) hR
+    have hk : ValRelInd W R ≡{n}≡ ValRelInd W S :=
+      Contractive.distLater_dist (f := fun R : ValShape => ValRelInd W R) hR
     exact ValRelBody.dist hR hk t v
 
 /-- The mixed recursive value relation. -/
-def ValHasType (Θ : TypeEnv) : ValShape :=
-  fixpoint (ValRelF Θ)
+def ValHasType (W : World) : ValShape :=
+  fixpoint (ValRelF W)
 
 /-- Final tuple/list relation induced by the mixed recursive value relation. -/
-def ValsHaveTypes (Θ : TypeEnv) (vs : List Runtime.Val) (ts : List Typ) : iProp :=
-  ValsRelBody (ValHasType Θ) vs ts (ValRelInd Θ (ValHasType Θ))
+def ValsHaveTypes (W : World) (vs : List Runtime.Val) (ts : List Typ) : iProp :=
+  ValsRelBody (ValHasType W) vs ts (ValRelInd W (ValHasType W))
 
 /-- Final sum-payload relation induced by the mixed recursive value relation. -/
-def ValSumRel (Θ : TypeEnv) (tag : Nat) (payload : Runtime.Val)
+def ValSumRel (W : World) (tag : Nat) (payload : Runtime.Val)
     (ts : List Typ) : iProp :=
-  ValSumRelBody (ValHasType Θ) tag payload ts (ValRelInd Θ (ValHasType Θ))
+  ValSumRelBody (ValHasType W) tag payload ts (ValRelInd W (ValHasType W))
 
-theorem ValHasType.unfold (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
-    ValHasType Θ v t ≡ ValRelBody (ValHasType Θ) v t (ValRelInd Θ (ValHasType Θ)) := by
+theorem ValHasType.unfold (W : World) (v : Runtime.Val) (t : Typ) :
+    ValHasType W v t ≡ ValRelBody (ValHasType W) v t (ValRelInd W (ValHasType W)) := by
   let F : ValShape -c> ValShape := {
-    f := ValRelF Θ
+    f := ValRelF W
     contractive := inferInstance
   }
   exact (fixpoint_unfold F) v t
@@ -424,143 +425,143 @@ mutual
         exact ValSumRelBody.persistent R ts n payload hk
 end
 
-private instance ValRelIndF.persistent (Θ : TypeEnv) (R : ValShape) (Φ : RecIdx → iProp)
-    [∀ x, Persistent (Φ x)] (x : RecIdx) : Persistent (ValRelIndF Θ R Φ x) := by
+private instance ValRelIndF.persistent (W : World) (R : ValShape) (Φ : RecIdx → iProp)
+    [∀ x, Persistent (Φ x)] (x : RecIdx) : Persistent (ValRelIndF W R Φ x) := by
   obtain ⟨v, T, args⟩ := x
   simp only [ValRelIndF]
   have : ∀ ty, Persistent (ValRelBody R v ty (RecCont.ofPred Φ)) :=
     fun ty => ValRelBody.persistent R ty v (fun _ _ _ => inferInstance)
   infer_instance
 
-private instance ValRelIndF.absorbing (Θ : TypeEnv) (R : ValShape) (Φ : RecIdx → iProp)
-    [∀ x, Absorbing (Φ x)] (x : RecIdx) : Absorbing (ValRelIndF Θ R Φ x) := by
+private instance ValRelIndF.absorbing (W : World) (R : ValShape) (Φ : RecIdx → iProp)
+    [∀ x, Absorbing (Φ x)] (x : RecIdx) : Absorbing (ValRelIndF W R Φ x) := by
   obtain ⟨v, T, args⟩ := x
   simp only [ValRelIndF]
   infer_instance
 
-instance (Θ : TypeEnv) (R : ValShape) (v : Runtime.Val) (T : TypeName)
-    (args : List Typ) : Persistent (ValRelInd Θ R v T args) :=
-  @Iris.least_fixpoint_persistent_absorbing iProp RecIdx _ _ (ValRelIndF Θ R) _
+instance (W : World) (R : ValShape) (v : Runtime.Val) (T : TypeName)
+    (args : List Typ) : Persistent (ValRelInd W R v T args) :=
+  @Iris.least_fixpoint_persistent_absorbing iProp RecIdx _ _ (ValRelIndF W R) _
     (fun _ _ _ => inferInstance) (fun _ _ _ => inferInstance) ⟨(v, T, args)⟩
 
-instance (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) : Persistent (ValHasType Θ v t) :=
-  (persistent_congr (equiv_iff.mp (ValHasType.unfold Θ v t))).mpr
-    (ValRelBody.persistent (ValHasType Θ) t v (fun _ _ _ => inferInstance))
+instance (W : World) (v : Runtime.Val) (t : Typ) : Persistent (ValHasType W v t) :=
+  (persistent_congr (equiv_iff.mp (ValHasType.unfold W v t))).mpr
+    (ValRelBody.persistent (ValHasType W) t v (fun _ _ _ => inferInstance))
 
-instance (Θ : TypeEnv) (vs : List Runtime.Val) (ts : List Typ) :
-    Persistent (ValsHaveTypes Θ vs ts) :=
-  ValsRelBody.persistent (ValHasType Θ) ts vs (fun _ _ _ => inferInstance)
+instance (W : World) (vs : List Runtime.Val) (ts : List Typ) :
+    Persistent (ValsHaveTypes W vs ts) :=
+  ValsRelBody.persistent (ValHasType W) ts vs (fun _ _ _ => inferInstance)
 
-instance (Θ : TypeEnv) (tag : Nat) (payload : Runtime.Val) (ts : List Typ) :
-    Persistent (ValSumRel Θ tag payload ts) :=
-  ValSumRelBody.persistent (ValHasType Θ) ts tag payload (fun _ _ _ => inferInstance)
+instance (W : World) (tag : Nat) (payload : Runtime.Val) (ts : List Typ) :
+    Persistent (ValSumRel W tag payload ts) :=
+  ValSumRelBody.persistent (ValHasType W) ts tag payload (fun _ _ _ => inferInstance)
 
 
 /-! Per-type unfoldings -/
 
-theorem ValHasType.unit (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v Typ.unit ⊣⊢ iprop(⌜v = .unit⌝) := by
-  change ValHasType Θ v (.prim .unit) ⊣⊢ iprop(⌜v = .unit⌝)
-  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.unit)
+theorem ValHasType.unit (W : World) (v : Runtime.Val) :
+    ValHasType W v Typ.unit ⊣⊢ iprop(⌜v = .unit⌝) := by
+  change ValHasType W v (.prim .unit) ⊣⊢ iprop(⌜v = .unit⌝)
+  exact equiv_iff.mp (ValHasType.unfold W v Typ.unit)
 
-theorem ValHasType.bool (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v Typ.bool ⊣⊢ iprop(⌜∃ b, v = .bool b⌝) := by
-  change ValHasType Θ v (.prim .bool) ⊣⊢ iprop(⌜∃ b, v = .bool b⌝)
-  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.bool)
+theorem ValHasType.bool (W : World) (v : Runtime.Val) :
+    ValHasType W v Typ.bool ⊣⊢ iprop(⌜∃ b, v = .bool b⌝) := by
+  change ValHasType W v (.prim .bool) ⊣⊢ iprop(⌜∃ b, v = .bool b⌝)
+  exact equiv_iff.mp (ValHasType.unfold W v Typ.bool)
 
-theorem ValHasType.int (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v Typ.int ⊣⊢ iprop(⌜∃ n, v = .int n⌝) := by
-  change ValHasType Θ v (.prim .int) ⊣⊢ iprop(⌜∃ n, v = .int n⌝)
-  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.int)
+theorem ValHasType.int (W : World) (v : Runtime.Val) :
+    ValHasType W v Typ.int ⊣⊢ iprop(⌜∃ n, v = .int n⌝) := by
+  change ValHasType W v (.prim .int) ⊣⊢ iprop(⌜∃ n, v = .int n⌝)
+  exact equiv_iff.mp (ValHasType.unfold W v Typ.int)
 
-theorem ValHasType.char (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v Typ.char ⊣⊢ iprop(⌜∃ c, v = .char c⌝) := by
-  change ValHasType Θ v (.prim .char) ⊣⊢ iprop(⌜∃ c, v = .char c⌝)
-  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.char)
+theorem ValHasType.char (W : World) (v : Runtime.Val) :
+    ValHasType W v Typ.char ⊣⊢ iprop(⌜∃ c, v = .char c⌝) := by
+  change ValHasType W v (.prim .char) ⊣⊢ iprop(⌜∃ c, v = .char c⌝)
+  exact equiv_iff.mp (ValHasType.unfold W v Typ.char)
 
-theorem ValHasType.string (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v Typ.string ⊣⊢ iprop(⌜∃ s, v = .str s⌝) := by
-  change ValHasType Θ v (.prim .string) ⊣⊢ iprop(⌜∃ s, v = .str s⌝)
-  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.string)
+theorem ValHasType.string (W : World) (v : Runtime.Val) :
+    ValHasType W v Typ.string ⊣⊢ iprop(⌜∃ s, v = .str s⌝) := by
+  change ValHasType W v (.prim .string) ⊣⊢ iprop(⌜∃ s, v = .str s⌝)
+  exact equiv_iff.mp (ValHasType.unfold W v Typ.string)
 
-theorem ValHasType.float (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v Typ.float ⊣⊢ iprop(⌜∃ b, v = .float b⌝) := by
-  change ValHasType Θ v (.prim .float) ⊣⊢ iprop(⌜∃ b, v = .float b⌝)
-  exact equiv_iff.mp (ValHasType.unfold Θ v Typ.float)
+theorem ValHasType.float (W : World) (v : Runtime.Val) :
+    ValHasType W v Typ.float ⊣⊢ iprop(⌜∃ b, v = .float b⌝) := by
+  change ValHasType W v (.prim .float) ⊣⊢ iprop(⌜∃ b, v = .float b⌝)
+  exact equiv_iff.mp (ValHasType.unfold W v Typ.float)
 
-theorem ValHasType.value (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v .value ⊣⊢ iprop(True) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v .value)
+theorem ValHasType.value (W : World) (v : Runtime.Val) :
+    ValHasType W v .value ⊣⊢ iprop(True) := by
+  exact equiv_iff.mp (ValHasType.unfold W v .value)
 
-theorem ValHasType.empty (Θ : TypeEnv) (v : Runtime.Val) :
-    ValHasType Θ v .empty ⊣⊢ iprop(False) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v .empty)
+theorem ValHasType.empty (W : World) (v : Runtime.Val) :
+    ValHasType W v .empty ⊣⊢ iprop(False) := by
+  exact equiv_iff.mp (ValHasType.unfold W v .empty)
 
-theorem ValHasType.arrow (Θ : TypeEnv) (v : Runtime.Val) (args : List Typ) (ret : Typ) :
-    ValHasType Θ v (.arrow args ret) ⊣⊢ iprop(False) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.arrow args ret))
+theorem ValHasType.arrow (W : World) (v : Runtime.Val) (args : List Typ) (ret : Typ) :
+    ValHasType W v (.arrow args ret) ⊣⊢ iprop(False) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.arrow args ret))
 
-theorem ValHasType.tvar (Θ : TypeEnv) (v : Runtime.Val) (x : TyVar) :
-    ValHasType Θ v (.tvar x) ⊣⊢ iprop(False) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.tvar x))
+theorem ValHasType.tvar (W : World) (v : Runtime.Val) (x : TyVar) :
+    ValHasType W v (.tvar x) ⊣⊢ iprop(False) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.tvar x))
 
-theorem ValHasType.ref (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
-    ValHasType Θ v (.ref t) ⊣⊢
-      iprop(∃ l, ⌜v = .loc l⌝ ∗ locinv l (fun w => ValHasType Θ w t)) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.ref t))
+theorem ValHasType.ref (W : World) (v : Runtime.Val) (t : Typ) :
+    ValHasType W v (.ref t) ⊣⊢
+      iprop(∃ l, ⌜v = .loc l⌝ ∗ locinv l (fun w => ValHasType W w t)) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.ref t))
 
-theorem ValHasType.owned (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
-    ValHasType Θ v (.owned t) ⊣⊢ iprop(∃ l, ⌜v = .loc l⌝) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.owned t))
+theorem ValHasType.owned (W : World) (v : Runtime.Val) (t : Typ) :
+    ValHasType W v (.owned t) ⊣⊢ iprop(∃ l, ⌜v = .loc l⌝) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.owned t))
 
-theorem ValHasType.array (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
-    ValHasType Θ v (.array t) ⊣⊢
-      iprop(∃ len l, ⌜v = .array len l⌝ ∗ arrayinv len l (fun w => ValHasType Θ w t)) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.array t))
+theorem ValHasType.array (W : World) (v : Runtime.Val) (t : Typ) :
+    ValHasType W v (.array t) ⊣⊢
+      iprop(∃ len l, ⌜v = .array len l⌝ ∗ arrayinv len l (fun w => ValHasType W w t)) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.array t))
 
 /-- Owned arrays expose their runtime shape; contents are carried by the
 spatial owned-array assertion. -/
-theorem ValHasType.ownedArray (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
-    ValHasType Θ v (.ownedArray t) ⊣⊢ iprop(∃ len l, ⌜v = .array len l⌝) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.ownedArray t))
+theorem ValHasType.ownedArray (W : World) (v : Runtime.Val) (t : Typ) :
+    ValHasType W v (.ownedArray t) ⊣⊢ iprop(∃ len l, ⌜v = .array len l⌝) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.ownedArray t))
 
-theorem ValHasType.vec (Θ : TypeEnv) (v : Runtime.Val) (t : Typ) :
-    ValHasType Θ v (.vec t) ⊣⊢
-      iprop(∃ vs, ⌜v = .vec vs⌝ ∗ [∗list] w ∈ vs, ValHasType Θ w t) := by
-  refine (equiv_iff.mp (ValHasType.unfold Θ v (.vec t))).trans ?_
+theorem ValHasType.vec (W : World) (v : Runtime.Val) (t : Typ) :
+    ValHasType W v (.vec t) ⊣⊢
+      iprop(∃ vs, ⌜v = .vec vs⌝ ∗ [∗list] w ∈ vs, ValHasType W w t) := by
+  refine (equiv_iff.mp (ValHasType.unfold W v (.vec t))).trans ?_
   apply equiv_iff.mp
   refine equiv_dist.mpr fun _ => ?_
   refine exists_ne fun vs => ?_
   refine sep_ne.ne (.of_eq rfl) ?_
-  exact (BigSepL.bigSepL_eqv fun _ => (ValHasType.unfold Θ _ t).symm).dist
+  exact (BigSepL.bigSepL_eqv fun _ => (ValHasType.unfold W _ t).symm).dist
 
-theorem ValHasType.tuple (Θ : TypeEnv) (v : Runtime.Val) (ts : List Typ) :
-    ValHasType Θ v (.tuple ts) ⊣⊢
-      iprop(∃ vs, ⌜v = .tuple vs⌝ ∗ ValsHaveTypes Θ vs ts) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.tuple ts))
+theorem ValHasType.tuple (W : World) (v : Runtime.Val) (ts : List Typ) :
+    ValHasType W v (.tuple ts) ⊣⊢
+      iprop(∃ vs, ⌜v = .tuple vs⌝ ∗ ValsHaveTypes W vs ts) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.tuple ts))
 
-theorem ValHasType.sum (Θ : TypeEnv) (v : Runtime.Val) (ts : List Typ) :
-    ValHasType Θ v (.sum ts) ⊣⊢
+theorem ValHasType.sum (W : World) (v : Runtime.Val) (ts : List Typ) :
+    ValHasType W v (.sum ts) ⊣⊢
       iprop(∃ tag payload, ⌜v = .inj tag ts.length payload⌝ ∗
-        ValSumRel Θ tag payload ts) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.sum ts))
+        ValSumRel W tag payload ts) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.sum ts))
 
-theorem ValHasType.named (Θ : TypeEnv) (v : Runtime.Val) (T : TypeName) (args : List Typ) :
-    ValHasType Θ v (.named T args) ⊣⊢
-      iprop(∃ ty, ⌜TypeName.unfold Θ T args = some ty⌝ ∗ ValHasType Θ v ty) := by
-  refine (equiv_iff.mp (ValHasType.unfold Θ v (.named T args))).trans ?_
+theorem ValHasType.named (W : World) (v : Runtime.Val) (T : TypeName) (args : List Typ) :
+    ValHasType W v (.named T args) ⊣⊢
+      iprop(∃ ty, ⌜TypeName.unfold W.Θ T args = some ty⌝ ∗ ValHasType W v ty) := by
+  refine (equiv_iff.mp (ValHasType.unfold W v (.named T args))).trans ?_
   refine ValRelInd.unfold.trans ?_
   apply equiv_iff.mp
   refine equiv_dist.mpr fun _ => ?_
   refine exists_ne fun ty => ?_
   refine sep_ne.ne (.of_eq rfl) ?_
-  exact (ValHasType.unfold Θ v ty).symm.dist
+  exact (ValHasType.unfold W v ty).symm.dist
 
-theorem ValHasType.named_of_unfold {Θ : TypeEnv} {v : Runtime.Val}
+theorem ValHasType.named_of_unfold {W : World} {v : Runtime.Val}
     {T : TypeName} {args : List Typ} {ty : Typ}
-    (hunfold : TypeName.unfold Θ T args = some ty) :
-    ValHasType Θ v (.named T args) ⊣⊢ ValHasType Θ v ty := by
-  refine (ValHasType.named Θ v T args).trans ?_
+    (hunfold : TypeName.unfold W.Θ T args = some ty) :
+    ValHasType W v (.named T args) ⊣⊢ ValHasType W v ty := by
+  refine (ValHasType.named W v T args).trans ?_
   constructor
   · iintro H
     icases H with ⟨%ty', %hunfold', Hty⟩
@@ -574,36 +575,36 @@ theorem ValHasType.named_of_unfold {Θ : TypeEnv} {v : Runtime.Val}
       exact hunfold
     · iexact Hty
 
-theorem ValsHaveTypes.nil (Θ : TypeEnv) :
-    ValsHaveTypes Θ [] [] ⊣⊢ iprop(emp) := by
+theorem ValsHaveTypes.nil (W : World) :
+    ValsHaveTypes W [] [] ⊣⊢ iprop(emp) := by
   unfold ValsHaveTypes ValsRelBody
   exact .rfl
 
-theorem ValsHaveTypes.cons (Θ : TypeEnv) (v : Runtime.Val) (vs : List Runtime.Val)
+theorem ValsHaveTypes.cons (W : World) (v : Runtime.Val) (vs : List Runtime.Val)
     (t : Typ) (ts : List Typ) :
-    ValsHaveTypes Θ (v :: vs) (t :: ts) ⊣⊢ ValHasType Θ v t ∗ ValsHaveTypes Θ vs ts := by
+    ValsHaveTypes W (v :: vs) (t :: ts) ⊣⊢ ValHasType W v t ∗ ValsHaveTypes W vs ts := by
   unfold ValsHaveTypes
-  change iprop(ValRelBody (ValHasType Θ) v t (ValRelInd Θ (ValHasType Θ)) ∗
-      ValsRelBody (ValHasType Θ) vs ts (ValRelInd Θ (ValHasType Θ))) ⊣⊢
-    iprop(ValHasType Θ v t ∗ ValsRelBody (ValHasType Θ) vs ts (ValRelInd Θ (ValHasType Θ)))
-  exact sep_congr (equiv_iff.mp (ValHasType.unfold Θ v t).symm) .rfl
+  change iprop(ValRelBody (ValHasType W) v t (ValRelInd W (ValHasType W)) ∗
+      ValsRelBody (ValHasType W) vs ts (ValRelInd W (ValHasType W))) ⊣⊢
+    iprop(ValHasType W v t ∗ ValsRelBody (ValHasType W) vs ts (ValRelInd W (ValHasType W)))
+  exact sep_congr (equiv_iff.mp (ValHasType.unfold W v t).symm) .rfl
 
-theorem ValsHaveTypes.nil_cons (Θ : TypeEnv) (t : Typ) (ts : List Typ) :
-    ValsHaveTypes Θ [] (t :: ts) ⊣⊢ iprop(False) := by
+theorem ValsHaveTypes.nil_cons (W : World) (t : Typ) (ts : List Typ) :
+    ValsHaveTypes W [] (t :: ts) ⊣⊢ iprop(False) := by
   unfold ValsHaveTypes ValsRelBody
   exact .rfl
 
-theorem ValsHaveTypes.cons_nil (Θ : TypeEnv) (v : Runtime.Val) (vs : List Runtime.Val) :
-    ValsHaveTypes Θ (v :: vs) [] ⊣⊢ iprop(False) := by
+theorem ValsHaveTypes.cons_nil (W : World) (v : Runtime.Val) (vs : List Runtime.Val) :
+    ValsHaveTypes W (v :: vs) [] ⊣⊢ iprop(False) := by
   unfold ValsHaveTypes ValsRelBody
   exact .rfl
 
 /-! ### The vector type -/
 
 /-- The canonical proof that a vector of well-typed elements has vector type. -/
-theorem ValHasType.vec_intro (Θ : TypeEnv) (vs : List Runtime.Val) (t : Typ) :
-    iprop([∗list] w ∈ vs, ValHasType Θ w t) ⊢ ValHasType Θ (.vec vs) (.vec t) := by
-  refine .trans ?_ (ValHasType.vec Θ (.vec vs) t).2
+theorem ValHasType.vec_intro (W : World) (vs : List Runtime.Val) (t : Typ) :
+    iprop([∗list] w ∈ vs, ValHasType W w t) ⊢ ValHasType W (.vec vs) (.vec t) := by
+  refine .trans ?_ (ValHasType.vec W (.vec vs) t).2
   iintro Hvs
   iexists vs
   isplitr [Hvs]
@@ -611,19 +612,19 @@ theorem ValHasType.vec_intro (Θ : TypeEnv) (vs : List Runtime.Val) (t : Typ) :
   · iexact Hvs
 
 /-- Overwriting an in-bounds slot with a well-typed value preserves well-typedness. -/
-theorem ValHasType.vec_set (Θ : TypeEnv) {vs : List Runtime.Val} {t : Typ}
+theorem ValHasType.vec_set (W : World) {vs : List Runtime.Val} {t : Typ}
     {n : Nat} {x w : Runtime.Val} (h : vs[n]? = some x) :
-    iprop(([∗list] w' ∈ vs, ValHasType Θ w' t) ∗ ValHasType Θ w t) ⊢
-      ValHasType Θ (.vec (vs.set n w)) (.vec t) := by
-  refine .trans ?_ (ValHasType.vec_intro Θ (vs.set n w) t)
+    iprop(([∗list] w' ∈ vs, ValHasType W w' t) ∗ ValHasType W w t) ⊢
+      ValHasType W (.vec (vs.set n w)) (.vec t) := by
+  refine .trans ?_ (ValHasType.vec_intro W (vs.set n w) t)
   refine (sep_mono_left (BigSepL.bigSepL_insert_acc h)).trans ?_
   refine (sep_mono_left sep_elim_right).trans ?_
   exact (sep_mono_left (forall_elim w)).trans wand_elim_left
 
 /-- A replicated well-typed value gives a well-typed vector. -/
-theorem ValHasType.vec_replicate (Θ : TypeEnv) (n : Nat) (x : Runtime.Val) (t : Typ) :
-    ValHasType Θ x t ⊢ ValHasType Θ (.vec (List.replicate n x)) (.vec t) := by
-  refine .trans ?_ (ValHasType.vec_intro Θ (List.replicate n x) t)
+theorem ValHasType.vec_replicate (W : World) (n : Nat) (x : Runtime.Val) (t : Typ) :
+    ValHasType W x t ⊢ ValHasType W (.vec (List.replicate n x)) (.vec t) := by
+  refine .trans ?_ (ValHasType.vec_intro W (List.replicate n x) t)
   induction n with
   | zero => exact affine
   | succ n ih =>
@@ -636,137 +637,137 @@ theorem ValHasType.vec_replicate (Θ : TypeEnv) (n : Nat) (x : Runtime.Val) (t :
     · iapply ih
       iexact Hx
 
-theorem ValSumRel.nil (Θ : TypeEnv) (tag : Nat) (payload : Runtime.Val) :
-    ValSumRel Θ tag payload [] ⊣⊢ iprop(False) := by
+theorem ValSumRel.nil (W : World) (tag : Nat) (payload : Runtime.Val) :
+    ValSumRel W tag payload [] ⊣⊢ iprop(False) := by
   unfold ValSumRel ValSumRelBody
   exact .rfl
 
-theorem ValSumRel.zero (Θ : TypeEnv) (payload : Runtime.Val) (t : Typ) (ts : List Typ) :
-    ValSumRel Θ 0 payload (t :: ts) ⊣⊢ ValHasType Θ payload t := by
+theorem ValSumRel.zero (W : World) (payload : Runtime.Val) (t : Typ) (ts : List Typ) :
+    ValSumRel W 0 payload (t :: ts) ⊣⊢ ValHasType W payload t := by
   unfold ValSumRel ValSumRelBody
-  exact equiv_iff.mp (ValHasType.unfold Θ payload t).symm
+  exact equiv_iff.mp (ValHasType.unfold W payload t).symm
 
-theorem ValSumRel.succ (Θ : TypeEnv) (tag : Nat) (payload : Runtime.Val)
+theorem ValSumRel.succ (W : World) (tag : Nat) (payload : Runtime.Val)
     (t : Typ) (ts : List Typ) :
-    ValSumRel Θ (tag + 1) payload (t :: ts) ⊣⊢ ValSumRel Θ tag payload ts := by
+    ValSumRel W (tag + 1) payload (t :: ts) ⊣⊢ ValSumRel W tag payload ts := by
   unfold ValSumRel
-  change ValSumRelBody (ValHasType Θ) tag payload ts (ValRelInd Θ (ValHasType Θ)) ⊣⊢
-    ValSumRelBody (ValHasType Θ) tag payload ts (ValRelInd Θ (ValHasType Θ))
+  change ValSumRelBody (ValHasType W) tag payload ts (ValRelInd W (ValHasType W)) ⊣⊢
+    ValSumRelBody (ValHasType W) tag payload ts (ValRelInd W (ValHasType W))
   exact .rfl
 
 /-! Indexing and subtyping compatibility. -/
 
-/-- `ValSumRel Θ tag payload ts` is the value relation at `ts[tag]`, when that
+/-- `ValSumRel W tag payload ts` is the value relation at `ts[tag]`, when that
 index exists. -/
-theorem ValSumRel.of_getElem? {Θ : TypeEnv} {payload : Runtime.Val} :
+theorem ValSumRel.of_getElem? {W : World} {payload : Runtime.Val} :
     ∀ {ts : List Typ} {tag : Nat} {s : Typ}, ts[tag]? = some s →
-      ValSumRel Θ tag payload ts ⊢ ValHasType Θ payload s
+      ValSumRel W tag payload ts ⊢ ValHasType W payload s
   | [], _, _, h => by
       simp at h
   | _ :: _, 0, _, h => by
       simp at h
       subst h
-      exact (ValSumRel.zero Θ payload _ _).1
+      exact (ValSumRel.zero W payload _ _).1
   | _ :: ts, n + 1, _, h => by
-      exact (ValSumRel.succ Θ n payload _ ts).1.trans
-        (ValSumRel.of_getElem? (Θ := Θ) (payload := payload) (ts := ts) (by simpa using h))
+      exact (ValSumRel.succ W n payload _ ts).1.trans
+        (ValSumRel.of_getElem? (W := W) (payload := payload) (ts := ts) (by simpa using h))
 
-theorem ValSumRel.to_getElem? {Θ : TypeEnv} {payload : Runtime.Val} :
+theorem ValSumRel.to_getElem? {W : World} {payload : Runtime.Val} :
     ∀ {ts : List Typ} {tag : Nat} {s : Typ}, ts[tag]? = some s →
-      ValHasType Θ payload s ⊢ ValSumRel Θ tag payload ts
+      ValHasType W payload s ⊢ ValSumRel W tag payload ts
   | [], _, _, h => by
       simp at h
   | _ :: _, 0, _, h => by
       simp at h
       subst h
-      exact (ValSumRel.zero Θ payload _ _).2
+      exact (ValSumRel.zero W payload _ _).2
   | _ :: ts, n + 1, _, h => by
-      exact (ValSumRel.to_getElem? (Θ := Θ) (payload := payload) (ts := ts) (by simpa using h)).trans
-        (ValSumRel.succ Θ n payload _ ts).2
+      exact (ValSumRel.to_getElem? (W := W) (payload := payload) (ts := ts) (by simpa using h)).trans
+        (ValSumRel.succ W n payload _ ts).2
 
 /-- `ValSumRel` implies the tag is in range. -/
-theorem ValSumRel.bound {Θ : TypeEnv} {payload : Runtime.Val} :
+theorem ValSumRel.bound {W : World} {payload : Runtime.Val} :
     ∀ {ts : List Typ} {tag : Nat},
-      ValSumRel Θ tag payload ts ⊢ iprop(⌜tag < ts.length⌝)
-  | [], tag => (ValSumRel.nil Θ tag payload).1.trans false_elim
+      ValSumRel W tag payload ts ⊢ iprop(⌜tag < ts.length⌝)
+  | [], tag => (ValSumRel.nil W tag payload).1.trans false_elim
   | _ :: _, 0 => true_intro.trans <| pure_intro (by simp)
   | _ :: ts, tag + 1 =>
-      (ValSumRel.succ Θ tag payload _ ts).1.trans <|
-        (ValSumRel.bound (Θ := Θ) (payload := payload) (ts := ts) (tag := tag)).trans <|
+      (ValSumRel.succ W tag payload _ ts).1.trans <|
+        (ValSumRel.bound (W := W) (payload := payload) (ts := ts) (tag := tag)).trans <|
         pure_mono (by simp)
 
 /-- Inject a typed payload at tag `tag` into a sum type whose `tag`-th component matches. -/
-theorem ValHasType.inj {Θ : TypeEnv} {payload : Runtime.Val}
+theorem ValHasType.inj {W : World} {payload : Runtime.Val}
     {tag arity : Nat} {ts : List Typ} {s : Typ}
     (hlen : ts.length = arity) (hget : ts[tag]? = some s) :
-    ValHasType Θ payload s ⊢ ValHasType Θ (.inj tag arity payload) (.sum ts) := by
-  refine Entails.trans ?_ (ValHasType.sum Θ (.inj tag arity payload) ts).2
+    ValHasType W payload s ⊢ ValHasType W (.inj tag arity payload) (.sum ts) := by
+  refine Entails.trans ?_ (ValHasType.sum W (.inj tag arity payload) ts).2
   iintro Hpayload
   iexists tag, payload
   isplitr
   · ipureintro; simp [hlen]
-  · iapply (ValSumRel.to_getElem? (Θ := Θ) (payload := payload) (ts := ts)
+  · iapply (ValSumRel.to_getElem? (W := W) (payload := payload) (ts := ts)
       (tag := tag) (s := s) hget)
     iexact Hpayload
 
 /-- The canonical proof that `unit` has type `unit`. -/
-theorem ValHasType.unit_intro (Θ : TypeEnv) :
-    ⊢ ValHasType Θ .unit Typ.unit := by
-  iapply (ValHasType.unit Θ .unit).2
+theorem ValHasType.unit_intro (W : World) :
+    ⊢ ValHasType W .unit Typ.unit := by
+  iapply (ValHasType.unit W .unit).2
   ipureintro; rfl
 
 /-- The canonical proof that a Boolean literal has type `bool`. -/
-theorem ValHasType.bool_intro (Θ : TypeEnv) (b : Bool) :
-    ⊢ ValHasType Θ (.bool b) Typ.bool := by
-  iapply (ValHasType.bool Θ (.bool b)).2
+theorem ValHasType.bool_intro (W : World) (b : Bool) :
+    ⊢ ValHasType W (.bool b) Typ.bool := by
+  iapply (ValHasType.bool W (.bool b)).2
   ipureintro
   exact ⟨b, rfl⟩
 
 /-- The canonical proof that an integer literal has type `int`. -/
-theorem ValHasType.int_intro (Θ : TypeEnv) (n : Int) :
-    ⊢ ValHasType Θ (.int n) Typ.int := by
-  iapply (ValHasType.int Θ (.int n)).2
+theorem ValHasType.int_intro (W : World) (n : Int) :
+    ⊢ ValHasType W (.int n) Typ.int := by
+  iapply (ValHasType.int W (.int n)).2
   ipureintro
   exact ⟨n, rfl⟩
 
 /-- The canonical proof that a character literal has type `char`. -/
-theorem ValHasType.char_intro (Θ : TypeEnv) (c : UInt8) :
-    ⊢ ValHasType Θ (.char c) Typ.char := by
-  iapply (ValHasType.char Θ (.char c)).2
+theorem ValHasType.char_intro (W : World) (c : UInt8) :
+    ⊢ ValHasType W (.char c) Typ.char := by
+  iapply (ValHasType.char W (.char c)).2
   ipureintro
   exact ⟨c, rfl⟩
 
 /-- The canonical proof that a string literal has type `string`. -/
-theorem ValHasType.string_intro (Θ : TypeEnv) (s : List UInt8) :
-    ⊢ ValHasType Θ (.str s) Typ.string := by
-  iapply (ValHasType.string Θ (.str s)).2
+theorem ValHasType.string_intro (W : World) (s : List UInt8) :
+    ⊢ ValHasType W (.str s) Typ.string := by
+  iapply (ValHasType.string W (.str s)).2
   ipureintro
   exact ⟨s, rfl⟩
 
 /-- The canonical proof that a float literal has type `float`. -/
-theorem ValHasType.float_intro (Θ : TypeEnv) (b : UInt64) :
-    ⊢ ValHasType Θ (.float b) Typ.float := by
-  iapply (ValHasType.float Θ (.float b)).2
+theorem ValHasType.float_intro (W : World) (b : UInt64) :
+    ⊢ ValHasType W (.float b) Typ.float := by
+  iapply (ValHasType.float W (.float b)).2
   ipureintro
   exact ⟨b, rfl⟩
 
 mutual
-  theorem ValHasType.sub {Θ : TypeEnv} {v : Runtime.Val} {t t' : Typ}
-      (hsub : Typ.Sub Θ t t') :
-      ValHasType Θ v t ⊢ ValHasType Θ v t' := by
+  theorem ValHasType.sub {W : World} {v : Runtime.Val} {t t' : Typ}
+      (hsub : Typ.Sub W.Θ t t') :
+      ValHasType W v t ⊢ ValHasType W v t' := by
     match hsub with
     | .refl =>
         exact .rfl
     | .bot =>
-        exact (ValHasType.empty Θ v).1.trans false_elim
+        exact (ValHasType.empty W v).1.trans false_elim
     | .top =>
-        exact true_intro.trans (ValHasType.value Θ v).2
+        exact true_intro.trans (ValHasType.value W v).2
     | .trans h1 h2 =>
         exact (ValHasType.sub h1).trans (ValHasType.sub h2)
     | .sum hlist =>
         have hlen := hlist.length_eq
-        refine (ValHasType.sum Θ v _).1.trans ?_
-        refine .trans ?_ (ValHasType.sum Θ v _).2
+        refine (ValHasType.sum W v _).1.trans ?_
+        refine .trans ?_ (ValHasType.sum W v _).2
         iintro H
         icases H with ⟨%tag, %payload, %heq, Hsum⟩
         iexists tag, payload
@@ -776,10 +777,10 @@ mutual
         · iapply (ValSumRel.sub hlist payload tag)
           iexact Hsum
     | .arrow _ _ =>
-        exact (ValHasType.arrow Θ v _ _).1.trans false_elim
+        exact (ValHasType.arrow W v _ _).1.trans false_elim
     | .tuple hlist =>
-        refine (ValHasType.tuple Θ v _).1.trans ?_
-        refine .trans ?_ (ValHasType.tuple Θ v _).2
+        refine (ValHasType.tuple W v _).1.trans ?_
+        refine .trans ?_ (ValHasType.tuple W v _).2
         iintro H
         icases H with ⟨%vs, %heq, Hvs⟩
         iexists vs
@@ -793,37 +794,37 @@ mutual
     | .named_right hunfold hsub' =>
         exact (ValHasType.sub hsub').trans (ValHasType.named_of_unfold (v := v) hunfold).2
 
-  theorem ValsHaveTypes.sub {Θ : TypeEnv} {vs : List Runtime.Val} {ts ts' : List Typ}
-      (hsub : Typ.SubList Θ ts ts') :
-      ValsHaveTypes Θ vs ts ⊢ ValsHaveTypes Θ vs ts' := by
+  theorem ValsHaveTypes.sub {W : World} {vs : List Runtime.Val} {ts ts' : List Typ}
+      (hsub : Typ.SubList W.Θ ts ts') :
+      ValsHaveTypes W vs ts ⊢ ValsHaveTypes W vs ts' := by
     match hsub, vs with
     | .nil, _ =>
         exact .rfl
     | .cons (s := s) (ss := ss) _ _, [] =>
-        exact (ValsHaveTypes.nil_cons Θ s ss).1.trans false_elim
+        exact (ValsHaveTypes.nil_cons W s ss).1.trans false_elim
     | .cons (s := s) (t := t) (ss := ss) (ts := ts) hst hrest, v :: vs =>
-        refine (ValsHaveTypes.cons Θ v vs s ss).1.trans ?_
-        refine .trans ?_ (ValsHaveTypes.cons Θ v vs t ts).2
+        refine (ValsHaveTypes.cons W v vs s ss).1.trans ?_
+        refine .trans ?_ (ValsHaveTypes.cons W v vs t ts).2
         exact sep_mono (ValHasType.sub hst) (ValsHaveTypes.sub (vs := vs) hrest)
 
-  theorem ValSumRel.sub {Θ : TypeEnv} {ss ts : List Typ}
-      (hsub : Typ.SubList Θ ss ts) (payload : Runtime.Val) (tag : Nat) :
-      ValSumRel Θ tag payload ss ⊢ ValSumRel Θ tag payload ts := by
+  theorem ValSumRel.sub {W : World} {ss ts : List Typ}
+      (hsub : Typ.SubList W.Θ ss ts) (payload : Runtime.Val) (tag : Nat) :
+      ValSumRel W tag payload ss ⊢ ValSumRel W tag payload ts := by
     match hsub, tag with
     | .nil, _ =>
         exact .rfl
     | .cons (s := s) (t := t) (ss := ss) (ts := ts) hst _, 0 =>
-        exact (ValSumRel.zero Θ payload s ss).1.trans
-          ((ValHasType.sub hst).trans (ValSumRel.zero Θ payload t ts).2)
+        exact (ValSumRel.zero W payload s ss).1.trans
+          ((ValHasType.sub hst).trans (ValSumRel.zero W payload t ts).2)
     | .cons (s := s) (t := t) (ss := ss) (ts := ts) _ hrest, n + 1 =>
-        exact (ValSumRel.succ Θ n payload s ss).1.trans
-          ((ValSumRel.sub hrest payload n).trans (ValSumRel.succ Θ n payload t ts).2)
+        exact (ValSumRel.succ W n payload s ss).1.trans
+          ((ValSumRel.sub hrest payload n).trans (ValSumRel.succ W n payload t ts).2)
 
-  theorem ValHasType.subList {Θ : TypeEnv} {payload : Runtime.Val} {s : Typ}
-      {ss ts : List Typ} (hsub : Typ.SubList Θ ss ts) {tag : Nat}
+  theorem ValHasType.subList {W : World} {payload : Runtime.Val} {s : Typ}
+      {ss ts : List Typ} (hsub : Typ.SubList W.Θ ss ts) {tag : Nat}
       (hs : ss[tag]? = some s) :
-      ValHasType Θ payload s ⊢
-        iprop(∃ t, ⌜ts[tag]? = some t⌝ ∗ ValHasType Θ payload t) := by
+      ValHasType W payload s ⊢
+        iprop(∃ t, ⌜ts[tag]? = some t⌝ ∗ ValHasType W payload t) := by
     match hsub, tag, hs with
     | .nil, _, h =>
         simp at h
@@ -851,36 +852,36 @@ mutual
 end
 
 /-- Length agreement for `ValsHaveTypes`, as an entailment. -/
-theorem ValsHaveTypes.length_eq {Θ : TypeEnv} {vs : List Runtime.Val} {ts : List Typ} :
-    ValsHaveTypes Θ vs ts ⊢ iprop(⌜vs.length = ts.length⌝) := by
+theorem ValsHaveTypes.length_eq {W : World} {vs : List Runtime.Val} {ts : List Typ} :
+    ValsHaveTypes W vs ts ⊢ iprop(⌜vs.length = ts.length⌝) := by
   match vs, ts with
   | [], [] =>
-      exact (ValsHaveTypes.nil Θ).1.trans (pure_intro rfl)
+      exact (ValsHaveTypes.nil W).1.trans (pure_intro rfl)
   | v :: vs, t :: ts =>
-      exact ((ValsHaveTypes.cons Θ v vs t ts).1.trans sep_elim_right).trans
-        ((ValsHaveTypes.length_eq (Θ := Θ) (vs := vs) (ts := ts)).trans
+      exact ((ValsHaveTypes.cons W v vs t ts).1.trans sep_elim_right).trans
+        ((ValsHaveTypes.length_eq (W := W) (vs := vs) (ts := ts)).trans
           (pure_mono (fun h => by simp [h])))
   | [], t :: ts =>
-      exact (ValsHaveTypes.nil_cons Θ t ts).1.trans false_elim
+      exact (ValsHaveTypes.nil_cons W t ts).1.trans false_elim
   | v :: vs, [] =>
-      exact (ValsHaveTypes.cons_nil Θ v vs).1.trans false_elim
+      exact (ValsHaveTypes.cons_nil W v vs).1.trans false_elim
 
 /-- If `ts[n]? = some t`, then a related list of values contains a value at
 index `n` related at type `t`. -/
-theorem ValsHaveTypes.of_getElem? {Θ : TypeEnv} :
+theorem ValsHaveTypes.of_getElem? {W : World} :
     ∀ {vs : List Runtime.Val} {ts : List Typ} {n : Nat} {t : Typ},
       ts[n]? = some t →
-      ValsHaveTypes Θ vs ts ⊢ iprop(∃ v, ⌜vs[n]? = some v⌝ ∗ ValHasType Θ v t)
+      ValsHaveTypes W vs ts ⊢ iprop(∃ v, ⌜vs[n]? = some v⌝ ∗ ValHasType W v t)
   | [], [], _, _, h => by
       simp at h
   | [], t :: ts, _, _, _ => by
-      exact (ValsHaveTypes.nil_cons Θ t ts).1.trans false_elim
+      exact (ValsHaveTypes.nil_cons W t ts).1.trans false_elim
   | v :: vs, [], _, _, _ => by
-      exact (ValsHaveTypes.cons_nil Θ v vs).1.trans false_elim
+      exact (ValsHaveTypes.cons_nil W v vs).1.trans false_elim
   | v :: vs, t :: ts, 0, t', h => by
       simp at h
       subst h
-      refine (ValsHaveTypes.cons Θ v vs t ts).1.trans ?_
+      refine (ValsHaveTypes.cons W v vs t ts).1.trans ?_
       iintro H
       icases H with ⟨Hv, _⟩
       iexists v
@@ -891,12 +892,12 @@ theorem ValsHaveTypes.of_getElem? {Θ : TypeEnv} :
   | v :: vs, t :: ts, n + 1, t', h => by
       have h' : ts[n]? = some t' := by
         simpa using h
-      refine (ValsHaveTypes.cons Θ v vs t ts).1.trans ?_
+      refine (ValsHaveTypes.cons W v vs t ts).1.trans ?_
       iintro H
       icases H with ⟨_, Hvs⟩
       iapply
-        (show iprop(∃ w, ⌜vs[n]? = some w⌝ ∗ ValHasType Θ w t') ⊢
-            iprop(∃ w, ⌜(v :: vs)[n + 1]? = some w⌝ ∗ ValHasType Θ w t') by
+        (show iprop(∃ w, ⌜vs[n]? = some w⌝ ∗ ValHasType W w t') ⊢
+            iprop(∃ w, ⌜(v :: vs)[n + 1]? = some w⌝ ∗ ValHasType W w t') by
           iintro H'
           icases H' with ⟨%w, %hget, Hwitness⟩
           iexists w
@@ -904,22 +905,22 @@ theorem ValsHaveTypes.of_getElem? {Θ : TypeEnv} :
           · ipureintro
             simpa using hget
           · iexact Hwitness)
-      iapply (ValsHaveTypes.of_getElem? (Θ := Θ) (vs := vs) (ts := ts) (n := n) (t := t') h')
+      iapply (ValsHaveTypes.of_getElem? (W := W) (vs := vs) (ts := ts) (n := n) (t := t') h')
       iexact Hvs
 
 
 /-! Type preservation for primitive operations. -/
 
-theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
+theorem evalBinOp_typed {W : World} {op : BinOp}
     {v1 v2 : Runtime.Val} {t1 t2 ty : Typ}
     (hndiv : op ≠ .div) (hnmod : op ≠ .mod)
     (hty : BinOp.typeOf op t1 t2 = some ty) :
-    iprop(ValHasType Θ v1 t1 ∗ ValHasType Θ v2 t2) ⊢
-      iprop(∃ w, ⌜evalBinOp op v1 v2 = some w⌝ ∗ ValHasType Θ w ty) := by
+    iprop(ValHasType W v1 t1 ∗ ValHasType W v2 t2) ⊢
+      iprop(∃ w, ⌜evalBinOp op v1 v2 = some w⌝ ∗ ValHasType W w ty) := by
   cases op with
   | add =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_arith (by simp) hty
-      refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.int W v1).1 (ValHasType.int W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -930,10 +931,10 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.int_intro Θ (a + b)
+      · exact ValHasType.int_intro W (a + b)
   | sub =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_arith (by simp) hty
-      refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.int W v1).1 (ValHasType.int W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -944,10 +945,10 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.int_intro Θ (a - b)
+      · exact ValHasType.int_intro W (a - b)
   | mul =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_arith (by simp) hty
-      refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.int W v1).1 (ValHasType.int W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -958,14 +959,14 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.int_intro Θ (a * b)
+      · exact ValHasType.int_intro W (a * b)
   | div =>
       cases (hndiv rfl)
   | mod =>
       cases (hnmod rfl)
   | eq =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
-      refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.int W v1).1 (ValHasType.int W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -976,10 +977,10 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.bool_intro Θ (a == b)
+      · exact ValHasType.bool_intro W (a == b)
   | lt =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
-      refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.int W v1).1 (ValHasType.int W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -990,10 +991,10 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.bool_intro Θ (a < b)
+      · exact ValHasType.bool_intro W (a < b)
   | le =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
-      refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.int W v1).1 (ValHasType.int W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -1004,10 +1005,10 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.bool_intro Θ (a ≤ b)
+      · exact ValHasType.bool_intro W (a ≤ b)
   | gt =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
-      refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.int W v1).1 (ValHasType.int W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -1018,10 +1019,10 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.bool_intro Θ (a > b)
+      · exact ValHasType.bool_intro W (a > b)
   | ge =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_compare (by simp) hty
-      refine (sep_mono (ValHasType.int Θ v1).1 (ValHasType.int Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.int W v1).1 (ValHasType.int W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -1032,10 +1033,10 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.bool_intro Θ (a ≥ b)
+      · exact ValHasType.bool_intro W (a ≥ b)
   | and =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_bool (by simp) hty
-      refine (sep_mono (ValHasType.bool Θ v1).1 (ValHasType.bool Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.bool W v1).1 (ValHasType.bool W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -1046,10 +1047,10 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.bool_intro Θ (a && b)
+      · exact ValHasType.bool_intro W (a && b)
   | or =>
       obtain ⟨rfl, rfl, rfl⟩ := BinOp.typeOf_bool (by simp) hty
-      refine (sep_mono (ValHasType.bool Θ v1).1 (ValHasType.bool Θ v2).1).trans ?_
+      refine (sep_mono (ValHasType.bool W v1).1 (ValHasType.bool W v2).1).trans ?_
       iintro H
       icases H with ⟨H1, H2⟩
       icases H1 with ⟨%a, %hv1⟩
@@ -1060,17 +1061,17 @@ theorem evalBinOp_typed {Θ : TypeEnv} {op : BinOp}
       isplitr
       · ipureintro
         simp [evalBinOp]
-      · exact ValHasType.bool_intro Θ (a || b)
+      · exact ValHasType.bool_intro W (a || b)
 
-theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
+theorem evalUnOp_typed {W : World} {op : UnOp}
     {v : Runtime.Val} {t ty : Typ}
     (hty : UnOp.typeOf op t = some ty) :
-    ValHasType Θ v t ⊢
-      iprop(∃ w, ⌜evalUnOp op v = some w⌝ ∗ ValHasType Θ w ty) := by
+    ValHasType W v t ⊢
+      iprop(∃ w, ⌜evalUnOp op v = some w⌝ ∗ ValHasType W w ty) := by
   cases op with
   | neg =>
       obtain ⟨rfl, rfl⟩ := UnOp.typeOf_int rfl hty
-      refine (ValHasType.int Θ v).1.trans ?_
+      refine (ValHasType.int W v).1.trans ?_
       iintro Hv
       icases Hv with ⟨%n, %hv⟩
       subst v
@@ -1078,10 +1079,10 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
       isplitr
       · ipureintro
         simp [evalUnOp]
-      · exact ValHasType.int_intro Θ (-n)
+      · exact ValHasType.int_intro W (-n)
   | not =>
       obtain ⟨rfl, rfl⟩ := UnOp.typeOf_bool rfl hty
-      refine (ValHasType.bool Θ v).1.trans ?_
+      refine (ValHasType.bool W v).1.trans ?_
       iintro Hv
       icases Hv with ⟨%b, %hv⟩
       subst v
@@ -1089,18 +1090,18 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
       isplitr
       · ipureintro
         simp [evalUnOp]
-      · exact ValHasType.bool_intro Θ (!b)
+      · exact ValHasType.bool_intro W (!b)
   | proj n =>
       cases t with
       | tuple ts =>
           simp [UnOp.typeOf] at hty
-          refine (ValHasType.tuple Θ v ts).1.trans ?_
+          refine (ValHasType.tuple W v ts).1.trans ?_
           iintro H
           icases H with ⟨%vs, %hv, Hvs⟩
           subst v
           iapply
-            (show iprop(∃ w, ⌜vs[n]? = some w⌝ ∗ ValHasType Θ w ty) ⊢
-                iprop(∃ w, ⌜evalUnOp (.proj n) (.tuple vs) = some w⌝ ∗ ValHasType Θ w ty) by
+            (show iprop(∃ w, ⌜vs[n]? = some w⌝ ∗ ValHasType W w ty) ⊢
+                iprop(∃ w, ⌜evalUnOp (.proj n) (.tuple vs) = some w⌝ ∗ ValHasType W w ty) by
               iintro H'
               icases H' with ⟨%w, %hget, Hwitness⟩
               iexists w
@@ -1108,7 +1109,7 @@ theorem evalUnOp_typed {Θ : TypeEnv} {op : UnOp}
               · ipureintro
                 simpa [evalUnOp] using hget
               · iexact Hwitness)
-          iapply (ValsHaveTypes.of_getElem? (Θ := Θ) (vs := vs) (ts := ts) (n := n) (t := ty) hty)
+          iapply (ValsHaveTypes.of_getElem? (W := W) (vs := vs) (ts := ts) (n := n) (t := ty) hty)
           iexact Hvs
       | prim _ | sum _ | arrow _ _ | ref _ | array _ | ownedArray _ | vec _ | owned _ | empty | value | tvar _
       | named _ _ =>
@@ -1150,11 +1151,11 @@ theorem PrimitiveType.typeConstraints_wfIn {p : PrimitiveType} {t : Term .value}
 
 /-- Primitive value typing entails the generated primitive type constraints. -/
 theorem PrimitiveType.typeConstraints_hold {p : PrimitiveType} {t : Term .value} {ρ : Env}
-    {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ = v) :
-    TinyML.ValHasType Θ v (.prim p) ⊢ ⌜∀ φ ∈ p.typeConstraints t, φ.eval ρ⌝ := by
+    {W : TinyML.World} {v : Runtime.Val} (ht : t.eval ρ = v) :
+    TinyML.ValHasType W v (.prim p) ⊢ ⌜∀ φ ∈ p.typeConstraints t, φ.eval ρ⌝ := by
   cases p
   · iintro _; ipureintro; simp [PrimitiveType.typeConstraints]
-  · refine (TinyML.ValHasType.bool Θ v).1.trans ?_
+  · refine (TinyML.ValHasType.bool W v).1.trans ?_
     iintro %h
     rcases h with ⟨b, rfl⟩
     ipureintro
@@ -1162,7 +1163,7 @@ theorem PrimitiveType.typeConstraints_hold {p : PrimitiveType} {t : Term .value}
     simp [PrimitiveType.typeConstraints] at hφ
     rcases hφ with rfl
     simp [Formula.eval, ht]
-  · refine (TinyML.ValHasType.int Θ v).1.trans ?_
+  · refine (TinyML.ValHasType.int W v).1.trans ?_
     iintro %h
     rcases h with ⟨n, rfl⟩
     ipureintro
@@ -1170,7 +1171,7 @@ theorem PrimitiveType.typeConstraints_hold {p : PrimitiveType} {t : Term .value}
     simp [PrimitiveType.typeConstraints] at hφ
     rcases hφ with rfl
     simp [Formula.eval, ht]
-  · refine (TinyML.ValHasType.char Θ v).1.trans ?_
+  · refine (TinyML.ValHasType.char W v).1.trans ?_
     iintro %h
     rcases h with ⟨c, rfl⟩
     ipureintro
@@ -1178,7 +1179,7 @@ theorem PrimitiveType.typeConstraints_hold {p : PrimitiveType} {t : Term .value}
     simp [PrimitiveType.typeConstraints] at hφ
     rcases hφ with rfl
     simp [Formula.eval, ht]
-  · refine (TinyML.ValHasType.string Θ v).1.trans ?_
+  · refine (TinyML.ValHasType.string W v).1.trans ?_
     iintro %h
     rcases h with ⟨s, rfl⟩
     ipureintro
@@ -1186,7 +1187,7 @@ theorem PrimitiveType.typeConstraints_hold {p : PrimitiveType} {t : Term .value}
     simp [PrimitiveType.typeConstraints] at hφ
     rcases hφ with rfl
     simp [Formula.eval, ht]
-  · refine (TinyML.ValHasType.float Θ v).1.trans ?_
+  · refine (TinyML.ValHasType.float W v).1.trans ?_
     iintro %h
     rcases h with ⟨b, rfl⟩
     ipureintro
@@ -1333,13 +1334,13 @@ end
 mutual
   /-- If `ValHasType v ty` and `t.eval ρ = v`, then all formulas in `typeConstraints ty t` hold. -/
   theorem typeConstraints_hold {ty : TinyML.Typ} {t : Term .value} {ρ : Env}
-      {Θ : TinyML.TypeEnv} {v : Runtime.Val} (ht : t.eval ρ = v) :
-      TinyML.ValHasType Θ v ty ⊢ ⌜∀ φ ∈ typeConstraints ty t, φ.eval ρ⌝ := by
+      {W : TinyML.World} {v : Runtime.Val} (ht : t.eval ρ = v) :
+      TinyML.ValHasType W v ty ⊢ ⌜∀ φ ∈ typeConstraints ty t, φ.eval ρ⌝ := by
     cases ty with
     | prim p =>
-      simpa [typeConstraints] using PrimitiveType.typeConstraints_hold (p := p) (Θ := Θ) (v := v) ht
+      simpa [typeConstraints] using PrimitiveType.typeConstraints_hold (p := p) (W := W) (v := v) ht
     | owned inner =>
-      refine (TinyML.ValHasType.owned Θ v inner).1.trans ?_
+      refine (TinyML.ValHasType.owned W v inner).1.trans ?_
       iintro Hty
       icases Hty with ⟨%l, %hv⟩
       subst v
@@ -1349,7 +1350,7 @@ mutual
       subst hφ
       simp [Formula.eval, hv]
     | array inner =>
-      refine (TinyML.ValHasType.array Θ v inner).1.trans ?_
+      refine (TinyML.ValHasType.array W v inner).1.trans ?_
       iintro Hty
       icases Hty with ⟨%len, %l, %hv, _⟩
       ipureintro
@@ -1359,7 +1360,7 @@ mutual
       · simp [Formula.eval, Term.eval, UnOp.eval, ht, hv]
       · cases hfalse
     | ownedArray inner =>
-      refine (TinyML.ValHasType.ownedArray Θ v inner).1.trans ?_
+      refine (TinyML.ValHasType.ownedArray W v inner).1.trans ?_
       iintro Hty
       icases Hty with ⟨%len, %l, %hv⟩
       ipureintro
@@ -1369,7 +1370,7 @@ mutual
       · simp [Formula.eval, Term.eval, UnOp.eval, ht, hv]
       · cases hfalse
     | vec inner =>
-      refine (TinyML.ValHasType.vec Θ v inner).1.trans ?_
+      refine (TinyML.ValHasType.vec W v inner).1.trans ?_
       iintro Hty
       icases Hty with ⟨%vs, %hv, _⟩
       ipureintro
@@ -1380,12 +1381,12 @@ mutual
       · simp [Formula.eval, Term.eval, UnOp.eval, BinPred.eval, ht, hv]
       · cases hfalse
     | tuple ts =>
-      refine (TinyML.ValHasType.tuple Θ v ts).1.trans ?_
+      refine (TinyML.ValHasType.tuple W v ts).1.trans ?_
       iintro Hty
       icases Hty with ⟨%vs, Hty'⟩
       icases Hty' with ⟨%hv, hvs⟩
       ihave %htail := (typeConstraintsList_hold (ts := ts) (tl := .unop .toValList t)
-        (ρ := ρ) (Θ := Θ) (vs := vs) (by simp [Term.eval, UnOp.eval, ht, hv])) $$ hvs
+        (ρ := ρ) (W := W) (vs := vs) (by simp [Term.eval, UnOp.eval, ht, hv])) $$ hvs
       iclear hvs
       ipureintro
       intro φ hφ
@@ -1396,27 +1397,27 @@ mutual
         exact htail φ hφ
     | sum _ | ref _ | value | named _ _ =>
       iintro _; ipureintro; simp [typeConstraints]
-    | arrow args ret => exact (TinyML.ValHasType.arrow Θ v args ret).1.trans false_elim
-    | empty => exact (TinyML.ValHasType.empty Θ v).1.trans false_elim
-    | tvar x => exact (TinyML.ValHasType.tvar Θ v x).1.trans false_elim
+    | arrow args ret => exact (TinyML.ValHasType.arrow W v args ret).1.trans false_elim
+    | empty => exact (TinyML.ValHasType.empty W v).1.trans false_elim
+    | tvar x => exact (TinyML.ValHasType.tvar W v x).1.trans false_elim
 
   theorem typeConstraintsList_hold {ts : List TinyML.Typ} {tl : Term .vallist} {ρ : Env}
-      {Θ : TinyML.TypeEnv} {vs : List Runtime.Val} (htl : tl.eval ρ = vs) :
-      TinyML.ValsHaveTypes Θ vs ts ⊢ ⌜∀ φ ∈ typeConstraintsList ts tl, φ.eval ρ⌝ := by
+      {W : TinyML.World} {vs : List Runtime.Val} (htl : tl.eval ρ = vs) :
+      TinyML.ValsHaveTypes W vs ts ⊢ ⌜∀ φ ∈ typeConstraintsList ts tl, φ.eval ρ⌝ := by
     match vs, ts with
     | [], [] =>
-        refine (TinyML.ValsHaveTypes.nil Θ).1.trans ?_
+        refine (TinyML.ValsHaveTypes.nil W).1.trans ?_
         iintro _
         ipureintro
         simp [typeConstraintsList]
     | v :: vs, ty :: ts =>
-        refine (TinyML.ValsHaveTypes.cons Θ v vs ty ts).1.trans ?_
+        refine (TinyML.ValsHaveTypes.cons W v vs ty ts).1.trans ?_
         iintro hvals
         icases hvals with ⟨hv, hvs⟩
         ihave %hhead := (typeConstraints_hold (ty := ty) (t := .unop .vhead tl)
-          (ρ := ρ) (Θ := Θ) (v := v) (by simp [Term.eval, UnOp.eval, htl])) $$ hv
+          (ρ := ρ) (W := W) (v := v) (by simp [Term.eval, UnOp.eval, htl])) $$ hv
         ihave %htail := (typeConstraintsList_hold (ts := ts) (tl := .unop .vtail tl)
-          (ρ := ρ) (Θ := Θ) (vs := vs) (by simp [Term.eval, UnOp.eval, htl])) $$ hvs
+          (ρ := ρ) (W := W) (vs := vs) (by simp [Term.eval, UnOp.eval, htl])) $$ hvs
         iclear hv hvs
         ipureintro
         intro φ hφ
@@ -1424,23 +1425,23 @@ mutual
         | inl h => exact hhead φ h
         | inr h => exact htail φ h
     | [], ty :: ts =>
-        exact (TinyML.ValsHaveTypes.nil_cons Θ ty ts).1.trans false_elim
+        exact (TinyML.ValsHaveTypes.nil_cons W ty ts).1.trans false_elim
     | v :: vs, [] =>
-        exact (TinyML.ValsHaveTypes.cons_nil Θ v vs).1.trans false_elim
+        exact (TinyML.ValsHaveTypes.cons_nil W v vs).1.trans false_elim
 end
 
 /-- A single element type constraint holds at every in-bounds index of a
 well-typed vector snapshot. -/
 private theorem elementConstraint_hold {ty : TinyML.Typ}
-    {contents : Term .value} {ρ : Env} {Θ : TinyML.TypeEnv}
+    {contents : Term .value} {ρ : Env} {W : TinyML.World}
     {vs : List Runtime.Val} {constraint : Formula}
     (hcontents : contents.eval ρ = .vec vs)
     (hconstraint : constraint ∈ typeConstraints ty
       (.binop .vecGet (.unop .toVec contents)
         (.var .int (Fresh.freshName contents.names "i")))) :
-    TinyML.ValHasType Θ (.vec vs) (.vec ty) ⊢
+    TinyML.ValHasType W (.vec vs) (.vec ty) ⊢
       ⌜(elementConstraint contents (Fresh.freshName contents.names "i") constraint).eval ρ⌝ := by
-  refine (TinyML.ValHasType.vec Θ (.vec vs) ty).1.trans ?_
+  refine (TinyML.ValHasType.vec W (.vec vs) ty).1.trans ?_
   iintro Hvec
   icases Hvec with ⟨%ws, %hws, #Htys⟩
   have hws_eq : ws = vs := Runtime.Val.vec.inj hws.symm
@@ -1458,7 +1459,7 @@ private theorem elementConstraint_hold {ty : TinyML.Typ}
       Int.ofNat_lt.mp (hi_nat.trans_lt hbounds.2)
     have hlookup : vs[i.toNat]? = some vs[i.toNat] := List.getElem?_eq_getElem hlt
     ihave Hty :=
-      (BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType Θ w ty) hlookup) $$ Htys
+      (BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType W w ty) hlookup) $$ Htys
     have helem :
         Term.eval (ρ.updateConst .int name i)
           (.binop .vecGet (.unop .toVec contents) (.var .int name)) = vs[i.toNat] := by
@@ -1466,7 +1467,7 @@ private theorem elementConstraint_hold {ty : TinyML.Typ}
     ihave %hconstraints :=
       (typeConstraints_hold (ty := ty)
         (t := .binop .vecGet (.unop .toVec contents) (.var .int name))
-        (ρ := ρ.updateConst .int name i) (Θ := Θ) helem) $$ Hty
+        (ρ := ρ.updateConst .int name i) (W := W) helem) $$ Hty
     iclear Htys
     ipureintro
     intro _
@@ -1481,9 +1482,9 @@ private theorem elementConstraint_hold {ty : TinyML.Typ}
 /-- A well-typed vector snapshot entails the bounded solver constraints for
 all of its in-bounds elements. -/
 theorem elementConstraints_hold {ty : TinyML.Typ} {contents : Term .value}
-    {ρ : Env} {Θ : TinyML.TypeEnv} {vs : List Runtime.Val}
+    {ρ : Env} {W : TinyML.World} {vs : List Runtime.Val}
     (hcontents : contents.eval ρ = .vec vs) :
-    TinyML.ValHasType Θ (.vec vs) (.vec ty) ⊢
+    TinyML.ValHasType W (.vec vs) (.vec ty) ⊢
       ⌜∀ φ ∈ elementConstraints ty contents, φ.eval ρ⌝ := by
   iintro #Hvec
   iapply pure_forall.2
@@ -1492,7 +1493,7 @@ theorem elementConstraints_hold {ty : TinyML.Typ} {contents : Term .value}
   · simp only [elementConstraints, List.mem_map] at hφ
     obtain ⟨constraint, hconstraint, rfl⟩ := hφ
     ihave %heval :=
-      (elementConstraint_hold (Θ := Θ) hcontents hconstraint) $$ Hvec
+      (elementConstraint_hold (W := W) hcontents hconstraint) $$ Hvec
     iclear Hvec
     ipureintro
     exact fun _ => heval

--- a/Mica/SeparationLogic/LogicalRelation.lean
+++ b/Mica/SeparationLogic/LogicalRelation.lean
@@ -496,9 +496,9 @@ theorem ValHasType.empty (Θ : TypeEnv) (v : Runtime.Val) :
     ValHasType Θ v .empty ⊣⊢ iprop(False) := by
   exact equiv_iff.mp (ValHasType.unfold Θ v .empty)
 
-theorem ValHasType.arrow (Θ : TypeEnv) (v : Runtime.Val) (t1 t2 : Typ) :
-    ValHasType Θ v (.arrow t1 t2) ⊣⊢ iprop(False) := by
-  exact equiv_iff.mp (ValHasType.unfold Θ v (.arrow t1 t2))
+theorem ValHasType.arrow (Θ : TypeEnv) (v : Runtime.Val) (args : List Typ) (ret : Typ) :
+    ValHasType Θ v (.arrow args ret) ⊣⊢ iprop(False) := by
+  exact equiv_iff.mp (ValHasType.unfold Θ v (.arrow args ret))
 
 theorem ValHasType.tvar (Θ : TypeEnv) (v : Runtime.Val) (x : TyVar) :
     ValHasType Θ v (.tvar x) ⊣⊢ iprop(False) := by
@@ -1396,7 +1396,7 @@ mutual
         exact htail φ hφ
     | sum _ | ref _ | value | named _ _ =>
       iintro _; ipureintro; simp [typeConstraints]
-    | arrow t1 t2 => exact (TinyML.ValHasType.arrow Θ v t1 t2).1.trans false_elim
+    | arrow args ret => exact (TinyML.ValHasType.arrow Θ v args ret).1.trans false_elim
     | empty => exact (TinyML.ValHasType.empty Θ v).1.trans false_elim
     | tvar x => exact (TinyML.ValHasType.tvar Θ v x).1.trans false_elim
 

--- a/Mica/SeparationLogic/OUTLINE.md
+++ b/Mica/SeparationLogic/OUTLINE.md
@@ -7,4 +7,5 @@
 - `PrimitiveLaws.lean` — Spatially lifted weakest-precondition laws for TinyML primitive operations.
 - `ProofModePatterns.lean` — Worked examples of Iris proof mode patterns used in the project.
 - `SpatialAtom.lean` — Syntactic spatial atoms and contexts for verifier state, together with their well-formedness conditions and basic operations.
+- `World.lean` — The fixed meta-level world in which the logical relation interprets types.
 - `Wp.lean` — The Iris weakest precondition for TinyML and its derived proof rules, including invariant-based heap rules and primitive-call lifting.

--- a/Mica/SeparationLogic/PrimitiveLaws.lean
+++ b/Mica/SeparationLogic/PrimitiveLaws.lean
@@ -129,7 +129,7 @@ theorem wp_bind_ref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
 
 /-- Reference allocation at values. The continuation receives fresh ownership in
     the updated environment for a caller-chosen fresh value constant. -/
-theorem wp_ref (Θ : TinyML.TypeEnv) {v : Runtime.Val} {Q : Runtime.Val → iProp}
+theorem wp_ref (W : TinyML.World) {v : Runtime.Val} {Q : Runtime.Val → iProp}
     {ctx : SpatialContext} {ρ : Env} {R : iProp} {Δ : Signature}
     {vt : Term .value} {ty : TinyML.Typ} {name : String} {newctx : SpatialContext}
     (hctx : wfIn ctx Δ)
@@ -138,38 +138,38 @@ theorem wp_ref (Θ : TinyML.TypeEnv) {v : Runtime.Val} {Q : Runtime.Val → iPro
     (hfresh : name ∉ Δ.allNames)
     (hnewctx : insert (.pointsTo (.const (.uninterpreted name .value)) vt ty) ctx = newctx)
     (h : ∀ loc,
-      newctx.interp Θ (ρ.updateConst .value name (.loc loc)) ∗ R ⊢
+      newctx.interp W (ρ.updateConst .value name (.loc loc)) ∗ R ⊢
       Q (.loc loc)) :
-    ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R  ⊢ wp pctx (.ref (.val v)) Q := by
-  have hforall : ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R ⊢
+    ctx.interp W ρ ∗ TinyML.ValHasType W v ty ∗ R  ⊢ wp W.pctx (.ref (.val v)) Q := by
+  have hforall : ctx.interp W ρ ∗ TinyML.ValHasType W v ty ∗ R ⊢
       BIBase.forall fun (loc : Runtime.Location) => loc ↦ [v] -∗ Q (.loc loc) := by
     apply forall_intro
     intro loc
     apply wand_intro
-    -- goal: (ctx.interp ρ ∗ ValHasType Θ v ty ∗ R) ∗ (loc ↦ [v]) ⊢ Q (.loc loc)
+    -- goal: (ctx.interp ρ ∗ ValHasType W v ty ∗ R) ∗ (loc ↦ [v]) ⊢ Q (.loc loc)
     let ρ' := ρ.updateConst .value name (.loc loc)
     let a : SpatialAtom := .pointsTo (.const (.uninterpreted name .value)) vt ty
     have hagree : Env.agreeOn Δ ρ ρ' := Env.agreeOn_update_fresh_const (c := ⟨name, .value⟩) hfresh
-    have hctxeq : ctx.interp Θ ρ ⊢ ctx.interp Θ ρ' := by
-      exact (SpatialContext.interp_env_agree Θ hctx hagree).1
+    have hctxeq : ctx.interp W ρ ⊢ ctx.interp W ρ' := by
+      exact (SpatialContext.interp_env_agree W hctx hagree).1
     have hveq : Term.eval ρ' vt = v := by
       simpa [ρ'] using (Term.eval_update_fresh (t := vt) hvt hfresh).trans hv
     have hloc : Term.eval ρ' (.const (.uninterpreted name .value)) = .loc loc := by
       simp [ρ', Term.eval, Env.updateConst]
-    have hptIntro : loc ↦ [v] ∗ TinyML.ValHasType Θ v ty ⊢ a.interp Θ ρ' := by
+    have hptIntro : loc ↦ [v] ∗ TinyML.ValHasType W v ty ⊢ a.interp W ρ' := by
       rw [← hveq]
-      exact (SpatialAtom.interp_pointsTo Θ (ρ := ρ')
+      exact (SpatialAtom.interp_pointsTo W (ρ := ρ')
         (lt := .const (.uninterpreted name .value)) (vt := vt) (ty := ty) (loc := loc) hloc).2
-    have hinsert : ctx.interp Θ ρ ∗ (loc ↦ [v] ∗ TinyML.ValHasType Θ v ty) ⊢
-        (insert a ctx).interp Θ ρ' := by
+    have hinsert : ctx.interp W ρ ∗ (loc ↦ [v] ∗ TinyML.ValHasType W v ty) ⊢
+        (insert a ctx).interp W ρ' := by
       apply (sep_mono_left hctxeq).trans
       apply sep_comm.1.trans
       apply (sep_mono_left hptIntro).trans
       simp [a, SpatialContext.interp]
     -- rearrange the heap and type resources into the new spatial atom.
     have hrearrange :
-        (ctx.interp Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ R) ∗ (loc ↦ [v]) ⊢
-          (ctx.interp Θ ρ ∗ (loc ↦ [v] ∗ TinyML.ValHasType Θ v ty)) ∗ R := by
+        (ctx.interp W ρ ∗ TinyML.ValHasType W v ty ∗ R) ∗ (loc ↦ [v]) ⊢
+          (ctx.interp W ρ ∗ (loc ↦ [v] ∗ TinyML.ValHasType W v ty)) ∗ R := by
       istart
       iintro ⟨⟨Hctx, Hty, HR⟩, Hpt⟩
       isplitl [Hctx Hpt Hty]
@@ -198,22 +198,22 @@ theorem wp_bind_deref {e : Runtime.Expr} {Q : Runtime.Val → iProp}
     The pure premises identify the runtime value `v` with the location named
     by `lt`, and the continuation premise `h` works with the remaining
     context. -/
-theorem wp_deref (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
+theorem wp_deref (W : TinyML.World) {Q : Runtime.Val → iProp}
     {ctx : SpatialContext} {ρ : Env} {R : iProp}
     {n : Nat} {lt vt : Term .value} {ty : TinyML.Typ} {rest : SpatialContext}
     {v : Runtime.Val} {loc : Runtime.Location}
-    (h : ctx.interp Θ ρ ∗ R ⊢ Q (Term.eval ρ vt)) :
+    (h : ctx.interp W ρ ∗ R ⊢ Q (Term.eval ρ vt)) :
     remove ctx n = some (.pointsTo lt vt ty, rest) →
     Term.eval ρ lt = v →
     v = .loc loc →
-    ctx.interp Θ ρ ∗ R ⊢ wp pctx (.deref (.val v)) Q := by
+    ctx.interp W ρ ∗ R ⊢ wp W.pctx (.deref (.val v)) Q := by
   intro hrem hlt hv
   subst hv
   -- Split the context and rewrite the selected atom to a raw points-to fact.
-  have hsplit : ctx.interp Θ ρ ⊢
-      (loc ↦ [Term.eval ρ vt] ∗ TinyML.ValHasType Θ (Term.eval ρ vt) ty) ∗
-        rest.interp Θ ρ :=
-    (interp_remove Θ ρ ctx n _ _ hrem).1 |>.trans (sep_mono_left (SpatialAtom.interp_pointsTo Θ hlt).1)
+  have hsplit : ctx.interp W ρ ⊢
+      (loc ↦ [Term.eval ρ vt] ∗ TinyML.ValHasType W (Term.eval ρ vt) ty) ∗
+        rest.interp W ρ :=
+    (interp_remove W ρ ctx n _ _ hrem).1 |>.trans (sep_mono_left (SpatialAtom.interp_pointsTo W hlt).1)
   -- Rebuild the original context inside the wand, since reading preserves it.
   apply (sep_mono_left hsplit).trans
   istart
@@ -223,12 +223,12 @@ theorem wp_deref (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
   · iexact Hpt
   · iintro Hpt
     have hctx :
-        (loc ↦ [Term.eval ρ vt] ∗ TinyML.ValHasType Θ (Term.eval ρ vt) ty) ∗
-          rest.interp Θ ρ ⊢ ctx.interp Θ ρ :=
-      (sep_mono_left (SpatialAtom.interp_pointsTo Θ hlt).2).trans (interp_remove Θ ρ ctx n _ _ hrem).2
+        (loc ↦ [Term.eval ρ vt] ∗ TinyML.ValHasType W (Term.eval ρ vt) ty) ∗
+          rest.interp W ρ ⊢ ctx.interp W ρ :=
+      (sep_mono_left (SpatialAtom.interp_pointsTo W hlt).2).trans (interp_remove W ρ ctx n _ _ hrem).2
     have hq :
-        (loc ↦ [Term.eval ρ vt] ∗ TinyML.ValHasType Θ (Term.eval ρ vt) ty) ∗
-          rest.interp Θ ρ ∗ R ⊢ Q (Term.eval ρ vt) :=
+        (loc ↦ [Term.eval ρ vt] ∗ TinyML.ValHasType W (Term.eval ρ vt) ty) ∗
+          rest.interp W ρ ∗ R ⊢ Q (Term.eval ρ vt) :=
       sep_assoc.2.trans ((sep_mono_left hctx).trans h)
     iapply hq
     isplitl [Hpt Hty]
@@ -326,22 +326,22 @@ theorem wp_bind_arrayGet {arr idx : Runtime.Expr} {Q : Runtime.Val → iProp}
     preserved, while the continuation receives the element typing fact. The
     array and index values are generic; their runtime shapes are recovered from
     the value-typing assumptions. -/
-theorem wp_arrayGet_inv (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
+theorem wp_arrayGet_inv (W : TinyML.World) {Q : Runtime.Val → iProp}
     {ctx : SpatialContext} {ρ : Env} {R : iProp}
     {arr idx : Term .value} {elemTy : TinyML.Typ}
     {varr vidx : Runtime.Val}
     (harr : Term.eval ρ arr = varr) (hidx : Term.eval ρ idx = vidx)
     (hi : 0 ≤ Term.eval ρ (.unop .toInt idx))
     (hlt : Term.eval ρ (.unop .toInt idx) < Term.eval ρ (.unop .arrayLengthOf arr))
-    (h : ∀ w, ctx.interp Θ ρ ∗ TinyML.ValHasType Θ w elemTy ∗ R ⊢ Q w) :
-    ctx.interp Θ ρ ∗ TinyML.ValHasType Θ varr (.array elemTy) ∗
-      TinyML.ValHasType Θ vidx .int ∗ R ⊢
-    wp pctx (.arrayGet (.val varr) (.val vidx)) Q := by
+    (h : ∀ w, ctx.interp W ρ ∗ TinyML.ValHasType W w elemTy ∗ R ⊢ Q w) :
+    ctx.interp W ρ ∗ TinyML.ValHasType W varr (.array elemTy) ∗
+      TinyML.ValHasType W vidx .int ∗ R ⊢
+    wp W.pctx (.arrayGet (.val varr) (.val vidx)) Q := by
   istart
   iintro ⟨Hctx, Harr, #Hidx, HR⟩
-  ihave Harr' := (TinyML.ValHasType.array Θ varr elemTy).1 $$ Harr
+  ihave Harr' := (TinyML.ValHasType.array W varr elemTy).1 $$ Harr
   icases Harr' with ⟨%len, %loc, %hv_arr, #Hinv⟩
-  ihave Hidx' := (TinyML.ValHasType.int Θ vidx).1 $$ Hidx
+  ihave Hidx' := (TinyML.ValHasType.int W vidx).1 $$ Hidx
   icases Hidx' with ⟨%i, %hv_idx⟩
   have hi' : 0 ≤ i := by
     simpa [Term.eval, UnOp.eval, hidx, hv_idx] using hi
@@ -351,7 +351,7 @@ theorem wp_arrayGet_inv (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     omega
   subst hv_arr
   subst hv_idx
-  iapply (wp.arrayGet_inv (I := fun w => TinyML.ValHasType Θ w elemTy) hi' hlt')
+  iapply (wp.arrayGet_inv (I := fun w => TinyML.ValHasType W w elemTy) hi' hlt')
   isplitl []
   · iexact Hinv
   · iintro %w #Hw
@@ -364,7 +364,7 @@ theorem wp_arrayGet_inv (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
 
 /-- `Array.get` through an owned-array atom: consume the atom, read the
 selected element, and restore the unchanged snapshot. -/
-theorem wp_arrayGet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
+theorem wp_arrayGet_owned (W : TinyML.World) {Q : Runtime.Val → iProp}
     {ρ : Env} {R : iProp}
     {arr contents idx result : Term .value} {elemTy : TinyML.Typ}
     {rest : SpatialContext} {varr vidx : Runtime.Val}
@@ -372,33 +372,33 @@ theorem wp_arrayGet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     (hi : 0 ≤ Term.eval ρ (.unop .toInt idx))
     (hlt : Term.eval ρ (.unop .toInt idx) < Term.eval ρ (.unop .arrayLengthOf arr))
     (hresult : result = .binop .vecGet (.unop .toVec contents) (.unop .toInt idx))
-    (h : (insert (.arrayPointsTo arr contents elemTy) rest).interp Θ ρ ∗
-      TinyML.ValHasType Θ (Term.eval ρ result) elemTy ∗ R ⊢ Q (Term.eval ρ result)) :
-    SpatialAtom.interp Θ ρ (.arrayPointsTo arr contents elemTy) ∗ rest.interp Θ ρ ∗
-      TinyML.ValHasType Θ varr (.ownedArray elemTy) ∗
-      TinyML.ValHasType Θ vidx .int ∗ R ⊢
-      wp pctx (.arrayGet (.val varr) (.val vidx)) Q := by
+    (h : (insert (.arrayPointsTo arr contents elemTy) rest).interp W ρ ∗
+      TinyML.ValHasType W (Term.eval ρ result) elemTy ∗ R ⊢ Q (Term.eval ρ result)) :
+    SpatialAtom.interp W ρ (.arrayPointsTo arr contents elemTy) ∗ rest.interp W ρ ∗
+      TinyML.ValHasType W varr (.ownedArray elemTy) ∗
+      TinyML.ValHasType W vidx .int ∗ R ⊢
+      wp W.pctx (.arrayGet (.val varr) (.val vidx)) Q := by
   istart
   iintro ⟨Hatom, Hrest, _HarrTy, HidxTy, HR⟩
-  ihave Hacc := (SpatialAtom.interp_arrayPointsTo_lookup Θ hidx hi hlt) $$ Hatom
+  ihave Hacc := (SpatialAtom.interp_arrayPointsTo_lookup W hidx hi hlt) $$ Hatom
   ispecialize Hacc $$ HidxTy
   icases Hacc with ⟨%loc, %vs, %i, %ha, %hv, %hvidx, %hi', %hlt', Hpt, #HvecTy⟩
   have hvarr : varr = .array vs.length loc := harr ▸ ha
   subst hvarr
   subst hvidx
   have hraw : iprop(loc ↦ vs ∗ (loc ↦ vs -∗ Q vs[i.toNat])) ⊢
-      wp pctx (.arrayGet (.val (.array vs.length loc)) (.val (.int i))) Q :=
+      wp W.pctx (.arrayGet (.val (.array vs.length loc)) (.val (.int i))) Q :=
     wp.arrayGet hi' hlt' rfl BIBase.Entails.rfl
   iapply hraw
   isplitl [Hpt]
   · iexact Hpt
   · iintro HptNew
     have hlookup : vs[i.toNat]? = some vs[i.toNat] := List.getElem?_eq_getElem hlt'
-    ihave Helem := (TinyML.ValHasType.vec Θ (.vec vs) elemTy).1 $$ HvecTy
+    ihave Helem := (TinyML.ValHasType.vec W (.vec vs) elemTy).1 $$ HvecTy
     icases Helem with ⟨%ws, %hws, Htys⟩
     have hws_eq : ws = vs := Runtime.Val.vec.inj hws.symm
     subst ws
-    ihave Hty := (BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType Θ w elemTy) hlookup) $$ Htys
+    ihave Hty := (BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType W w elemTy) hlookup) $$ Htys
     have hresult_eval : Term.eval ρ result = vs[i.toNat] := by
       subst hresult
       simp [Term.eval, UnOp.eval, BinOp.eval, hv, hidx, hi', hlookup]
@@ -407,7 +407,7 @@ theorem wp_arrayGet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     isplitl [HptNew HvecTy Hrest]
     · simp only [SpatialContext.interp]
       isplitr [Hrest]
-      · iapply (SpatialAtom.interp_arrayPointsTo Θ ha hv).2
+      · iapply (SpatialAtom.interp_arrayPointsTo W ha hv).2
         isplitl [HptNew]
         · iexact HptNew
         · iexact HvecTy
@@ -444,22 +444,22 @@ theorem wp_bind_arraySet {arr idx val : Runtime.Expr} {Q : Runtime.Val → iProp
     preserved, while the new element typing fact is used to restore the array
     invariant. The array and index values are generic; their runtime shapes are
     recovered from the value-typing assumptions. -/
-theorem wp_arraySet_inv (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
+theorem wp_arraySet_inv (W : TinyML.World) {Q : Runtime.Val → iProp}
     {ctx : SpatialContext} {ρ : Env} {R : iProp}
     {arr idx : Term .value} {elemTy : TinyML.Typ}
     {varr vidx val : Runtime.Val}
     (harr : Term.eval ρ arr = varr) (hidx : Term.eval ρ idx = vidx)
     (hi : 0 ≤ Term.eval ρ (.unop .toInt idx))
     (hlt : Term.eval ρ (.unop .toInt idx) < Term.eval ρ (.unop .arrayLengthOf arr))
-    (h : ctx.interp Θ ρ ∗ TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Q .unit) :
-    ctx.interp Θ ρ ∗ TinyML.ValHasType Θ varr (.array elemTy) ∗
-      TinyML.ValHasType Θ vidx .int ∗ TinyML.ValHasType Θ val elemTy ∗ R ⊢
-    wp pctx (.arraySet (.val varr) (.val vidx) (.val val)) Q := by
+    (h : ctx.interp W ρ ∗ TinyML.ValHasType W .unit .unit ∗ R ⊢ Q .unit) :
+    ctx.interp W ρ ∗ TinyML.ValHasType W varr (.array elemTy) ∗
+      TinyML.ValHasType W vidx .int ∗ TinyML.ValHasType W val elemTy ∗ R ⊢
+    wp W.pctx (.arraySet (.val varr) (.val vidx) (.val val)) Q := by
   istart
   iintro ⟨Hctx, Harr, #Hidx, #Hval, HR⟩
-  ihave Harr' := (TinyML.ValHasType.array Θ varr elemTy).1 $$ Harr
+  ihave Harr' := (TinyML.ValHasType.array W varr elemTy).1 $$ Harr
   icases Harr' with ⟨%len, %loc, %hv_arr, #Hinv⟩
-  ihave Hidx' := (TinyML.ValHasType.int Θ vidx).1 $$ Hidx
+  ihave Hidx' := (TinyML.ValHasType.int W vidx).1 $$ Hidx
   icases Hidx' with ⟨%i, %hv_idx⟩
   have hi' : 0 ≤ i := by
     simpa [Term.eval, UnOp.eval, hidx, hv_idx] using hi
@@ -469,7 +469,7 @@ theorem wp_arraySet_inv (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     omega
   subst hv_arr
   subst hv_idx
-  iapply (wp.arraySet_inv (I := fun w => TinyML.ValHasType Θ w elemTy) hi' hlt')
+  iapply (wp.arraySet_inv (I := fun w => TinyML.ValHasType W w elemTy) hi' hlt')
   isplitl []
   · iexact Hinv
   · isplitl []
@@ -484,7 +484,7 @@ theorem wp_arraySet_inv (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
 
 /-- `Array.set` through an owned-array atom: consume the old snapshot and
 restore ownership with the selected element updated. -/
-theorem wp_arraySet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
+theorem wp_arraySet_owned (W : TinyML.World) {Q : Runtime.Val → iProp}
     {ρ : Env} {R : iProp}
     {arr contents contents' idx val : Term .value} {elemTy : TinyML.Typ}
     {rest : SpatialContext} {varr vidx vval : Runtime.Val}
@@ -494,35 +494,35 @@ theorem wp_arraySet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     (hlt : Term.eval ρ (.unop .toInt idx) < Term.eval ρ (.unop .arrayLengthOf arr))
     (hcontents' : contents' = .unop .ofVec
       (.terop .vecSet (.unop .toVec contents) (.unop .toInt idx) val))
-    (h : (insert (.arrayPointsTo arr contents' elemTy) rest).interp Θ ρ ∗
-      TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Q .unit) :
-    SpatialAtom.interp Θ ρ (.arrayPointsTo arr contents elemTy) ∗ rest.interp Θ ρ ∗
-      TinyML.ValHasType Θ varr (.ownedArray elemTy) ∗
-      TinyML.ValHasType Θ vidx .int ∗ TinyML.ValHasType Θ vval elemTy ∗ R ⊢
-      wp pctx (.arraySet (.val varr) (.val vidx) (.val vval)) Q := by
+    (h : (insert (.arrayPointsTo arr contents' elemTy) rest).interp W ρ ∗
+      TinyML.ValHasType W .unit .unit ∗ R ⊢ Q .unit) :
+    SpatialAtom.interp W ρ (.arrayPointsTo arr contents elemTy) ∗ rest.interp W ρ ∗
+      TinyML.ValHasType W varr (.ownedArray elemTy) ∗
+      TinyML.ValHasType W vidx .int ∗ TinyML.ValHasType W vval elemTy ∗ R ⊢
+      wp W.pctx (.arraySet (.val varr) (.val vidx) (.val vval)) Q := by
   istart
   iintro ⟨Hatom, Hrest, _HarrTy, HidxTy, #HvalTy, HR⟩
-  ihave Hacc := (SpatialAtom.interp_arrayPointsTo_lookup Θ hidx hi hlt) $$ Hatom
+  ihave Hacc := (SpatialAtom.interp_arrayPointsTo_lookup W hidx hi hlt) $$ Hatom
   ispecialize Hacc $$ HidxTy
   icases Hacc with ⟨%loc, %vs, %i, %ha, %hv, %hvidx, %hi', %hlt', Hpt, #HvecTy⟩
   have hvarr : varr = .array vs.length loc := harr ▸ ha
   subst hvarr
   subst hvidx
   have hraw : iprop(loc ↦ vs ∗ (loc ↦ vs.set i.toNat vval -∗ Q .unit)) ⊢
-      wp pctx (.arraySet (.val (.array vs.length loc)) (.val (.int i)) (.val vval)) Q :=
+      wp W.pctx (.arraySet (.val (.array vs.length loc)) (.val (.int i)) (.val vval)) Q :=
     wp.arraySet hi' hlt' rfl BIBase.Entails.rfl
   iapply hraw
   isplitl [Hpt]
   · iexact Hpt
   · iintro HptNew
     have hlookup : vs[i.toNat]? = some vs[i.toNat] := List.getElem?_eq_getElem hlt'
-    ihave Hvec := (TinyML.ValHasType.vec Θ (.vec vs) elemTy).1 $$ HvecTy
+    ihave Hvec := (TinyML.ValHasType.vec W (.vec vs) elemTy).1 $$ HvecTy
     icases Hvec with ⟨%ws, %hws, Htys⟩
     have hws_eq : ws = vs := Runtime.Val.vec.inj hws.symm
     subst ws
-    ihave HvecTyNew : iprop(TinyML.ValHasType Θ (.vec (vs.set i.toNat vval)) (.vec elemTy))
+    ihave HvecTyNew : iprop(TinyML.ValHasType W (.vec (vs.set i.toNat vval)) (.vec elemTy))
         $$ [Htys HvalTy]
-    · iapply (TinyML.ValHasType.vec_set Θ hlookup)
+    · iapply (TinyML.ValHasType.vec_set W hlookup)
       isplitl [Htys]
       · iexact Htys
       · iexact HvalTy
@@ -533,7 +533,7 @@ theorem wp_arraySet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
     isplitl [HptNew HvecTyNew Hrest]
     · simp only [SpatialContext.interp]
       isplitr [Hrest]
-      · iapply (SpatialAtom.interp_arrayPointsTo Θ (by simpa using ha) hcontents'_eval).2
+      · iapply (SpatialAtom.interp_arrayPointsTo W (by simpa using ha) hcontents'_eval).2
         isplitl [HptNew]
         · iexact HptNew
         · iexact HvecTyNew
@@ -543,23 +543,23 @@ theorem wp_arraySet_owned (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
       · iexact HR
 
 /-- Store at values: replace the selected points-to atom with the updated one. -/
-theorem wp_store (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
+theorem wp_store (W : TinyML.World) {Q : Runtime.Val → iProp}
     {ctx : SpatialContext} {ρ : Env} {R : iProp}
     {n : Nat} {lt vt_old vt_new : Term .value} {ty : TinyML.Typ} {rest : SpatialContext}
     {vloc vnew : Runtime.Val} {loc : Runtime.Location}
-    (h : (insert (.pointsTo lt vt_new ty) rest).interp Θ ρ ∗ R ⊢ Q .unit) :
+    (h : (insert (.pointsTo lt vt_new ty) rest).interp W ρ ∗ R ⊢ Q .unit) :
     remove ctx n = some (.pointsTo lt vt_old ty, rest) →
     Term.eval ρ lt = vloc →
     vloc = .loc loc →
     Term.eval ρ vt_new = vnew →
-    ctx.interp Θ ρ ∗ TinyML.ValHasType Θ vnew ty ∗ R ⊢
-      wp pctx (.store (.val vloc) (.val vnew)) Q := by
+    ctx.interp W ρ ∗ TinyML.ValHasType W vnew ty ∗ R ⊢
+      wp W.pctx (.store (.val vloc) (.val vnew)) Q := by
   intro hrem hlt hvloc hvnew
   subst hvloc
-  have hsplit : ctx.interp Θ ρ ⊢
-      (loc ↦ [Term.eval ρ vt_old] ∗ TinyML.ValHasType Θ (Term.eval ρ vt_old) ty) ∗
-        rest.interp Θ ρ :=
-    (interp_remove Θ ρ ctx n _ _ hrem).1 |>.trans (sep_mono_left (SpatialAtom.interp_pointsTo Θ hlt).1)
+  have hsplit : ctx.interp W ρ ⊢
+      (loc ↦ [Term.eval ρ vt_old] ∗ TinyML.ValHasType W (Term.eval ρ vt_old) ty) ∗
+        rest.interp W ρ :=
+    (interp_remove W ρ ctx n _ _ hrem).1 |>.trans (sep_mono_left (SpatialAtom.interp_pointsTo W hlt).1)
   apply (sep_mono_left hsplit).trans
   istart
   iintro ⟨⟨⟨Hold, _HoldTy⟩, Hrest⟩, HnewTy, HR⟩
@@ -567,14 +567,14 @@ theorem wp_store (Θ : TinyML.TypeEnv) {Q : Runtime.Val → iProp}
   isplitl [Hold]
   · iexact Hold
   · iintro Hnew
-    have hnew : loc ↦ [vnew] ∗ TinyML.ValHasType Θ vnew ty ⊢
-        SpatialAtom.interp Θ ρ (.pointsTo lt vt_new ty) := by
+    have hnew : loc ↦ [vnew] ∗ TinyML.ValHasType W vnew ty ⊢
+        SpatialAtom.interp W ρ (.pointsTo lt vt_new ty) := by
       rw [← hvnew]
-      exact (SpatialAtom.interp_pointsTo Θ hlt).2
-    have hctx : (loc ↦ [vnew] ∗ TinyML.ValHasType Θ vnew ty) ∗ rest.interp Θ ρ ⊢
-        (insert (.pointsTo lt vt_new ty) rest).interp Θ ρ := by
+      exact (SpatialAtom.interp_pointsTo W hlt).2
+    have hctx : (loc ↦ [vnew] ∗ TinyML.ValHasType W vnew ty) ∗ rest.interp W ρ ⊢
+        (insert (.pointsTo lt vt_new ty) rest).interp W ρ := by
       simpa [insert, interp] using (sep_mono_left hnew)
-    have hq : (loc ↦ [vnew] ∗ TinyML.ValHasType Θ vnew ty) ∗ rest.interp Θ ρ ∗ R ⊢ Q .unit :=
+    have hq : (loc ↦ [vnew] ∗ TinyML.ValHasType W vnew ty) ∗ rest.interp W ρ ∗ R ⊢ Q .unit :=
       sep_assoc.2.trans ((sep_mono_left hctx).trans h)
     iapply hq
     isplitl [Hnew HnewTy]

--- a/Mica/SeparationLogic/SpatialAtom.lean
+++ b/Mica/SeparationLogic/SpatialAtom.lean
@@ -95,22 +95,22 @@ theorem wfIn_mono {a : SpatialAtom} {Δ Δ' : Signature}
   | arrayPointsTo a v _ => exact ⟨Term.wfIn_mono a h.1 hsub hwf, Term.wfIn_mono v h.2 hsub hwf⟩
 
 /-- Iris interpretation of a single spatial atom. -/
-def interp [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (ρ : Env) :
+def interp [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (ρ : Env) :
     SpatialAtom → iProp
   | .pointsTo l v ty => ∃ (loc : Runtime.Location),
       ⌜Term.eval ρ l = .loc loc⌝ ∗ loc ↦ [Term.eval ρ v] ∗
-        TinyML.ValHasType Θ (Term.eval ρ v) ty
+        TinyML.ValHasType W (Term.eval ρ v) ty
   | .arrayPointsTo a v ty => ∃ (loc : Runtime.Location) (vs : List Runtime.Val),
       ⌜Term.eval ρ a = .array vs.length loc⌝ ∗
       ⌜Term.eval ρ v = .vec vs⌝ ∗ loc ↦ vs ∗
-        TinyML.ValHasType Θ (.vec vs) (.vec ty)
+        TinyML.ValHasType W (.vec vs) (.vec ty)
 
 /-- Congruence of interpretation in the key and value terms, at equal evaluation. -/
-theorem congr [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) {ρ : Env} {k : Kind}
+theorem congr [MicaGS HasLC.hasLC Sig] (W : TinyML.World) {ρ : Env} {k : Kind}
     {t t' v v' : Term .value} {ty : TinyML.Typ}
     (ht : Term.eval ρ t = Term.eval ρ t')
     (hv : Term.eval ρ v = Term.eval ρ v') :
-    interp Θ ρ (k.atom t v ty) ⊣⊢ interp Θ ρ (k.atom t' v' ty) := by
+    interp W ρ (k.atom t v ty) ⊣⊢ interp W ρ (k.atom t' v' ty) := by
   cases k <;> simp only [Kind.atom, interp, ht, hv] <;>
     exact ⟨BIBase.Entails.rfl, BIBase.Entails.rfl⟩
 

--- a/Mica/SeparationLogic/World.lean
+++ b/Mica/SeparationLogic/World.lean
@@ -1,0 +1,17 @@
+-- SUMMARY: The fixed meta-level world in which the logical relation interprets types.
+import Mica.TinyML.Types
+import Mica.TinyML.OpSem
+
+namespace TinyML
+
+/-- The fixed model in which the logical relation interprets types: the
+    primitive-operational context its weakest preconditions are taken in, and
+    the type environment unfolding named types.
+
+    A world appears only in semantic definitions and correctness theorems;
+    executable verifier definitions never receive one. -/
+structure World where
+  pctx : PrimCtx
+  Θ    : TypeEnv
+
+end TinyML

--- a/Mica/SeparationLogic/World.lean
+++ b/Mica/SeparationLogic/World.lean
@@ -1,17 +1,51 @@
 -- SUMMARY: The fixed meta-level world in which the logical relation interprets types.
 import Mica.TinyML.Types
 import Mica.TinyML.OpSem
+import Mica.FOL.Variables
 
 namespace TinyML
 
-/-- The fixed model in which the logical relation interprets types: the
-    primitive-operational context its weakest preconditions are taken in, and
-    the type environment unfolding named types.
+/-- The fixed model in which the logical relation interprets types and
+    specifications: the primitive-operational context its weakest preconditions
+    are taken in, the type environment unfolding named types, and the FOL
+    signature and environment specifications are interpreted against.
+
+    `Δ_spec`/`ρ_spec` are fixed, unlike the verifier's own growing `st.decls`
+    and `ρ`; correctness maintains `W.agrees st.decls ρ.env` (see `World.agrees`).
 
     A world appears only in semantic definitions and correctness theorems;
     executable verifier definitions never receive one. -/
 structure World where
-  pctx : PrimCtx
-  Θ    : TypeEnv
+  pctx   : PrimCtx
+  Θ      : TypeEnv
+  Δ_spec : Signature
+  ρ_spec : Env
+
+set_option linter.dupNamespace false in
+/-- The world's specification signature is well-formed and closed: its names are
+    distinct and it declares no variables. These conditions are fixed with the
+    world, independent of the verifier's growing state. -/
+structure World.wf (W : World) : Prop where
+  /-- The spec signature's names are distinct. -/
+  wf : W.Δ_spec.wf
+  /-- The spec signature declares no variables. -/
+  vars : W.Δ_spec.vars = []
+
+/-- The world agrees with a verifier signature `Δ` and environment `ρ`: the
+    fixed spec signature is a subset of `Δ`, and the fixed spec environment
+    agrees with `ρ` on it. -/
+structure World.agrees (W : World) (Δ : Signature) (ρ : Env) : Prop where
+  /-- The fixed spec signature is contained in `Δ`. -/
+  subset : W.Δ_spec.Subset Δ
+  /-- The fixed spec environment agrees with `ρ` on the spec signature. -/
+  agree : Env.agreeOn W.Δ_spec W.ρ_spec ρ
+
+/-- Agreement is preserved as the verifier signature and environment grow: from
+    a signature step `Δ.Subset Δ'` and an environment step agreeing on `Δ`. -/
+theorem World.agrees.step {W : World} {Δ Δ' : Signature} {ρ ρ' : Env}
+    (hag : W.agrees Δ ρ) (hΔ : Δ.Subset Δ') (hρ : Env.agreeOn Δ ρ ρ') :
+    W.agrees Δ' ρ' where
+  subset := hag.subset.trans hΔ
+  agree := Env.agreeOn_trans hag.agree (Env.agreeOn_mono hag.subset hρ)
 
 end TinyML

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -356,9 +356,9 @@ def matchType (inst : List (TinyML.TyVar × TinyML.Typ))
     match pattern, actual with
     | .tvar v, t => .ok (if inst.lookup v |>.isSome then inst else (v, t) :: inst)
     | .sum ps, .sum ts => matchTypes inst ps ts
-    | .arrow p₁ p₂, .arrow t₁ t₂ => do
-        let inst ← matchType inst p₁ t₁
-        matchType inst p₂ t₂
+    | .arrow ps p, .arrow ts t => do
+        let inst ← matchTypes inst ps ts
+        matchType inst p t
     | .ref p, .ref t | .array p, .array t | .vec p, .vec t | .owned p, .owned t =>
         matchType inst p t
     | .tuple ps, .tuple ts => matchTypes inst ps ts

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -16,10 +16,10 @@ namespace Intrinsics
 
 /-- Apply a `.ret (s, .assert φ ...)` spec at a value, discharging the asserted
     `φ` as a pure side condition. -/
-theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
+theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runtime.Val → iProp)
     (s : String) (ρ : VerifM.Env) (φ : Formula) (v : Runtime.Val)
     (hφ : φ.eval (ρ.updateConst .value s v).env) :
-    PredTrans.apply Θ Φ (.ret (s, .assert φ (.ret ()))) ρ ⊢ Φ v := by
+    PredTrans.apply W Φ (.ret (s, .assert φ (.ret ()))) ρ ⊢ Φ v := by
   simp only [PredTrans.apply, Assertion.pre, Assertion.post]
   refine (forall_elim v).trans ?_
   iintro Hw
@@ -36,10 +36,10 @@ def withPre : Option Formula → PredTrans → PredTrans
 
 /-- Eliminate `withPre`: applying the wrapped predicate yields the precondition
     as a pure fact (vacuous for `none`) alongside the unwrapped application. -/
-theorem withPre_apply [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp)
+theorem withPre_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runtime.Val → iProp)
     (pre : Option Formula) (post : PredTrans) (ρ : VerifM.Env) :
-    PredTrans.apply Θ Φ (withPre pre post) ρ ⊢
-      iprop(⌜∀ φ, pre = some φ → φ.eval ρ.env⌝ ∗ PredTrans.apply Θ Φ post ρ) := by
+    PredTrans.apply W Φ (withPre pre post) ρ ⊢
+      iprop(⌜∀ φ, pre = some φ → φ.eval ρ.env⌝ ∗ PredTrans.apply W Φ post ρ) := by
   cases pre with
   | none =>
     simp only [withPre]
@@ -56,10 +56,10 @@ theorem withPre_apply [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv) (Φ : Runti
 
 /-- A length-mismatched argument list makes the typing premise inconsistent, so
     it entails anything. -/
-theorem valsHaveTypes_off_shape [MicaGS HasLC.hasLC Sig] {Θ : TinyML.TypeEnv}
+theorem valsHaveTypes_off_shape [MicaGS HasLC.hasLC Sig] {W : TinyML.World}
     {vs : List Runtime.Val} {tys : List TinyML.Typ} (P : iProp)
     (hlen : vs.length ≠ tys.length) :
-    TinyML.ValsHaveTypes Θ vs tys ⊢ P := by
+    TinyML.ValsHaveTypes W vs tys ⊢ P := by
   refine TinyML.ValsHaveTypes.length_eq.trans ?_
   iintro %h
   simp at h; omega
@@ -135,7 +135,7 @@ structure Embedding where
   inject   : carrier → Runtime.Val
   project  : Runtime.Val → carrier
   typePred : ∀ [MicaGS.{0} HasLC.hasLC Sig],
-              (TinyML.TyVar → TinyML.Typ) → TinyML.TypeEnv → carrier → iProp
+              (TinyML.TyVar → TinyML.Typ) → TinyML.World → carrier → iProp
   isOf     : Option (UnPred .value)
 
 /-- Integer projection of a runtime value, matching FOL's `toInt`. -/
@@ -189,12 +189,12 @@ def Embedding.float : Embedding :=
     type axiom. -/
 def Embedding.poly (v : TinyML.TyVar) : Embedding :=
   ⟨.tvar v, Runtime.Val, id, id,
-    fun σ Θ w => TinyML.ValHasType Θ w (σ v), none⟩
+    fun σ W w => TinyML.ValHasType W w (σ v), none⟩
 
 /-- An arbitrary type scheme represented by the runtime value itself. -/
 def Embedding.logical (typ : TinyML.Typ) : Embedding :=
   ⟨typ, Runtime.Val, id, id,
-    fun σ Θ w => TinyML.ValHasType Θ w (typ.subst σ), none⟩
+    fun σ W w => TinyML.ValHasType W w (typ.subst σ), none⟩
 
 /-- The empty type: no closed values inhabit it. Trivial `Unit` carrier with a
     `False` type predicate, so only an intrinsic with an unsatisfiable domain
@@ -206,7 +206,7 @@ def Embedding.empty : Embedding :=
     instantiated element typings as the type predicate. -/
 def Embedding.vec (elem : TinyML.Typ) : Embedding :=
   ⟨.vec elem, List Runtime.Val, .vec, valVec,
-    fun σ Θ l => iprop([∗list] w ∈ l, TinyML.ValHasType Θ w (elem.subst σ)),
+    fun σ W l => iprop([∗list] w ∈ l, TinyML.ValHasType W w (elem.subst σ)),
     some .isVec⟩
 
 /-- Coherence laws for an `Embedding`. The `member`/`intro` laws are stated at
@@ -217,12 +217,12 @@ structure Embedding.Lawful (e : Embedding) where
   isOf_inject    : ∀ (ρ : Env) (x : e.carrier) p, e.isOf = some p →
                      UnPred.eval ρ p (e.inject x)
   member         : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
-                     (Θ : TinyML.TypeEnv) (w : Runtime.Val),
-                     TinyML.ValHasType Θ w (e.typ.subst σ) ⊣⊢
-                       iprop(∃ x, ⌜w = e.inject x⌝ ∗ e.typePred σ Θ x)
+                     (W : TinyML.World) (w : Runtime.Val),
+                     TinyML.ValHasType W w (e.typ.subst σ) ⊣⊢
+                       iprop(∃ x, ⌜w = e.inject x⌝ ∗ e.typePred σ W x)
   intro          : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
-                     (Θ : TinyML.TypeEnv) (x : e.carrier),
-                     e.typePred σ Θ x ⊢ TinyML.ValHasType Θ (e.inject x) (e.typ.subst σ)
+                     (W : TinyML.World) (x : e.carrier),
+                     e.typePred σ W x ⊢ TinyML.ValHasType W (e.inject x) (e.typ.subst σ)
 
 /-- Lift the pure membership fact of an embedding with trivial type predicate
     to the predicate-carrying `member` shape (`∗ emp` under the existential). -/
@@ -235,52 +235,52 @@ def Embedding.lawfulInt : Embedding.int.Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := by cases h; trivial
   isOf_inject _ _ _ h := by cases h; simp [Embedding.int]
-  member _ Θ w := pure_member (φ := fun x => w = .int x)
-    (by simpa [Embedding.int, TinyML.Typ.subst] using TinyML.ValHasType.int Θ w)
-  intro _ Θ x := by simpa [Embedding.int, TinyML.Typ.subst] using TinyML.ValHasType.int_intro Θ x
+  member _ W w := pure_member (φ := fun x => w = .int x)
+    (by simpa [Embedding.int, TinyML.Typ.subst] using TinyML.ValHasType.int W w)
+  intro _ W x := by simpa [Embedding.int, TinyML.Typ.subst] using TinyML.ValHasType.int_intro W x
 
 /-- Booleans are a lawful embedding. -/
 def Embedding.lawfulBool : Embedding.bool.Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := by cases h; trivial
   isOf_inject _ _ _ h := by cases h; simp [Embedding.bool]
-  member _ Θ w := pure_member (φ := fun x => w = .bool x)
-    (by simpa [Embedding.bool, TinyML.Typ.subst] using TinyML.ValHasType.bool Θ w)
-  intro _ Θ x := by simpa [Embedding.bool, TinyML.Typ.subst] using TinyML.ValHasType.bool_intro Θ x
+  member _ W w := pure_member (φ := fun x => w = .bool x)
+    (by simpa [Embedding.bool, TinyML.Typ.subst] using TinyML.ValHasType.bool W w)
+  intro _ W x := by simpa [Embedding.bool, TinyML.Typ.subst] using TinyML.ValHasType.bool_intro W x
 
 /-- Characters are a lawful embedding. -/
 def Embedding.lawfulChar : Embedding.char.Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := by cases h; trivial
   isOf_inject _ _ _ h := by cases h; simp [Embedding.char]
-  member _ Θ w := pure_member (φ := fun x => w = .char x)
-    (by simpa [Embedding.char, TinyML.Typ.subst] using TinyML.ValHasType.char Θ w)
-  intro _ Θ x := by simpa [Embedding.char, TinyML.Typ.subst] using TinyML.ValHasType.char_intro Θ x
+  member _ W w := pure_member (φ := fun x => w = .char x)
+    (by simpa [Embedding.char, TinyML.Typ.subst] using TinyML.ValHasType.char W w)
+  intro _ W x := by simpa [Embedding.char, TinyML.Typ.subst] using TinyML.ValHasType.char_intro W x
 
 /-- Byte strings are a lawful embedding. -/
 def Embedding.lawfulStr : Embedding.str.Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := by cases h; trivial
   isOf_inject _ _ _ h := by cases h; simp [Embedding.str]
-  member _ Θ w := pure_member (φ := fun x => w = .str x)
-    (by simpa [Embedding.str, TinyML.Typ.subst] using TinyML.ValHasType.string Θ w)
-  intro _ Θ x := by simpa [Embedding.str, TinyML.Typ.subst] using TinyML.ValHasType.string_intro Θ x
+  member _ W w := pure_member (φ := fun x => w = .str x)
+    (by simpa [Embedding.str, TinyML.Typ.subst] using TinyML.ValHasType.string W w)
+  intro _ W x := by simpa [Embedding.str, TinyML.Typ.subst] using TinyML.ValHasType.string_intro W x
 
 /-- Floats are a lawful embedding. -/
 def Embedding.lawfulFloat : Embedding.float.Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := by cases h; trivial
   isOf_inject _ _ _ h := by cases h; simp [Embedding.float]
-  member _ Θ w := pure_member (φ := fun x => w = .float x)
-    (by simpa [Embedding.float, TinyML.Typ.subst] using TinyML.ValHasType.float Θ w)
-  intro _ Θ x := by simpa [Embedding.float, TinyML.Typ.subst] using TinyML.ValHasType.float_intro Θ x
+  member _ W w := pure_member (φ := fun x => w = .float x)
+    (by simpa [Embedding.float, TinyML.Typ.subst] using TinyML.ValHasType.float W w)
+  intro _ W x := by simpa [Embedding.float, TinyML.Typ.subst] using TinyML.ValHasType.float_intro W x
 
 /-- Type variables are a lawful embedding: the type predicate is the typing fact itself. -/
 def Embedding.lawfulPoly (v : TinyML.TyVar) : (Embedding.poly v).Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := nomatch h
   isOf_inject _ _ _ h := nomatch h
-  member σ Θ w := by
+  member σ W w := by
     simp only [Embedding.poly, TinyML.Typ.subst]
     constructor
     · iintro H
@@ -291,7 +291,7 @@ def Embedding.lawfulPoly (v : TinyML.TyVar) : (Embedding.poly v).Lawful where
     · iintro ⟨%x, %hw, H⟩
       obtain rfl := hw
       iexact H
-  intro σ Θ x := by
+  intro σ W x := by
     simp only [Embedding.poly, TinyML.Typ.subst]
     exact .rfl
 
@@ -300,7 +300,7 @@ def Embedding.lawfulLogical (typ : TinyML.Typ) : (Embedding.logical typ).Lawful 
   project_inject _ := rfl
   isOf_wf _ _ h := nomatch h
   isOf_inject _ _ _ h := nomatch h
-  member σ Θ w := by
+  member σ W w := by
     simp only [Embedding.logical]
     constructor
     · iintro H
@@ -319,14 +319,14 @@ def Embedding.lawfulEmpty : Embedding.empty.Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := nomatch h
   isOf_inject _ _ _ h := nomatch h
-  member σ Θ w := by
+  member σ W w := by
     simp only [Embedding.empty, TinyML.Typ.subst]
-    refine (TinyML.ValHasType.empty Θ w).trans ?_
+    refine (TinyML.ValHasType.empty W w).trans ?_
     constructor
     · exact false_elim
     · iintro ⟨%x, %hw, H⟩
       iexact H
-  intro σ Θ x := by
+  intro σ W x := by
     simp only [Embedding.empty, TinyML.Typ.subst]
     exact false_elim
 
@@ -335,10 +335,10 @@ def Embedding.lawfulVec (elem : TinyML.Typ) : (Embedding.vec elem).Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := by cases h; trivial
   isOf_inject _ _ _ h := by cases h; simp [Embedding.vec]
-  member σ Θ w := by
-    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec Θ w (elem.subst σ)
-  intro σ Θ l := by
-    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec_intro Θ l (elem.subst σ)
+  member σ W w := by
+    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec W w (elem.subst σ)
+  intro σ W l := by
+    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec_intro W l (elem.subst σ)
 
 /-! ## Scheme matching -/
 
@@ -481,7 +481,7 @@ structure Zero.Lawful (b : Zero) where
   resL         : b.res.Lawful
   nameFresh    : b.name ≠ "ret"
   semWellTyped : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
-                 (Θ : TinyML.TypeEnv), iprop(emp) ⊢ b.res.typePred σ Θ b.f
+                 (W : TinyML.World), iprop(emp) ⊢ b.res.typePred σ W b.f
   specBaseWf   : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
@@ -511,16 +511,16 @@ structure Zero.Lawful (b : Zero) where
       subst hv
       iexact HΦ
   bridge := by
-    intro _ σ Θ vs ρ Φ hρ
+    intro _ σ W vs ρ Φ hρ
     simp only [Zero.instantiate_retTy, Spec.instantiate_pred]
-    show TinyML.ValsHaveTypes Θ vs [] ∗ _ ⊢ _
+    show TinyML.ValsHaveTypes W vs [] ∗ _ ⊢ _
     match vs with
     | _ :: _ => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [] =>
       simp only [Zero.toIntrinsic, Intrinsic.toWp_zero_of_arity]
-      refine (sep_mono_left (TinyML.ValsHaveTypes.nil Θ).1).trans ?_
+      refine (sep_mono_left (TinyML.ValsHaveTypes.nil W).1).trans ?_
       refine emp_sep.1.trans ?_
-      refine (assert_ret_apply Θ _ "ret" _ _ (b.res.inject b.f) ?_).trans ?_
+      refine (assert_ret_apply W _ "ret" _ _ (b.res.inject b.f) ?_).trans ?_
       · have hconst : (ρ.updateConst .value "ret" (b.res.inject b.f)).env.lookupConst
             .value b.name = b.res.inject b.f := by
           rw [VerifM.Env.updateConst_env]
@@ -529,7 +529,7 @@ structure Zero.Lawful (b : Zero) where
         simpa [Zero.opTerm, Term.eval, Const.denote] using hconst.symm
       · iintro Hwand
         iapply Hwand
-        exact (l.semWellTyped σ Θ).trans (l.resL.intro σ Θ b.f)
+        exact (l.semWellTyped σ W).trans (l.resL.intro σ W b.f)
   axiomWf := by
     intro Δ hsub hwf a hφ
     simp only [Zero.toIntrinsic, List.mem_cons, Option.mem_toList,
@@ -638,8 +638,8 @@ structure Unary.Lawful (b : Unary) where
                    (p "a").eval (ρ.updateConst .value "a" (b.arg.inject x))) →
                  b.dom x
   semWellTyped : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
-                 (Θ : TinyML.TypeEnv) (x : b.arg.carrier), b.dom x →
-                 b.arg.typePred σ Θ x ⊢ b.res.typePred σ Θ (b.f x)
+                 (W : TinyML.World) (x : b.arg.carrier), b.dom x →
+                 b.arg.typePred σ W x ⊢ b.res.typePred σ W (b.f x)
   specBaseWf   : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
@@ -681,7 +681,7 @@ structure Unary.Lawful (b : Unary) where
       subst hv
       iexact HΦ
   bridge := by
-    intro _ σ Θ vs ρ Φ hρ
+    intro _ σ W vs ρ Φ hρ
     simp only [Unary.instantiate_args, Unary.instantiate_retTy,
       Spec.instantiate_pred, Unary.spec_pred, List.map_cons, List.map_nil]
     match vs with
@@ -690,20 +690,20 @@ structure Unary.Lawful (b : Unary) where
         exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [v] =>
       iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v [] _ _).1 $$ Hvs
+      ihave Hcons := (TinyML.ValsHaveTypes.cons W v [] _ _).1 $$ Hvs
       icases Hcons with ⟨Hv, _⟩
-      ihave Hveq := (l.argL.member σ Θ v).1 $$ Hv
+      ihave Hveq := (l.argL.member σ W v).1 $$ Hv
       icases Hveq with ⟨%x, %hw, Hrel⟩
       obtain rfl := hw
-      ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
+      ihave Hsplit := withPre_apply W _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x := by
         refine l.domSound ρ.env x fun p hp => ?_
         have h := hpre (p "a") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
-      ihave Hty : iprop(TinyML.ValHasType Θ (b.res.inject (b.f x)) (b.res.typ.subst σ)) $$ [Hrel]
-      · iapply (l.resL.intro σ Θ (b.f x))
-        iapply (l.semWellTyped σ Θ x hdom)
+      ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x)) (b.res.typ.subst σ)) $$ [Hrel]
+      · iapply (l.resL.intro σ W (b.f x))
+        iapply (l.semWellTyped σ W x hdom)
         iexact Hrel
       simp only [Unary.toIntrinsic, Intrinsic.toWp_one_of_arity]
       iexists x
@@ -722,7 +722,7 @@ structure Unary.Lawful (b : Unary) where
               .value .value b.name (b.arg.inject x)
           simp [hun, Unary.sym, l.argL.project_inject]
         refine (sep_mono_left
-          (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x)) hassert)).trans ?_
+          (assert_ret_apply W _ "ret" _ _ (b.res.inject (b.f x)) hassert)).trans ?_
         iintro ⟨Hwand, Hty⟩
         iapply Hwand
         iexact Hty
@@ -849,9 +849,9 @@ structure Binary.Lawful (b : Binary) where
                      .value "b" (b.arg₂.inject y))) →
                  b.dom x y
   semWellTyped : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
-                 (Θ : TinyML.TypeEnv) (x : b.arg₁.carrier) (y : b.arg₂.carrier),
+                 (W : TinyML.World) (x : b.arg₁.carrier) (y : b.arg₂.carrier),
                  b.dom x y →
-                 b.arg₁.typePred σ Θ x ∗ b.arg₂.typePred σ Θ y ⊢ b.res.typePred σ Θ (b.f x y)
+                 b.arg₁.typePred σ W x ∗ b.arg₂.typePred σ W y ⊢ b.res.typePred σ W (b.f x y)
   specBaseWf   : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
@@ -898,10 +898,10 @@ structure Binary.Lawful (b : Binary) where
       subst hv
       iexact HΦ
   bridge := by
-    intro _ σ Θ vs ρ Φ hρ
+    intro _ σ W vs ρ Φ hρ
     simp only [Binary.instantiate_args, Binary.instantiate_retTy,
       Spec.instantiate_pred, Binary.spec_pred, List.map_cons, List.map_nil]
-    show TinyML.ValsHaveTypes Θ vs [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ] ∗ _ ⊢ _
+    show TinyML.ValsHaveTypes W vs [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ] ∗ _ ⊢ _
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -909,26 +909,26 @@ structure Binary.Lawful (b : Binary) where
         exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [v1, v2] =>
       iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v1 [v2] _ _).1 $$ Hvs
+      ihave Hcons := (TinyML.ValsHaveTypes.cons W v1 [v2] _ _).1 $$ Hvs
       icases Hcons with ⟨Hv1, Hvs2⟩
-      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [] _ _).1 $$ Hvs2
+      ihave Hcons2 := (TinyML.ValsHaveTypes.cons W v2 [] _ _).1 $$ Hvs2
       icases Hcons2 with ⟨Hv2, _⟩
-      ihave Hv1eq := (l.argL₁.member σ Θ v1).1 $$ Hv1
+      ihave Hv1eq := (l.argL₁.member σ W v1).1 $$ Hv1
       icases Hv1eq with ⟨%x, %hw1, Hrel1⟩
       obtain rfl := hw1
-      ihave Hv2eq := (l.argL₂.member σ Θ v2).1 $$ Hv2
+      ihave Hv2eq := (l.argL₂.member σ W v2).1 $$ Hv2
       icases Hv2eq with ⟨%y, %hw2, Hrel2⟩
       obtain rfl := hw2
-      ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
+      ihave Hsplit := withPre_apply W _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x y := by
         refine l.domSound ρ.env x y fun p hp => ?_
         have h := hpre (p "a" "b") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
-      ihave Hty : iprop(TinyML.ValHasType Θ (b.res.inject (b.f x y))
+      ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x y))
           (b.res.typ.subst σ)) $$ [Hrel1 Hrel2]
-      · iapply (l.resL.intro σ Θ (b.f x y))
-        iapply (l.semWellTyped σ Θ x y hdom)
+      · iapply (l.resL.intro σ W (b.f x y))
+        iapply (l.semWellTyped σ W x y hdom)
         isplitl [Hrel1]
         · iexact Hrel1
         · iexact Hrel2
@@ -954,7 +954,7 @@ structure Binary.Lawful (b : Binary) where
               .value .value .value b.name (b.arg₁.inject x) (b.arg₂.inject y)
           simp [hbin, Binary.sym, l.argL₁.project_inject, l.argL₂.project_inject]
         refine (sep_mono_left
-          (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x y)) hassert)).trans ?_
+          (assert_ret_apply W _ "ret" _ _ (b.res.inject (b.f x y)) hassert)).trans ?_
         iintro ⟨Hwand, Hty⟩
         iapply Hwand
         iexact Hty
@@ -1085,10 +1085,10 @@ structure Ternary.Lawful (b : Ternary) where
                      (b.arg₂.inject y)).updateConst .value "c" (b.arg₃.inject z))) →
                  b.dom x y z
   semWellTyped : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
-                 (Θ : TinyML.TypeEnv) (x : b.arg₁.carrier) (y : b.arg₂.carrier)
+                 (W : TinyML.World) (x : b.arg₁.carrier) (y : b.arg₂.carrier)
                  (z : b.arg₃.carrier), b.dom x y z →
-                 b.arg₁.typePred σ Θ x ∗ b.arg₂.typePred σ Θ y ∗ b.arg₃.typePred σ Θ z ⊢
-                   b.res.typePred σ Θ (b.f x y z)
+                 b.arg₁.typePred σ W x ∗ b.arg₂.typePred σ W y ∗ b.arg₃.typePred σ W z ⊢
+                   b.res.typePred σ W (b.f x y z)
   specBaseWf   : PredTrans.wfIn
                  ((Intrinsic.sigOf [b.toIntrinsic]).declVars
                    (Spec.argVars b.toIntrinsic.specArgs)) b.toIntrinsic.spec.pred
@@ -1139,10 +1139,10 @@ structure Ternary.Lawful (b : Ternary) where
       subst hv
       iexact HΦ
   bridge := by
-    intro _ σ Θ vs ρ Φ hρ
+    intro _ σ W vs ρ Φ hρ
     simp only [Ternary.instantiate_args, Ternary.instantiate_retTy,
       Spec.instantiate_pred, Ternary.spec_pred, List.map_cons, List.map_nil]
-    show TinyML.ValsHaveTypes Θ vs
+    show TinyML.ValsHaveTypes W vs
       [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ, b.arg₃.typ.subst σ] ∗ _ ⊢ _
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -1152,31 +1152,31 @@ structure Ternary.Lawful (b : Ternary) where
         exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [v1, v2, v3] =>
       iintro ⟨Hvs, Hpred⟩
-      ihave Hcons := (TinyML.ValsHaveTypes.cons Θ v1 [v2, v3] _ _).1 $$ Hvs
+      ihave Hcons := (TinyML.ValsHaveTypes.cons W v1 [v2, v3] _ _).1 $$ Hvs
       icases Hcons with ⟨Hv1, Hvs2⟩
-      ihave Hcons2 := (TinyML.ValsHaveTypes.cons Θ v2 [v3] _ _).1 $$ Hvs2
+      ihave Hcons2 := (TinyML.ValsHaveTypes.cons W v2 [v3] _ _).1 $$ Hvs2
       icases Hcons2 with ⟨Hv2, Hvs3⟩
-      ihave Hcons3 := (TinyML.ValsHaveTypes.cons Θ v3 [] _ _).1 $$ Hvs3
+      ihave Hcons3 := (TinyML.ValsHaveTypes.cons W v3 [] _ _).1 $$ Hvs3
       icases Hcons3 with ⟨Hv3, _⟩
-      ihave Hv1eq := (l.argL₁.member σ Θ v1).1 $$ Hv1
+      ihave Hv1eq := (l.argL₁.member σ W v1).1 $$ Hv1
       icases Hv1eq with ⟨%x, %hw1, Hrel1⟩
       obtain rfl := hw1
-      ihave Hv2eq := (l.argL₂.member σ Θ v2).1 $$ Hv2
+      ihave Hv2eq := (l.argL₂.member σ W v2).1 $$ Hv2
       icases Hv2eq with ⟨%y, %hw2, Hrel2⟩
       obtain rfl := hw2
-      ihave Hv3eq := (l.argL₃.member σ Θ v3).1 $$ Hv3
+      ihave Hv3eq := (l.argL₃.member σ W v3).1 $$ Hv3
       icases Hv3eq with ⟨%z, %hw3, Hrel3⟩
       obtain rfl := hw3
-      ihave Hsplit := withPre_apply Θ _ _ _ _ $$ Hpred
+      ihave Hsplit := withPre_apply W _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x y z := by
         refine l.domSound ρ.env x y z fun p hp => ?_
         have h := hpre (p "a" "b" "c") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
-      ihave Hty : iprop(TinyML.ValHasType Θ (b.res.inject (b.f x y z))
+      ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x y z))
           (b.res.typ.subst σ)) $$ [Hrel1 Hrel2 Hrel3]
-      · iapply (l.resL.intro σ Θ (b.f x y z))
-        iapply (l.semWellTyped σ Θ x y z hdom)
+      · iapply (l.resL.intro σ W (b.f x y z))
+        iapply (l.semWellTyped σ W x y z hdom)
         isplitl [Hrel1]
         · iexact Hrel1
         · isplitl [Hrel2]
@@ -1208,7 +1208,7 @@ structure Ternary.Lawful (b : Ternary) where
           simp [hter, Ternary.sym, l.argL₁.project_inject, l.argL₂.project_inject,
             l.argL₃.project_inject]
         refine (sep_mono_left
-          (assert_ret_apply Θ _ "ret" _ _ (b.res.inject (b.f x y z)) hassert)).trans ?_
+          (assert_ret_apply W _ "ret" _ _ (b.res.inject (b.f x y z)) hassert)).trans ?_
         iintro ⟨Hwand, Hty⟩
         iapply Hwand
         iexact Hty

--- a/Mica/Stdlib/ListStd.lean
+++ b/Mica/Stdlib/ListStd.lean
@@ -10,9 +10,9 @@ open Verifier
 namespace Intrinsics
 
 theorem valHasType_list_unfold [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (v : Runtime.Val) (t : TinyML.Typ) :
-    TinyML.ValHasType Θ v (.list t) ⊣⊢
-      TinyML.ValHasType Θ v (.sum [.unit, .tuple [t, .list t]]) := by
+    (W : TinyML.World) (v : Runtime.Val) (t : TinyML.Typ) :
+    TinyML.ValHasType W v (.list t) ⊣⊢
+      TinyML.ValHasType W v (.sum [.unit, .tuple [t, .list t]]) := by
   apply TinyML.ValHasType.named_of_unfold
   simp [TinyML.Typ.list, TinyML.Typ.predef, TinyML.TypeName.unfold,
     TinyML.Predef.arity, TinyML.Predef.decl, TinyML.Predef.tparams,
@@ -26,65 +26,65 @@ def listCons (head tail : Runtime.Val) : Runtime.Val :=
   .inj 1 2 (.tuple [head, tail])
 
 theorem valHasType_list_nil [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (t : TinyML.Typ) :
-    ⊢ TinyML.ValHasType Θ listNil (.list t) := by
-  exact (TinyML.ValHasType.unit_intro Θ).trans
+    (W : TinyML.World) (t : TinyML.Typ) :
+    ⊢ TinyML.ValHasType W listNil (.list t) := by
+  exact (TinyML.ValHasType.unit_intro W).trans
     ((TinyML.ValHasType.inj (tag := 0) (arity := 2) (s := .unit)
       (ts := [.unit, .tuple [t, .list t]]) (by simp) (by simp)).trans
-      (valHasType_list_unfold Θ listNil t).2)
+      (valHasType_list_unfold W listNil t).2)
 
 theorem valHasType_list_cons [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (head tail : Runtime.Val) (t : TinyML.Typ) :
-    TinyML.ValHasType Θ head t ∗ TinyML.ValHasType Θ tail (.list t) ⊢
-      TinyML.ValHasType Θ (listCons head tail) (.list t) := by
+    (W : TinyML.World) (head tail : Runtime.Val) (t : TinyML.Typ) :
+    TinyML.ValHasType W head t ∗ TinyML.ValHasType W tail (.list t) ⊢
+      TinyML.ValHasType W (listCons head tail) (.list t) := by
   istart
   iintro H
   icases H with ⟨Hhead, Htail⟩
-  iapply (valHasType_list_unfold Θ (listCons head tail) t).2
+  iapply (valHasType_list_unfold W (listCons head tail) t).2
   simp only [listCons]
   iapply (TinyML.ValHasType.inj (tag := 1) (arity := 2)
     (s := .tuple [t, .list t]) (ts := [.unit, .tuple [t, .list t]]) (by simp) (by simp))
-  iapply (TinyML.ValHasType.tuple Θ (.tuple [head, tail]) [t, .list t]).2
+  iapply (TinyML.ValHasType.tuple W (.tuple [head, tail]) [t, .list t]).2
   iexists [head, tail]
   isplitr
   · ipureintro; rfl
-  · iapply (TinyML.ValsHaveTypes.cons Θ head [tail] t [.list t]).2
+  · iapply (TinyML.ValsHaveTypes.cons W head [tail] t [.list t]).2
     isplitl [Hhead]
     · iexact Hhead
-    · iapply (TinyML.ValsHaveTypes.cons Θ tail [] (.list t) []).2
+    · iapply (TinyML.ValsHaveTypes.cons W tail [] (.list t) []).2
       isplitl [Htail]
       · iexact Htail
       · exact affine
 
 theorem valHasType_list_cons_raw [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (head tail : Runtime.Val) (t : TinyML.Typ) :
-    TinyML.ValHasType Θ head t ∗ TinyML.ValHasType Θ tail (.list t) ⊢
-      TinyML.ValHasType Θ (.inj 1 2 (.tuple [head, tail])) (.list t) := by
-  simpa only [listCons] using valHasType_list_cons Θ head tail t
+    (W : TinyML.World) (head tail : Runtime.Val) (t : TinyML.Typ) :
+    TinyML.ValHasType W head t ∗ TinyML.ValHasType W tail (.list t) ⊢
+      TinyML.ValHasType W (.inj 1 2 (.tuple [head, tail])) (.list t) := by
+  simpa only [listCons] using valHasType_list_cons W head tail t
 
 theorem valHasType_list_cases [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (v : Runtime.Val) (t : TinyML.Typ) :
-    TinyML.ValHasType Θ v (.list t) ⊢
+    (W : TinyML.World) (v : Runtime.Val) (t : TinyML.Typ) :
+    TinyML.ValHasType W v (.list t) ⊢
       iprop(⌜v = listNil⌝ ∨ ∃ head tail,
         ⌜v = listCons head tail⌝ ∗
-        TinyML.ValHasType Θ head t ∗ TinyML.ValHasType Θ tail (.list t)) := by
+        TinyML.ValHasType W head t ∗ TinyML.ValHasType W tail (.list t)) := by
   istart
   iintro H
-  ihave Hsum := (valHasType_list_unfold Θ v t).1 $$ H
-  ihave Hsum := (TinyML.ValHasType.sum Θ v [.unit, .tuple [t, .list t]]).1 $$ Hsum
+  ihave Hsum := (valHasType_list_unfold W v t).1 $$ H
+  ihave Hsum := (TinyML.ValHasType.sum W v [.unit, .tuple [t, .list t]]).1 $$ Hsum
   icases Hsum with ⟨%tag, %payload, %hv, Htag⟩
-  ihave %hbound := (TinyML.ValSumRel.bound (Θ := Θ) (payload := payload)) $$ Htag
+  ihave %hbound := (TinyML.ValSumRel.bound (W := W) (payload := payload)) $$ Htag
   simp at hbound
   have htag : tag = 0 ∨ tag = 1 := by omega
   rcases htag with rfl | rfl
-  · ihave Hunit := (TinyML.ValSumRel.zero Θ payload .unit [.tuple [t, .list t]]).1 $$ Htag
-    ihave %hpayload := (TinyML.ValHasType.unit Θ payload).1 $$ Hunit
+  · ihave Hunit := (TinyML.ValSumRel.zero W payload .unit [.tuple [t, .list t]]).1 $$ Htag
+    ihave %hpayload := (TinyML.ValHasType.unit W payload).1 $$ Hunit
     iapply or_intro_l
     ipureintro
     simp [listNil, hv, hpayload]
-  · ihave Htuple := (TinyML.ValSumRel.succ Θ 0 payload .unit [.tuple [t, .list t]]).1 $$ Htag
-    ihave Htuple := (TinyML.ValSumRel.zero Θ payload (.tuple [t, .list t]) []).1 $$ Htuple
-    icases (TinyML.ValHasType.tuple Θ payload [t, .list t]).1 $$ Htuple with
+  · ihave Htuple := (TinyML.ValSumRel.succ W 0 payload .unit [.tuple [t, .list t]]).1 $$ Htag
+    ihave Htuple := (TinyML.ValSumRel.zero W payload (.tuple [t, .list t]) []).1 $$ Htuple
+    icases (TinyML.ValHasType.tuple W payload [t, .list t]).1 $$ Htuple with
       ⟨%vs, %hpayload, Hvals⟩
     ihave %hlen := TinyML.ValsHaveTypes.length_eq $$ Hvals
     match vs with
@@ -94,9 +94,9 @@ theorem valHasType_list_cases [MicaGS HasLC.hasLC Sig]
       isplitr
       · ipureintro
         simp [listCons, hv, hpayload]
-      · ihave Hvals := (TinyML.ValsHaveTypes.cons Θ head [tail] t [.list t]).1 $$ Hvals
+      · ihave Hvals := (TinyML.ValsHaveTypes.cons W head [tail] t [.list t]).1 $$ Hvals
         icases Hvals with ⟨Hhead, Hvals⟩
-        ihave Hvals := (TinyML.ValsHaveTypes.cons Θ tail [] (.list t) []).1 $$ Hvals
+        ihave Hvals := (TinyML.ValsHaveTypes.cons W tail [] (.list t) []).1 $$ Hvals
         icases Hvals with ⟨Htail, _⟩
         isplitl [Hhead]
         · iexact Hhead
@@ -127,13 +127,13 @@ termination_by value => sizeOf value
 decreasing_by simp_wf; omega
 
 theorem listAppend_typed [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (left right : Runtime.Val) (t : TinyML.Typ) :
-    TinyML.ValHasType Θ left (.list t) ∗ TinyML.ValHasType Θ right (.list t) ⊢
-      TinyML.ValHasType Θ (listAppend left right) (.list t) := by
+    (W : TinyML.World) (left right : Runtime.Val) (t : TinyML.Typ) :
+    TinyML.ValHasType W left (.list t) ∗ TinyML.ValHasType W right (.list t) ⊢
+      TinyML.ValHasType W (listAppend left right) (.list t) := by
   istart
   iintro H
   icases H with ⟨Hleft, Hright⟩
-  ihave Hcases := valHasType_list_cases Θ left t $$ Hleft
+  ihave Hcases := valHasType_list_cases W left t $$ Hleft
   icases Hcases with (Hnil | Hcons)
   · ihave %hleft := Hnil
     subst hleft
@@ -153,17 +153,17 @@ termination_by sizeOf left
 decreasing_by simp_all [listCons]; omega
 
 theorem listRev_typed [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (value : Runtime.Val) (t : TinyML.Typ) :
-    TinyML.ValHasType Θ value (.list t) ⊢
-      TinyML.ValHasType Θ (listRev value) (.list t) := by
+    (W : TinyML.World) (value : Runtime.Val) (t : TinyML.Typ) :
+    TinyML.ValHasType W value (.list t) ⊢
+      TinyML.ValHasType W (listRev value) (.list t) := by
   istart
   iintro H
-  ihave Hcases := valHasType_list_cases Θ value t $$ H
+  ihave Hcases := valHasType_list_cases W value t $$ H
   icases Hcases with (Hnil | Hcons)
   · ihave %hvalue := Hnil
     subst hvalue
     simp only [listRev, listNil]
-    exact valHasType_list_nil Θ t
+    exact valHasType_list_nil W t
   · icases Hcons with ⟨%head, %tail, %hvalue, Hhead, Htail⟩
     subst hvalue
     simp only [listCons, listRev]
@@ -174,7 +174,7 @@ theorem listRev_typed [MicaGS HasLC.hasLC Sig]
     · iapply valHasType_list_cons_raw
       isplitl [Hhead]
       · iexact Hhead
-      · exact valHasType_list_nil Θ t
+      · exact valHasType_list_nil W t
 termination_by sizeOf value
 decreasing_by simp_all [listCons]; omega
 
@@ -237,9 +237,9 @@ def listAppendLawful : listAppendB.Lawful where
   resL := Embedding.lawfulLogical listTy
   domSound := fun _ _ _ _ => trivial
   semWellTyped := by
-    refine fun σ Θ (left : Runtime.Val) (right : Runtime.Val) _ => ?_
+    refine fun σ W (left : Runtime.Val) (right : Runtime.Val) _ => ?_
     simpa [listAppendB, Embedding.logical, listTy, TinyML.Typ.subst] using
-      listAppend_typed Θ left right (σ "a")
+      listAppend_typed W left right (σ "a")
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf := by apply Formula.checkWf_ok; rfl
   typeWf := fun _ h => nomatch h
@@ -271,9 +271,9 @@ def listRevLawful : listRevB.Lawful where
   resL := Embedding.lawfulLogical listTy
   domSound := fun _ _ _ => trivial
   semWellTyped := by
-    refine fun σ Θ (value : Runtime.Val) _ => ?_
+    refine fun σ W (value : Runtime.Val) _ => ?_
     simpa [listRevB, Embedding.logical, listTy, TinyML.Typ.subst] using
-      listRev_typed Θ value (σ "a")
+      listRev_typed W value (σ "a")
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf := by apply Formula.checkWf_ok; rfl
   typeWf := fun _ h => nomatch h

--- a/Mica/Stdlib/OptionStd.lean
+++ b/Mica/Stdlib/OptionStd.lean
@@ -10,9 +10,9 @@ open Verifier
 namespace Intrinsics
 
 theorem valHasType_option_unfold [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (v : Runtime.Val) (t : TinyML.Typ) :
-    TinyML.ValHasType Θ v (.option t) ⊣⊢
-      TinyML.ValHasType Θ v (.sum [.unit, t]) := by
+    (W : TinyML.World) (v : Runtime.Val) (t : TinyML.Typ) :
+    TinyML.ValHasType W v (.option t) ⊣⊢
+      TinyML.ValHasType W v (.sum [.unit, t]) := by
   apply TinyML.ValHasType.named_of_unfold
   simp [TinyML.TypeName.unfold, TinyML.Predef.arity, TinyML.Predef.decl, TinyML.Predef.tparams,
     TinyML.Predef.ctors, TinyML.DataDecl.instantiate, TinyML.Typ.subst]
@@ -24,26 +24,26 @@ def optionNone : Runtime.Val := .inj 0 2 .unit
 def optionSome (value : Runtime.Val) : Runtime.Val := .inj 1 2 value
 
 theorem valHasType_option_cases [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (v : Runtime.Val) (t : TinyML.Typ) :
-    TinyML.ValHasType Θ v (.option t) ⊢
+    (W : TinyML.World) (v : Runtime.Val) (t : TinyML.Typ) :
+    TinyML.ValHasType W v (.option t) ⊢
       iprop(⌜v = optionNone⌝ ∨ ∃ value,
-        ⌜v = optionSome value⌝ ∗ TinyML.ValHasType Θ value t) := by
+        ⌜v = optionSome value⌝ ∗ TinyML.ValHasType W value t) := by
   istart
   iintro H
-  ihave Hsum := (valHasType_option_unfold Θ v t).1 $$ H
-  ihave Hsum := (TinyML.ValHasType.sum Θ v [.unit, t]).1 $$ Hsum
+  ihave Hsum := (valHasType_option_unfold W v t).1 $$ H
+  ihave Hsum := (TinyML.ValHasType.sum W v [.unit, t]).1 $$ Hsum
   icases Hsum with ⟨%tag, %payload, %hv, Htag⟩
-  ihave %hbound := (TinyML.ValSumRel.bound (Θ := Θ) (payload := payload)) $$ Htag
+  ihave %hbound := (TinyML.ValSumRel.bound (W := W) (payload := payload)) $$ Htag
   simp at hbound
   have htag : tag = 0 ∨ tag = 1 := by omega
   rcases htag with rfl | rfl
-  · ihave Hunit := (TinyML.ValSumRel.zero Θ payload .unit [t]).1 $$ Htag
-    ihave %hpayload := (TinyML.ValHasType.unit Θ payload).1 $$ Hunit
+  · ihave Hunit := (TinyML.ValSumRel.zero W payload .unit [t]).1 $$ Htag
+    ihave %hpayload := (TinyML.ValHasType.unit W payload).1 $$ Hunit
     iapply or_intro_l
     ipureintro
     simp [optionNone, hv, hpayload]
-  · ihave Hvalue := (TinyML.ValSumRel.succ Θ 0 payload .unit [t]).1 $$ Htag
-    ihave Hvalue := (TinyML.ValSumRel.zero Θ payload t []).1 $$ Hvalue
+  · ihave Hvalue := (TinyML.ValSumRel.succ W 0 payload .unit [t]).1 $$ Htag
+    ihave Hvalue := (TinyML.ValSumRel.zero W payload t []).1 $$ Hvalue
     iapply or_intro_r
     iexists payload
     isplitr
@@ -67,13 +67,13 @@ def optionValue : Runtime.Val → Runtime.Val
   | _ => .unit
 
 theorem optionValue_typed [MicaGS HasLC.hasLC Sig]
-    (Θ : TinyML.TypeEnv) (option value : Runtime.Val) (t : TinyML.Typ)
+    (W : TinyML.World) (option value : Runtime.Val) (t : TinyML.Typ)
     (hvalue : option = optionSome value) :
-    TinyML.ValHasType Θ option (.option t) ⊢
-      TinyML.ValHasType Θ (optionValue option) t := by
+    TinyML.ValHasType W option (.option t) ⊢
+      TinyML.ValHasType W (optionValue option) t := by
   istart
   iintro H
-  ihave Hcases := valHasType_option_cases Θ option t $$ H
+  ihave Hcases := valHasType_option_cases W option t $$ H
   icases Hcases with (Hnone | Hsome)
   · ihave %hnone := Hnone
     rw [hnone] at hvalue
@@ -223,10 +223,10 @@ def optionValueLawful : optionValueB.Lawful where
       optionPayload, Formula.eval, Term.eval,
       Env.lookupConst_updateConst_same] using hpre
   semWellTyped := by
-    refine fun σ Θ (option : Runtime.Val) hdom => ?_
+    refine fun σ W (option : Runtime.Val) hdom => ?_
     obtain ⟨value, hvalue⟩ := hdom
     simpa [optionValueB, Embedding.logical, Embedding.poly, optionTy,
-      TinyML.Typ.subst] using optionValue_typed Θ option value (σ "a") hvalue
+      TinyML.Typ.subst] using optionValue_typed W option value (σ "a") hvalue
   specBaseWf := by apply PredTrans.checkWf_ok; rfl
   defWf := by apply Formula.checkWf_ok; rfl
   typeWf := fun _ h => nomatch h

--- a/Mica/Stdlib/VecStd.lean
+++ b/Mica/Stdlib/VecStd.lean
@@ -145,7 +145,7 @@ def vecGetLawful : vecGetB.Lawful where
       Formula.eval, Term.eval, Const.denote, Env.lookupConst_updateConst_same,
       Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), valVec, valInt] using hpre
   semWellTyped := by
-    refine fun σ Θ (l : List Runtime.Val) (n : Int) hdom => ?_
+    refine fun σ W (l : List Runtime.Val) (n : Int) hdom => ?_
     obtain ⟨h0, hlen⟩ := hdom
     have hlt : n.toNat < l.length := by omega
     have hget : l[n.toNat]? = some l[n.toNat] := List.getElem?_eq_getElem hlt
@@ -153,7 +153,7 @@ def vecGetLawful : vecGetB.Lawful where
       vecGetB, if_pos h0,
       hget, Option.getD_some]
     refine sep_emp.1.trans ?_
-    exact BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType Θ w (σ "a")) hget
+    exact BigSepL.bigSepL_lookup (Φ := fun _ w => TinyML.ValHasType W w (σ "a")) hget
   specBaseWf   := by apply PredTrans.checkWf_ok; rfl
   defWf        := by apply Formula.checkWf_ok; rfl
   typeWf       := by intro φ h; exact nomatch h
@@ -202,7 +202,7 @@ def vecSetLawful : vecSetB.Lawful where
       Env.lookupConst_updateConst_ne (show "a" ≠ "c" by decide),
       Env.lookupConst_updateConst_ne (show "b" ≠ "c" by decide), valVec, valInt] using hpre
   semWellTyped := by
-    refine fun σ Θ (l : List Runtime.Val) (n : Int) (x : Runtime.Val) hdom => ?_
+    refine fun σ W (l : List Runtime.Val) (n : Int) (x : Runtime.Val) hdom => ?_
     obtain ⟨h0, hlen⟩ := hdom
     have hlt : n.toNat < l.length := by omega
     have hget : l[n.toNat]? = some l[n.toNat] := List.getElem?_eq_getElem hlt
@@ -210,7 +210,7 @@ def vecSetLawful : vecSetB.Lawful where
       vecSetB, if_pos h0]
     refine (sep_mono_right emp_sep.1).trans ?_
     refine (sep_mono_left (BigSepL.bigSepL_insert_acc
-      (Φ := fun _ w => TinyML.ValHasType Θ w (σ "a")) hget)).trans ?_
+      (Φ := fun _ w => TinyML.ValHasType W w (σ "a")) hget)).trans ?_
     refine (sep_mono_left sep_elim_right).trans ?_
     exact (sep_mono_left (forall_elim x)).trans wand_elim_left
   specBaseWf   := by apply PredTrans.checkWf_ok; rfl
@@ -256,13 +256,13 @@ def vecMakeLawful : vecMakeB.Lawful where
       Const.denote, Env.lookupConst_updateConst_same,
       Env.lookupConst_updateConst_ne (show "a" ≠ "b" by decide), valInt] using hpre
   semWellTyped := by
-    refine fun σ Θ (m : Int) (x : Runtime.Val) hdom => ?_
+    refine fun σ W (m : Int) (x : Runtime.Val) hdom => ?_
     have hnonneg : 0 ≤ m := hdom
     simp only [Embedding.vec, Embedding.int, Embedding.poly, TinyML.Typ.subst,
       vecMakeB, if_pos hnonneg]
     refine emp_sep.1.trans ?_
-    refine (TinyML.ValHasType.vec_replicate Θ m.toNat x (σ "a")).trans ?_
-    refine (TinyML.ValHasType.vec Θ _ (σ "a")).1.trans ?_
+    refine (TinyML.ValHasType.vec_replicate W m.toNat x (σ "a")).trans ?_
+    refine (TinyML.ValHasType.vec W _ (σ "a")).1.trans ?_
     istart
     iintro ⟨%vs, %hv, Hs⟩
     obtain rfl : List.replicate m.toNat x = vs := by injection hv

--- a/Mica/TinyML/Printer.lean
+++ b/Mica/TinyML/Printer.lean
@@ -12,7 +12,8 @@ namespace TinyML
 def Typ.print : Typ → String
   | .prim p => p.print
   | .sum ts => s!"sum ({", ".intercalate (ts.map Typ.print)})"
-  | .arrow t1 t2 => s!"{wrapArg t1 (Typ.print t1)} -> {Typ.print t2}"
+  | .arrow args ret =>
+      " -> ".intercalate ((args.map fun arg => wrapArg arg (Typ.print arg)) ++ [Typ.print ret])
   | .ref t => s!"ref {wrapArg t (Typ.print t)}"
   | .array t => s!"array {wrapArg t (Typ.print t)}"
   | .ownedArray t => s!"owned-array {wrapArg t (Typ.print t)}"

--- a/Mica/TinyML/Typed.lean
+++ b/Mica/TinyML/Typed.lean
@@ -240,17 +240,13 @@ def Const.ty : Const → Typ
   | .float _ => .float
   | .unit => .unit
 
-def arrowOfArgs : List Binder → Typ → Typ
-  | [], retTy => retTy
-  | arg :: args, retTy => .arrow arg.ty (arrowOfArgs args retTy)
-
 def Expr.ty : Expr → Typ
   | .const c => Const.ty c
   | .var _ ty => ty
   | .prim _ _ ty => ty
   | .unop _ _ ty => ty
   | .binop _ _ _ ty => ty
-  | .fix _ args retTy _ => arrowOfArgs args retTy
+  | .fix _ args retTy _ => .arrow (args.map Binder.ty) retTy
   | .app _ _ ty => ty
   | .ifThenElse _ _ _ ty => ty
   | .letIn _ _ body => body.ty

--- a/Mica/TinyML/Types.lean
+++ b/Mica/TinyML/Types.lean
@@ -128,7 +128,7 @@ theorem PrimitiveType.unOpTypeOf_bool {op : UnOp} {p p' : PrimitiveType}
 inductive Typ where
   | prim (p : PrimitiveType)
   | sum (ts : List Typ)
-  | arrow (t1 t2 : Typ)
+  | arrow (args : List Typ) (ret : Typ)
   | ref (t: Typ)
   /-- Shared array whose elements have type `t`. -/
   | array (t : Typ)
@@ -178,8 +178,8 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
   | .sum ss, .sum ts => match typesDecEq ss ts with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .arrow s1 s2, .arrow t1 t2 =>
-    match s1.decEq t1, s2.decEq t2 with
+  | .arrow ss s, .arrow ts t =>
+    match typesDecEq ss ts, s.decEq t with
     | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
     | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
     | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -282,7 +282,7 @@ variable-sensitive once `Typ` grows `tvar`/`named`.
 def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
   | .prim p => .prim p
   | .sum ts => .sum (ts.map (Typ.subst _σ))
-  | .arrow t1 t2 => .arrow (Typ.subst _σ t1) (Typ.subst _σ t2)
+  | .arrow args ret => .arrow (args.map (Typ.subst _σ)) (Typ.subst _σ ret)
   | .ref t => .ref (Typ.subst _σ t)
   | .array t => .array (Typ.subst _σ t)
   | .ownedArray t => .ownedArray (Typ.subst _σ t)
@@ -298,7 +298,7 @@ def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
 def Typ.closed : Typ → Bool
   | .prim _ => true
   | .sum ts => (ts.map Typ.closed).all id
-  | .arrow t1 t2 => Typ.closed t1 && Typ.closed t2
+  | .arrow args ret => (args.map Typ.closed).all id && Typ.closed ret
   | .ref t => Typ.closed t
   | .array t => Typ.closed t
   | .ownedArray t => Typ.closed t
@@ -379,7 +379,7 @@ mutual
   def Typ.weight : Typ → Nat
     | .prim _ | .empty | .value | .tvar _ => 1
     | .sum ts => 1 + Typ.weights ts
-    | .arrow t1 t2 => 1 + Typ.weight t1 + Typ.weight t2
+    | .arrow args ret => 1 + Typ.weights args + Typ.weight ret
     | .ref t => 1 + Typ.weight t
     | .array t => 1 + Typ.weight t
     | .ownedArray t => 1 + Typ.weight t
@@ -399,7 +399,7 @@ mutual
   def Typ.depth : Typ → Nat
     | .prim _ | .empty | .value | .tvar _ => 1
     | .sum ts => 1 + Typ.depths ts
-    | .arrow t1 t2 => 1 + max (Typ.depth t1) (Typ.depth t2)
+    | .arrow args ret => 1 + max (Typ.depths args) (Typ.depth ret)
     | .ref t => 1 + Typ.depth t
     | .array t => 1 + Typ.depth t
     | .ownedArray t => 1 + Typ.depth t
@@ -427,8 +427,8 @@ mutual
         | .empty, _ => true
         | _, .value => true
         | .sum ss, .sum ts => Typ.subListBody Θ recur ss ts
-        | .arrow s1 s2, .arrow t1 t2 =>
-            Typ.subBody Θ recur t1 s1 && Typ.subBody Θ recur s2 t2
+        | .arrow ss s, .arrow ts t =>
+            Typ.subListBody Θ recur ts ss && Typ.subBody Θ recur s t
         | .tuple ss, .tuple ts => Typ.subListBody Θ recur ss ts
         | _, _ =>
             if s == t then true
@@ -487,9 +487,9 @@ mutual
     | trans : Typ.Sub Θ s t → Typ.Sub Θ t u → Typ.Sub Θ s u
     | sum   : Typ.SubList Θ ss ts
             → Typ.Sub Θ (.sum ss) (.sum ts)
-    | arrow : Typ.Sub Θ t1 s1
-            → Typ.Sub Θ s2 t2
-            → Typ.Sub Θ (.arrow s1 s2) (.arrow t1 t2)
+    | arrow : Typ.SubList Θ ts ss
+            → Typ.Sub Θ s t
+            → Typ.Sub Θ (.arrow ss s) (.arrow ts t)
     | tuple : Typ.SubList Θ ss ts
             → Typ.Sub Θ (.tuple ss) (.tuple ts)
     | named_left : TypeName.unfold Θ T args = some ty
@@ -519,7 +519,7 @@ mutual
     · exact .top
     · exact .sum (subListBody_sound hrecur h)
     · simp [Bool.and_eq_true] at h
-      exact .arrow (subBody_sound hrecur h.1) (subBody_sound hrecur h.2)
+      exact .arrow (subListBody_sound hrecur h.1) (subBody_sound hrecur h.2)
     · exact .tuple (subListBody_sound hrecur h)
     · -- catchall: if s == t then true else match (s, t) for named
       split at h
@@ -606,7 +606,9 @@ mutual
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
                                     then .sum (Typ.joinList Θ ss ts)
                                     else .value
-    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.meet Θ s1 t1) (Typ.join Θ s2 t2)
+    | .arrow ss s, .arrow ts t => if ss.length == ts.length
+                                  then .arrow (Typ.meetList Θ ss ts) (Typ.join Θ s t)
+                                  else .value
     | .ref s,       .ref t       => if s == t then .ref s else .value
     | .array s,     .array t     => if s == t then .array s else .value
     | .ownedArray s, .ownedArray t => if s == t then .ownedArray s else .value
@@ -626,7 +628,9 @@ mutual
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
                                     then .sum (Typ.meetList Θ ss ts)
                                     else .empty
-    | .arrow s1 s2, .arrow t1 t2 => .arrow (Typ.join Θ s1 t1) (Typ.meet Θ s2 t2)
+    | .arrow ss s, .arrow ts t => if ss.length == ts.length
+                                  then .arrow (Typ.joinList Θ ss ts) (Typ.meet Θ s t)
+                                  else .empty
     | .ref s,       .ref t       => if s == t then .ref s else .empty
     | .array s,     .array t     => if s == t then .array s else .empty
     | .ownedArray s, .ownedArray t => if s == t then .ownedArray s else .empty

--- a/Mica/TinyML/Typing.lean
+++ b/Mica/TinyML/Typing.lean
@@ -168,54 +168,59 @@ structure PrimSig where
 /-- The primitive context threaded through typing: name to typing face. -/
 abbrev Prims := String → Option PrimSig
 
-/-- Subsume already-inferred arguments against the domains of `ty`, inserting
-    casts. Peels one arrow per argument like `checkArgs`, but takes the
-    arguments post-inference — used for primitive applications, whose arrow
-    type is only known after the instantiation is solved from the inferred
-    argument types. -/
+/-- The domain and result types of `ty` applied to `arity` arguments.
+    Applications are n-ary and saturated: a wrong argument count is an arity
+    error, not a partial application. -/
+def domains (ty : Typ) (arity : Nat) : Except TypeError (List Typ × Typ) :=
+  match ty with
+  | .arrow doms ret =>
+      if doms.length == arity then .ok (doms, ret)
+      else .error (.arityMismatch doms.length arity)
+  | _ => .error (.notAFunction ty)
+
+/-- Subsume an already-inferred argument list against the domain types,
+    inserting casts. Used for primitive applications, whose arrow type is only
+    known after the instantiation is solved from the inferred argument types. -/
 def checkInferred (Θ : TypeEnv) :
-    Typ → List (Typ × Typed.Expr) → Except TypeError (List Typed.Expr × Typ)
-  | ty, [] => .ok ([], ty)
-  | .arrow dom cod, (argTy, arg) :: rest =>
+    List Typ → List (Typ × Typed.Expr) → Except TypeError (List Typed.Expr)
+  | [], [] => .ok []
+  | dom :: doms, (argTy, arg) :: rest =>
       if argTy == dom then do
-        let (args', retTy) ← checkInferred Θ cod rest
-        .ok (arg :: args', retTy)
+        let args' ← checkInferred Θ doms rest
+        .ok (arg :: args')
       else if Typ.sub Θ argTy dom then do
-        let (args', retTy) ← checkInferred Θ cod rest
-        .ok (arg.cast dom :: args', retTy)
+        let args' ← checkInferred Θ doms rest
+        .ok (arg.cast dom :: args')
       else .error (.subsumptionFailure argTy dom)
-  | _, rest => .error (.arityMismatch 0 rest.length)
+  | doms, rest => .error (.arityMismatch doms.length rest.length)
 
 /-- `checkInferred` preserves erasure: casts are transparent at runtime. -/
 theorem checkInferred_runtime (Θ : TypeEnv) :
-    (pairs : List (Typ × Typed.Expr)) → ∀ ty result,
-      checkInferred Θ ty pairs = .ok result →
-      result.1.map Expr.runtime = (pairs.map Prod.snd).map Expr.runtime
+    (pairs : List (Typ × Typed.Expr)) → ∀ doms result,
+      checkInferred Θ doms pairs = .ok result →
+      result.map Expr.runtime = (pairs.map Prod.snd).map Expr.runtime
   | [] => by
-      intro ty result h
-      simp [checkInferred] at h
-      cases h
-      rfl
+      intro doms result h
+      cases doms <;> simp [checkInferred] at h
+      case nil => cases h; rfl
   | (argTy, arg) :: rest => by
-      intro ty result h
-      cases ty <;> simp only [checkInferred] at h <;> try cases h
-      case arrow dom cod =>
+      intro doms result h
+      cases doms with
+      | nil => simp [checkInferred] at h
+      | cons dom doms =>
+        simp only [checkInferred] at h
         split at h
-        · have ⟨res, hrest, hcont⟩ := Except.bind_ok h
-          cases res with
-          | mk args' retTy =>
+        · have ⟨args', hrest, hcont⟩ := Except.bind_ok h
+          simp at hcont
+          cases hcont
+          simp only [List.map]
+          rw [checkInferred_runtime Θ rest doms _ hrest]
+        · split at h
+          · have ⟨args', hrest, hcont⟩ := Except.bind_ok h
             simp at hcont
             cases hcont
-            simp only [List.map]
-            rw [checkInferred_runtime Θ rest cod _ hrest]
-        · split at h
-          · have ⟨res, hrest, hcont⟩ := Except.bind_ok h
-            cases res with
-            | mk args' retTy =>
-              simp at hcont
-              cases hcont
-              simp only [List.map, Expr.runtime]
-              rw [checkInferred_runtime Θ rest cod _ hrest]
+            simp only [List.map, Expr.runtime]
+            rw [checkInferred_runtime Θ rest doms _ hrest]
           · simp at h
 
 mutual
@@ -245,7 +250,7 @@ mutual
     | .fix self args retTy body => do
         let retTy := retTy.getD .value
         let typedArgs := args.map (fun b => Typed.Binder.ofUntyped b (Typed.Binder.expectedTy b .value))
-        let selfTy := Typed.arrowOfArgs typedArgs retTy
+        let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy
         let typedSelf := Typed.Binder.ofUntyped self selfTy
         let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
         let body' ← check prims Θ Γ' body retTy
@@ -262,13 +267,15 @@ mutual
             | .ok inst =>
               let ty := sig.scheme.subst fun v => (inst.lookup v).getD (.tvar v)
               if ty.closed then do
-                let (args', retTy) ← checkInferred Θ ty inferred
+                let (doms, retTy) ← domains ty inferred.length
+                let args' ← checkInferred Θ doms inferred
                 .ok (retTy, .app (.prim n inst ty) args' retTy)
               else
                 .error (.cannotInstantiate n "unresolved type variables")
         | none => do
             let (fnTy, fn') ← infer prims Θ Γ fn
-            let (args', retTy) ← checkArgs prims Θ Γ fnTy args
+            let (doms, retTy) ← domains fnTy args.length
+            let args' ← checkArgs prims Θ Γ doms args
             .ok (retTy, .app fn' args' retTy)
     | .ifThenElse cond thn els => do
         let cond' ← check prims Θ Γ cond .bool
@@ -393,13 +400,15 @@ mutual
         let tail ← inferList prims Θ Γ es
         .ok (head :: tail)
 
-  def checkArgs (prims : Prims) (Θ : TypeEnv) (Γ : TinyML.TyCtx) : Typ → List Untyped.Expr → Except TypeError (List Typed.Expr × Typ)
-    | ty, [] => .ok ([], ty)
-    | .arrow dom cod, arg :: args => do
+  /-- Check an argument list against the domain types of the function applied. -/
+  def checkArgs (prims : Prims) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
+      List Typ → List Untyped.Expr → Except TypeError (List Typed.Expr)
+    | [], [] => .ok []
+    | dom :: doms, arg :: args => do
         let arg' ← check prims Θ Γ arg dom
-        let (args', retTy) ← checkArgs prims Θ Γ cod args
-        .ok (arg' :: args', retTy)
-    | _ty, args => .error (.arityMismatch 0 args.length)
+        let args' ← checkArgs prims Θ Γ doms args
+        .ok (arg' :: args')
+    | doms, args => .error (.arityMismatch doms.length args.length)
 
   def inferBranches (prims : Prims) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
       List Typ → List (Untyped.Binder × Untyped.Expr) → Except TypeError (List (Typed.Binder × Typed.Expr))
@@ -634,7 +643,7 @@ mutual
     | .fix self args retTy body => by
         let retTy' := retTy.getD .value
         let typedArgs := args.map (fun b => Typed.Binder.ofUntyped b (Typed.Binder.expectedTy b .value))
-        let selfTy := Typed.arrowOfArgs typedArgs retTy'
+        let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy'
         let typedSelf := Typed.Binder.ofUntyped self selfTy
         let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
         let ih := check_runtime prims Θ Γ' body retTy'
@@ -662,9 +671,10 @@ mutual
             | ok inst =>
               simp only [hty] at hcont
               split at hcont
-              · have ⟨res, hchk, hcont⟩ := Except.bind_ok hcont
-                cases res with
-                | mk args' retTy =>
+              · have ⟨sig, hdoms, hcont⟩ := Except.bind_ok hcont
+                cases sig with
+                | mk doms retTy =>
+                  have ⟨args', hchk, hcont⟩ := Except.bind_ok hcont
                   rcases (by simpa using hcont) with ⟨rfl, rfl⟩
                   simp only [Expr.runtime, Untyped.Expr.runtime,
                     Untyped.Expr.primName?_runtime hpn]
@@ -674,10 +684,11 @@ mutual
           simp only [hpn] at h
           obtain ⟨fp, hfn, hcont⟩ := Except.bind_ok h
           obtain ⟨fnTy, fn'⟩ := fp
-          obtain ⟨res, hargs, hcont⟩ := Except.bind_ok hcont
-          obtain ⟨args', retTy⟩ := res
+          obtain ⟨sig, hdoms, hcont⟩ := Except.bind_ok hcont
+          obtain ⟨doms, retTy⟩ := sig
+          obtain ⟨args', hargs, hcont⟩ := Except.bind_ok hcont
           rcases (by simpa [hargs] using hcont) with ⟨rfl, rfl⟩
-          simp [Expr.runtime, Untyped.Expr.runtime, ihFn _ hfn, ihArgs fnTy _ hargs]
+          simp [Expr.runtime, Untyped.Expr.runtime, ihFn _ hfn, ihArgs doms _ hargs]
     | .ifThenElse cond thn els => by
         let ihCond := check_runtime prims Θ Γ cond .bool
         let ihThn := infer_runtime prims Θ Γ thn
@@ -973,26 +984,25 @@ mutual
           simp [ihHead _ hinfer, ihTail _ htail]
 
   theorem checkArgs_runtime (prims : Prims) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
-      (args : List Untyped.Expr) → ∀ ty result, Typed.checkArgs prims Θ Γ ty args = .ok result →
-        result.1.map Expr.runtime = args.map Untyped.Expr.runtime
+      (args : List Untyped.Expr) → ∀ doms result, Typed.checkArgs prims Θ Γ doms args = .ok result →
+        result.map Expr.runtime = args.map Untyped.Expr.runtime
     | [] => by
-        intro ty result h
-        simp [Typed.checkArgs] at h
-        cases h
-        rfl
+        intro doms result h
+        cases doms <;> simp [Typed.checkArgs] at h
+        case nil => cases h; rfl
     | arg :: args => by
         let ihRest := checkArgs_runtime prims Θ Γ args
-        intro ty result h
-        cases ty <;> simp [Typed.checkArgs] at h
-        case arrow dom cod =>
+        intro doms result h
+        cases doms with
+        | nil => simp [Typed.checkArgs] at h
+        | cons dom doms =>
+          simp only [Typed.checkArgs] at h
           have ⟨arg', harg, hcont⟩ := Except.bind_ok h
-          have ⟨rest, hrest, hcont⟩ := Except.bind_ok hcont
-          cases rest with
-          | mk args' retTy =>
-            simp at hcont
-            cases hcont
-            simp only [List.map]
-            rw [check_runtime prims Θ Γ arg dom _ harg, ihRest cod _ hrest]
+          have ⟨args', hrest, hcont⟩ := Except.bind_ok hcont
+          simp at hcont
+          cases hcont
+          simp only [List.map]
+          rw [check_runtime prims Θ Γ arg dom _ harg, ihRest doms _ hrest]
 
   theorem inferBranches_runtime (prims : Prims) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
       (branches : List (Untyped.Binder × Untyped.Expr)) →

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -32,6 +32,45 @@ inductive Assertion : Type → Type where
   | pred   : (v : Var) → Atom v.sort → Assertion α → Assertion α
   | ite    : Formula → Assertion α → Assertion α → Assertion α
 
+private def Assertion.decideEq [DecidableEq α] : (a b : Assertion α) → Decidable (a = b)
+  | .ret a, .ret b => match decEq a b with
+    | isTrue h => isTrue (by subst h; rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .assert φ₁ k₁, .assert φ₂ k₂ => match decEq φ₁ φ₂, k₁.decideEq k₂ with
+    | isTrue h₁, isTrue h₂ => isTrue (by subst h₁; subst h₂; rfl)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .let_ v₁ t₁ k₁, .let_ v₂ t₂ k₂ => match decEq v₁ v₂ with
+    | isTrue hv => by
+        subst hv
+        exact match decEq t₁ t₂, k₁.decideEq k₂ with
+          | isTrue ht, isTrue hk => isTrue (by subst ht; subst hk; rfl)
+          | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+          | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .pred v₁ p₁ k₁, .pred v₂ p₂ k₂ => match decEq v₁ v₂ with
+    | isTrue hv => by
+        subst hv
+        exact match decEq p₁ p₂, k₁.decideEq k₂ with
+          | isTrue hp, isTrue hk => isTrue (by subst hp; subst hk; rfl)
+          | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+          | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .ite φ₁ kt₁ ke₁, .ite φ₂ kt₂ ke₂ =>
+    match decEq φ₁ φ₂, kt₁.decideEq kt₂, ke₁.decideEq ke₂ with
+    | isTrue hφ, isTrue ht, isTrue he => isTrue (by subst hφ; subst ht; subst he; rfl)
+    | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .ret _, .assert .. | .ret _, .let_ .. | .ret _, .pred .. | .ret _, .ite ..
+  | .assert .., .ret _ | .assert .., .let_ .. | .assert .., .pred .. | .assert .., .ite ..
+  | .let_ .., .ret _ | .let_ .., .assert .. | .let_ .., .pred .. | .let_ .., .ite ..
+  | .pred .., .ret _ | .pred .., .assert .. | .pred .., .let_ .. | .pred .., .ite ..
+  | .ite .., .ret _ | .ite .., .assert .. | .ite .., .let_ .. | .ite .., .pred .. =>
+    isFalse (by intro h; cases h)
+
+instance [DecidableEq α] : DecidableEq (Assertion α) := Assertion.decideEq
+
 
 -- ---------------------------------------------------------------------------
 -- Semantics

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -76,26 +76,26 @@ instance [DecidableEq α] : DecidableEq (Assertion α) := Assertion.decideEq
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Assertion.pre (Θ : TinyML.TypeEnv) (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
+def Assertion.pre (W : TinyML.World) (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   (match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ.env⌝ ∗ Assertion.pre Θ Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ.env; Assertion.pre Θ Φ k (ρ.updateConst x.sort x.name v)
-  | .pred x p k   => ∃ (v : x.sort.denote), p.eval Θ ρ v ∗ Assertion.pre Θ Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ.env⌝ ∗ Assertion.pre W Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ.env; Assertion.pre W Φ k (ρ.updateConst x.sort x.name v)
+  | .pred x p k   => ∃ (v : x.sort.denote), p.eval W ρ v ∗ Assertion.pre W Φ k (ρ.updateConst x.sort x.name v)
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.pre Θ Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.pre Θ Φ ke ρ)))
+      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.pre W Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.pre W Φ ke ρ)))
 
-def Assertion.post (Θ : TinyML.TypeEnv) {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
+def Assertion.post (W : TinyML.World) {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ.env⌝ -∗ Assertion.post Θ Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ.env; Assertion.post Θ Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ.env⌝ -∗ Assertion.post W Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ.env; Assertion.post W Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => iprop(∀ (v : x.sort.denote),
-      p.eval Θ ρ v -∗ Assertion.post Θ Φ k (ρ.updateConst x.sort x.name v))
+      p.eval W ρ v -∗ Assertion.post W Φ k (ρ.updateConst x.sort x.name v))
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.post Θ Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.post Θ Φ ke ρ))
+      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.post W Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.post W Φ ke ρ))
 
 
 -- ---------------------------------------------------------------------------
@@ -164,11 +164,11 @@ theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Pro
 -- Environment agreement
 -- ---------------------------------------------------------------------------
 
-theorem Assertion.pre_env_agree (Θ : TinyML.TypeEnv) {m : Assertion α} {retWf : α → Signature → Prop}
+theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : α → Signature → Prop}
     {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
-    Assertion.pre Θ Φ m ρ ⊢ Assertion.pre Θ Φ m ρ' := by
+    Assertion.pre W Φ m ρ ⊢ Assertion.pre W Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
   | assert φ k ih =>
@@ -193,8 +193,8 @@ theorem Assertion.pre_env_agree (Θ : TinyML.TypeEnv) {m : Assertion α} {retWf 
     iintro ⟨%w, Hsep⟩
     iexists w
     iapply (sep_mono
-      (show p.eval Θ ρ w ⊢ p.eval Θ ρ' w by
-        simp [(Atom.eval_env_agree Θ hpwf hagree)])
+      (show p.eval W ρ w ⊢ p.eval W ρ' w by
+        simp [(Atom.eval_env_agree W hpwf hagree)])
       (ih hkwf (VerifM.Env.agreeOn_declVar hagree)))
     iexact Hsep
   | ite φ kt ke iht ihe =>
@@ -224,11 +224,11 @@ theorem Assertion.pre_env_agree (Θ : TinyML.TypeEnv) {m : Assertion α} {retWf 
       iapply hnφ
       iapply Hnφ
 
-theorem Assertion.post_env_agree (Θ : TinyML.TypeEnv) {m : Assertion α} {retWf : α → Signature → Prop}
+theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : α → Signature → Prop}
     {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
-    Assertion.post Θ Φ m ρ ⊢ Assertion.post Θ Φ m ρ' := by
+    Assertion.post W Φ m ρ ⊢ Assertion.post W Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
   | assert φ k ih =>
@@ -253,7 +253,7 @@ theorem Assertion.post_env_agree (Θ : TinyML.TypeEnv) {m : Assertion α} {retWf
     iintro %w Hw
     iapply (ih hkwf (VerifM.Env.agreeOn_declVar hagree))
     iapply H
-    iapply (show p.eval Θ ρ' w ⊢ p.eval Θ ρ w by simp [(Atom.eval_env_agree Θ hpwf hagree)])
+    iapply (show p.eval W ρ' w ⊢ p.eval W ρ w by simp [(Atom.eval_env_agree W hpwf hagree)])
     iexact Hw
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
@@ -277,13 +277,13 @@ theorem Assertion.post_env_agree (Θ : TinyML.TypeEnv) {m : Assertion α} {retWf
       exact hnφ'
 
 /-- Combining caller-side `pre` with verifier-side `post`. -/
-theorem Assertion.pre_post_combine (Θ : TinyML.TypeEnv) {α : Type}
+theorem Assertion.pre_post_combine (W : TinyML.World) {α : Type}
     {m : Assertion α}
     {Φ : α → VerifM.Env → iProp} {Ψ : α → VerifM.Env → iProp}
     {ρ : VerifM.Env}
     {R : iProp}
     (hR : ∀ (a : α) (ρ0 : VerifM.Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
-    : (Assertion.pre Θ Φ m ρ ∗ Assertion.post Θ Ψ m ρ) ⊢ R := by
+    : (Assertion.pre W Φ m ρ ∗ Assertion.post W Ψ m ρ) ⊢ R := by
   induction m generalizing ρ R with
   | ret a =>
     simpa [Assertion.pre, Assertion.post] using hR a ρ
@@ -399,7 +399,7 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
 -- Correctness theorems
 -- ---------------------------------------------------------------------------
 
-theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
+theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
@@ -409,8 +409,8 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
     VerifM.eval (Assertion.assume σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
       retWf a (Δ_base.declVars σ'.dom) →
-      st'.sl Θ ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
-    st.sl Θ ρ ∗ R ⊢ Assertion.post Θ Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
+      st'.sl W ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
+    st.sl W ρ ∗ R ⊢ Assertion.post W Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
   intro hσwf hwf heval hpost
   induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
@@ -451,10 +451,10 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
         simpa [σ', FiniteSubst.rename_source_eq] using hkwf
       have hih := ih Δ_base σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
         (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
-      have hinterp_bi : st.sl Θ ρ ⊣⊢ st.sl Θ (ρ.updateConst v.sort v'.name u) :=
-        SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
+      have hinterp_bi : st.sl W ρ ⊣⊢ st.sl W (ρ.updateConst v.sort v'.name u) :=
+        SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf
           (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-      exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.post_env_agree Θ hkwf'
+      exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.post_env_agree W hkwf'
         (by
           simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
             (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -486,22 +486,22 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
         Atom.toItem_wfIn
           (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
             (Signature.wf_addConst hσwf.useWf hv'_fresh_decls)) hvar_wf
-      have hpu' : p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-          (p.subst σ.subst).eval Θ (ρ.updateConst v.sort v'.name u)
+      have hpu' : p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+          (p.subst σ.subst).eval W (ρ.updateConst v.sort v'.name u)
             ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
               (ρ.updateConst v.sort v'.name u).env) := by
         have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
             (ρ.updateConst v.sort v'.name u).env) = u := by
           simp [Term.eval, Const.denote, Env.updateConst]
         rw [hconst]
-        rw [Atom.eval_subst Θ hpwf hσwf.subst hσwf.rangeWf]
+        rw [Atom.eval_subst W hpwf hσwf.subst hσwf.rangeWf]
         have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
           (τ := v.sort) (name' := v'.name) (u := u) hσwf hv'_fresh_range
         have heval_agree :
-            p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) =
-              p.eval Θ ((ρ.updateConst v.sort v'.name u).withEnv
+            p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) =
+              p.eval W ((ρ.updateConst v.sort v'.name u).withEnv
                 (σ.subst.eval (ρ.updateConst v.sort v'.name u).env)) :=
-          Atom.eval_env_agree Θ (p := p)
+          Atom.eval_env_agree W (p := p)
             (ρ := ρ.withEnv (σ.subst.eval ρ.env))
             (ρ' := (ρ.updateConst v.sort v'.name u).withEnv
               (σ.subst.eval (ρ.updateConst v.sort v'.name u).env))
@@ -519,10 +519,10 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
         simpa [σ', FiniteSubst.rename_source_eq] using hkwf
       cases hitem : item with
       | pure φ =>
-        have hφ_entail : p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+        have hφ_entail : p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
             ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ := by
           simpa [item, hitem] using
-            (hpu'.trans (Atom.eval_purePart Θ (p := p.subst σ.subst)
+            (hpu'.trans (Atom.eval_purePart W (p := p.subst σ.subst)
               (t := .const (.uninterpreted v'.name v.sort))
               (ρ := (ρ.updateConst v.sort v'.name u))))
         ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ $$ [Hpu]
@@ -541,16 +541,16 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
         have hih := ih Δ_base σ' st''
           (ρ.updateConst v.sort v'.name u) Ψ hσ''wf hkwf' hassume hpost
         have hframe :
-            st.sl Θ ρ ∗ R ⊢
-              st''.sl Θ (ρ.updateConst v.sort v'.name u) ∗ R := by
+            st.sl W ρ ∗ R ⊢
+              st''.sl W (ρ.updateConst v.sort v'.name u) ∗ R := by
           simp only [TransState.sl_eq, howns'', TransState.addItem]
           exact sep_mono
-            (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
+            (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf
               (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
             (by
               iintro HR
               iexact HR)
-        iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree Θ hkwf'
+        iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree W hkwf'
           (by
             simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -565,20 +565,20 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
         have hitem_wf' : (.spatial a : CtxItem).wfIn (st.decls.addConst v') := by
           simpa [item, hitem] using hitem_wf
         have hitem_interp :
-            p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-              CtxItem.interp Θ (ρ.updateConst v.sort v'.name u) item := by
+            p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+              CtxItem.interp W (ρ.updateConst v.sort v'.name u) item := by
           simpa [item] using
-            (hpu'.trans (Atom.toItem_eval Θ (p := p.subst σ.subst)
+            (hpu'.trans (Atom.toItem_eval W (p := p.subst σ.subst)
               (t := .const (.uninterpreted v'.name v.sort))
               (ρ := (ρ.updateConst v.sort v'.name u))).2)
         have hspatial_interp :
-            p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-              SpatialAtom.interp Θ (ρ.updateConst v.sort v'.name u).env a := by
+            p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+              SpatialAtom.interp W (ρ.updateConst v.sort v'.name u).env a := by
           simpa [item, hitem, CtxItem.interp] using hitem_interp
-        ihave Ha : SpatialAtom.interp Θ (ρ.updateConst v.sort v'.name u).env a $$ [Hpu]
+        ihave Ha : SpatialAtom.interp W (ρ.updateConst v.sort v'.name u).env a $$ [Hpu]
         · iapply hspatial_interp
           simp [VerifM.Env.withEnv]
-        ihave Hfacts := SpatialAtom.interp_facts Θ a $$ Ha
+        ihave Hfacts := SpatialAtom.interp_facts W a $$ Ha
         icases Hfacts with ⟨%hfacts, Ha⟩
         obtain ⟨st'', hdecls'', howns'', hassume⟩ :=
           VerifM.eval_acquire hb2' hitem_wf' trivial (by simpa [CtxItem.facts] using hfacts)
@@ -586,11 +586,11 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
         have hih := ih Δ_base σ' st''
           (ρ.updateConst v.sort v'.name u) Ψ hσ''wf hkwf' hassume hpost
         have howns_agree :
-            st.sl Θ ρ ⊢
-              st.sl Θ (ρ.updateConst v.sort v'.name u) :=
-          (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
+            st.sl W ρ ⊢
+              st.sl W (ρ.updateConst v.sort v'.name u) :=
+          (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf
             (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
-        iapply (hih.trans <| Assertion.post_env_agree Θ hkwf'
+        iapply (hih.trans <| Assertion.post_env_agree W hkwf'
           (by
             simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -629,7 +629,7 @@ theorem Assertion.assume_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_ba
         iapply (ihe Δ_base σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hkewf hassume hpost)
         simp [TransState.sl]
 
-theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
+theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
@@ -639,8 +639,8 @@ theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_bas
     VerifM.eval (Assertion.prove σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
       retWf a (Δ_base.declVars σ'.dom) →
-      st'.sl Θ ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
-    st.sl Θ ρ ∗ R ⊢ Assertion.pre Θ Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
+      st'.sl W ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
+    st.sl W ρ ∗ R ⊢ Assertion.pre W Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
   intro hσwf hwf heval hpost
   induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
@@ -651,8 +651,8 @@ theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_bas
       have hassert := VerifM.eval_assert (VerifM.eval_bind heval)
         (FiniteSubst.subst_wfIn_formula hσwf hφwf)
       have hφ_holds := (FiniteSubst.eval_subst_formula hσwf hφwf).mp hassert.1
-      show st.sl Θ ρ ∗ R ⊢
-        (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre Θ Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
+      show st.sl W ρ ∗ R ⊢
+        (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre W Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
       istart
       iintro ⟨Howns, HR⟩
       isplitr [Howns HR]
@@ -685,10 +685,10 @@ theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_bas
         simpa [σ', FiniteSubst.rename_source_eq] using hkwf
       have hih := ih Δ_base σ' { st with decls := st.decls.addConst v', asserts := _ :: st.asserts }
         (ρ.updateConst v.sort v'.name u) Ψ hσ'wf hkwf' hassume hpost
-      have hinterp_bi : st.sl Θ ρ ⊣⊢ st.sl Θ (ρ.updateConst v.sort v'.name u) :=
-        SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf
+      have hinterp_bi : st.sl W ρ ⊣⊢ st.sl W (ρ.updateConst v.sort v'.name u) :=
+        SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf
           (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-      exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.pre_env_agree Θ hkwf'
+      exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.pre_env_agree W hkwf'
         (by
           simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
             (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -702,7 +702,7 @@ theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_bas
         Atom.wfIn_mono
           (Atom.subst_wfIn hpwf hσwf.subst (fun _ hx => hx) hσwf.srcSymbolSubset hσwf.rangeWf)
           hσwf.rangeSubset hσwf.useWf
-      exact VerifM.eval_resolve Θ hb hpwf_decls
+      exact VerifM.eval_resolve W hb hpwf_decls
         (fun st' ρ' hq hsub hagree => by
           exact (VerifM.eval_fatal hq).elim)
         (fun t st' ρ' hq hsub hagree htwf => by
@@ -715,12 +715,12 @@ theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_bas
           iexists (t.eval ρ'.env)
           isplitr [Howns HR]
           · have hpred_subst :
-                (p.subst σ.subst).eval Θ ρ' (t.eval ρ'.env) ⊢
-                  p.eval Θ (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) := by
+                (p.subst σ.subst).eval W ρ' (t.eval ρ'.env) ⊢
+                  p.eval W (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) := by
               simpa [VerifM.Env.withEnv] using
-                (show (p.subst σ.subst).eval Θ ρ' (t.eval ρ'.env) ⊢
-                    p.eval Θ (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) by
-                  rw [Atom.eval_subst Θ hpwf hσwf.subst hσwf.rangeWf]
+                (show (p.subst σ.subst).eval W ρ' (t.eval ρ'.env) ⊢
+                    p.eval W (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) by
+                  rw [Atom.eval_subst W hpwf hσwf.subst hσwf.rangeWf]
                   exact BIBase.Entails.rfl)
             have hagree_subst :
                 VerifM.Env.agreeOn (Δ_base.declVars σ.dom)
@@ -728,9 +728,9 @@ theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_bas
                   (ρ'.withEnv (σ.subst.eval ρ'.env)) := by
               exact FiniteSubst.eval_agreeOn hσwf hagree
             have hpred_transport :
-                p.eval Θ (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) ⊢
-                  p.eval Θ (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ'.env) := by
-              rw [Atom.eval_env_agree Θ hpwf (VerifM.Env.agreeOn_symm hagree_subst)]
+                p.eval W (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) ⊢
+                  p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ'.env) := by
+              rw [Atom.eval_env_agree W hpwf (VerifM.Env.agreeOn_symm hagree_subst)]
               exact BIBase.Entails.rfl
             iapply hpred_transport
             iapply hpred_subst
@@ -756,13 +756,13 @@ theorem Assertion.prove_correct (Θ : TinyML.TypeEnv) (m : Assertion α) (Δ_bas
               simpa [σ', FiniteSubst.rename_source_eq] using hkwf
             have hih := ih Δ_base σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
               (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) Ψ hσ'wf hkwf' hassume hpost
-            have hinterp_bi : st'.sl Θ ρ' ⊣⊢ st'.sl Θ (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) :=
-              SpatialContext.interp_env_agree Θ (VerifM.eval.wf hq).ownsWf
+            have hinterp_bi : st'.sl W ρ' ⊣⊢ st'.sl W (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) :=
+              SpatialContext.interp_env_agree W (VerifM.eval.wf hq).ownsWf
                 (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-            have hframe : st'.sl Θ ρ' ∗ R ⊢
-                st'.sl Θ (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) ∗ R :=
+            have hframe : st'.sl W ρ' ∗ R ⊢
+                st'.sl W (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) ∗ R :=
               sep_mono_left hinterp_bi.1
-            iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree Θ hkwf'
+            iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree W hkwf'
               (by
                 have hrename := (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st'.decls)
                     (v := v) (name' := v'.name) (ρ := ρ'.env) (u := t.eval ρ'.env)

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -61,16 +61,16 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Atom.eval (Θ : TinyML.TypeEnv) {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
+def Atom.eval (W : TinyML.World) {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
   match p with
   | isint t  => λ v => ⌜.int v = t.eval ρ.env⌝
   | isbool t => λ v => ⌜.bool v = t.eval ρ.env⌝
   | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ.env⌝
   | own l ty => λ v => ∃ loc : Runtime.Location,
-      ⌜l.eval ρ.env = .loc loc⌝ ∗ loc ↦ [v] ∗ TinyML.ValHasType Θ v ty
+      ⌜l.eval ρ.env = .loc loc⌝ ∗ loc ↦ [v] ∗ TinyML.ValHasType W v ty
   | arr a ty => λ v => ∃ loc : Runtime.Location, ∃ vs : List Runtime.Val,
       ⌜a.eval ρ.env = .array vs.length loc⌝ ∗ ⌜v = .vec vs⌝ ∗ loc ↦ vs ∗
-        TinyML.ValHasType Θ (.vec vs) (.vec ty)
+        TinyML.ValHasType W (.vec vs) (.vec ty)
   | rel name arg => λ v =>
     ⌜(SpecFn.isDefined name arg).eval ρ.env ∧ (SpecFn.call name arg).eval ρ.env = v⌝
 
@@ -140,9 +140,9 @@ theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
 def Atom.resolve (a : Atom τ) (C : List Formula) : Option (Term τ) :=
   C.findSome? (·.matchAtom a)
 
-theorem Atom.resolve_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {C : List Formula} {t : Term τ}
+theorem Atom.resolve_correct (W : TinyML.World) {a : Atom τ} {C : List Formula} {t : Term τ}
     (h : a.resolve C = some t) (ρ : VerifM.Env) (hC : ∀ φ ∈ C, φ.eval ρ.env) :
-    ⊢ (a.toItem t).interp Θ ρ := by
+    ⊢ (a.toItem t).interp W ρ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
   rw [Formula.matchAtom_correct hφ_match]
   simpa [CtxItem.interp, hC _ hφ_mem] using (pure_intro (PROP := iProp) trivial)
@@ -215,8 +215,8 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | rel name t =>
     exact ⟨Formula.wfIn_mono _ h.1 hmono hwf, Term.wfIn_mono _ h.2 hmono hwf⟩
 
-theorem Atom.eval_env_agree (Θ : TinyML.TypeEnv) {p : Atom τ} {ρ ρ' : VerifM.Env} {Δ : Signature}
-    (hwf : p.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') : p.eval Θ ρ = p.eval Θ ρ' := by
+theorem Atom.eval_env_agree (W : TinyML.World) {p : Atom τ} {ρ ρ' : VerifM.Env} {Δ : Signature}
+    (hwf : p.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') : p.eval W ρ = p.eval W ρ' := by
   cases p with
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
@@ -253,8 +253,8 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     simp only [Atom.toItem, CtxItem.wfIn, Formula.wfIn]
     exact ⟨hp.1, hp.2, ht⟩
 
-theorem Atom.toItem_eval (Θ : TinyML.TypeEnv) {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
-    CtxItem.interp Θ ρ (p.toItem t) ⊣⊢ p.eval Θ ρ (t.eval ρ.env) := by
+theorem Atom.toItem_eval (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    CtxItem.interp W ρ (p.toItem t) ⊣⊢ p.eval W ρ (t.eval ρ.env) := by
   cases p with
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
@@ -268,8 +268,8 @@ theorem Atom.toItem_eval (Θ : TinyML.TypeEnv) {p : Atom τ} {t : Term τ} {ρ :
   | rel name arg =>
     simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval]
 
-theorem Atom.eval_purePart (Θ : TinyML.TypeEnv) {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
-    p.eval Θ ρ (t.eval ρ.env) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
+theorem Atom.eval_purePart (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
+    p.eval W ρ (t.eval ρ.env) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
   cases p with
   | isint v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
@@ -292,9 +292,9 @@ theorem Atom.eval_purePart (Θ : TinyML.TypeEnv) {p : Atom τ} {t : Term τ} {ρ
 -- ---------------------------------------------------------------------------
 
 -- @agent: change eval_subst to a bi-entailment in the future.
-theorem Atom.eval_subst (Θ : TinyML.TypeEnv) {p : Atom τ} {σ : Subst} {ρ : VerifM.Env} {Δ Δ' : Signature}
+theorem Atom.eval_subst (W : TinyML.World) {p : Atom τ} {σ : Subst} {ρ : VerifM.Env} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hwfΔ' : Δ'.wf) :
-    (p.subst σ).eval Θ ρ = p.eval Θ (ρ.withEnv (σ.eval ρ.env)) := by
+    (p.subst σ).eval W ρ = p.eval W (ρ.withEnv (σ.eval ρ.env)) := by
   cases p with
   | isint t =>
     funext v
@@ -363,8 +363,8 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .arr _ _ => []
   | .rel _ _ => []
 
-theorem Atom.candidates_correct (Θ : TinyML.TypeEnv) {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : VerifM.Env}
-    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ.env) : ⊢ (a.toItem t).interp Θ ρ := by
+theorem Atom.candidates_correct (W : TinyML.World) {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : VerifM.Env}
+    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ.env) : ⊢ (a.toItem t).interp W ρ := by
   cases a with
   | isint v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
@@ -421,7 +421,7 @@ def VerifM.tryCandidates : List (Formula × Term τ) → VerifM (Option (Term τ
     if ← VerifM.check .high φ then pure (some t)
     else VerifM.tryCandidates rest
 
-private theorem VerifM.eval_tryCandidates (Θ : TinyML.TypeEnv)
+private theorem VerifM.eval_tryCandidates (W : TinyML.World)
     {candidates : List (Formula × Term τ)} {a : Atom τ}
     {st : TransState} {ρ : VerifM.Env} {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     (h : VerifM.eval (VerifM.tryCandidates candidates) st ρ Q)
@@ -429,7 +429,7 @@ private theorem VerifM.eval_tryCandidates (Θ : TinyML.TypeEnv)
     (hpwf : a.wfIn st.decls) :
     ∃ result : Option (Term τ),
       Q result st ρ
-      ∧ (∀ t, result = some t → ⊢ (a.toItem t).interp Θ ρ)
+      ∧ (∀ t, result = some t → ⊢ (a.toItem t).interp W ρ)
       ∧ (∀ t, result = some t → t.wfIn st.decls) := by
   induction candidates with
   | nil =>
@@ -447,7 +447,7 @@ private theorem VerifM.eval_tryCandidates (Θ : TinyML.TypeEnv)
     | true =>
       simp at hq
       exact ⟨some t, VerifM.eval_ret hq,
-             fun t' ht' => by cases ht'; exact Atom.candidates_correct Θ hmem (hb_sound rfl),
+             fun t' ht' => by cases ht'; exact Atom.candidates_correct W hmem (hb_sound rfl),
              fun t' ht' => by cases ht'; exact twf⟩
     | false =>
       simp at hq
@@ -566,7 +566,7 @@ theorem VerifM.eval_findMatchIn {k : SpatialAtom.Kind} {tq : Term .value} {ty : 
     continuations for the `some` and `none` branches. On `some v`, the
     postcondition state has the matched atom consumed from `st.owns`, and the
     caller receives its interpretation at key `tq` separately. -/
-theorem VerifM.eval_findMatch (Θ : TinyML.TypeEnv) {k : SpatialAtom.Kind}
+theorem VerifM.eval_findMatch (W : TinyML.World) {k : SpatialAtom.Kind}
     {tq : Term .value} {ty : TinyML.Typ}
     {st : TransState} {ρ : VerifM.Env}
     {Q : Option (Term .value) → TransState → VerifM.Env → Prop}
@@ -575,9 +575,9 @@ theorem VerifM.eval_findMatch (Θ : TinyML.TypeEnv) {k : SpatialAtom.Kind}
     (htq : tq.wfIn st.decls)
     (hsome : ∀ v st', Q (some v) st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp Θ ρ.env (k.atom tq v ty) ∗ st'.sl Θ ρ ∗ R ⊢ Φ)
-    (hnone : Q none st ρ → st.sl Θ ρ ∗ R ⊢ Φ) :
-    st.sl Θ ρ ∗ R ⊢ Φ := by
+        SpatialAtom.interp W ρ.env (k.atom tq v ty) ∗ st'.sl W ρ ∗ R ⊢ Φ)
+    (hnone : Q none st ρ → st.sl W ρ ∗ R ⊢ Φ) :
+    st.sl W ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatch at h
   have hb := VerifM.eval_bind h
   have ⟨hk, howns, _, _⟩ := VerifM.eval_ctx hb
@@ -603,8 +603,8 @@ theorem VerifM.eval_findMatch (Θ : TinyML.TypeEnv) {k : SpatialAtom.Kind}
     have ⟨hk3, _, _, _⟩ := VerifM.eval_ctx hb3
     have hk3' := hk3 hrest_wf
     have hQ : Q (some v) { st with owns := rest } ρ := VerifM.eval_ret hk3'
-    have hsplit := SpatialContext.interp_remove Θ ρ.env st.owns n _ _ hrem
-    have hcong := SpatialAtom.congr Θ (k := k) (t := t) (t' := tq) (v := v) (v' := v)
+    have hsplit := SpatialContext.interp_remove W ρ.env st.owns n _ _ hrem
+    have hcong := SpatialAtom.congr W (k := k) (t := t) (t' := tq) (v := v) (v' := v)
       (ty := ty) heq.symm rfl
     -- goal: st.owns.interp ρ ∗ R ⊢ Φ
     -- st.owns.interp ρ ⊣⊢ (k.atom t v ty).interp ρ ∗ rest.interp ρ
@@ -624,7 +624,7 @@ def VerifM.findMatchForce (k : SpatialAtom.Kind) (tq : Term .value) (ty : TinyML
 
 /-- CPS correctness for `findMatchForce`: only a `some`-style continuation is
     required, since the `none` branch is discharged by the fatal error. -/
-theorem VerifM.eval_findMatchForce (Θ : TinyML.TypeEnv) {k : SpatialAtom.Kind}
+theorem VerifM.eval_findMatchForce (W : TinyML.World) {k : SpatialAtom.Kind}
     {tq : Term .value} {ty : TinyML.Typ}
     {st : TransState} {ρ : VerifM.Env}
     {Q : Term .value → TransState → VerifM.Env → Prop}
@@ -633,11 +633,11 @@ theorem VerifM.eval_findMatchForce (Θ : TinyML.TypeEnv) {k : SpatialAtom.Kind}
     (htq : tq.wfIn st.decls)
     (hsome : ∀ v st', Q v st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp Θ ρ.env (k.atom tq v ty) ∗ st'.sl Θ ρ ∗ R ⊢ Φ) :
-    st.sl Θ ρ ∗ R ⊢ Φ := by
+        SpatialAtom.interp W ρ.env (k.atom tq v ty) ∗ st'.sl W ρ ∗ R ⊢ Φ) :
+    st.sl W ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatchForce at h
   have hb := VerifM.eval_bind h
-  refine eval_findMatch Θ (R := R) (Φ := Φ) hb htq ?_ ?_
+  refine eval_findMatch W (R := R) (Φ := Φ) hb htq ?_ ?_
   · intros v st' hQ hdecls hv
     simp at hQ
     exact hsome v st' (VerifM.eval_ret hQ) hdecls hv
@@ -681,17 +681,17 @@ theorem VerifM.eval_acquire {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
 /-- CPS correctness for acquiring a spatial atom: the ownership context is
     extended by the atom, whose pure facts are justified from its
     interpretation. -/
-theorem VerifM.eval_acquireSpatial (Θ : TinyML.TypeEnv) {a : SpatialAtom}
+theorem VerifM.eval_acquireSpatial (W : TinyML.World) {a : SpatialAtom}
     {st : TransState} {ρ : VerifM.Env}
     {Q : Unit → TransState → VerifM.Env → Prop} {R Φ : iProp}
     (h : VerifM.eval (VerifM.acquire (.spatial a)) st ρ Q)
     (hwf : a.wfIn st.decls)
     (hk : ∀ st', Q () st' ρ → st'.decls = st.decls → st'.owns = a :: st.owns →
-      st'.sl Θ ρ ∗ R ⊢ Φ) :
-    SpatialAtom.interp Θ ρ.env a ∗ st.sl Θ ρ ∗ R ⊢ Φ := by
+      st'.sl W ρ ∗ R ⊢ Φ) :
+    SpatialAtom.interp W ρ.env a ∗ st.sl W ρ ∗ R ⊢ Φ := by
   istart
   iintro ⟨Ha, Howns, HR⟩
-  ihave Hfacts := SpatialAtom.interp_facts Θ a $$ Ha
+  ihave Hfacts := SpatialAtom.interp_facts W a $$ Ha
   icases Hfacts with ⟨%hfacts, Ha⟩
   obtain ⟨st', hdecls, howns, hq⟩ := VerifM.eval_acquire h hwf trivial hfacts
   have howns' : st'.owns = a :: st.owns := howns
@@ -724,7 +724,7 @@ def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
       | none => VerifM.tryCandidates a.candidates
 
 /-- Helper: resolution of a pure atom via formula matching or SMT candidates. -/
-private theorem VerifM.eval_resolve_pure (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
+private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
     {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (do
@@ -733,11 +733,11 @@ private theorem VerifM.eval_resolve_pure (Θ : TinyML.TypeEnv) {pred : Atom τ} 
       | none => VerifM.tryCandidates pred.candidates) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st' ρ', Q .none st' ρ' → st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl Θ ρ' ∗ R ⊢ Φ)
+      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl W ρ' ∗ R ⊢ Φ)
     (hsome : ∀ v st' ρ', Q (.some v) st' ρ' → st.decls.Subset st'.decls →
       VerifM.Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
-      Atom.eval Θ pred ρ' (v.eval ρ'.env) ∗ st'.sl Θ ρ' ∗ R ⊢ Φ) :
-    st.sl Θ ρ ∗ R ⊢ Φ := by
+      Atom.eval W pred ρ' (v.eval ρ'.env) ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
+    st.sl W ρ ∗ R ⊢ Φ := by
     have hb1 := VerifM.eval_bind h
     have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
     cases hres : pred.resolve st.asserts with
@@ -745,14 +745,14 @@ private theorem VerifM.eval_resolve_pure (Θ : TinyML.TypeEnv) {pred : Atom τ} 
       simp [hres] at hctx_q
       have hq := VerifM.eval_ret hctx_q
       have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
-      have hpred : ⊢ Atom.eval Θ pred ρ (t.eval ρ.env) :=
-        (Atom.resolve_correct Θ hres ρ hholds.asserts).trans (Atom.toItem_eval Θ).1
+      have hpred : ⊢ Atom.eval W pred ρ (t.eval ρ.env) :=
+        (Atom.resolve_correct W hres ρ hholds.asserts).trans (Atom.toItem_eval W).1
       exact (sep_intro_valid_left hpred).trans
         (hsome t st ρ hq (Signature.Subset.refl _) VerifM.Env.agreeOn_refl htwf)
     | none =>
       simp [hres] at hctx_q
       obtain ⟨result, hq, hresult_eval, hresult_wf⟩ :=
-        eval_tryCandidates Θ hctx_q (fun p hp => hp) hwf
+        eval_tryCandidates W hctx_q (fun p hp => hp) hwf
       cases hr : result with
       | none =>
         have hqnone : Q .none st ρ := by simpa [hr] using hq
@@ -760,32 +760,32 @@ private theorem VerifM.eval_resolve_pure (Θ : TinyML.TypeEnv) {pred : Atom τ} 
       | some t =>
         have htwf : t.wfIn st.decls := hresult_wf t hr
         have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
-        have hpred : ⊢ Atom.eval Θ pred ρ (t.eval ρ.env) :=
-          (hresult_eval t hr).trans (Atom.toItem_eval Θ).1
+        have hpred : ⊢ Atom.eval W pred ρ (t.eval ρ.env) :=
+          (hresult_eval t hr).trans (Atom.toItem_eval W).1
         exact (sep_intro_valid_left hpred).trans
           (hsome t st ρ hqsome (Signature.Subset.refl _) VerifM.Env.agreeOn_refl htwf)
 
-theorem VerifM.eval_resolve (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
+theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
     {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st' ρ', Q .none st' ρ' → st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl Θ ρ' ∗ R ⊢ Φ)
+      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl W ρ' ∗ R ⊢ Φ)
     (hsome : ∀ v st' ρ', Q (.some v) st' ρ' → st.decls.Subset st'.decls →
       VerifM.Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
-      Atom.eval Θ pred ρ' (v.eval ρ'.env) ∗ st'.sl Θ ρ' ∗ R ⊢ Φ) :
-    st.sl Θ ρ ∗ R ⊢ Φ := by
+      Atom.eval W pred ρ' (v.eval ρ'.env) ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
+    st.sl W ρ ∗ R ⊢ Φ := by
   match pred, hwf, hsome, h with
   | .own l ty, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    refine VerifM.eval_findMatch Θ (R := R) (Φ := Φ) h hwf ?_ ?_
+    refine VerifM.eval_findMatch W (R := R) (Φ := Φ) h hwf ?_ ?_
     · intros v st' hqsome hdecls hvwf
       have hsub : st.decls.Subset st'.decls := by rw [hdecls]; exact Signature.Subset.refl _
       have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
       have hsome' := hsome v st' ρ hqsome hsub VerifM.Env.agreeOn_refl hvwf'
-      have heq : SpatialAtom.interp Θ ρ.env (SpatialAtom.Kind.ref.atom l v ty) ⊢
-          Atom.eval Θ (Atom.own l ty) ρ (v.eval ρ.env) := by
+      have heq : SpatialAtom.interp W ρ.env (SpatialAtom.Kind.ref.atom l v ty) ⊢
+          Atom.eval W (Atom.own l ty) ρ (v.eval ρ.env) := by
         simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
@@ -793,13 +793,13 @@ theorem VerifM.eval_resolve (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransSt
       exact hnone st ρ hqnone (Signature.Subset.refl _) VerifM.Env.agreeOn_refl
   | .arr a ty, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    refine VerifM.eval_findMatch Θ (R := R) (Φ := Φ) h hwf ?_ ?_
+    refine VerifM.eval_findMatch W (R := R) (Φ := Φ) h hwf ?_ ?_
     · intros v st' hqsome hdecls hvwf
       have hsub : st.decls.Subset st'.decls := by rw [hdecls]; exact Signature.Subset.refl _
       have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
       have hsome' := hsome v st' ρ hqsome hsub VerifM.Env.agreeOn_refl hvwf'
-      have heq : SpatialAtom.interp Θ ρ.env (SpatialAtom.Kind.array.atom a v ty) ⊢
-          Atom.eval Θ (Atom.arr a ty) ρ (v.eval ρ.env) := by
+      have heq : SpatialAtom.interp W ρ.env (SpatialAtom.Kind.array.atom a v ty) ⊢
+          Atom.eval W (Atom.arr a ty) ρ (v.eval ρ.env) := by
         simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
@@ -807,13 +807,13 @@ theorem VerifM.eval_resolve (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransSt
       exact hnone st ρ hqnone (Signature.Subset.refl _) VerifM.Env.agreeOn_refl
   | .isint t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    exact VerifM.eval_resolve_pure Θ (pred := .isint t) h hwf hnone hsome
+    exact VerifM.eval_resolve_pure W (pred := .isint t) h hwf hnone hsome
   | .isbool t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    exact VerifM.eval_resolve_pure Θ (pred := .isbool t) h hwf hnone hsome
+    exact VerifM.eval_resolve_pure W (pred := .isbool t) h hwf hnone hsome
   | .isinj tag arity t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
-    exact VerifM.eval_resolve_pure Θ (pred := .isinj tag arity t) h hwf hnone hsome
+    exact VerifM.eval_resolve_pure W (pred := .isinj tag arity t) h hwf hnone hsome
   | .rel name t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
     have hb := VerifM.eval_bind h
@@ -827,7 +827,7 @@ theorem VerifM.eval_resolve (Θ : TinyML.TypeEnv) {pred : Atom τ} {st : TransSt
       simp at hafter
       have hdef : (SpecFn.isDefined name t).eval ρ.env := hok_sound rfl
       have hqsome : Q (some (SpecFn.call name t)) st ρ := VerifM.eval_ret hafter
-      have hpred : ⊢ Atom.eval Θ (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ.env) :=
+      have hpred : ⊢ Atom.eval W (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ.env) :=
         pure_intro (PROP := iProp) ⟨hdef, rfl⟩
       exact (sep_intro_valid_left hpred).trans (hsome (SpecFn.call name t) st ρ hqsome
         (Signature.Subset.refl _) VerifM.Env.agreeOn_refl hwf.2)

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -31,6 +31,7 @@ inductive Atom : Srt → Type where
   | own    : Term .value → TinyML.Typ → Atom .value
   | arr : Term .value → TinyML.Typ → Atom .value
   | rel    (name : String) : Term .value → Atom .value
+  deriving DecidableEq
 
 
 -- ---------------------------------------------------------------------------

--- a/Mica/Verifier/Bindings.lean
+++ b/Mica/Verifier/Bindings.lean
@@ -48,16 +48,16 @@ theorem Bindings.wfIn_cons {B : Bindings} {decls : Signature} {x : TinyML.Var} {
   · exact List.Mem.tail _ (hbwf p hp)
 
 /-- The substitution `γ` maps every binding to a value well-typed by `Γ`. -/
-def Bindings.typedSubst (Θ : TinyML.TypeEnv) (B : Bindings) (Γ : TinyML.TyCtx) (γ : Runtime.Subst) : iProp :=
-  iprop(□ ∀ x x' t, ⌜B.lookup x = some x'⌝ -∗ ⌜Γ x = some t⌝ -∗ ∃ v, ⌜γ x = some v⌝ ∗ TinyML.ValHasType Θ v t)
+def Bindings.typedSubst (W : TinyML.World) (B : Bindings) (Γ : TinyML.TyCtx) (γ : Runtime.Subst) : iProp :=
+  iprop(□ ∀ x x' t, ⌜B.lookup x = some x'⌝ -∗ ⌜Γ x = some t⌝ -∗ ∃ v, ⌜γ x = some v⌝ ∗ TinyML.ValHasType W v t)
 
-instance Bindings.typedSubst_persistent {B Γ γ} (Θ : TinyML.TypeEnv) : Persistent (Bindings.typedSubst Θ B Γ γ) :=
+instance Bindings.typedSubst_persistent {B Γ γ} (W : TinyML.World) : Persistent (Bindings.typedSubst W B Γ γ) :=
   by
     unfold Bindings.typedSubst
     infer_instance
 
-theorem Bindings.typedSubst_nil (Θ : TinyML.TypeEnv) (γ : Runtime.Subst) :
-    ⊢ Bindings.typedSubst Θ [] TinyML.TyCtx.empty γ := by
+theorem Bindings.typedSubst_nil (W : TinyML.World) (γ : Runtime.Subst) :
+    ⊢ Bindings.typedSubst W [] TinyML.TyCtx.empty γ := by
   unfold Bindings.typedSubst
   imodintro
   iintro %x %x' %t
@@ -66,8 +66,8 @@ theorem Bindings.typedSubst_nil (Θ : TinyML.TypeEnv) (γ : Runtime.Subst) :
 
 theorem Bindings.typedSubst_cons {B : Bindings} {Γ : TinyML.TyCtx} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : FOL.Const} {te : TinyML.Typ} {w : Runtime.Val}
-    : ⊢ B.typedSubst Θ Γ γ -∗ TinyML.ValHasType Θ w te -∗
-      Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x te) (Runtime.Subst.update γ x w) := by
+    : ⊢ B.typedSubst W Γ γ -∗ TinyML.ValHasType W w te -∗
+      Bindings.typedSubst W ((x, v) :: B) (Γ.extend x te) (Runtime.Subst.update γ x w) := by
   iintro #Hts #Hw
   unfold Bindings.typedSubst
   imodintro
@@ -121,8 +121,8 @@ theorem Bindings.typedSubst_of_agreeOnLinked
     {B : Bindings} {Γ : TinyML.TyCtx} {γ : Runtime.Subst} {ρ : Env}
     (hagree : B.agreeOnLinked ρ γ)
     : ⊢ □ (∀ x x' t, ⌜B.lookup x = some x'⌝ -∗ ⌜Γ x = some t⌝ -∗
-        TinyML.ValHasType Θ (ρ.consts .value x'.name) t) -∗
-      B.typedSubst Θ Γ γ := by
+        TinyML.ValHasType W (ρ.consts .value x'.name) t) -∗
+      B.typedSubst W Γ γ := by
   iintro #Htyped
   unfold Bindings.typedSubst
   imodintro
@@ -260,8 +260,8 @@ theorem valHasType_lookup_zip_reverse
     (hlookup : List.lookup x ((args.map Prod.fst).zip vars).reverse = some x')
     (hΓ : (args.foldl (fun ctx a => ctx.extend a.1 a.2) Γ₀) x = some t)
     (hlookups : List.Forall₂ (fun av val => ρ.consts .value av.name = val) vars vals)
-    : ⊢ TinyML.ValsHaveTypes Θ vals (args.map Prod.snd) -∗
-        TinyML.ValHasType Θ (ρ.consts .value x'.name) t := by
+    : ⊢ TinyML.ValsHaveTypes W vals (args.map Prod.snd) -∗
+        TinyML.ValHasType W (ρ.consts .value x'.name) t := by
   induction args generalizing vars vals Γ₀ with
   | nil => simp at hlookup
   | cons a as' ih =>
@@ -274,10 +274,10 @@ theorem valHasType_lookup_zip_reverse
         simp [List.map_cons, List.length_cons] at hlen_v hlen_vl
         cases hlookups with
         | cons hlk_head hlk_tail =>
-          exact (show ⊢ TinyML.ValsHaveTypes Θ (vl :: vls) (a.2 :: as'.map Prod.snd) -∗
-                TinyML.ValHasType Θ (ρ.consts .value x'.name) t by
+          exact (show ⊢ TinyML.ValsHaveTypes W (vl :: vls) (a.2 :: as'.map Prod.snd) -∗
+                TinyML.ValHasType W (ρ.consts .value x'.name) t by
               iintro Hvals
-              ihave Hpair := (TinyML.ValsHaveTypes.cons Θ vl vls a.2 (as'.map Prod.snd)).1 $$ Hvals
+              ihave Hpair := (TinyML.ValsHaveTypes.cons W vl vls a.2 (as'.map Prod.snd)).1 $$ Hvals
               icases Hpair with ⟨Htype_head, Htype_tail⟩
               simp only [List.map_cons, List.zip_cons_cons, List.reverse_cons] at hlookup
               rw [List.lookup_append] at hlookup

--- a/Mica/Verifier/BoundedQuantifier.lean
+++ b/Mica/Verifier/BoundedQuantifier.lean
@@ -182,7 +182,7 @@ def intrinsic (name : String) (path : String) : Verifier.Intrinsic where
   reduce := fun _ _ _ _ => False
   wp := fun _ _ => iprop(False)
   spec :=
-    { args := [("lo", .int), ("hi", .int), ("body", .arrow .int .bool)]
+    { args := [("lo", .int), ("hi", .int), ("body", .arrow [.int] .bool)]
       retTy := .bool
       pred := .assert .false_ (.ret ("ret", .ret ())) }
   typing := Verifier.monoTyping .three
@@ -322,7 +322,7 @@ private def lift (decl : Option String) (all : Bool) (binder : Typed.Binder)
   set ({ declIdx := st.declIdx,
          count := st.count + 1,
          syms := st.syms ++ [{ name, all, captured, arg := name ++ "-x", body := gBody }] } : LiftState)
-  pure (.app (.var name (.arrow .value .bool))
+  pure (.app (.var name (.arrow [.value] .bool))
     [.tuple (lo :: hi :: captured.map (fun x => Typed.Expr.var x .value))] .bool)
 
 /-- Rewrite every bounded-quantifier occurrence in a spec leaf, bottom-up:

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -476,45 +476,45 @@ theorem compileBranches_length_get (reg : Verifier.Registry) (Θ : TinyML.TypeEn
 
 namespace Helpers
 
-theorem ctx_dup (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_dup (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-      st.sl Θ ρ ∗
-        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R)) := by
+    st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+      st.sl W ρ ∗
+        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R)) := by
   iintro ⟨Howns, #HS, #HT, HR⟩
   iframe # ∗
 
-theorem ctx_dup_flip (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_dup_flip (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-      st.sl Θ ρ ∗
-        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
-          (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))) := by
+    st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+      st.sl W ρ ∗
+        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗
+          (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))) := by
   iintro ⟨Howns, #HS, #HT, HR⟩
   iframe # ∗
 
-theorem ctx_push (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_push (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-      st.sl Θ ρ ∗
-        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
-          (TinyML.ValHasType Θ v ty ∗ R)) := by
+    st.sl W ρ ∗ TinyML.ValHasType W v ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+      st.sl W ρ ∗
+        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗
+          (TinyML.ValHasType W v ty ∗ R)) := by
   iintro ⟨Howns, Hv, #HS, #HT, HR⟩
   iframe # ∗
 
-theorem ctx_push_flip (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_push_flip (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl Θ ρ ∗ TinyML.ValHasType Θ v ty ∗ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-      st.sl Θ ρ ∗
-        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗
-          (TinyML.ValHasType Θ v ty ∗ R)) := by
+    st.sl W ρ ∗ TinyML.ValHasType W v ty ∗ (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
+      st.sl W ρ ∗
+        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗
+          (TinyML.ValHasType W v ty ∗ R)) := by
   iintro ⟨Howns, Hv, #HT, #HS, HR⟩
   iframe # ∗
 
@@ -537,10 +537,11 @@ private theorem specInvariants_mono
   exact VerifM.Env.agreeOn_mono hΔspec hagree
 
 def correctExpr (reg : Verifier.Registry) (e : Expr) : Prop :=
-  ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
+  ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
   (Δ_spec : Signature) (ρ_spec : VerifM.Env)
   (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
-    VerifM.eval (compile reg Θ Δ_spec S B Γ e) st ρ Ψ →
+    W.pctx = reg.primCtx →
+    VerifM.eval (compile reg W.Θ Δ_spec S B Γ e) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
     S.wfIn Δ_spec →
@@ -551,17 +552,18 @@ def correctExpr (reg : Verifier.Registry) (e : Expr) : Prop :=
     Verifier.Registry.symSubset reg Δ_spec →
     Verifier.Registry.symAgree reg ρ_spec.env →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
-      st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢ Φ v) →
-    st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp reg.primCtx (e.runtime.subst γ) Φ
+      st'.sl W ρ' ∗ TinyML.ValHasType W v e.ty ∗ R ⊢ Φ v) →
+    st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (e.runtime.subst γ) Φ
 
 def correctBranch (reg : Verifier.Registry) (branch : Binder × Expr) : Prop :=
-  ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp),
-    VerifM.eval (compileBranch reg Θ Δ_spec S B Γ sc n i ty_i branch) st ρ Ψ →
+    W.pctx = reg.primCtx →
+    VerifM.eval (compileBranch reg W.Θ Δ_spec S B Γ sc n i ty_i branch) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
     S.wfIn Δ_spec →
@@ -573,17 +575,18 @@ def correctBranch (reg : Verifier.Registry) (branch : Binder × Expr) : Prop :=
     Verifier.Registry.symAgree reg ρ_spec.env →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v branch.2.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl W ρ' ∗ TinyML.ValHasType W v branch.2.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
-      st.sl Θ ρ ∗ TinyML.ValHasType Θ payload ty_i ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp reg.primCtx (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
+      st.sl W ρ ∗ TinyML.ValHasType W payload ty_i ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
 
 def correctBranches (reg : Verifier.Registry) (branches : List (Binder × Expr)) : Prop :=
-  ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n : Nat) (ts : List TinyML.Typ) (idx : Nat)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp),
+    W.pctx = reg.primCtx →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
     S.wfIn Δ_spec →
@@ -595,19 +598,20 @@ def correctBranches (reg : Verifier.Registry) (branches : List (Binder × Expr))
     Verifier.Registry.symAgree reg ρ_spec.env →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v (branches[j]).2.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl W ρ' ∗ TinyML.ValHasType W v (branches[j]).2.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
-      VerifM.eval (compileBranch reg Θ Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
+      VerifM.eval (compileBranch reg W.Θ Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
-        st.sl Θ ρ ∗ TinyML.ValHasType Θ payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wp reg.primCtx (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
+        st.sl W ρ ∗ TinyML.ValHasType W payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
 
 def correctExprs (reg : Verifier.Registry) (es : List Expr) : Prop :=
-  ∀ (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+  ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (Ψ : List (Term .value) → TransState → VerifM.Env → Prop)
     (Φ : List Runtime.Val → iProp),
-    VerifM.eval (compileExprs reg Θ Δ_spec S B Γ es) st ρ Ψ →
+    W.pctx = reg.primCtx →
+    VerifM.eval (compileExprs reg W.Θ Δ_spec S B Γ es) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
     S.wfIn Δ_spec →
@@ -620,14 +624,14 @@ def correctExprs (reg : Verifier.Registry) (es : List Expr) : Prop :=
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ'.env terms vs →
-       st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
-    st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢ wps reg.primCtx (es.map (fun e => e.runtime.subst γ)) Φ
+       st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
+    st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wps W.pctx (es.map (fun e => e.runtime.subst γ)) Φ
 
 /-! #### Correctness Compatibility Lemmas -/
 
 theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
     correctExpr reg (.const c) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hΔreg hρreg hpost
   cases c with
   | int n =>
     simp only [compile] at heval
@@ -641,7 +645,7 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
       (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
       (by simp [Term.eval, UnOp.eval, Const.denote]))
     iframe
-    exact TinyML.ValHasType.int_intro Θ n
+    exact TinyML.ValHasType.int_intro W n
   | bool b =>
     simp only [compile] at heval
     simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
@@ -654,7 +658,7 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
       (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
       (by simp [Term.eval, UnOp.eval, Const.denote]))
     iframe
-    exact TinyML.ValHasType.bool_intro Θ b
+    exact TinyML.ValHasType.bool_intro W b
   | char c =>
     simp only [compile] at heval
     simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
@@ -667,7 +671,7 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
       (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
       (by simp [Term.eval, UnOp.eval, Const.denote]))
     iframe
-    exact TinyML.ValHasType.char_intro Θ c
+    exact TinyML.ValHasType.char_intro W c
   | string s =>
     simp only [compile] at heval
     simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
@@ -680,7 +684,7 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
       (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
       (by simp [Term.eval, UnOp.eval, Const.denote]))
     iframe
-    exact TinyML.ValHasType.string_intro Θ s
+    exact TinyML.ValHasType.string_intro W s
   | float b =>
     simp only [compile] at heval
     simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
@@ -693,7 +697,7 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
       (by simp [Term.wfIn, Const.wfIn, UnOp.wfIn])
       (by simp [Term.eval, UnOp.eval, Const.denote]))
     iframe
-    exact TinyML.ValHasType.float_intro Θ b
+    exact TinyML.ValHasType.float_intro W b
   | unit =>
     simp only [compile] at heval
     simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
@@ -706,11 +710,11 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
       (by simp [Term.wfIn, Const.wfIn])
       (by simp [Term.eval]))
     iframe
-    exact TinyML.ValHasType.unit_intro Θ
+    exact TinyML.ValHasType.unit_intro W
 
 theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.Typ) :
     correctExpr reg (.var x vty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hΔreg hρreg hpost
   simp only [compile] at heval
   obtain ⟨x', hbind, heval⟩ := VerifM.eval_bind_expectSome heval
   obtain ⟨hcheck, hcont⟩ := VerifM.eval_bind_expectEq heval
@@ -732,7 +736,7 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
       simp only at hsort; subst hsort
       exact Term.const_wfIn_of_mem hwfst h
   have htyped {t : TinyML.Typ} (hΓ : Γ x = some t) :
-      B.typedSubst Θ Γ γ ⊢ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) t := by
+      B.typedSubst W Γ γ ⊢ TinyML.ValHasType W (ρ.env.consts .value x'.name) t := by
     unfold Bindings.typedSubst
     iintro #Hts
     ispecialize Hts $$ %x %x' %t %hbind %hΓ
@@ -747,16 +751,16 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
   | none =>
     have hvty : vty = .value := by simpa [hΓx] using hcheck.symm
     subst hvty
-    have hvalue : ⊢ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) .value := by
-      iapply (TinyML.ValHasType.value Θ (ρ.env.consts .value x'.name)).2
+    have hvalue : ⊢ TinyML.ValHasType W (ρ.env.consts .value x'.name) .value := by
+      iapply (TinyML.ValHasType.value W (ρ.env.consts .value x'.name)).2
       ipureintro
       trivial
     have hprep :
-        st.sl Θ ρ ∗ (B.typedSubst Θ Γ γ ∗ R) ⊢
-          st.sl Θ ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) .value ∗ R := by
+        st.sl W ρ ∗ (B.typedSubst W Γ γ ∗ R) ⊢
+          st.sl W ρ ∗ TinyML.ValHasType W (ρ.env.consts .value x'.name) .value ∗ R := by
       exact sep_mono_right (sep_mono_left (true_intro.trans hvalue))
     have hpost' :
-        st.sl Θ ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) .value ∗ R ⊢
+        st.sl W ρ ∗ TinyML.ValHasType W (ρ.env.consts .value x'.name) .value ∗ R ⊢
           Φ (ρ.env.consts .value x'.name) := by
       simpa [hΓx] using
         (hpost (ρ.env.consts .value x'.name) ρ st (Term.const (.uninterpreted x'.name .value))
@@ -766,12 +770,12 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
     have hΓ : Γ x = some t := hΓx
     have htv : t = vty := by simpa [hΓx] using hcheck
     have hprep :
-        st.sl Θ ρ ∗ (B.typedSubst Θ Γ γ ∗ R) ⊢
-          st.sl Θ ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty ∗ R := by
+        st.sl W ρ ∗ (B.typedSubst W Γ γ ∗ R) ⊢
+          st.sl W ρ ∗ TinyML.ValHasType W (ρ.env.consts .value x'.name) vty ∗ R := by
       rw [← htv]
       exact sep_mono_right (sep_mono_left (htyped hΓ))
     have hpost' :
-        st.sl Θ ρ ∗ TinyML.ValHasType Θ (ρ.env.consts .value x'.name) vty ∗ R ⊢
+        st.sl W ρ ∗ TinyML.ValHasType W (ρ.env.consts .value x'.name) vty ∗ R ⊢
           Φ (ρ.env.consts .value x'.name) :=
       hpost (ρ.env.consts .value x'.name) ρ st (Term.const (.uninterpreted x'.name .value))
         hΨ hwfv (by simp [Term.eval, Const.denote])
@@ -780,7 +784,7 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
 theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload : Expr)
     (ihPayload : correctExpr reg payload) :
     correctExpr reg (.inj tag arity payload) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
@@ -789,8 +793,8 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
     exact (VerifM.eval_fatal heval).elim
   · push Not at htag
     simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
-    have heval_p : (compile reg Θ Δ_spec S B Γ payload).eval st ρ _ := VerifM.eval_bind heval
-    refine SpatialContext.wp_bind_inj <| ihPayload Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+    have heval_p : (compile reg W.Θ Δ_spec S B Γ payload).eval st ρ _ := VerifM.eval_bind heval
+    refine SpatialContext.wp_bind_inj <| ihPayload W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
     intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p
     obtain ⟨_hdecls_p, _hagreeOn_p, hΨ_p⟩ := hΨ_p
@@ -799,15 +803,15 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
     let ts := (List.replicate arity TinyML.Typ.empty).set tag payload.ty
     have hlen_ts : ts.length = arity := by simp [ts]
     have hget_ts : ts[tag]? = some payload.ty := by simp [ts, htag]
-    have hinj : TinyML.ValHasType Θ v_p payload.ty ⊢
-        TinyML.ValHasType Θ (.inj tag arity v_p) (.sum ts) :=
+    have hinj : TinyML.ValHasType W v_p payload.ty ⊢
+        TinyML.ValHasType W (.inj tag arity v_p) (.sum ts) :=
       TinyML.ValHasType.inj hlen_ts hget_ts
     have hprep :
-        st_p.sl Θ ρ_p ∗ TinyML.ValHasType Θ v_p payload.ty ∗ R ⊢
-          st_p.sl Θ ρ_p ∗ TinyML.ValHasType Θ (.inj tag arity v_p) (.sum ts) ∗ R :=
+        st_p.sl W ρ_p ∗ TinyML.ValHasType W v_p payload.ty ∗ R ⊢
+          st_p.sl W ρ_p ∗ TinyML.ValHasType W (.inj tag arity v_p) (.sum ts) ∗ R :=
       sep_mono_right (sep_mono_left hinj)
     have hpost' :
-        st_p.sl Θ ρ_p ∗ TinyML.ValHasType Θ (.inj tag arity v_p) (.sum ts) ∗ R ⊢
+        st_p.sl W ρ_p ∗ TinyML.ValHasType W (.inj tag arity v_p) (.sum ts) ∗ R ⊢
           Φ (.inj tag arity v_p) := by
       simpa [ts, hlen_ts] using
         (hpost (.inj tag arity v_p) ρ_p st_p _ hΨ_p
@@ -818,37 +822,37 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
 theorem compileCast_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.Typ)
     (ih : correctExpr reg e) :
     correctExpr reg (.cast e ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   simp only [compile] at heval
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
   simp [Expr.runtime]
-  refine ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  refine ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v ρ' st' se hΨ hse_wf heval_se
   obtain ⟨_, _, hΨ⟩ := hΨ
-  cases hsub : TinyML.Typ.sub Θ e.ty ty with
+  cases hsub : TinyML.Typ.sub W.Θ e.ty ty with
   | false =>
     simp [hsub] at hΨ
     exact (VerifM.eval_fatal hΨ).elim
   | true =>
     simp [hsub] at hΨ
     obtain hΨ := VerifM.eval_ret hΨ
-    have hsub' : TinyML.Typ.Sub Θ e.ty ty := TinyML.Typ.sub_sound hsub
+    have hsub' : TinyML.Typ.Sub W.Θ e.ty ty := TinyML.Typ.sub_sound hsub
     have hprep :
-        st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v e.ty ∗ R ⊢
-          st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v ty ∗ R :=
+        st'.sl W ρ' ∗ TinyML.ValHasType W v e.ty ∗ R ⊢
+          st'.sl W ρ' ∗ TinyML.ValHasType W v ty ∗ R :=
       sep_mono_right (sep_mono_left (TinyML.ValHasType.sub hsub'))
     exact hprep.trans <| hpost v ρ' st' se hΨ hse_wf heval_se
 
 theorem compileAssert_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.assert e) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_assert <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_assert <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_, _, hΨ_e⟩ := hΨ_e
@@ -865,36 +869,36 @@ theorem compileAssert_correct (reg : Verifier.Registry) (e : Expr)
   simp only [Expr.ty] at hpost
   subst hvtrue
   have hprep :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ (.bool true) e.ty ∗ R ⊢
-        st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ .unit .unit ∗ R :=
-    sep_mono_right (sep_mono_left (true_intro.trans (TinyML.ValHasType.unit_intro Θ)))
+      st₁.sl W ρ_e ∗ TinyML.ValHasType W (.bool true) e.ty ∗ R ⊢
+        st₁.sl W ρ_e ∗ TinyML.ValHasType W .unit .unit ∗ R :=
+    sep_mono_right (sep_mono_left (true_intro.trans (TinyML.ValHasType.unit_intro W)))
   exact SpatialContext.wp_assert <| hprep.trans <| hpost .unit ρ_e st₁ (Term.const .unit) hΨ_pure
     trivial
     (by simp [Term.eval])
 
 theorem compileFix_correct (reg : Verifier.Registry) (self : Binder) (args : List Binder) (retTy : TinyML.Typ) (body : Expr) :
     correctExpr reg (.fix self args retTy body) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
   simp only [compile] at heval
   exact (VerifM.eval_fatal heval).elim
 
 theorem compilePrim_correct (reg : Verifier.Registry) (n : String)
     (inst : List (TinyML.TyVar × TinyML.Typ)) (ty : TinyML.Typ) :
     correctExpr reg (.prim n inst ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
   simp only [compile] at heval
   exact (VerifM.eval_fatal heval).elim
 
 theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.ref .shared e) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_ref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_ref <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -905,10 +909,10 @@ theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
   have hwf_addConst : TransState.wf { st₁ with decls := st₁.decls.addConst c } :=
     TransState.freshConst.wf _ hwf_st₁
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp reg.primCtx (.ref (.val v_e)) Φ := by
+      st₁.sl W ρ_e ∗ TinyML.ValHasType W v_e e.ty ∗ R ⊢ wp W.pctx (.ref (.val v_e)) Φ := by
     istart
     iintro ⟨Howns, #Hty, HR⟩
-    iapply (wp.ref_inv (I := fun w => TinyML.ValHasType Θ w e.ty))
+    iapply (wp.ref_inv (I := fun w => TinyML.ValHasType W w e.ty))
     isplitl []
     · imodintro
       iexact Hty
@@ -929,18 +933,18 @@ theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
               hwf_st₁.namesDisjoint hfresh)
       have hval_eval : Term.eval ρ_e'.env (Term.const (.uninterpreted c.name .value)) = .loc loc := by
         simp [Term.eval, Const.denote, ρ_e', VerifM.Env.updateConst, Env.updateConst]
-      have hlocTy : locinv loc (fun w => TinyML.ValHasType Θ w e.ty) ⊢
-          TinyML.ValHasType Θ (.loc loc) (.ref e.ty) := by
-        refine Entails.trans ?_ (TinyML.ValHasType.ref Θ (.loc loc) e.ty).2
+      have hlocTy : locinv loc (fun w => TinyML.ValHasType W w e.ty) ⊢
+          TinyML.ValHasType W (.loc loc) (.ref e.ty) := by
+        refine Entails.trans ?_ (TinyML.ValHasType.ref W (.loc loc) e.ty).2
         iintro Hinv
         iexists loc
         isplitr
         · ipureintro
           rfl
         · iexact Hinv
-      have hsl_agree : st₁.sl Θ ρ_e ⊢ st₂.sl Θ ρ_e' := by
+      have hsl_agree : st₁.sl W ρ_e ⊢ st₂.sl W ρ_e' := by
         simp only [TransState.sl_eq, st₂]
-        apply (SpatialContext.interp_env_agree Θ hwf_st₁.ownsWf ?_).1
+        apply (SpatialContext.interp_env_agree W hwf_st₁.ownsWf ?_).1
         exact Env.agreeOn_update_fresh_const (c := c) hfresh
       iapply (hpost (.loc loc) ρ_e' st₂ (Term.const (.uninterpreted c.name .value))
         hret hc_wf hval_eval)
@@ -956,13 +960,13 @@ theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
 theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.ref .owned e) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_ref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_ref <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -974,8 +978,8 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
   have hc_fresh : c.name ∉ st₁.decls.allNames :=
     TransState.freshConst_fresh st₁ none .value
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp reg.primCtx (.ref (.val v_e)) Φ := by
-    refine SpatialContext.wp_ref Θ
+      st₁.sl W ρ_e ∗ TinyML.ValHasType W v_e e.ty ∗ R ⊢ wp W.pctx (.ref (.val v_e)) Φ := by
+    refine SpatialContext.wp_ref W
       (ctx := st₁.owns) (ρ := ρ_e.env) (R := R) (Δ := st₁.decls)
       (vt := se) (ty := e.ty) (name := c.name)
       (newctx := SpatialContext.insert (.pointsTo sl se e.ty) st₁.owns)
@@ -1005,8 +1009,8 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
         (fun φ hφ => TinyML.typeConstraints_wfIn hsl_wf φ hφ) htyped
     have hret := VerifM.eval_ret hq₃
     have hsl_wf₃ : sl.wfIn st₃.decls := by rw [hdecls₃]; exact hsl_wf
-    have hlocTy : ⊢ TinyML.ValHasType Θ (.loc loc) (.owned e.ty) := by
-      refine Entails.trans ?_ (TinyML.ValHasType.owned Θ (.loc loc) e.ty).2
+    have hlocTy : ⊢ TinyML.ValHasType W (.loc loc) (.owned e.ty) := by
+      refine Entails.trans ?_ (TinyML.ValHasType.owned W (.loc loc) e.ty).2
       istart
       iintro _
       iexists loc
@@ -1035,14 +1039,14 @@ theorem compileDerefShared_correct (reg : Verifier.Registry) (e : Expr) (ty : Ti
     (href : e.ty = .ref ty)
     (ih : correctExpr reg e) :
     correctExpr reg (.deref e ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, href] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_deref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_deref <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e _hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -1058,14 +1062,14 @@ theorem compileDerefShared_correct (reg : Verifier.Registry) (e : Expr) (ty : Ti
         (Term.const_wfIn_addConst_of_fresh (Δ := st₁.decls) (c := c)
           (VerifM.eval.wf hdecl_eval).namesDisjoint hc_fresh)
   have hwp :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢ wp reg.primCtx (.deref (.val v_e)) Φ := by
+      st₁.sl W ρ_e ∗ TinyML.ValHasType W v_e e.ty ∗ R ⊢ wp W.pctx (.deref (.val v_e)) Φ := by
     rw [href]
     istart
     iintro ⟨Howns, Href, HR⟩
-    ihave Href' := (TinyML.ValHasType.ref Θ v_e ty).1 $$ Href
+    ihave Href' := (TinyML.ValHasType.ref W v_e ty).1 $$ Href
     icases Href' with ⟨%loc, %hvloc, Hinv⟩
     subst hvloc
-    iapply (wp.deref_inv (l := loc) (I := fun w => TinyML.ValHasType Θ w ty))
+    iapply (wp.deref_inv (l := loc) (I := fun w => TinyML.ValHasType W w ty))
     isplitl [Hinv]
     · iexact Hinv
     · iintro %w #Hw
@@ -1076,16 +1080,16 @@ theorem compileDerefShared_correct (reg : Verifier.Registry) (e : Expr) (ty : Ti
       have hsv_eval : sv.eval ρ₂.env = w := by
         simp [sv, ρ₂, Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
       ihave Hcheck := TinyML.typeConstraints_hold (ty := ty) (t := sv)
-        (ρ := ρ₂.env) (Θ := Θ) (v := w) hsv_eval $$ Hw
+        (ρ := ρ₂.env) (W := W) (v := w) hsv_eval $$ Hw
       ipure Hcheck
       obtain ⟨st₃, hst₃_decls, hst₃_owns, _, heval_ret⟩ := VerifM.eval_assumeAll hassume_eval
         (fun φ hφ => TinyML.typeConstraints_wfIn hc_wf φ hφ)
         (fun φ hφ => Hcheck φ hφ)
       have hΨ_ret := VerifM.eval_ret heval_ret
       have hsv_wf : sv.wfIn st₃.decls := hst₃_decls ▸ hc_wf
-      have hsl_agree : st₁.sl Θ ρ_e ⊢ st₃.sl Θ ρ₂ := by
+      have hsl_agree : st₁.sl W ρ_e ⊢ st₃.sl W ρ₂ := by
         simp [TransState.sl_eq, st₂, hst₃_owns]
-        exact (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hdecl_eval).ownsWf
+        exact (SpatialContext.interp_env_agree W (VerifM.eval.wf hdecl_eval).ownsWf
           (Env.agreeOn_update_fresh_const (c := c) hc_fresh)).1
       iapply (hpost w ρ₂ st₃ sv hΨ_ret hsv_wf hsv_eval)
       isplitl [Howns]
@@ -1100,22 +1104,22 @@ theorem compileDerefOwned_correct (reg : Verifier.Registry) (e : Expr) (ty : Tin
     (howned : e.ty = .owned ty)
     (ih : correctExpr reg e) :
     correctExpr reg (.deref e ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, howned] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_deref <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_deref <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hfind_eval := VerifM.eval_bind hΨ_e
   rw [howned]
-  refine VerifM.eval_findMatchForce Θ
-    (R := TinyML.ValHasType Θ v_e (.owned ty) ∗ R)
-    (Φ := wp reg.primCtx (.deref (.val v_e)) Φ) hfind_eval hse_wf ?_
+  refine VerifM.eval_findMatchForce W
+    (R := TinyML.ValHasType W v_e (.owned ty) ∗ R)
+    (Φ := wp W.pctx (.deref (.val v_e)) Φ) hfind_eval hse_wf ?_
   intro v st₂ hQ hdecls hv_wf
   have hassume_eval := VerifM.eval_bind hQ
   have hatom_wf : (SpatialAtom.pointsTo se v ty).wfIn st₂.decls := by
@@ -1127,8 +1131,8 @@ theorem compileDerefOwned_correct (reg : Verifier.Registry) (e : Expr) (ty : Tin
     rw [hdecls]
     exact hv_wf
   have hwp :
-      SpatialAtom.interp Θ ρ_e.env (.pointsTo se v ty) ∗ st₂.sl Θ ρ_e ∗
-        (TinyML.ValHasType Θ v_e (.owned ty) ∗ R) ⊢ wp reg.primCtx (.deref (.val v_e)) Φ := by
+      SpatialAtom.interp W ρ_e.env (.pointsTo se v ty) ∗ st₂.sl W ρ_e ∗
+        (TinyML.ValHasType W v_e (.owned ty) ∗ R) ⊢ wp W.pctx (.deref (.val v_e)) Φ := by
     simp only [SpatialAtom.interp]
     istart
     iintro ⟨Hatom, Howns, _Howned, HR⟩
@@ -1167,7 +1171,7 @@ theorem compileDeref_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.T
       by_cases heq : ty' = ty
       · have href : e.ty = .ref ty := by simpa [heq] using hty
         exact compileDerefShared_correct reg e ty href ih
-      · intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
+      · intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
@@ -1175,12 +1179,12 @@ theorem compileDeref_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.T
       by_cases heq : ty' = ty
       · have howned : e.ty = .owned ty := by simpa [heq] using hty
         exact compileDerefOwned_correct reg e ty howned ih
-      · intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
+      · intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
   | prim _ | sum _ | arrow _ _ | array _ | ownedArray _ | vec _ | empty | value | tuple _ | tvar _ | named _ _ =>
-      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
@@ -1188,36 +1192,36 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
     (href : loc.ty = .ref val.ty)
     (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
     correctExpr reg (.store loc val) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, href] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_v : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
+  have heval_v : (compile reg W.Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl Θ ρ ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))) :=
-    Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        st.sl W ρ ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))) :=
+    Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihVal W (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
   have hagree_v : B.agreeOnLinked ρ_v.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
-  have heval_l : (compile reg Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
+  have heval_l : (compile reg W.Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
   have hlocStart :
-      st₁.sl Θ ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
-        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl Θ ρ_v ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (TinyML.ValHasType Θ v_v val.ty ∗ R)) :=
-    Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
+      st₁.sl W ρ_v ∗ TinyML.ValHasType W v_v val.ty ∗
+        (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
+          st₁.sl W ρ_v ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (TinyML.ValHasType W v_v val.ty ∗ R)) :=
+    Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
   have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
-  refine hlocStart.trans <| ihLoc Θ (TinyML.ValHasType Θ v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _
+  refine hlocStart.trans <| ihLoc W (TinyML.ValHasType W v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 hΔreg hρreg ?_
   intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
@@ -1225,18 +1229,18 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
   have hunit_wf : (Term.const .unit).wfIn st₂.decls := by
     simp [Term.wfIn, Const.wfIn]
   have hgoal :
-      st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Φ .unit :=
+      st₂.sl W ρ_l ∗ TinyML.ValHasType W .unit .unit ∗ R ⊢ Φ .unit :=
     hpost .unit ρ_l st₂ _ hret hunit_wf (by simp [Term.eval])
   have hwp :
-      st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ v_l loc.ty ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R)) ⊢
-        wp reg.primCtx (.store (.val v_l) (.val v_v)) Φ := by
+      st₂.sl W ρ_l ∗ (TinyML.ValHasType W v_l loc.ty ∗ (TinyML.ValHasType W v_v val.ty ∗ R)) ⊢
+        wp W.pctx (.store (.val v_l) (.val v_v)) Φ := by
     rw [href]
     istart
     iintro ⟨Howns, Hloc, #Hval, HR⟩
-    ihave Href := (TinyML.ValHasType.ref Θ v_l val.ty).1 $$ Hloc
+    ihave Href := (TinyML.ValHasType.ref W v_l val.ty).1 $$ Hloc
     icases Href with ⟨%lref, %hv_l, Hinv⟩
     subst hv_l
-    iapply (wp.store_inv (l := lref) (v := v_v) (I := fun w => TinyML.ValHasType Θ w val.ty))
+    iapply (wp.store_inv (l := lref) (v := v_v) (I := fun w => TinyML.ValHasType W w val.ty))
     isplitl [Hinv]
     · iexact Hinv
     · isplitl []
@@ -1246,7 +1250,7 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
         isplitl [Howns]
         · iexact Howns
         · isplitl []
-          · iapply (TinyML.ValHasType.unit_intro Θ)
+          · iapply (TinyML.ValHasType.unit_intro W)
           · iexact HR
   exact hwp
 
@@ -1254,36 +1258,36 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
     (howned : loc.ty = .owned val.ty)
     (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
     correctExpr reg (.store loc val) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, howned] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_v : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
+  have heval_v : (compile reg W.Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl Θ ρ ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))) :=
-    Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        st.sl W ρ ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))) :=
+    Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal Θ (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihVal W (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
   have hagree_v : B.agreeOnLinked ρ_v.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
-  have heval_l : (compile reg Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
+  have heval_l : (compile reg W.Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
   have hlocStart :
-      st₁.sl Θ ρ_v ∗ TinyML.ValHasType Θ v_v val.ty ∗
-        (Bindings.typedSubst Θ B Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl Θ ρ_v ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (TinyML.ValHasType Θ v_v val.ty ∗ R)) :=
-    Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
+      st₁.sl W ρ_v ∗ TinyML.ValHasType W v_v val.ty ∗
+        (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
+          st₁.sl W ρ_v ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (TinyML.ValHasType W v_v val.ty ∗ R)) :=
+    Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
   have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
-  refine hlocStart.trans <| ihLoc Θ (TinyML.ValHasType Θ v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _
+  refine hlocStart.trans <| ihLoc W (TinyML.ValHasType W v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 hΔreg hρreg ?_
   intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨_hdecls_l, _hagreeOn_l, hΨ_l⟩ := hΨ_l
@@ -1294,9 +1298,9 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
     rw [← Term.eval_env_agree hsv_wf _hagreeOn_l]
     exact heval_sv
   rw [howned]
-  refine VerifM.eval_findMatchForce Θ
-    (R := TinyML.ValHasType Θ v_l (.owned val.ty) ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R))
-    (Φ := wp reg.primCtx (.store (.val v_l) (.val v_v)) Φ) hfind_eval hsl_wf ?_
+  refine VerifM.eval_findMatchForce W
+    (R := TinyML.ValHasType W v_l (.owned val.ty) ∗ (TinyML.ValHasType W v_v val.ty ∗ R))
+    (Φ := wp W.pctx (.store (.val v_l) (.val v_v)) Φ) hfind_eval hsl_wf ?_
   intro old st₃ hQ hdecls hold_wf
   have hassume_eval := VerifM.eval_bind hQ
   have hatom_wf : (SpatialAtom.pointsTo sl sv val.ty).wfIn st₃.decls := by
@@ -1307,9 +1311,9 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
   have hunit_wf : (Term.const .unit).wfIn ({ st₃ with owns := .pointsTo sl sv val.ty :: st₃.owns }).decls := by
     simp [Term.wfIn, Const.wfIn]
   have hwp :
-      SpatialAtom.interp Θ ρ_l.env (.pointsTo sl old val.ty) ∗ st₃.sl Θ ρ_l ∗
-        (TinyML.ValHasType Θ v_l (.owned val.ty) ∗ (TinyML.ValHasType Θ v_v val.ty ∗ R)) ⊢
-          wp reg.primCtx (.store (.val v_l) (.val v_v)) Φ := by
+      SpatialAtom.interp W ρ_l.env (.pointsTo sl old val.ty) ∗ st₃.sl W ρ_l ∗
+        (TinyML.ValHasType W v_l (.owned val.ty) ∗ (TinyML.ValHasType W v_v val.ty ∗ R)) ⊢
+          wp W.pctx (.store (.val v_l) (.val v_v)) Φ := by
     simp only [SpatialAtom.interp]
     istart
     iintro ⟨Hatom, Howns, _Howned, #HnewTy, HR⟩
@@ -1338,7 +1342,7 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
               iexact HnewTy
         · iexact Howns
       · isplitl []
-        · iapply (TinyML.ValHasType.unit_intro Θ)
+        · iapply (TinyML.ValHasType.unit_intro W)
         · iexact HR
   exact hwp
 
@@ -1350,7 +1354,7 @@ theorem compileStore_correct (reg : Verifier.Registry) (loc val : Expr)
       by_cases heq : ty = val.ty
       · have href : loc.ty = .ref val.ty := by simpa [heq] using hty
         exact compileStoreShared_correct reg loc val href ihVal ihLoc
-      · intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
+      · intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
@@ -1358,12 +1362,12 @@ theorem compileStore_correct (reg : Verifier.Registry) (loc val : Expr)
       by_cases heq : ty = val.ty
       · have howned : loc.ty = .owned val.ty := by simpa [heq] using hty
         exact compileStoreOwned_correct reg loc val howned ihVal ihLoc
-      · intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
+      · intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
   | prim _ | sum _ | arrow _ _ | array _ | ownedArray _ | vec _ | empty | value | tuple _ | tvar _ | named _ _ =>
-      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
@@ -1396,28 +1400,28 @@ owned branch acquires a fresh owned-array atom. -/
 theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.Ownership) (len init : Expr)
     (ihLen : correctExpr reg len) (ihInit : correctExpr reg init) :
     correctExpr reg (.arrayMake ownership len init) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   obtain ⟨hlenty, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_init : (compile reg Θ Δ_spec S B Γ init).eval st ρ _ := VerifM.eval_bind heval
+  have heval_init : (compile reg W.Θ Δ_spec S B Γ init).eval st ρ _ := VerifM.eval_bind heval
   refine SpatialContext.wp_bind_arrayMake <| ?_
   -- Evaluate `init`.
-  have hstart := Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
-  refine hstart.trans <| ihInit Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
-    S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_init)
+  have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
+  refine hstart.trans <| ihInit W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
+    S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_init)
     hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_init ρ_init st₁ s_init hΨ_init hsinit_wf heval_sinit
   obtain ⟨hdecls_init, hagreeOn_init, hΨ_init⟩ := hΨ_init
   have hagree_init : B.agreeOnLinked ρ_init.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_init hbwf
   have hbwf_init : B.wfIn st₁.decls := fun p hp => hdecls_init.consts _ (hbwf p hp)
-  have heval_len : (compile reg Θ Δ_spec S B Γ len).eval st₁ ρ_init _ := VerifM.eval_bind hΨ_init
-  have hlenStart := Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_init γ R v_init init.ty
+  have heval_len : (compile reg W.Θ Δ_spec S B Γ len).eval st₁ ρ_init _ := VerifM.eval_bind hΨ_init
+  have hlenStart := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_init γ R v_init init.ty
   have hspecInv_init := specInvariants_mono hΔspec hρspec hdecls_init hagreeOn_init
   -- Evaluate `len`, carrying `init`'s typing.
-  refine hlenStart.trans <| ihLen Θ (TinyML.ValHasType Θ v_init init.ty ∗ R) S B Γ st₁ ρ_init γ Δ_spec ρ_spec _ _
+  refine hlenStart.trans <| ihLen W (TinyML.ValHasType W v_init init.ty ∗ R) S B Γ st₁ ρ_init γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ_init heval_len) hagree_init hbwf_init hSwf hΔwf hΔvars
     hspecInv_init.1 hspecInv_init.2 hΔreg hρreg ?_
   intro v_len ρ_len st₂ slen hΨ_len hslen_wf heval_slen
@@ -1440,7 +1444,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
   rw [hlenty]
   istart
   iintro ⟨Howns, Hlen, #Hinit, HR⟩
-  ihave Hlen' := (TinyML.ValHasType.int Θ v_len).1 $$ Hlen
+  ihave Hlen' := (TinyML.ValHasType.int W v_len).1 $$ Hlen
   icases Hlen' with ⟨%n, %hv_len⟩
   have hn : (0 : Int) ≤ n := by
     simpa [φ, Formula.eval, BinPred.eval, Term.eval, Const.denote, UnOp.eval,
@@ -1449,7 +1453,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
   | shared =>
     simp only [Expr.ty] at hpost
     iapply (SpatialContext.wp_arrayMake_inv (vlen := v_len) (init := v_init) (n := n)
-      (I := fun w => TinyML.ValHasType Θ w init.ty) (Q := Φ) hv_len hn)
+      (I := fun w => TinyML.ValHasType W w init.ty) (Q := Φ) hv_len hn)
     isplitl []
     · imodintro
       iexact Hinit
@@ -1480,13 +1484,13 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
         omega
       have hassumeAll := VerifM.eval_assume hassume_eval heqφ_wf heqφ_hold
       have hassumeAll_eval := VerifM.eval_bind hassumeAll
-      ihave HarrTy := (TinyML.ValHasType.array Θ (.array n.toNat l) init.ty).2 $$ [Hinv_l]
+      ihave HarrTy := (TinyML.ValHasType.array W (.array n.toNat l) init.ty).2 $$ [Hinv_l]
       · iexists n.toNat, l
         isplitr
         · ipureintro; rfl
         · iexact Hinv_l
       ihave %htyped_formulas := (TinyML.typeConstraints_hold
-        (ty := TinyML.Typ.array init.ty) (t := sa) (ρ := ρ'.env) (Θ := Θ)
+        (ty := TinyML.Typ.array init.ty) (t := sa) (ρ := ρ'.env) (W := W)
         (v := .array n.toNat l) hsa_eval) $$ HarrTy
       obtain ⟨st_final, hst_final_decls, hst_final_owns, _, heval_ret⟩ :=
         VerifM.eval_assumeAll hassumeAll_eval
@@ -1494,16 +1498,16 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
           (fun ψ hψ => htyped_formulas ψ hψ)
       have hΨ_ret := VerifM.eval_ret heval_ret
       have hsa_wf : sa.wfIn st_final.decls := hst_final_decls ▸ hc_wf
-      have hsl_agree : st₂.sl Θ ρ_len ⊢ st_final.sl Θ ρ' := by
+      have hsl_agree : st₂.sl W ρ_len ⊢ st_final.sl W ρ' := by
         simp only [TransState.sl_eq, hst_final_owns, TransState.addItem, hst_c_def]
-        exact (SpatialContext.interp_env_agree Θ hst₂_wf.ownsWf
+        exact (SpatialContext.interp_env_agree W hst₂_wf.ownsWf
           (Env.agreeOn_update_fresh_const (c := c) hc_fresh)).1
       iapply (hpost (.array n.toNat l) ρ' st_final sa hΨ_ret hsa_wf hsa_eval)
       isplitl [Howns]
       · iapply hsl_agree
         iexact Howns
       · isplitl [Hinv_l]
-        · iapply (TinyML.ValHasType.array Θ (.array n.toNat l) init.ty).2
+        · iapply (TinyML.ValHasType.array W (.array n.toNat l) init.ty).2
           iexists n.toNat, l
           isplitr
           · ipureintro; rfl
@@ -1551,7 +1555,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
       ⟨hc_wf, hcontents_wf⟩
     have hcontents_eval : contents.eval ρ'.env = .vec (List.replicate n.toNat v_init) := by
       simp [contents, Term.eval, UnOp.eval, BinOp.eval, hslen_eval', hsinit_eval', hn]
-    ihave #HvecTy : iprop(TinyML.ValHasType Θ (.vec (List.replicate n.toNat v_init)) (.vec init.ty)) $$ [Hinit]
+    ihave #HvecTy : iprop(TinyML.ValHasType W (.vec (List.replicate n.toNat v_init)) (.vec init.ty)) $$ [Hinit]
     · iapply TinyML.ValHasType.vec_replicate
       iexact Hinit
     ihave %helements := TinyML.elementConstraints_hold (ty := init.ty) hcontents_eval $$ HvecTy
@@ -1565,13 +1569,13 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
       · exact helements ψ hψ
     obtain ⟨st_a, hdecls_a, howns_a, hq_a⟩ :=
       VerifM.eval_acquire (VerifM.eval_bind hassume) hatom_wf trivial hfacts
-    have hArrTy : ⊢ TinyML.ValHasType Θ (.array n.toNat l) (.ownedArray init.ty) := by
-      iapply (TinyML.ValHasType.ownedArray Θ _ _).2
+    have hArrTy : ⊢ TinyML.ValHasType W (.array n.toNat l) (.ownedArray init.ty) := by
+      iapply (TinyML.ValHasType.ownedArray W _ _).2
       iexists n.toNat, l
       ipureintro; rfl
     ihave HarrTy := hArrTy
     ihave %htyped := TinyML.typeConstraints_hold (ty := .ownedArray init.ty) (t := sa)
-      (ρ := ρ'.env) (Θ := Θ) hsa_eval $$ HarrTy
+      (ρ := ρ'.env) (W := W) hsa_eval $$ HarrTy
     obtain ⟨st_final, hdecls_final, howns_final, _, heval_ret⟩ :=
       VerifM.eval_assumeAll (VerifM.eval_bind hq_a)
         (fun ψ hψ => by rw [hdecls_a]; exact TinyML.typeConstraints_wfIn hc_wf ψ hψ)
@@ -1579,10 +1583,10 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
     have hret := VerifM.eval_ret heval_ret
     have hsa_wf_final : sa.wfIn st_final.decls := by
       rw [hdecls_final, hdecls_a]; exact hc_wf
-    have hsl_agree : SpatialContext.interp Θ ρ_len.env st₂.owns ⊢
-        SpatialContext.interp Θ ρ'.env st₂.owns := by
+    have hsl_agree : SpatialContext.interp W ρ_len.env st₂.owns ⊢
+        SpatialContext.interp W ρ'.env st₂.owns := by
       rw [show ρ'.env = ρ_len.env.updateConst .value c.name (.array n.toNat l) by rfl]
-      exact (SpatialContext.interp_env_agree Θ hst₂_wf.ownsWf
+      exact (SpatialContext.interp_env_agree W hst₂_wf.ownsWf
         (Env.agreeOn_update_fresh_const (ρ := ρ_len.env) (c := c)
           (u := Runtime.Val.array n.toNat l) hc_fresh)).1
     iapply (hpost (.array n.toNat l) ρ' st_final sa hret hsa_wf_final hsa_eval)
@@ -1590,7 +1594,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
     · simp only [TransState.sl_eq, howns_final, howns_a, TransState.addItem, st_c,
         SpatialContext.interp]
       isplitl [Hpt]
-      · iapply (SpatialAtom.interp_arrayPointsTo Θ (by simpa using hsa_eval) hcontents_eval).2
+      · iapply (SpatialAtom.interp_arrayPointsTo W (by simpa using hsa_eval) hcontents_eval).2
         isplitl [Hpt]
         · iexact Hpt
         · iexact HvecTy
@@ -1605,13 +1609,13 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
     correctExpr reg (.arrayLen arr) := by
   cases hty : arr.ty with
   | array elem =>
-      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
       unfold Expr.runtime
       simp only [Runtime.Expr.subst]
       simp only [compile, hty] at heval
-      have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st ρ _ :=
+      have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st ρ _ :=
         VerifM.eval_bind heval
-      refine SpatialContext.wp_bind_arrayLen <| ihArr Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+      refine SpatialContext.wp_bind_arrayLen <| ihArr W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
         (VerifM.eval.decls_grow ρ heval_arr) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
       intro v_arr ρ_arr st₁ sa hΨ_arr hsa_wf heval_sa
       obtain ⟨_, _, hΨ_arr⟩ := hΨ_arr
@@ -1620,37 +1624,37 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
       have ht_wf : t.wfIn st₁.decls := by
         exact ⟨trivial, ⟨trivial, hsa_wf⟩⟩
       have hwp :
-          st₁.sl Θ ρ_arr ∗ TinyML.ValHasType Θ v_arr arr.ty ∗ R ⊢
-            wp reg.primCtx (.arrayLen (.val v_arr)) Φ := by
+          st₁.sl W ρ_arr ∗ TinyML.ValHasType W v_arr arr.ty ∗ R ⊢
+            wp W.pctx (.arrayLen (.val v_arr)) Φ := by
         rw [hty]
         istart
         iintro ⟨Howns, Harr, HR⟩
-        ihave Harr' := (TinyML.ValHasType.array Θ v_arr elem).1 $$ Harr
+        ihave Harr' := (TinyML.ValHasType.array W v_arr elem).1 $$ Harr
         icases Harr' with ⟨%len, %loc, %hv_arr, _⟩
         have ht_eval : t.eval ρ_arr.env = Runtime.Val.int len := by
           simp [t, Term.eval, UnOp.eval, heval_sa, hv_arr]
         have hgoal :
-            st₁.sl Θ ρ_arr ∗ TinyML.ValHasType Θ (.int len) TinyML.Typ.int ∗ R ⊢
+            st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R ⊢
               Φ (.int len) :=
           by
             simpa [Expr.ty] using hpost (.int len) ρ_arr st₁ t hret ht_wf ht_eval
         iapply (SpatialContext.wp_arrayLen
-          (R := st₁.sl Θ ρ_arr ∗ TinyML.ValHasType Θ (.int len) TinyML.Typ.int ∗ R)
+          (R := st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R)
           (Q := Φ) (v := v_arr) (len := len) (l := loc) hv_arr hgoal)
         isplitl [Howns]
         · iexact Howns
         · isplitl []
-          · iapply (TinyML.ValHasType.int_intro Θ)
+          · iapply (TinyML.ValHasType.int_intro W)
           · iexact HR
       exact hwp
   | ownedArray elem =>
-      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
       unfold Expr.runtime
       simp only [Runtime.Expr.subst]
       simp only [compile, hty] at heval
-      have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st ρ _ :=
+      have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st ρ _ :=
         VerifM.eval_bind heval
-      refine SpatialContext.wp_bind_arrayLen <| ihArr Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+      refine SpatialContext.wp_bind_arrayLen <| ihArr W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
         (VerifM.eval.decls_grow ρ heval_arr) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
       intro v_arr ρ_arr st₁ sa hΨ_arr hsa_wf heval_sa
       obtain ⟨_, _, hΨ_arr⟩ := hΨ_arr
@@ -1660,25 +1664,25 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
       rw [hty]
       istart
       iintro ⟨Howns, Harr, HR⟩
-      ihave Harr' := (TinyML.ValHasType.ownedArray Θ v_arr elem).1 $$ Harr
+      ihave Harr' := (TinyML.ValHasType.ownedArray W v_arr elem).1 $$ Harr
       icases Harr' with ⟨%len, %loc, %hv_arr⟩
       have ht_eval : t.eval ρ_arr.env = Runtime.Val.int len := by
         simp [t, Term.eval, UnOp.eval, heval_sa, hv_arr]
       have hgoal :
-          st₁.sl Θ ρ_arr ∗ TinyML.ValHasType Θ (.int len) TinyML.Typ.int ∗ R ⊢
+          st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R ⊢
             Φ (.int len) := by
         simpa [Expr.ty] using hpost (.int len) ρ_arr st₁ t hret ht_wf ht_eval
       iapply (SpatialContext.wp_arrayLen
-        (R := st₁.sl Θ ρ_arr ∗ TinyML.ValHasType Θ (.int len) TinyML.Typ.int ∗ R)
+        (R := st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R)
         (Q := Φ) (v := v_arr) (len := len) (l := loc) hv_arr hgoal)
       isplitl [Howns]
       · iexact Howns
       · isplitl []
-        · iapply (TinyML.ValHasType.int_intro Θ)
+        · iapply (TinyML.ValHasType.int_intro W)
         · iexact HR
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
-      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
 
@@ -1687,7 +1691,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     correctExpr reg (.arrayGet arr idx ty) := by
   cases hty : arr.ty with
   | array elemTy =>
-    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
@@ -1696,21 +1700,21 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     obtain ⟨helem, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
     subst helem
-    have heval_idx : (compile reg Θ Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind heval
+    have heval_idx : (compile reg W.Θ Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_arrayGet <| ?_
-    have hstart := Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
-    refine hstart.trans <| ihIdx Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_idx)
+    have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
+    refine hstart.trans <| ihIdx W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
+      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_idx)
       hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
     intro v_idx ρ_idx st₁ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
     have hagree_idx : B.agreeOnLinked ρ_idx.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_idx hbwf
     have hbwf_idx : B.wfIn st₁.decls := fun p hp => hdecls_idx.consts _ (hbwf p hp)
-    have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
-    have harrStart := Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_idx γ R v_idx idx.ty
+    have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
+    have harrStart := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_idx γ R v_idx idx.ty
     have hspecInv_idx := specInvariants_mono hΔspec hρspec hdecls_idx hagreeOn_idx
-    refine harrStart.trans <| ihArr Θ (TinyML.ValHasType Θ v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ Δ_spec ρ_spec _ _
+    refine harrStart.trans <| ihArr W (TinyML.ValHasType W v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ_idx heval_arr) hagree_idx hbwf_idx hSwf hΔwf hΔvars
       hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
     intro v_arr ρ_arr st₂ sa hΨ_arr hsa_wf heval_sa
@@ -1730,12 +1734,12 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
         (Term.const_wfIn_addConst_of_fresh (Δ := st₂.decls) (c := c)
           (VerifM.eval.wf hdecl_eval).namesDisjoint hc_fresh)
     have hwp :
-        st₂.sl Θ ρ_arr ∗ TinyML.ValHasType Θ v_arr arr.ty ∗
-          (TinyML.ValHasType Θ v_idx idx.ty ∗ R) ⊢
-          wp reg.primCtx (.arrayGet (.val v_arr) (.val v_idx)) Φ := by
+        st₂.sl W ρ_arr ∗ TinyML.ValHasType W v_arr arr.ty ∗
+          (TinyML.ValHasType W v_idx idx.ty ∗ R) ⊢
+          wp W.pctx (.arrayGet (.val v_arr) (.val v_idx)) Φ := by
       rw [hty, hidxty]
       simpa [TransState.sl_eq] using
-        (SpatialContext.wp_arrayGet_inv (pctx := reg.primCtx) (Θ := Θ)
+        (SpatialContext.wp_arrayGet_inv (W := W)
           (ctx := st₂.owns) (ρ := ρ_arr.env) (arr := sa) (idx := si)
           (elemTy := elemTy) (varr := v_arr) (vidx := v_idx) (Q := Φ) (R := R)
           heval_sa hsi_ρ_arr hi hlt (by
@@ -1749,18 +1753,18 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
             have hsv_eval : sv.eval ρ₂.env = w := by
               simp [sv, ρ₂, Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
             ihave Hcheck := TinyML.typeConstraints_hold (ty := elemTy) (t := sv)
-              (ρ := ρ₂.env) (Θ := Θ) (v := w) hsv_eval $$ Hw
+              (ρ := ρ₂.env) (W := W) (v := w) hsv_eval $$ Hw
             ipure Hcheck
             obtain ⟨st₃, hst₃_decls, hst₃_owns, _, heval_ret⟩ := VerifM.eval_assumeAll hassume_eval
               (fun φ hφ => TinyML.typeConstraints_wfIn hc_wf φ hφ)
               (fun φ hφ => Hcheck φ hφ)
             have hΨ_ret := VerifM.eval_ret heval_ret
             have hsv_wf : sv.wfIn st₃.decls := hst₃_decls ▸ hc_wf
-            have hsl_agree : st₂.sl Θ ρ_arr ⊢ st₃.sl Θ ρ₂ := by
+            have hsl_agree : st₂.sl W ρ_arr ⊢ st₃.sl W ρ₂ := by
               simp [TransState.sl_eq, st_c, hst₃_owns]
-              exact (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hdecl_eval).ownsWf
+              exact (SpatialContext.interp_env_agree W (VerifM.eval.wf hdecl_eval).ownsWf
                 (Env.agreeOn_update_fresh_const (c := c) hc_fresh)).1
-            have hsl_agree' : SpatialContext.interp Θ ρ_arr.env st₂.owns ⊢ st₃.sl Θ ρ₂ := by
+            have hsl_agree' : SpatialContext.interp W ρ_arr.env st₂.owns ⊢ st₃.sl W ρ₂ := by
               simpa [TransState.sl_eq] using hsl_agree
             iapply (hpost w ρ₂ st₃ sv hΨ_ret hsv_wf hsv_eval)
             isplitl [Howns]
@@ -1771,7 +1775,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
               · iexact HR))
     exact hwp
   | ownedArray elemTy =>
-    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
@@ -1780,20 +1784,20 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     obtain ⟨helem, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
     subst ty
-    have heval_idx : (compile reg Θ Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind heval
+    have heval_idx : (compile reg W.Θ Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_arrayGet <| ?_
-    have hstart := Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
-    refine hstart.trans <| ihIdx Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_idx)
+    have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
+    refine hstart.trans <| ihIdx W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
+      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_idx)
       hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
     intro v_idx ρ_idx st₁ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
     have hagree_idx := Bindings.agreeOnLinked_env_agree hagree hagreeOn_idx hbwf
     have hbwf_idx : B.wfIn st₁.decls := fun p hp => hdecls_idx.consts _ (hbwf p hp)
-    have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
-    have harrStart := Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_idx γ R v_idx idx.ty
+    have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
+    have harrStart := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_idx γ R v_idx idx.ty
     have hspecInv_idx := specInvariants_mono hΔspec hρspec hdecls_idx hagreeOn_idx
-    refine harrStart.trans <| ihArr Θ (TinyML.ValHasType Θ v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ Δ_spec ρ_spec _ _
+    refine harrStart.trans <| ihArr W (TinyML.ValHasType W v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ_idx heval_arr) hagree_idx hbwf_idx hSwf hΔwf hΔvars
       hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
     intro v_arr ρ_arr st₂ sa hΨ_arr hsa_wf heval_sa
@@ -1804,21 +1808,21 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₂ hsa_wf
     have hfind := VerifM.eval_bind hcont2
     rw [hty, hidxty]
-    refine VerifM.eval_findMatchForce Θ
-      (R := TinyML.ValHasType Θ v_arr (.ownedArray elemTy) ∗ TinyML.ValHasType Θ v_idx .int ∗ R)
-      (Φ := wp reg.primCtx (.arrayGet (.val v_arr) (.val v_idx)) Φ) hfind hsa_wf ?_
+    refine VerifM.eval_findMatchForce W
+      (R := TinyML.ValHasType W v_arr (.ownedArray elemTy) ∗ TinyML.ValHasType W v_idx .int ∗ R)
+      (Φ := wp W.pctx (.arrayGet (.val v_arr) (.val v_idx)) Φ) hfind hsa_wf ?_
     intro contents st₃ hQ hdecls hcontents_wf
     have hatom_wf : (SpatialAtom.arrayPointsTo sa contents elemTy).wfIn st₃.decls := by
       rw [hdecls]; exact ⟨hsa_wf, hcontents_wf⟩
     let result : Term .value := .binop .vecGet (.unop .toVec contents) (.unop .toInt si)
     simpa [TransState.sl_eq] using
-      (SpatialContext.wp_arrayGet_owned (pctx := reg.primCtx) (Θ := Θ)
+      (SpatialContext.wp_arrayGet_owned (W := W)
         (rest := st₃.owns) (arr := sa) (contents := contents) (idx := si)
         (result := result) (elemTy := elemTy) (varr := v_arr) (vidx := v_idx)
         (Q := Φ) (R := R) heval_sa hsi_eval hi hlt rfl (by
           -- Acquire the restored atom, then conclude with the postcondition.
-          have hstep := VerifM.eval_acquireSpatial Θ
-            (R := TinyML.ValHasType Θ (Term.eval ρ_arr.env result) elemTy ∗ R)
+          have hstep := VerifM.eval_acquireSpatial W
+            (R := TinyML.ValHasType W (Term.eval ρ_arr.env result) elemTy ∗ R)
             (Φ := Φ (Term.eval ρ_arr.env result)) (VerifM.eval_bind hQ) hatom_wf
             (fun st₄ hq₄ hdecls₄ _howns₄ =>
               hpost (Term.eval ρ_arr.env result) ρ_arr st₄ result (VerifM.eval_ret hq₄)
@@ -1839,7 +1843,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
               · iexact HR))
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
-      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
@@ -1848,7 +1852,7 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     correctExpr reg (.arraySet arr idx val) := by
   cases hty : arr.ty with
   | array elemTy =>
-    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
@@ -1856,41 +1860,41 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     replace heval := VerifM.eval_ret (VerifM.eval_bind heval)
     obtain ⟨helemTy, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
-    have heval_val : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
+    have heval_val : (compile reg W.Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_arraySet <| ?_
     -- Evaluate `val`.
-    have hstart := Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
-    refine hstart.trans <| ihVal Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_val)
+    have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
+    refine hstart.trans <| ihVal W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
+      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_val)
       hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
     intro v_val ρ_val st₁ sv hΨ_val hsv_wf heval_sv
     obtain ⟨hdecls_val, hagreeOn_val, hΨ_val⟩ := hΨ_val
     have hagree_val : B.agreeOnLinked ρ_val.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_val hbwf
     have hbwf_val : B.wfIn st₁.decls := fun p hp => hdecls_val.consts _ (hbwf p hp)
-    have heval_idx : (compile reg Θ Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
+    have heval_idx : (compile reg W.Θ Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
     have hspecInv_val := specInvariants_mono hΔspec hρspec hdecls_val hagreeOn_val
     -- Evaluate `idx`, re-exposing the spec context and carrying `val`'s typing.
     have hstepB :=
-      (Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_val γ R v_val val.ty).trans
-        (Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_val γ (TinyML.ValHasType Θ v_val val.ty ∗ R))
-    refine hstepB.trans <| ihIdx Θ
-      (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ (TinyML.ValHasType Θ v_val val.ty ∗ R)))
-      S B Γ st₁ ρ_val γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ_val heval_idx)
+      (Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_val γ R v_val val.ty).trans
+        (Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st₁ ρ_val γ (TinyML.ValHasType W v_val val.ty ∗ R))
+    refine hstepB.trans <| ihIdx W
+      (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ (TinyML.ValHasType W v_val val.ty ∗ R)))
+      S B Γ st₁ ρ_val γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ_val heval_idx)
       hagree_val hbwf_val hSwf hΔwf hΔvars hspecInv_val.1 hspecInv_val.2 hΔreg hρreg ?_
     intro v_idx ρ_idx st₂ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
     have hagree_idx : B.agreeOnLinked ρ_idx.env γ :=
       Bindings.agreeOnLinked_env_agree hagree_val hagreeOn_idx hbwf_val
     have hbwf_idx : B.wfIn st₂.decls := fun p hp => hdecls_idx.consts _ (hbwf_val p hp)
-    have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
+    have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
     have hspecInv_idx := specInvariants_mono hspecInv_val.1 hspecInv_val.2 hdecls_idx hagreeOn_idx
     -- Evaluate `arr`, carrying both `idx`'s and `val`'s typings.
-    have hstepC := Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₂ ρ_idx γ
-      (TinyML.ValHasType Θ v_val val.ty ∗ R) v_idx idx.ty
-    refine hstepC.trans <| ihArr Θ
-      (TinyML.ValHasType Θ v_idx idx.ty ∗ (TinyML.ValHasType Θ v_val val.ty ∗ R))
-      S B Γ st₂ ρ_idx γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ_idx heval_arr)
+    have hstepC := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₂ ρ_idx γ
+      (TinyML.ValHasType W v_val val.ty ∗ R) v_idx idx.ty
+    refine hstepC.trans <| ihArr W
+      (TinyML.ValHasType W v_idx idx.ty ∗ (TinyML.ValHasType W v_val val.ty ∗ R))
+      S B Γ st₂ ρ_idx γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ_idx heval_arr)
       hagree_idx hbwf_idx hSwf hΔwf hΔvars hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
     intro v_arr ρ_arr st₃ sa hΨ_arr hsa_wf heval_sa
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
@@ -1903,21 +1907,21 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     have hret := VerifM.eval_ret (VerifM.eval_ret (VerifM.eval_bind hcont2))
     have hunit_wf : (Term.const .unit).wfIn st₃.decls := by simp [Term.wfIn, Const.wfIn]
     have hgoal :
-        st₃.sl Θ ρ_arr ∗ TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Φ .unit :=
+        st₃.sl W ρ_arr ∗ TinyML.ValHasType W .unit .unit ∗ R ⊢ Φ .unit :=
       hpost .unit ρ_arr st₃ _ hret hunit_wf (by simp [Term.eval])
     have hwp :
-        st₃.sl Θ ρ_arr ∗ TinyML.ValHasType Θ v_arr arr.ty ∗
-          (TinyML.ValHasType Θ v_idx idx.ty ∗ (TinyML.ValHasType Θ v_val val.ty ∗ R)) ⊢
-          wp reg.primCtx (.arraySet (.val v_arr) (.val v_idx) (.val v_val)) Φ := by
+        st₃.sl W ρ_arr ∗ TinyML.ValHasType W v_arr arr.ty ∗
+          (TinyML.ValHasType W v_idx idx.ty ∗ (TinyML.ValHasType W v_val val.ty ∗ R)) ⊢
+          wp W.pctx (.arraySet (.val v_arr) (.val v_idx) (.val v_val)) Φ := by
       rw [hty, hidxty, ← helemTy]
       simpa [TransState.sl_eq] using
-        (SpatialContext.wp_arraySet_inv (pctx := reg.primCtx) (Θ := Θ)
+        (SpatialContext.wp_arraySet_inv (W := W)
           (ctx := st₃.owns) (ρ := ρ_arr.env) (arr := sa) (idx := si)
           (elemTy := elemTy) (varr := v_arr) (vidx := v_idx) (val := v_val)
           (Q := Φ) (R := R) heval_sa hsi_ρ_arr hi hlt (by
             have hgoal' :
-                SpatialContext.interp Θ ρ_arr.env st₃.owns ∗
-                  TinyML.ValHasType Θ .unit .unit ∗ R ⊢ Φ .unit := by
+                SpatialContext.interp W ρ_arr.env st₃.owns ∗
+                  TinyML.ValHasType W .unit .unit ∗ R ⊢ Φ .unit := by
               simpa [TransState.sl_eq] using hgoal
             istart
             iintro ⟨Howns, _, HR⟩
@@ -1925,11 +1929,11 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
             isplitl [Howns]
             · iexact Howns
             · isplitl []
-              · iapply (TinyML.ValHasType.unit_intro Θ)
+              · iapply (TinyML.ValHasType.unit_intro W)
               · iexact HR))
     exact hwp
   | ownedArray elemTy =>
-    intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
@@ -1937,36 +1941,36 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     replace heval := VerifM.eval_ret (VerifM.eval_bind heval)
     obtain ⟨helemTy, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
-    have heval_val : (compile reg Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
+    have heval_val : (compile reg W.Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_arraySet <| ?_
-    have hstart := Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
-    refine hstart.trans <| ihVal Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ heval_val)
+    have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
+    refine hstart.trans <| ihVal W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
+      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_val)
       hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
     intro v_val ρ_val st₁ sv hΨ_val hsv_wf heval_sv
     obtain ⟨hdecls_val, hagreeOn_val, hΨ_val⟩ := hΨ_val
     have hagree_val := Bindings.agreeOnLinked_env_agree hagree hagreeOn_val hbwf
     have hbwf_val : B.wfIn st₁.decls := fun p hp => hdecls_val.consts _ (hbwf p hp)
-    have heval_idx : (compile reg Θ Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
+    have heval_idx : (compile reg W.Θ Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
     have hspecInv_val := specInvariants_mono hΔspec hρspec hdecls_val hagreeOn_val
     have hstepB :=
-      (Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_val γ R v_val val.ty).trans
-        (Helpers.ctx_dup_flip reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_val γ (TinyML.ValHasType Θ v_val val.ty ∗ R))
-    refine hstepB.trans <| ihIdx Θ
-      (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ (TinyML.ValHasType Θ v_val val.ty ∗ R)))
-      S B Γ st₁ ρ_val γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ_val heval_idx)
+      (Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_val γ R v_val val.ty).trans
+        (Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st₁ ρ_val γ (TinyML.ValHasType W v_val val.ty ∗ R))
+    refine hstepB.trans <| ihIdx W
+      (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ (TinyML.ValHasType W v_val val.ty ∗ R)))
+      S B Γ st₁ ρ_val γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ_val heval_idx)
       hagree_val hbwf_val hSwf hΔwf hΔvars hspecInv_val.1 hspecInv_val.2 hΔreg hρreg ?_
     intro v_idx ρ_idx st₂ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
     have hagree_idx := Bindings.agreeOnLinked_env_agree hagree_val hagreeOn_idx hbwf_val
     have hbwf_idx : B.wfIn st₂.decls := fun p hp => hdecls_idx.consts _ (hbwf_val p hp)
-    have heval_arr : (compile reg Θ Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
+    have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
     have hspecInv_idx := specInvariants_mono hspecInv_val.1 hspecInv_val.2 hdecls_idx hagreeOn_idx
-    have hstepC := Helpers.ctx_push_flip reg Θ Δ_spec ρ_spec S B Γ st₂ ρ_idx γ
-      (TinyML.ValHasType Θ v_val val.ty ∗ R) v_idx idx.ty
-    refine hstepC.trans <| ihArr Θ
-      (TinyML.ValHasType Θ v_idx idx.ty ∗ (TinyML.ValHasType Θ v_val val.ty ∗ R))
-      S B Γ st₂ ρ_idx γ Δ_spec ρ_spec _ _ (VerifM.eval.decls_grow ρ_idx heval_arr)
+    have hstepC := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₂ ρ_idx γ
+      (TinyML.ValHasType W v_val val.ty ∗ R) v_idx idx.ty
+    refine hstepC.trans <| ihArr W
+      (TinyML.ValHasType W v_idx idx.ty ∗ (TinyML.ValHasType W v_val val.ty ∗ R))
+      S B Γ st₂ ρ_idx γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ_idx heval_arr)
       hagree_idx hbwf_idx hSwf hΔwf hΔvars hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
     intro v_arr ρ_arr st₃ sa hΨ_arr hsa_wf heval_sa
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
@@ -1984,10 +1988,10 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₃ hsa_wf
     have hfind := VerifM.eval_bind hcont2
     rw [hty, hidxty, ← helemTy]
-    refine VerifM.eval_findMatchForce Θ
-      (R := TinyML.ValHasType Θ v_arr (.ownedArray elemTy) ∗ TinyML.ValHasType Θ v_idx .int ∗
-        TinyML.ValHasType Θ v_val elemTy ∗ R)
-      (Φ := wp reg.primCtx (.arraySet (.val v_arr) (.val v_idx) (.val v_val)) Φ) hfind hsa_wf ?_
+    refine VerifM.eval_findMatchForce W
+      (R := TinyML.ValHasType W v_arr (.ownedArray elemTy) ∗ TinyML.ValHasType W v_idx .int ∗
+        TinyML.ValHasType W v_val elemTy ∗ R)
+      (Φ := wp W.pctx (.arraySet (.val v_arr) (.val v_idx) (.val v_val)) Φ) hfind hsa_wf ?_
     intro contents st₄ hQ hdecls hcontents_wf
     let contents' : Term .value := .unop .ofVec
       (.terop .vecSet (.unop .toVec contents) (.unop .toInt si) sv)
@@ -1998,13 +2002,13 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
       rw [hdecls]; exact ⟨hsa_wf, by simpa [hdecls] using hcontents'_wf⟩
     have hunit_wf : (Term.const .unit).wfIn st₄.decls := by simp [Term.wfIn, Const.wfIn]
     simpa [TransState.sl_eq] using
-      (SpatialContext.wp_arraySet_owned (pctx := reg.primCtx) (Θ := Θ)
+      (SpatialContext.wp_arraySet_owned (W := W)
         (rest := st₄.owns) (arr := sa) (contents := contents) (contents' := contents')
         (idx := si) (val := sv) (elemTy := elemTy) (varr := v_arr) (vidx := v_idx)
         (vval := v_val) (Q := Φ) (R := R) heval_sa hsi_eval hsv_eval hi hlt rfl (by
           -- Acquire the updated atom, then conclude with the postcondition.
-          have hstep := VerifM.eval_acquireSpatial Θ
-            (R := TinyML.ValHasType Θ .unit .unit ∗ R)
+          have hstep := VerifM.eval_acquireSpatial W
+            (R := TinyML.ValHasType W .unit .unit ∗ R)
             (Φ := Φ .unit) (VerifM.eval_bind hQ) hatom_wf
             (fun st₅ hq₅ hdecls₅ _howns₅ =>
               hpost .unit ρ_arr st₅ (.const .unit) (VerifM.eval_ret hq₅)
@@ -2023,19 +2027,19 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
               · iexact HR))
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
-      intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval _ _ _ _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
 theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
     (ih : correctExpr reg e) :
     correctExpr reg (.unop op e uty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_unop <| ih Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_unop <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_, _, hΨ_e⟩ := hΨ_e
@@ -2044,8 +2048,8 @@ theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Ex
   obtain ⟨t, hcompUnop, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
   obtain hΨ_e := VerifM.eval_ret hΨ_e
   have htyped :
-      st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ v_e e.ty ∗ R ⊢
-        st₁.sl Θ ρ_e ∗ iprop(∃ w, ⌜TinyML.evalUnOp op v_e = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R :=
+      st₁.sl W ρ_e ∗ TinyML.ValHasType W v_e e.ty ∗ R ⊢
+        st₁.sl W ρ_e ∗ iprop(∃ w, ⌜TinyML.evalUnOp op v_e = some w⌝ ∗ TinyML.ValHasType W w ty) ∗ R :=
     sep_mono_right (sep_mono_left (TinyML.evalUnOp_typed htypeOf))
   simp only [Expr.ty] at hpost
   refine htyped.trans ?_
@@ -2054,12 +2058,12 @@ theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Ex
   icases Hex with ⟨%w, %heval_op, Hwty⟩
   have ht_eval : t.eval ρ_e.env = w :=
     compileUnop_eval heval_se heval_op hcompUnop
-  have hq : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w :=
+  have hq : st₁.sl W ρ_e ∗ TinyML.ValHasType W w ty ∗ R ⊢ Φ w :=
     by simpa [hty_eq] using
       (hpost w ρ_e st₁ t hΨ_e (compileUnop_wfIn hse_wf hcompUnop) ht_eval)
-  have hwp : st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp reg.primCtx (.unop op (.val v_e)) Φ :=
+  have hwp : st₁.sl W ρ_e ∗ TinyML.ValHasType W w ty ∗ R ⊢ wp W.pctx (.unop op (.val v_e)) Φ :=
     SpatialContext.wp_unop
-      (R := st₁.sl Θ ρ_e ∗ TinyML.ValHasType Θ w ty ∗ R)
+      (R := st₁.sl W ρ_e ∗ TinyML.ValHasType W w ty ∗ R)
       (Q := Φ) (op := op) (v := v_e) (res := w) hq heval_op
   iapply hwp
   isplitl [Howns]
@@ -2071,36 +2075,36 @@ theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Ex
 theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
     (ihR : correctExpr reg r) (ihL : correctExpr reg l) :
     correctExpr reg (.binop op l r bty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_r : (compile reg Θ Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind heval
+  have heval_r : (compile reg W.Θ Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl Θ ρ ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        st.sl W ρ ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
+    Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_binop <| hstart.trans <|
-    ihR Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihR W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr
   obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
   have hagree_r : B.agreeOnLinked ρ_r.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
   have hbwf_r : B.wfIn st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
-  have heval_l : (compile reg Θ Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind hΨ_r
+  have heval_l : (compile reg W.Θ Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind hΨ_r
   have hleftStart :
-      st₁.sl Θ ρ_r ∗ TinyML.ValHasType Θ vr r.ty ∗
-        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st₁.sl Θ ρ_r ∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-              (TinyML.ValHasType Θ vr r.ty ∗ R)) :=
-    Helpers.ctx_push reg Θ Δ_spec ρ_spec S B Γ st₁ ρ_r γ R vr r.ty
+      st₁.sl W ρ_r ∗ TinyML.ValHasType W vr r.ty ∗
+        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+          st₁.sl W ρ_r ∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+              (TinyML.ValHasType W vr r.ty ∗ R)) :=
+    Helpers.ctx_push W Δ_spec ρ_spec S B Γ st₁ ρ_r γ R vr r.ty
   have hspecInv_r := specInvariants_mono hΔspec hρspec hdecls_r hagreeOn_r
   refine hleftStart.trans <|
-    ihL Θ (TinyML.ValHasType Θ vr r.ty ∗ R) S B Γ st₁ ρ_r γ Δ_spec ρ_spec _ _
+    ihL W (TinyML.ValHasType W vr r.ty ∗ R) S B Γ st₁ ρ_r γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hSwf hΔwf hΔvars hspecInv_r.1 hspecInv_r.2 hΔreg hρreg ?_
   intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
@@ -2138,22 +2142,22 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
       have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.div (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
         simpa using hΨ_post
       have hwp_int :
-          st₂.sl Θ ρ_l ∗
-              (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
-            wp reg.primCtx (.binop .div (.val vl) (.val vr)) Φ := by
+          st₂.sl W ρ_l ∗
+              (TinyML.ValHasType W vl .int ∗ (TinyML.ValHasType W vr .int ∗ R)) ⊢
+            wp W.pctx (.binop .div (.val vl) (.val vr)) Φ := by
         istart
         iintro H
         icases H with ⟨Howns, Hvl, Hvr, HR⟩
-        ihave Hvl_int := (TinyML.ValHasType.int Θ vl).1 $$ Hvl
-        ihave Hvr_int := (TinyML.ValHasType.int Θ vr).1 $$ Hvr
+        ihave Hvl_int := (TinyML.ValHasType.int W vl).1 $$ Hvl
+        ihave Hvr_int := (TinyML.ValHasType.int W vr).1 $$ Hvr
         icases Hvl_int with ⟨%a, %hvl⟩
         icases Hvr_int with ⟨%b, %hvr⟩
         subst hvl hvr
-        have hq : st₂.sl Θ ρ_l ∗ R ⊢ Φ (.int (a / b)) := by
-          have htype : ⊢ TinyML.ValHasType Θ (.int (a / b)) .int := by
-            exact TinyML.ValHasType.int_intro Θ (a / b)
+        have hq : st₂.sl W ρ_l ∗ R ⊢ Φ (.int (a / b)) := by
+          have htype : ⊢ TinyML.ValHasType W (.int (a / b)) .int := by
+            exact TinyML.ValHasType.int_intro W (a / b)
           have hgoal :
-              st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ (.int (a / b)) .int ∗ R ⊢ Φ (.int (a / b)) := by
+              st₂.sl W ρ_l ∗ TinyML.ValHasType W (.int (a / b)) .int ∗ R ⊢ Φ (.int (a / b)) := by
             simpa [hbty] using
               (hpost (.int (a / b)) ρ_l st₂ _ hΨ_post' hwf_bin
                 (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l]))
@@ -2189,22 +2193,22 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
       have hΨ_post' : Ψ (Term.unop .ofInt (Term.binop BinOp.mod (Term.unop .toInt sl) (Term.unop .toInt sr))) st₂ ρ_l := by
         simpa using hΨ_post
       have hwp_int :
-          st₂.sl Θ ρ_l ∗
-              (TinyML.ValHasType Θ vl .int ∗ (TinyML.ValHasType Θ vr .int ∗ R)) ⊢
-            wp reg.primCtx (.binop .mod (.val vl) (.val vr)) Φ := by
+          st₂.sl W ρ_l ∗
+              (TinyML.ValHasType W vl .int ∗ (TinyML.ValHasType W vr .int ∗ R)) ⊢
+            wp W.pctx (.binop .mod (.val vl) (.val vr)) Φ := by
         istart
         iintro H
         icases H with ⟨Howns, Hvl, Hvr, HR⟩
-        ihave Hvl_int := (TinyML.ValHasType.int Θ vl).1 $$ Hvl
-        ihave Hvr_int := (TinyML.ValHasType.int Θ vr).1 $$ Hvr
+        ihave Hvl_int := (TinyML.ValHasType.int W vl).1 $$ Hvl
+        ihave Hvr_int := (TinyML.ValHasType.int W vr).1 $$ Hvr
         icases Hvl_int with ⟨%a, %hvl⟩
         icases Hvr_int with ⟨%b, %hvr⟩
         subst hvl hvr
-        have hq : st₂.sl Θ ρ_l ∗ R ⊢ Φ (.int (a % b)) := by
-          have htype : ⊢ TinyML.ValHasType Θ (.int (a % b)) .int := by
-            exact TinyML.ValHasType.int_intro Θ (a % b)
+        have hq : st₂.sl W ρ_l ∗ R ⊢ Φ (.int (a % b)) := by
+          have htype : ⊢ TinyML.ValHasType W (.int (a % b)) .int := by
+            exact TinyML.ValHasType.int_intro W (a % b)
           have hgoal :
-              st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ (.int (a % b)) .int ∗ R ⊢ Φ (.int (a % b)) := by
+              st₂.sl W ρ_l ∗ TinyML.ValHasType W (.int (a % b)) .int ∗ R ⊢ Φ (.int (a % b)) := by
             simpa [hbty] using
               (hpost (.int (a % b)) ρ_l st₂ _ hΨ_post' hwf_bin
                 (by simp [Term.eval, UnOp.eval, BinOp.eval, heval_sl, hsr_ρ_l]))
@@ -2231,8 +2235,8 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
       simpa [hndivmod] using hΨ_l'
     obtain ⟨t, hcompOp, hΨ_ndiv⟩ := VerifM.eval_bind_expectSome hΨ_ndiv
     have hprep :
-        st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ vl l.ty ∗ (TinyML.ValHasType Θ vr r.ty ∗ R)) ⊢
-          st₂.sl Θ ρ_l ∗ ((TinyML.ValHasType Θ vl l.ty ∗ TinyML.ValHasType Θ vr r.ty) ∗ R) := by
+        st₂.sl W ρ_l ∗ (TinyML.ValHasType W vl l.ty ∗ (TinyML.ValHasType W vr r.ty ∗ R)) ⊢
+          st₂.sl W ρ_l ∗ ((TinyML.ValHasType W vl l.ty ∗ TinyML.ValHasType W vr r.ty) ∗ R) := by
       iintro ⟨Howns, Hvl, Hvr, HR⟩
       isplitl [Howns]
       · iexact Howns
@@ -2242,15 +2246,15 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
           · iexact Hvr
         · iexact HR
     have htyped :
-        st₂.sl Θ ρ_l ∗ (TinyML.ValHasType Θ vl l.ty ∗ (TinyML.ValHasType Θ vr r.ty ∗ R)) ⊢
-          st₂.sl Θ ρ_l ∗ iprop(∃ w, ⌜TinyML.evalBinOp op vl vr = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R :=
+        st₂.sl W ρ_l ∗ (TinyML.ValHasType W vl l.ty ∗ (TinyML.ValHasType W vr r.ty ∗ R)) ⊢
+          st₂.sl W ρ_l ∗ iprop(∃ w, ⌜TinyML.evalBinOp op vl vr = some w⌝ ∗ TinyML.ValHasType W w ty) ∗ R :=
       hprep.trans <|
         (sep_mono_right (sep_mono_left (TinyML.evalBinOp_typed
           (fun h => hndivmod (Or.inl h))
           (fun h => hndivmod (Or.inr h))
           htypeOf)) :
-          st₂.sl Θ ρ_l ∗ ((TinyML.ValHasType Θ vl l.ty ∗ TinyML.ValHasType Θ vr r.ty) ∗ R) ⊢
-            st₂.sl Θ ρ_l ∗ iprop(∃ w, ⌜TinyML.evalBinOp op vl vr = some w⌝ ∗ TinyML.ValHasType Θ w ty) ∗ R)
+          st₂.sl W ρ_l ∗ ((TinyML.ValHasType W vl l.ty ∗ TinyML.ValHasType W vr r.ty) ∗ R) ⊢
+            st₂.sl W ρ_l ∗ iprop(∃ w, ⌜TinyML.evalBinOp op vl vr = some w⌝ ∗ TinyML.ValHasType W w ty) ∗ R)
     have hwfst₂ : st₂.decls.wf := (VerifM.eval.wf hΨ_ndiv).namesDisjoint
     obtain hΨ_ndiv := VerifM.eval_ret hΨ_ndiv
     have hwf_sr_l : sr.wfIn st₂.decls :=
@@ -2260,12 +2264,12 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
     iintro ⟨Howns, Hex, HR⟩
     icases Hex with ⟨%w, %heval_op, Hwty⟩
     have ht_eval : t.eval ρ_l.env = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
-    have hq : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ Φ w := by
+    have hq : st₂.sl W ρ_l ∗ TinyML.ValHasType W w ty ∗ R ⊢ Φ w := by
       simpa [hty_eq] using
         (hpost w ρ_l st₂ t hΨ_ndiv (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval)
-    have hwp : st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R ⊢ wp reg.primCtx (.binop op (.val vl) (.val vr)) Φ :=
+    have hwp : st₂.sl W ρ_l ∗ TinyML.ValHasType W w ty ∗ R ⊢ wp W.pctx (.binop op (.val vl) (.val vr)) Φ :=
       SpatialContext.wp_binop
-        (R := st₂.sl Θ ρ_l ∗ TinyML.ValHasType Θ w ty ∗ R)
+        (R := st₂.sl W ρ_l ∗ TinyML.ValHasType W w ty ∗ R)
         (Q := Φ) (op := op) (vl := vl) (vr := vr) (res := w) hq heval_op
     iapply hwp
     isplitl [Howns]
@@ -2277,19 +2281,19 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
 theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Expr)
     (ihE : correctExpr reg e) (ihBody : correctExpr reg body) :
     correctExpr reg (.letIn b e body) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.letIn_subst]
-  have heval_e_outer : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  have heval_e_outer : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl Θ ρ ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
-  refine (hstart.trans <| ihE Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        st.sl W ρ ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
+    Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
+  refine (hstart.trans <| ihE W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_).trans wp.letIn
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e
   obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -2300,8 +2304,8 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
   | none =>
     simp [hname] at hΨ_e
     have hdrop :
-        st₁.sl Θ ρ_e ∗ (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-          st₁.sl Θ ρ_e ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl W ρ_e ∗ (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+          st₁.sl W ρ_e ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
       iintro ⟨Howns, _Hv, #HS, #HT, HR⟩
       isplitl [Howns]
       · iexact Howns
@@ -2311,15 +2315,15 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
           · iexact HT
           · iexact HR
     have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
-    have hbody := hdrop.trans <| ihBody Θ R S B Γ st₁ ρ_e γ Δ_spec ρ_spec _ _
+    have hbody := hdrop.trans <| ihBody W R S B Γ st₁ ρ_e γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hSwf hΔwf hΔvars hspecInv_e.1 hspecInv_e.2 hΔreg hρreg
       (fun v ρ' st' se hΨ hs hw =>
         let ⟨_, _, hΨ'⟩ := hΨ
         hpost v ρ' st' se hΨ' hs hw)
     have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ Runtime.Binder.none v_e
-    have hbody' : st₁.sl Θ ρ_e ∗
-          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-            wp reg.primCtx
+    have hbody' : st₁.sl W ρ_e ∗
+          (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+            wp W.pctx
               (Runtime.Expr.subst
                 (Runtime.Subst.updateBinder Runtime.Binder.none v_e Runtime.Subst.id)
                 (Runtime.Expr.subst (γ.remove' Runtime.Binder.none) body.runtime))
@@ -2341,20 +2345,20 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
         owns := st₁.owns }
     set ρ_body := ρ_e.updateConst .value v.name v_e
     set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
-    suffices st₂.sl Θ ρ_body ∗
-        (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-          wp reg.primCtx (body.runtime.subst γ_body) Φ by
+    suffices st₂.sl W ρ_body ∗
+        (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+          wp W.pctx (body.runtime.subst γ_body) Φ by
       have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ (.named x) v_e
-      have hbody' : st₂.sl Θ ρ_body ∗
-            (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-              wp reg.primCtx
+      have hbody' : st₂.sl W ρ_body ∗
+            (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+              wp W.pctx
                 (Runtime.Expr.subst
                   (Runtime.Subst.updateBinder (.named x) v_e Runtime.Subst.id)
                   (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
                 Φ :=
         hsubst.symm ▸ this
-      have hinterp_eq : SpatialContext.interp Θ ρ_e.env st₁.owns ⊢ SpatialContext.interp Θ ρ_body.env st₁.owns :=
-        (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hΨ_e).ownsWf
+      have hinterp_eq : SpatialContext.interp W ρ_e.env st₁.owns ⊢ SpatialContext.interp W ρ_body.env st₁.owns :=
+        (SpatialContext.interp_env_agree W (VerifM.eval.wf hΨ_e).ownsWf
           (Env.agreeOn_update_fresh_const hfresh)).1
       rw [Binder.runtime_of_name_some hname]
       exact (sep_mono_left hinterp_eq).trans <|
@@ -2362,7 +2366,7 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
           using hbody'
     have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
       Env.agreeOn_update_fresh_const hfresh
-    have hΨ_body : (compile reg Θ Δ_spec (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
+    have hΨ_body : (compile reg W.Θ Δ_spec (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
       have hdecl_eval := VerifM.eval_bind hΨ_e
       have hdecl := VerifM.eval_decl hdecl_eval
       have h := hdecl v_e
@@ -2397,19 +2401,19 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
       have h := Bindings.agreeOnLinked_cons (x := x) (γ := γ) hagree hρ_agree (hvty := (rfl : v.sort = .value))
       rwa [hρ_body_lookup] at h
     have hres :
-        st₂.sl Θ ρ_body ∗
-          (TinyML.ValHasType Θ v_e e.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-            st₂.sl Θ ρ_body ∗
-              (SpecMap.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
-                Bindings.typedSubst Θ ((x, v) :: B) (Γ.extend x e.ty) γ_body ∗ R) := by
+        st₂.sl W ρ_body ∗
+          (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+            st₂.sl W ρ_body ∗
+              (SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
+                Bindings.typedSubst W ((x, v) :: B) (Γ.extend x e.ty) γ_body ∗ R) := by
       iintro ⟨Howns, Hve, #HS, #HT, HR⟩
       isplitl [Howns]
       · iexact Howns
       · isplitr [Hve HR]
-        · iapply (SpecMap.satisfiedBy_erase (Θ := Θ) (S := S) (γ := γ) (x := x) (v := v_e))
+        · iapply (SpecMap.satisfiedBy_erase (W := W) (S := S) (γ := γ) (x := x) (v := v_e))
           iexact HS
         · isplitl [Hve]
-          · iapply (Bindings.typedSubst_cons (Θ := Θ) (B := B) (Γ := Γ) (γ := γ)
+          · iapply (Bindings.typedSubst_cons (W := W) (B := B) (Γ := Γ) (γ := γ)
               (x := x) (v := v) (te := e.ty) (w := v_e))
             · iexact HT
             · iexact Hve
@@ -2417,7 +2421,7 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
     have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
     have hspecInv_body := specInvariants_mono hspecInv_e.1 hspecInv_e.2
       (Signature.Subset.subset_addConst st₁.decls v) hagreeOn_body_e
-    refine hres.trans <| ihBody Θ R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body Δ_spec ρ_spec _ _
+    refine hres.trans <| ihBody W R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ (SpecMap.wfIn_erase hSwf) hΔwf hΔvars hspecInv_body.1 hspecInv_body.2 hΔreg hρreg ?_
     intro v' ρ' st' se' hΨ hs hw
     obtain ⟨_, _, hΨ'⟩ := hΨ
@@ -2426,12 +2430,13 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
 theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr)
     (ihBody : correctExpr reg body) :
     ∀ (names : List Binder) (tys : List TinyML.Typ) (tl : Term .vallist)
-      (vals : List Runtime.Val) (Θ : TinyML.TypeEnv) (R : iProp) (S : SpecMap)
+      (vals : List Runtime.Val) (W : TinyML.World) (R : iProp) (S : SpecMap)
       (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env)
       (γ : Runtime.Subst) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
       (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
+      W.pctx = reg.primCtx →
       VerifM.eval (compileProductBindersFrom S B Γ names tys tl) st ρ
-        (fun p st' ρ' => (compile reg Θ Δ_spec p.1 p.2.1 p.2.2 body).eval st' ρ' Ψ) →
+        (fun p st' ρ' => (compile reg W.Θ Δ_spec p.1 p.2.1 p.2.2 body).eval st' ρ' Ψ) →
       B.agreeOnLinked ρ.env γ →
       B.wfIn st.decls →
       S.wfIn Δ_spec →
@@ -2444,70 +2449,70 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
       tl.wfIn st.decls →
       Term.eval ρ.env tl = vals →
       (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
-        st'.sl Θ ρ' ∗ TinyML.ValHasType Θ v body.ty ∗ R ⊢ Φ v) →
-      st.sl Θ ρ ∗
-          (TinyML.ValsHaveTypes Θ vals tys ∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-              Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-        wp reg.primCtx
+        st'.sl W ρ' ∗ TinyML.ValHasType W v body.ty ∗ R ⊢ Φ v) →
+      st.sl W ρ ∗
+          (TinyML.ValsHaveTypes W vals tys ∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+              Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+        wp W.pctx
           (body.runtime.subst (γ.updateAllBinder (names.map Binder.runtime) vals)) Φ
-  | [], [], tl, vals, Θ, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
-      heval, hagree, hbwf, hSwf, hΔwf, hΔvars, hΔspec, hρspec, hΔreg, hρreg,
+  | [], [], tl, vals, W, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
+      hW, heval, hagree, hbwf, hSwf, hΔwf, hΔvars, hΔspec, hρspec, hΔreg, hρreg,
       htl_wf, htl_eval, hpost => by
       simp only [compileProductBindersFrom] at heval
-      have hbody_eval : (compile reg Θ Δ_spec S B Γ body).eval st ρ Ψ := by
+      have hbody_eval : (compile reg W.Θ Δ_spec S B Γ body).eval st ρ Ψ := by
         simpa using VerifM.eval_ret heval
       cases vals with
       | nil =>
           have hbody_wp :=
-            ihBody Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hbody_eval hagree hbwf hSwf
+            ihBody W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW hbody_eval hagree hbwf hSwf
               hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
           simpa using
-            ((show st.sl Θ ρ ∗
-                (TinyML.ValsHaveTypes Θ [] [] ∗
-                  (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-                    Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-                st.sl Θ ρ ∗
-                  (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-                    Bindings.typedSubst Θ B Γ γ ∗ R) by
+            ((show st.sl W ρ ∗
+                (TinyML.ValsHaveTypes W [] [] ∗
+                  (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                    Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+                st.sl W ρ ∗
+                  (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                    Bindings.typedSubst W B Γ γ ∗ R) by
                 iintro ⟨Hsl, Hvals, Hctx⟩
-                ihave Hemp := (TinyML.ValsHaveTypes.nil Θ).1 $$ Hvals
+                ihave Hemp := (TinyML.ValsHaveTypes.nil W).1 $$ Hvals
                 isplitl [Hsl]
                 · iexact Hsl
                 · iexact Hctx).trans hbody_wp)
       | cons v vs =>
-          exact (show st.sl Θ ρ ∗
-              (TinyML.ValsHaveTypes Θ (v :: vs) [] ∗
-                (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-                  Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-                wp reg.primCtx (body.runtime.subst (γ.updateAllBinder ([] : List Runtime.Binder) (v :: vs))) Φ by
+          exact (show st.sl W ρ ∗
+              (TinyML.ValsHaveTypes W (v :: vs) [] ∗
+                (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                  Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+                wp W.pctx (body.runtime.subst (γ.updateAllBinder ([] : List Runtime.Binder) (v :: vs))) Φ by
             iintro ⟨_Hsl, Hvals, _Hctx⟩
-            ihave Hfalse := (TinyML.ValsHaveTypes.cons_nil Θ v vs).1 $$ Hvals
+            ihave Hfalse := (TinyML.ValsHaveTypes.cons_nil W v vs).1 $$ Hvals
             iapply false_elim
             iexact Hfalse)
-  | [], ty :: tys, tl, vals, Θ, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
-      heval, _hagree, _hbwf, _hSwf, _hΔwf, _hΔvars, _hΔspec, _hρspec, _hΔreg, _hρreg,
+  | [], ty :: tys, tl, vals, W, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
+      hW, heval, _hagree, _hbwf, _hSwf, _hΔwf, _hΔvars, _hΔspec, _hρspec, _hΔreg, _hρreg,
       _htl_wf, _htl_eval, _hpost => by
       simp only [compileProductBindersFrom] at heval
       exact (VerifM.eval_fatal heval).elim
-  | b :: bs, [], tl, vals, Θ, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
-      heval, _hagree, _hbwf, _hSwf, _hΔwf, _hΔvars, _hΔspec, _hρspec, _hΔreg, _hρreg,
+  | b :: bs, [], tl, vals, W, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
+      hW, heval, _hagree, _hbwf, _hSwf, _hΔwf, _hΔvars, _hΔspec, _hρspec, _hΔreg, _hρreg,
       _htl_wf, _htl_eval, _hpost => by
       simp only [compileProductBindersFrom] at heval
       exact (VerifM.eval_fatal heval).elim
-  | b :: bs, ty :: tys, tl, vals, Θ, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
-      heval, hagree, hbwf, hSwf, hΔwf, hΔvars, hΔspec, hρspec, hΔreg, hρreg,
+  | b :: bs, ty :: tys, tl, vals, W, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
+      hW, heval, hagree, hbwf, hSwf, hΔwf, hΔvars, hΔspec, hρspec, hΔreg, hρreg,
       htl_wf, htl_eval, hpost => by
       cases vals with
       | nil =>
-          exact (show st.sl Θ ρ ∗
-              (TinyML.ValsHaveTypes Θ [] (ty :: tys) ∗
-                (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-                  Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-                wp reg.primCtx
+          exact (show st.sl W ρ ∗
+              (TinyML.ValsHaveTypes W [] (ty :: tys) ∗
+                (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                  Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+                wp W.pctx
                   (body.runtime.subst (γ.updateAllBinder ((b :: bs).map Binder.runtime) [])) Φ by
             iintro ⟨_Hsl, Hvals, _Hctx⟩
-            ihave Hfalse := (TinyML.ValsHaveTypes.nil_cons Θ ty tys).1 $$ Hvals
+            ihave Hfalse := (TinyML.ValsHaveTypes.nil_cons W ty tys).1 $$ Hvals
             iapply false_elim
             iexact Hfalse)
       | cons v vs =>
@@ -2525,19 +2530,19 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
           | none =>
               simp [hname] at hcont
               have hrec := compileProductBindersFrom_correct reg body ihBody bs tys
-                (Term.unop UnOp.vtail tl) vs Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ
+                (Term.unop UnOp.vtail tl) vs W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW
                 hcont hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg
                 htail_wf htail_eval hpost
-              refine (show st.sl Θ ρ ∗
-                  (TinyML.ValsHaveTypes Θ (v :: vs) (ty :: tys) ∗
-                    (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-                      Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-                    st.sl Θ ρ ∗
-                      (TinyML.ValsHaveTypes Θ vs tys ∗
-                        (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-                          Bindings.typedSubst Θ B Γ γ ∗ R)) by
+              refine (show st.sl W ρ ∗
+                  (TinyML.ValsHaveTypes W (v :: vs) (ty :: tys) ∗
+                    (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                      Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+                    st.sl W ρ ∗
+                      (TinyML.ValsHaveTypes W vs tys ∗
+                        (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                          Bindings.typedSubst W B Γ γ ∗ R)) by
                 iintro ⟨Hsl, Hvals, Hctx⟩
-                ihave Hpair := (TinyML.ValsHaveTypes.cons Θ v vs ty tys).1 $$ Hvals
+                ihave Hpair := (TinyML.ValsHaveTypes.cons W v vs ty tys).1 $$ Hvals
                 icases Hpair with ⟨_Hv, Hvs⟩
                 isplitl [Hsl]
                 · iexact Hsl
@@ -2604,8 +2609,8 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
               have hspecInv := specInvariants_mono hΔspec hρspec
                 (Signature.Subset.subset_addConst st.decls x') hagreeOn_body
               have hrec := compileProductBindersFrom_correct reg body ihBody bs tys
-                (Term.unop UnOp.vtail tl) vs Θ R (Finmap.erase x S) ((x, x') :: B)
-                (Γ.extend x ty) st₂ ρ₁ (Runtime.Subst.update γ x v) Δ_spec ρ_spec Ψ Φ
+                (Term.unop UnOp.vtail tl) vs W R (Finmap.erase x S) ((x, x') :: B)
+                (Γ.extend x ty) st₂ ρ₁ (Runtime.Subst.update γ x v) Δ_spec ρ_spec Ψ Φ hW
                 hrec_eval hagree₁ hbwf₁ (SpecMap.wfIn_erase hSwf) hΔwf hΔvars
                 hspecInv.1 hspecInv.2 hΔreg hρreg
                 (by
@@ -2618,22 +2623,22 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
                   exact htail_eval)
                 hpost
               have hctx :
-                  st.sl Θ ρ ∗
-                    (TinyML.ValsHaveTypes Θ (v :: vs) (ty :: tys) ∗
-                      (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-                        Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-                    st₂.sl Θ ρ₁ ∗
-                      (TinyML.ValsHaveTypes Θ vs tys ∗
-                        (SpecMap.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (Finmap.erase x S)
+                  st.sl W ρ ∗
+                    (TinyML.ValsHaveTypes W (v :: vs) (ty :: tys) ∗
+                      (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                        Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+                    st₂.sl W ρ₁ ∗
+                      (TinyML.ValsHaveTypes W vs tys ∗
+                        (SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.erase x S)
                           (Runtime.Subst.update γ x v) ∗
-                          Bindings.typedSubst Θ ((x, x') :: B) (Γ.extend x ty)
+                          Bindings.typedSubst W ((x, x') :: B) (Γ.extend x ty)
                             (Runtime.Subst.update γ x v) ∗ R)) := by
                 iintro ⟨Hsl, Hvals, #HS, #HT, HR⟩
-                ihave Hpair := (TinyML.ValsHaveTypes.cons Θ v vs ty tys).1 $$ Hvals
+                ihave Hpair := (TinyML.ValsHaveTypes.cons W v vs ty tys).1 $$ Hvals
                 icases Hpair with ⟨Hv, Hvs⟩
-                have hinterp_eq : SpatialContext.interp Θ ρ.env st.owns ⊢
-                    SpatialContext.interp Θ ρ₁.env st.owns :=
-                  (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hdecl_eval).ownsWf
+                have hinterp_eq : SpatialContext.interp W ρ.env st.owns ⊢
+                    SpatialContext.interp W ρ₁.env st.owns :=
+                  (SpatialContext.interp_env_agree W (VerifM.eval.wf hdecl_eval).ownsWf
                     (Env.agreeOn_update_fresh_const hfresh)).1
                 isplitl [Hsl]
                 · simp only [TransState.sl_eq]
@@ -2642,11 +2647,11 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
                 · isplitl [Hvs]
                   · iexact Hvs
                   · isplitr [Hv HR]
-                    · iapply (SpecMap.satisfiedBy_erase (Θ := Θ) (S := S) (γ := γ)
+                    · iapply (SpecMap.satisfiedBy_erase (W := W) (S := S) (γ := γ)
                         (x := x) (v := v))
                       iexact HS
                     · isplitl [Hv]
-                      · iapply (Bindings.typedSubst_cons (Θ := Θ) (B := B) (Γ := Γ)
+                      · iapply (Bindings.typedSubst_cons (W := W) (B := B) (Γ := Γ)
                           (γ := γ) (x := x) (v := x') (te := ty) (w := v))
                         · iexact HT
                         · iexact Hv
@@ -2659,23 +2664,23 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
 theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (e body : Expr)
     (ihE : correctExpr reg e) (ihBody : correctExpr reg body) :
     correctExpr reg (.letProd names e body) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval
     hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.letProd_subst]
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st ρ _ :=
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ :=
     VerifM.eval_bind heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl Θ ρ ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        st.sl W ρ ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
+    Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_letProd <| hstart.trans <|
-    ihE Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)
-      S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihE W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)
+      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec
       hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
@@ -2687,37 +2692,37 @@ theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (
       have hprod_body :
           (do
             let p ← compileProductBinders S B Γ names tys se
-            compile reg Θ Δ_spec p.1 p.2.1 p.2.2 body).eval st₁ ρ_e Ψ :=
+            compile reg W.Θ Δ_spec p.1 p.2.1 p.2.2 body).eval st₁ ρ_e Ψ :=
         VerifM.eval_ret hpure_eval
       have hprod_eval := VerifM.eval_bind hprod_body
       have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
       have hbwf_e : B.wfIn st₁.decls := fun p hp => hdecls_e.consts _ (hbwf p hp)
       have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
-      refine (show st₁.sl Θ ρ_e ∗
-          (TinyML.ValHasType Θ v_e (.tuple tys) ∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-              Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-            wp reg.primCtx
+      refine (show st₁.sl W ρ_e ∗
+          (TinyML.ValHasType W v_e (.tuple tys) ∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+              Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+            wp W.pctx
               (Runtime.Expr.letProd (names.map Binder.runtime) (.val v_e)
                 (Runtime.Expr.subst (γ.removeAll' (names.map Binder.runtime)) body.runtime)) Φ from ?_)
       iintro ⟨Hsl, Hve, #HS, #HT, HR⟩
-      ihave Htuple := (TinyML.ValHasType.tuple Θ v_e tys).1 $$ Hve
+      ihave Htuple := (TinyML.ValHasType.tuple W v_e tys).1 $$ Hve
       icases Htuple with ⟨%vs, %hveq, Hvals⟩
       subst hveq
-      ihave %hlen_vals := (TinyML.ValsHaveTypes.length_eq (Θ := Θ) (vs := vs) (ts := tys)) $$ Hvals
+      ihave %hlen_vals := (TinyML.ValsHaveTypes.length_eq (W := W) (vs := vs) (ts := tys)) $$ Hvals
       have hnames_len : (names.map Binder.runtime).length = vs.length := by
         have htl_wf : (Term.unop UnOp.toValList se).wfIn st₁.decls := ⟨trivial, hse_wf⟩
         have hlen_compile := compileProductBindersFrom_length htl_wf hprod_eval
         simp [hlen_compile, hlen_vals]
       have hbody_subst := Runtime.Expr.subst_removeAll'_updateAllBinder body.runtime γ
         (names.map Binder.runtime) vs hnames_len
-      iapply (wp.letProd_val (ctx := reg.primCtx) (names := names.map Binder.runtime)
+      iapply (wp.letProd_val (ctx := W.pctx) (names := names.map Binder.runtime)
         (vs := vs)
         (body := Runtime.Expr.subst (γ.removeAll' (names.map Binder.runtime)) body.runtime)
         hnames_len)
       rw [hbody_subst]
       iapply (compileProductBindersFrom_correct reg body ihBody names tys
-        (Term.unop UnOp.toValList se) vs Θ R S B Γ st₁ ρ_e γ Δ_spec ρ_spec Ψ Φ
+        (Term.unop UnOp.toValList se) vs W R S B Γ st₁ ρ_e γ Δ_spec ρ_spec Ψ Φ hW
         hprod_eval hagree_e hbwf_e hSwf hΔwf hΔvars hspecInv_e.1 hspecInv_e.2
         hΔreg hρreg ?_ ?_ hpost)
       · exact ⟨trivial, hse_wf⟩
@@ -2739,20 +2744,20 @@ theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (
 theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr) (ty : TinyML.Typ)
     (ihCond : correctExpr reg cond) (ihThn : correctExpr reg thn) (ihEls : correctExpr reg els) :
     correctExpr reg (.ifThenElse cond thn els ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_cond : (compile reg Θ Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind heval
+  have heval_cond : (compile reg W.Θ Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-        st.sl Θ ρ ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) :=
-    Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        st.sl W ρ ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
+    Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
   refine SpatialContext.wp_bind_if <| hstart.trans <|
-    ihCond Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihCond W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c
   obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
@@ -2778,13 +2783,13 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
   let st_thn : TransState := { st₁ with asserts := φ_eq.not :: st₁.asserts }
   let st_els : TransState := { st₁ with asserts := φ_eq :: st₁.asserts }
   have hbool_cases_bool :
-      st₁.sl Θ ρ_c ∗
-          (TinyML.ValHasType Θ v_c .bool ∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-        st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+      st₁.sl W ρ_c ∗
+          (TinyML.ValHasType W v_c .bool ∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+        st₁.sl W ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
     iintro ⟨Howns, Hv, #HS, #HT, HR⟩
-    ihave Hv_bool := (TinyML.ValHasType.bool Θ v_c).1 $$ Hv
+    ihave Hv_bool := (TinyML.ValHasType.bool W v_c).1 $$ Hv
     icases Hv_bool with ⟨%b, %hv⟩
     isplitl [Howns]
     · iexact Howns
@@ -2796,9 +2801,9 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
           · iexact HT
           · iexact HR
   have hbool_cases :
-      st₁.sl Θ ρ_c ∗ (TinyML.ValHasType Θ v_c cond.ty ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-        st₁.sl Θ ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+      st₁.sl W ρ_c ∗ (TinyML.ValHasType W v_c cond.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+        st₁.sl W ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
+          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
     simpa [hcond_bool] using hbool_cases_bool
   refine hbool_cases.trans ?_
   istart
@@ -2806,21 +2811,21 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
   icases Hbool with %hbool
   rcases hbool with hfalse_val | htrue_val
   · subst hfalse_val
-    have heval_els : (compile reg Θ Δ_spec S B Γ els).eval st_els ρ_c Ψ :=
+    have heval_els : (compile reg W.Θ Δ_spec S B Γ els).eval st_els ρ_c Ψ :=
       hfalse_cont hwf_eq (by
         simp only [Term.isFalse, Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_c)
     have hwp :
-        st_els.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          wp reg.primCtx (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
+        st_els.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+          wp W.pctx (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_false
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
-        ihEls Θ R S B Γ st_els ρ_c γ Δ_spec ρ_spec Ψ Φ heval_els hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
+        ihEls W R S B Γ st_els ρ_c γ Δ_spec ρ_spec Ψ Φ hW heval_els hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hels_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_els.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+          st_els.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
       simp [st_els, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -2834,21 +2839,21 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
     have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by
       rw [heval_c]
       simp
-    have heval_thn : (compile reg Θ Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
+    have heval_thn : (compile reg W.Θ Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
       htrue_cont hwf_ne (by
         simp only [Term.isFalse, Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_ne)
     have hwp :
-        st_thn.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          wp reg.primCtx (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
+        st_thn.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+          wp W.pctx (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_true
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
-        ihThn Θ R S B Γ st_thn ρ_c γ Δ_spec ρ_spec Ψ Φ heval_thn hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
+        ihThn W R S B Γ st_thn ρ_c γ Δ_spec ρ_spec Ψ Φ hW heval_thn hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hthn_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) ⊢
-          st_thn.sl Θ ρ_c ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R) := by
+        st₁.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+          st_thn.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
       simp [st_thn, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -2862,13 +2867,13 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
 theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
     (ihEs : correctExprs reg es) :
     correctExpr reg (.tuple es) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
-  have heval_es : (compileExprs reg Θ Δ_spec S B Γ es).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_tuple <| ihEs Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+  have heval_es : (compileExprs reg W.Θ Δ_spec S B Γ es).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_tuple <| ihEs W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   intro vs ρ' st' terms hΨ hwf_terms heval_terms
   obtain ⟨_, _, hΨ⟩ := hΨ
@@ -2880,13 +2885,13 @@ theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
     exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
   refine SpatialContext.wp_tuple ?_
   have hstep :
-      st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (es.map Expr.ty) ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) ⊢
-        st'.sl Θ ρ' ∗ TinyML.ValHasType Θ (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
+      st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) ⊢
+        st'.sl W ρ' ∗ TinyML.ValHasType W (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
     iintro ⟨Howns, Hvals, #HS, HR⟩
     isplitl [Howns]
     · iexact Howns
     · isplitl [Hvals]
-      · iapply (TinyML.ValHasType.tuple Θ (.tuple vs) (es.map Expr.ty)).2
+      · iapply (TinyML.ValHasType.tuple W (.tuple vs) (es.map Expr.ty)).2
         iexists vs
         isplitr
         · ipureintro; rfl
@@ -2900,7 +2905,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
     (ihArgs : correctExprs reg args) :
     correctExpr reg (.app fn args aty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst, List.map_map]
@@ -2908,9 +2913,9 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
   | var f fty =>
     simp only [compile] at heval
     obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
-    have heval_args : (compileExprs reg Θ Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind heval
-    refine SpecMap.project (pctx := reg.primCtx)
-      (P := st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) Θ Δ_spec ρ_spec S γ ?_ hlookup ?_
+    have heval_args : (compileExprs reg W.Θ Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind heval
+    refine SpecMap.project
+      (P := st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) W Δ_spec ρ_spec S γ ?_ hlookup ?_
     · istart
       iintro ⟨_, #HS, _⟩
       iexact HS
@@ -2918,11 +2923,11 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       simp [Expr.runtime, Runtime.Expr.subst, hγf]
       refine SpatialContext.wp_bind_app ?_
       have hctx :
-          spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ∗
-              (st.sl Θ ρ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B Γ γ ∗ R)) ⊢
-            st.sl Θ ρ ∗
-              (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗
-                Bindings.typedSubst Θ B Γ γ ∗ (spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ∗ R)) := by
+          spec.isPrecondFor W Δ_spec ρ_spec fval ∗
+              (st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+            st.sl W ρ ∗
+              (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                Bindings.typedSubst W B Γ γ ∗ (spec.isPrecondFor W Δ_spec ρ_spec fval ∗ R)) := by
         istart
         iintro ⟨#Hspec, Howns, #HS, #HT, HR⟩
         isplitl [Howns]
@@ -2935,7 +2940,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
               · iexact Hspec
               · iexact HR
       refine hctx.trans <|
-        ihArgs Θ (spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+        ihArgs W (spec.isPrecondFor W Δ_spec ρ_spec fval ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
           (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
       intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
       obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
@@ -2954,9 +2959,9 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
         intro p hp
         have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
         exact hsargs_wf _ hp''
-      have hcall_eval : VerifM.eval (Spec.call Θ (FiniteSubst.base Δ_spec) spec typedArgs) st_args ρ_args
+      have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base Δ_spec) spec typedArgs) st_args ρ_args
           (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind hΨ_args
-      have hcall := Spec.call_correct Θ spec Δ_spec (FiniteSubst.base Δ_spec) typedArgs st_args ρ_args
+      have hcall := Spec.call_correct W spec Δ_spec (FiniteSubst.base Δ_spec) typedArgs st_args ρ_args
         (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
         hwf_pred
         hbase_wf htypedArgs_wf hcall_eval
@@ -2982,7 +2987,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       ipure Hlen
       have hlen_typed : (args.map Expr.ty).length = sargs.length := by
         rw [← Hlen]; exact hlen_sargs.symm
-      have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
+      have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
         simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
       have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args.env) = vs := by
         have hsnd :
@@ -3000,8 +3005,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
         have := hsub_ty'.length_eq
         rw [Hlen]; exact this
       have happly' :
-          st_args.sl Θ ρ_args ∗ R ⊢
-            PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r spec.retTy -∗ Φ r) spec.pred
+          st_args.sl W ρ_args ∗ R ⊢
+            PredTrans.apply W (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.pred
               (Spec.argsEnv ρ_args spec.args vs) := by
         rw [heval_sargs_map] at happly
         exact happly
@@ -3023,13 +3028,13 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     simp only [compile] at heval
     obtain ⟨i, hilookup, heval⟩ := VerifM.eval_bind_expectSome heval
     obtain ⟨hret_eq, heval⟩ := VerifM.eval_bind_expectEq heval
-    have heval_args : (compileExprs reg Θ Δ_spec S B Γ args).eval st ρ _ :=
+    have heval_args : (compileExprs reg W.Θ Δ_spec S B Γ args).eval st ρ _ :=
       VerifM.eval_bind heval
     have hi_mem : i ∈ reg := Verifier.Registry.mem_of_lookup? hilookup
     have hbridge := Verifier.Registry.Sound.get hSound hi_mem
     simp only [Expr.runtime, Runtime.Expr.subst_val]
     refine SpatialContext.wp_bind_app ?_
-    refine ihArgs Θ R S B Γ st ρ γ Δ_spec ρ_spec _ _
+    refine ihArgs W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
     intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
     obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
@@ -3051,9 +3056,9 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       intro p hp
       have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
       exact hsargs_wf _ hp''
-    have hcall_eval : VerifM.eval (Spec.call Θ (FiniteSubst.base Δ_spec) spec typedArgs) st_args ρ_args
+    have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base Δ_spec) spec typedArgs) st_args ρ_args
         (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind hΨ_args
-    have hcall := Spec.call_correct Θ spec Δ_spec (FiniteSubst.base Δ_spec) typedArgs st_args ρ_args
+    have hcall := Spec.call_correct W spec Δ_spec (FiniteSubst.base Δ_spec) typedArgs st_args ρ_args
       (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
       hwf_pred hbase_wf htypedArgs_wf hcall_eval
       (fun v st' ρ' t hΨ hwf heval => by
@@ -3071,6 +3076,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
           · iexact HR')
     obtain ⟨hsub_ty, happly⟩ := hcall
     refine SpatialContext.wp_val ?_
+    rw [hW]
     refine BIBase.Entails.trans ?_ (Verifier.Registry.wp_prim reg hSound)
     show _ ⊢ reg.wpCtx n vs Φ
     have hctx_eq : reg.wpCtx n vs Φ = i.toWp vs Φ := by
@@ -3083,7 +3089,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     ipure Hlen
     have hlen_typed : (args.map Expr.ty).length = sargs.length := by
       rw [← Hlen]; exact hlen_sargs.symm
-    have hsub_ty' : @TinyML.Typ.SubList Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
+    have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
       have hfst : typedArgs.map Prod.fst = args.map Expr.ty := by
         simpa [typedArgs] using
           (List.map_fst_zip (l₁ := args.map Expr.ty) (l₂ := sargs)
@@ -3102,8 +3108,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
                   congrArg (List.map (fun t => t.eval ρ_args.env)) hsnd
         _ = vs := Terms.Eval.map_eval heval_sargs
     have happly' :
-        st_args.sl Θ ρ_args ∗ R ⊢
-          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r spec.retTy -∗ Φ r) spec.pred
+        st_args.sl W ρ_args ∗ R ⊢
+          PredTrans.apply W (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.pred
             (Spec.argsEnv ρ_args spec.args vs) := by
       rw [heval_sargs_map] at happly
       exact happly
@@ -3112,10 +3118,10 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     have hρ_args_reg : ρ_args.env.respects i.folSym :=
       Env.respects_of_agreeOn_extendWithSym (hρreg i hi_mem) (hΔreg i hi_mem) hagree_ρ_args
     iapply (show
-        TinyML.ValsHaveTypes Θ vs (spec.args.map Prod.snd) ∗
-          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r spec.retTy -∗ Φ r) spec.pred
+        TinyML.ValsHaveTypes W vs (spec.args.map Prod.snd) ∗
+          PredTrans.apply W (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.pred
             (Spec.argsEnv ρ_args spec.args vs) ⊢ i.toWp vs Φ from
-        hbridge.bridge σi Θ vs ρ_args Φ hρ_args_reg)
+        hbridge.bridge σi W vs ρ_args Φ hρ_args_reg)
     isplitl [Hvals]
     · iapply (TinyML.ValsHaveTypes.sub hsub_ty')
       iexact Hvals
@@ -3130,16 +3136,16 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
 theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches : List (Binder × Expr)) (ty : TinyML.Typ)
     (ihScrut : correctExpr reg scrut) (ihBranches : correctBranches reg branches) :
     correctExpr reg (.match_ scrut branches ty) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
-  have heval_scrut : (compile reg Θ Δ_spec S B Γ scrut).eval st ρ _ := VerifM.eval_bind heval
+  have heval_scrut : (compile reg W.Θ Δ_spec S B Γ scrut).eval st ρ _ := VerifM.eval_bind heval
   refine SpatialContext.wp_bind_match <| BIBase.Entails.trans ?_ <|
-    ihScrut Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihScrut W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
-  · exact Helpers.ctx_dup reg Θ Δ_spec ρ_spec S B Γ st ρ γ R
+  · exact Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
   intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se
   obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
   cases hscrut_ty : scrut.ty with
@@ -3156,12 +3162,12 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
       by_cases htys : ∀ br ∈ branches, br.2.ty = ty
       · have hΨ_scrut' :
             (do
-              let i ← VerifM.all (List.range (compileBranches reg Θ Δ_spec S B Γ se_scrut ts branches 0).length)
-              match (compileBranches reg Θ Δ_spec S B Γ se_scrut ts branches 0)[i]? with
+              let i ← VerifM.all (List.range (compileBranches reg W.Θ Δ_spec S B Γ se_scrut ts branches 0).length)
+              match (compileBranches reg W.Θ Δ_spec S B Γ se_scrut ts branches 0)[i]? with
               | some m => m
               | none => VerifM.fatal "match branch index out of range").eval st_scrut ρ_scrut Ψ := by
           simpa [if_pos hlen, if_pos htys] using hΨ_scrut
-        have hcb := compileBranches_length_get reg Θ Δ_spec S B Γ se_scrut ts branches 0
+        have hcb := compileBranches_length_get reg W.Θ Δ_spec S B Γ se_scrut ts branches 0
         have hactions_len := hcb.1
         have heval_all := VerifM.eval_bind hΨ_scrut'
         have hall := VerifM.eval_all heval_all
@@ -3169,11 +3175,11 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
         have hbwf_scrut : B.wfIn st_scrut.decls := fun p hp => hdecls_scrut.consts _ (hbwf p hp)
         exact (by
           iintro ⟨Hsl, Hscrut, #HS, #HT, HR⟩
-          ihave Hscrut_sum := (TinyML.ValHasType.sum Θ v_scrut ts).1 $$ Hscrut
+          ihave Hscrut_sum := (TinyML.ValHasType.sum W v_scrut ts).1 $$ Hscrut
           icases Hscrut_sum with ⟨%tag, %v_payload, %hval_eq, Hsum⟩
           ihave %htag_bound := TinyML.ValSumRel.bound $$ Hsum
           have htag_branches : tag < branches.length := hlen ▸ htag_bound
-          have htag_range : tag ∈ List.range (compileBranches reg Θ Δ_spec S B Γ se_scrut ts branches 0).length := by
+          have htag_range : tag ∈ List.range (compileBranches reg W.Θ Δ_spec S B Γ se_scrut ts branches 0).length := by
             rw [hactions_len]
             exact List.mem_range.mpr htag_branches
           have heval_tag := hall tag htag_range
@@ -3184,8 +3190,8 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
             rw [List.getElem?_eq_getElem htag_bound]
             simp
           have hspecInv_scrut := specInvariants_mono hΔspec hρspec hdecls_scrut hagreeOn_scrut
-          have hbranch_wp := ihBranches Θ R S B Γ se_scrut ts.length ts 0
-            st_scrut ρ_scrut γ Δ_spec ρ_spec Ψ Φ
+          have hbranch_wp := ihBranches W R S B Γ se_scrut ts.length ts 0
+            st_scrut ρ_scrut γ Δ_spec ρ_spec Ψ Φ hW
             hagree_scrut hbwf_scrut hSwf hΔwf hΔvars hspecInv_scrut.1 hspecInv_scrut.2 hΔreg hρreg hse_wf
             (fun j hj v ρ' st' se hΨ hse_wf hse_eval => by
               iintro ⟨Hsl, Hv, #HS, HR⟩
@@ -3200,10 +3206,10 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
           have hsc_eval : se_scrut.eval ρ_scrut.env = Runtime.Val.inj tag ts.length v_payload := by
             exact heval_se.trans hval_eq
           have hbranch_entail :
-              st_scrut.sl Θ ρ_scrut ∗
-                  TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-                wp reg.primCtx
+              st_scrut.sl W ρ_scrut ∗
+                  TinyML.ValSumRel W tag v_payload ts ∗
+                    (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+                wp W.pctx
                   ((Runtime.Expr.subst γ
                         (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime)).app
                     [Runtime.Expr.val v_payload])
@@ -3214,7 +3220,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
             · simp only [TransState.sl_eq]
               iexact Hsl
             · isplitl [Hsum]
-              · iapply (TinyML.ValSumRel.of_getElem? (Θ := Θ) hget)
+              · iapply (TinyML.ValSumRel.of_getElem? (W := W) hget)
                 iexact Hsum
               · isplitl []
                 · iexact HS
@@ -3222,18 +3228,18 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
                   · iexact HT
                   · iexact HR
           have hmatch_entail :
-              st_scrut.sl Θ ρ_scrut ∗
-                  TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R) ⊢
-                wp reg.primCtx
+              st_scrut.sl W ρ_scrut ∗
+                  TinyML.ValSumRel W tag v_payload ts ∗
+                    (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+                wp W.pctx
                   ((Runtime.Expr.val (Runtime.Val.inj tag ts.length v_payload)).match_
                     (List.map (Runtime.Expr.subst γ ∘ fun p =>
                       Runtime.Expr.fix Runtime.Binder.none [p.1.runtime] p.2.runtime) branches))
                   Φ :=
             SpatialContext.wp_match
-              (R := st_scrut.sl Θ ρ_scrut ∗
-                  TinyML.ValSumRel Θ tag v_payload ts ∗
-                    (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ B.typedSubst Θ Γ γ ∗ R))
+              (R := st_scrut.sl W ρ_scrut ∗
+                  TinyML.ValSumRel W tag v_payload ts ∗
+                    (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R))
               (branch :=
                 Runtime.Expr.subst γ
                   (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime))
@@ -3258,7 +3264,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
 theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) (body : Expr)
     (ihBody : correctExpr reg body) :
     correctBranch reg (binder, body) := by
-  intro Θ R S B Γ sc n i ty_i st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost payload hsc_eval
+  intro W R S B Γ sc n i ty_i st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost payload hsc_eval
   simp only [compileBranch] at heval
   by_cases hty : binder.ty = ty_i
   · have hexpect := VerifM.eval_bind heval
@@ -3294,19 +3300,19 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
     have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁.env = payload := by
       simp [Term.eval, Const.denote, ρ₁, Env.updateConst]
     have hassume_bind₂ := VerifM.eval_bind heval_assumeAll
-    have hinterp_eq : SpatialContext.interp Θ ρ.env st.owns ⊢ SpatialContext.interp Θ ρ₁.env st.owns :=
-      (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval_decl).ownsWf
+    have hinterp_eq : SpatialContext.interp W ρ.env st.owns ⊢ SpatialContext.interp W ρ₁.env st.owns :=
+      (SpatialContext.interp_env_agree W (VerifM.eval.wf heval_decl).ownsWf
         (Env.agreeOn_update_fresh_const hxv_fresh)).1
     have hagreeOn_st : Env.agreeOn st.decls ρ.env ρ₁.env :=
       Env.agreeOn_update_fresh_const hxv_fresh
-    -- Extract the type-constraints Prop from the iProp `ValHasType Θ payload ty_i`
+    -- Extract the type-constraints Prop from the iProp `ValHasType W payload ty_i`
     -- assumption, then dispatch into iproof mode to build the final entailment.
     istart
     iintro ⟨Howns, Hpay, #HS, #HT, HR⟩
     iintuitionistic Hpay
     ihave Hcheck := TinyML.typeConstraints_hold (ty := ty_i)
         (t := Term.const (.uninterpreted xv.name .value))
-        (ρ := ρ₁.env) (Θ := Θ) (v := payload) hxv_eval $$ Hpay
+        (ρ := ρ₁.env) (W := W) (v := payload) hxv_eval $$ Hpay
     ipure Hcheck
     obtain ⟨st₂, hst₂_decls, hst₂_owns, _, heval_body'⟩ := VerifM.eval_assumeAll hassume_bind₂
       (fun φ hφ => TinyML.typeConstraints_wfIn hxv_wf φ hφ)
@@ -3318,16 +3324,16 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
       have hagree₁ : B.agreeOnLinked ρ₁.env γ :=
         Bindings.agreeOnLinked_env_agree hagree hagreeOn_st hbwf
       have hbwf₁ : B.wfIn st₂.decls := hst₂_decls ▸ fun p hp => List.Mem.tail _ (hbwf p hp)
-      have heval_body'' : (compile reg Θ Δ_spec S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+      have heval_body'' : (compile reg W.Θ Δ_spec S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, hname] using heval_body'
       have hspecInv₁ := specInvariants_mono hΔspec hρspec
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
-          st₂.sl Θ ρ₁ ∗
-              (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ Bindings.typedSubst Θ B (Γ.extendBinder binder ty_i) γ ∗
-                (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-            wp reg.primCtx (body.runtime.subst γ) Φ :=
-        ihBody Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Δ_spec ρ_spec Ψ Φ
+          st₂.sl W ρ₁ ∗
+              (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B (Γ.extendBinder binder ty_i) γ ∗
+                (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
+            wp W.pctx (body.runtime.subst γ) Φ :=
+        ihBody W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Δ_spec ρ_spec Ψ Φ hW
           heval_body'' hagree₁ hbwf₁ hSwf hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
           hΔreg hρreg
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
@@ -3340,10 +3346,10 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
       refine BIBase.Entails.trans ?_ hBodyWp
       istart
       iintro ⟨⟨⟨⟨Howns, #HS⟩, #HT⟩, HR⟩, #Hpay⟩
-      -- spatial: Howns (st.sl Θ ρ), HR; persistent: Hpay, HS, HT
-      -- goal: st₂.sl Θ ρ₁ ∗ (S.satisfiedBy ∗ typedSubst extended ∗ (S.satisfiedBy ∗ R))
+      -- spatial: Howns (st.sl W ρ), HR; persistent: Hpay, HS, HT
+      -- goal: st₂.sl W ρ₁ ∗ (S.satisfiedBy ∗ typedSubst extended ∗ (S.satisfiedBy ∗ R))
       isplitl [Howns]
-      · have hsl_trans : st.sl Θ ρ ⊢ st₂.sl Θ ρ₁ := by
+      · have hsl_trans : st.sl W ρ ⊢ st₂.sl W ρ₁ := by
           simp only [TransState.sl_eq, hst₂_owns_eq]; exact hinterp_eq
         iapply hsl_trans
         iexact Howns
@@ -3377,18 +3383,18 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
         have h := Bindings.agreeOnLinked_cons (x := x) (v := xv) (γ := γ) hagree hagreeOn_B (hvty := rfl)
         rwa [hρ₁_lookup] at h
       have heval_body'' :
-          (compile reg Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+          (compile reg W.Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, TinyML.TyCtx.extendBinder, hname] using heval_body'
       have hspecInv₁ := specInvariants_mono hΔspec hρspec
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
-          st₂.sl Θ ρ₁ ∗
-              (SpecMap.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
-                Bindings.typedSubst Θ ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) ∗
-                (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) ⊢
-            wp reg.primCtx (body.runtime.subst (Runtime.Subst.update γ x payload)) Φ :=
-        ihBody Θ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
-          (Runtime.Subst.update γ x payload) Δ_spec ρ_spec Ψ Φ heval_body'' hagree₁ hbwf₂ (SpecMap.wfIn_erase hSwf)
+          st₂.sl W ρ₁ ∗
+              (SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
+                Bindings.typedSubst W ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) ∗
+                (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
+            wp W.pctx (body.runtime.subst (Runtime.Subst.update γ x payload)) Φ :=
+        ihBody W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
+          (Runtime.Subst.update γ x payload) Δ_spec ρ_spec Ψ Φ hW heval_body'' hagree₁ hbwf₂ (SpecMap.wfIn_erase hSwf)
           hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
           hΔreg hρreg
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
@@ -3402,18 +3408,18 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
       istart
       iintro ⟨⟨⟨⟨Howns, #HS⟩, #HT⟩, HR⟩, #Hpay⟩
       isplitl [Howns]
-      · have hsl_trans : st.sl Θ ρ ⊢ st₂.sl Θ ρ₁ := by
+      · have hsl_trans : st.sl W ρ ⊢ st₂.sl W ρ₁ := by
           simp only [TransState.sl_eq, hst₂_owns_eq]; exact hinterp_eq
         iapply hsl_trans
         iexact Howns
       · isplitl []
         · -- satisfiedBy for erased S: derive from S.satisfiedBy (persistent)
-          iapply (SpecMap.satisfiedBy_erase (Θ := Θ) (S := S) (γ := γ) (x := x) (v := payload))
+          iapply (SpecMap.satisfiedBy_erase (W := W) (S := S) (γ := γ) (x := x) (v := payload))
           iexact HS
         · isplitl [Hpay]
           · -- typedSubst extended for (x :: B) and Γ.extend x ty_i
             simp only [TinyML.TyCtx.extendBinder, hname]
-            iapply (Bindings.typedSubst_cons (Θ := Θ) (B := B) (Γ := Γ) (γ := γ)
+            iapply (Bindings.typedSubst_cons (W := W) (B := B) (Γ := Γ) (γ := γ)
               (x := x) (v := xv) (te := ty_i) (w := payload))
             · iexact HT
             · iexact Hpay
@@ -3426,18 +3432,18 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
 theorem compileBranchesCons_correct (reg : Verifier.Registry) (b : Binder × Expr) (bs : List (Binder × Expr))
     (ihHead : correctBranch reg b) (ihTail : correctBranches reg bs) :
     correctBranches reg (b :: bs) := by
-  intro Θ R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost j hj
+  intro W R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hW hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost j hj
   cases j with
   | zero =>
     simp only [Nat.add_zero, List.getElem_cons_zero]
     intro heval
-    exact ihHead Θ R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Δ_spec ρ_spec Ψ Φ
+    exact ihHead W R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Δ_spec ρ_spec Ψ Φ hW
       heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf (by simpa using hpost 0 hj)
   | succ k =>
     have hk : k < bs.length := by simp at hj; omega
     have hidx : idx + (k + 1) = (idx + 1) + k := by omega
     simp only [hidx, List.getElem_cons_succ]
-    exact ihTail Θ R S B Γ sc n ts (idx + 1) st ρ γ Δ_spec ρ_spec Ψ Φ
+    exact ihTail W R S B Γ sc n ts (idx + 1) st ρ γ Δ_spec ρ_spec Ψ Φ hW
       hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf
       (by
         intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
@@ -3447,12 +3453,12 @@ theorem compileBranchesCons_correct (reg : Verifier.Registry) (b : Binder × Exp
 theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : List Expr)
     (ihE : correctExpr reg e) (ihRest : correctExprs reg rest) :
     correctExprs reg (e :: rest) := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [compileExprs] at heval
   simp only [List.map, wps_cons]
-  have heval_rest : (compileExprs reg Θ Δ_spec S B Γ rest).eval st ρ _ := VerifM.eval_bind heval
+  have heval_rest : (compileExprs reg W.Θ Δ_spec S B Γ rest).eval st ρ _ := VerifM.eval_bind heval
   refine BIBase.Entails.trans ?_ <|
-    ihRest Θ (B.typedSubst Θ Γ γ ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _
+    ihRest W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
   · iintro ⟨Hsl, #HS, #HT, HR⟩
     isplitl [Hsl]
@@ -3471,11 +3477,11 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
   have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
   have hbwf_vs : B.wfIn st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
-  have heval_e : (compile reg Θ Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind hΨ_vs
+  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind hΨ_vs
   have hspecInv_vs := specInvariants_mono hΔspec hρspec hdecls_vs hagreeOn_vs
   refine BIBase.Entails.trans ?_ <|
-    ihE Θ (TinyML.ValsHaveTypes Θ vs (rest.map Expr.ty) ∗ (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ R))
-    S B Γ st_vs ρ_vs γ Δ_spec ρ_spec _ _
+    ihE W (TinyML.ValsHaveTypes W vs (rest.map Expr.ty) ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
+    S B Γ st_vs ρ_vs γ Δ_spec ρ_spec _ _ hW
     (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hSwf hΔwf hΔvars hspecInv_vs.1 hspecInv_vs.2 hΔreg hρreg ?_
   · iintro ⟨Hsl, Hvs, #HS, #HT, #HSpare, HR⟩
     isplitl [Hsl]
@@ -3511,11 +3517,11 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
     isplitl [Hsl]
     · iexact Hsl
     · isplitl [Hv Hvs]
-      · iapply (show TinyML.ValHasType Θ v e.ty ∗
-            TinyML.ValsHaveTypes Θ vs (rest.map Expr.ty) ⊢
-            TinyML.ValsHaveTypes Θ (v :: vs) ((e :: rest).map Expr.ty) by
+      · iapply (show TinyML.ValHasType W v e.ty ∗
+            TinyML.ValsHaveTypes W vs (rest.map Expr.ty) ⊢
+            TinyML.ValsHaveTypes W (v :: vs) ((e :: rest).map Expr.ty) by
           simpa [List.map] using
-            (TinyML.ValsHaveTypes.cons Θ v vs e.ty (rest.map Expr.ty)).2)
+            (TinyML.ValsHaveTypes.cons W v vs e.ty (rest.map Expr.ty)).2)
         isplitl [Hv]
         · iexact Hv
         · iexact Hvs
@@ -3525,12 +3531,12 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
 
 theorem compileBranchesNil_correct (reg : Verifier.Registry) :
     correctBranches reg [] := by
-  intro Θ R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost j hj
+  intro W R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hW hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost j hj
   exact absurd hj (Nat.not_lt_zero _)
 
 theorem compileExprsNil_correct (reg : Verifier.Registry) :
     correctExprs reg [] := by
-  intro Θ R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
   simp only [compileExprs] at heval
   simp only [List.map, wps]
   obtain heval := VerifM.eval_ret heval
@@ -3539,8 +3545,8 @@ theorem compileExprsNil_correct (reg : Verifier.Registry) :
   isplitl [Hsl]
   · iexact Hsl
   · isplitl []
-    · iapply (show iprop(emp) ⊢ TinyML.ValsHaveTypes Θ [] ([].map Expr.ty) by
-        simpa [List.map] using (TinyML.ValsHaveTypes.nil Θ).2)
+    · iapply (show iprop(emp) ⊢ TinyML.ValsHaveTypes W [] ([].map Expr.ty) by
+        simpa [List.map] using (TinyML.ValsHaveTypes.nil W).2)
       iempintro
     · isplitl []
       · iexact HS

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -476,44 +476,44 @@ theorem compileBranches_length_get (reg : Verifier.Registry) (Θ : TinyML.TypeEn
 
 namespace Helpers
 
-theorem ctx_dup (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_dup (W : TinyML.World)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+    st.sl W ρ ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
       st.sl W ρ ∗
-        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R)) := by
+        (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗
+          (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R)) := by
   iintro ⟨Howns, #HS, #HT, HR⟩
   iframe # ∗
 
-theorem ctx_dup_flip (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_dup_flip (W : TinyML.World)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
-    st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+    st.sl W ρ ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
       st.sl W ρ ∗
-        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗
-          (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))) := by
+        (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗
+          (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R))) := by
   iintro ⟨Howns, #HS, #HT, HR⟩
   iframe # ∗
 
-theorem ctx_push (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_push (W : TinyML.World)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl W ρ ∗ TinyML.ValHasType W v ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+    st.sl W ρ ∗ TinyML.ValHasType W v ty ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
       st.sl W ρ ∗
-        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗
+        (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗
           (TinyML.ValHasType W v ty ∗ R)) := by
   iintro ⟨Howns, Hv, #HS, #HT, HR⟩
   iframe # ∗
 
-theorem ctx_push_flip (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+theorem ctx_push_flip (W : TinyML.World)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
-    st.sl W ρ ∗ TinyML.ValHasType W v ty ∗ (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
+    st.sl W ρ ∗ TinyML.ValHasType W v ty ∗ (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R)) ⊢
       st.sl W ρ ∗
-        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗
+        (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗
           (TinyML.ValHasType W v ty ∗ R)) := by
   iintro ⟨Howns, Hv, #HT, #HS, HR⟩
   iframe # ∗
@@ -525,113 +525,90 @@ end Helpers
 
 /-! #### Correctness Statements -/
 
-omit [MicaGS HasLC.hasLC Sig] in
-private theorem specInvariants_mono
-    {Δ_spec : Signature} {ρ_spec st st' : VerifM.Env} {decls decls' : Signature}
-    (hΔspec : Δ_spec.Subset decls)
-    (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec st)
-    (hdecls : decls.Subset decls')
-    (hagree : VerifM.Env.agreeOn decls st st') :
-    Δ_spec.Subset decls' ∧ VerifM.Env.agreeOn Δ_spec ρ_spec st' := by
-  refine ⟨hΔspec.trans hdecls, VerifM.Env.agreeOn_trans hρspec ?_⟩
-  exact VerifM.Env.agreeOn_mono hΔspec hagree
-
 def correctExpr (reg : Verifier.Registry) (e : Expr) : Prop :=
   ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-  (Δ_spec : Signature) (ρ_spec : VerifM.Env)
   (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
     W.pctx = reg.primCtx →
-    VerifM.eval (compile reg W.Θ Δ_spec S B Γ e) st ρ Ψ →
+    VerifM.eval (compile reg W.Θ W.Δ_spec S B Γ e) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
-    S.wfIn Δ_spec →
-    Δ_spec.wf →
-    Δ_spec.vars = [] →
-    Δ_spec.Subset st.decls →
-    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
-    Verifier.Registry.symSubset reg Δ_spec →
-    Verifier.Registry.symAgree reg ρ_spec.env →
+    S.wfIn W.Δ_spec →
+    W.wf →
+    W.agrees st.decls ρ.env →
+    Verifier.Registry.symSubset reg W.Δ_spec →
+    Verifier.Registry.symAgree reg W.ρ_spec →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
       st'.sl W ρ' ∗ TinyML.ValHasType W v e.ty ∗ R ⊢ Φ v) →
-    st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (e.runtime.subst γ) Φ
+    st.sl W ρ ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (e.runtime.subst γ) Φ
 
 def correctBranch (reg : Verifier.Registry) (branch : Binder × Expr) : Prop :=
   ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
-    (Ψ : Term .value → TransState → VerifM.Env → Prop)
+      (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp),
     W.pctx = reg.primCtx →
-    VerifM.eval (compileBranch reg W.Θ Δ_spec S B Γ sc n i ty_i branch) st ρ Ψ →
+    VerifM.eval (compileBranch reg W.Θ W.Δ_spec S B Γ sc n i ty_i branch) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
-    S.wfIn Δ_spec →
-    Δ_spec.wf →
-    Δ_spec.vars = [] →
-    Δ_spec.Subset st.decls →
-    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
-    Verifier.Registry.symSubset reg Δ_spec →
-    Verifier.Registry.symAgree reg ρ_spec.env →
+    S.wfIn W.Δ_spec →
+    W.wf →
+    W.agrees st.decls ρ.env →
+    Verifier.Registry.symSubset reg W.Δ_spec →
+    Verifier.Registry.symAgree reg W.ρ_spec →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl W ρ' ∗ TinyML.ValHasType W v branch.2.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl W ρ' ∗ TinyML.ValHasType W v branch.2.ty ∗ (S.satisfiedBy W γ ∗ R) ⊢ Φ v) →
     ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
-      st.sl W ρ ∗ TinyML.ValHasType W payload ty_i ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
+      st.sl W ρ ∗ TinyML.ValHasType W payload ty_i ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
 
 def correctBranches (reg : Verifier.Registry) (branches : List (Binder × Expr)) : Prop :=
   ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n : Nat) (ts : List TinyML.Typ) (idx : Nat)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
-    (Ψ : Term .value → TransState → VerifM.Env → Prop)
+      (Ψ : Term .value → TransState → VerifM.Env → Prop)
     (Φ : Runtime.Val → iProp),
     W.pctx = reg.primCtx →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
-    S.wfIn Δ_spec →
-    Δ_spec.wf →
-    Δ_spec.vars = [] →
-    Δ_spec.Subset st.decls →
-    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
-    Verifier.Registry.symSubset reg Δ_spec →
-    Verifier.Registry.symAgree reg ρ_spec.env →
+    S.wfIn W.Δ_spec →
+    W.wf →
+    W.agrees st.decls ρ.env →
+    Verifier.Registry.symSubset reg W.Δ_spec →
+    Verifier.Registry.symAgree reg W.ρ_spec →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl W ρ' ∗ TinyML.ValHasType W v (branches[j]).2.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) ⊢ Φ v) →
+      se.eval ρ'.env = v → st'.sl W ρ' ∗ TinyML.ValHasType W v (branches[j]).2.ty ∗ (S.satisfiedBy W γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
-      VerifM.eval (compileBranch reg W.Θ Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
+      VerifM.eval (compileBranch reg W.Θ W.Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
       ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
-        st.sl W ρ ∗ TinyML.ValHasType W payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
+        st.sl W ρ ∗ TinyML.ValHasType W payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
 
 def correctExprs (reg : Verifier.Registry) (es : List Expr) : Prop :=
   ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
-    (Ψ : List (Term .value) → TransState → VerifM.Env → Prop)
+      (Ψ : List (Term .value) → TransState → VerifM.Env → Prop)
     (Φ : List Runtime.Val → iProp),
     W.pctx = reg.primCtx →
-    VerifM.eval (compileExprs reg W.Θ Δ_spec S B Γ es) st ρ Ψ →
+    VerifM.eval (compileExprs reg W.Θ W.Δ_spec S B Γ es) st ρ Ψ →
     B.agreeOnLinked ρ.env γ →
     B.wfIn st.decls →
-    S.wfIn Δ_spec →
-    Δ_spec.wf →
-    Δ_spec.vars = [] →
-    Δ_spec.Subset st.decls →
-    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
-    Verifier.Registry.symSubset reg Δ_spec →
-    Verifier.Registry.symAgree reg ρ_spec.env →
+    S.wfIn W.Δ_spec →
+    W.wf →
+    W.agrees st.decls ρ.env →
+    Verifier.Registry.symSubset reg W.Δ_spec →
+    Verifier.Registry.symAgree reg W.ρ_spec →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ'.env terms vs →
-       st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) ⊢ Φ vs) →
-    st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wps W.pctx (es.map (fun e => e.runtime.subst γ)) Φ
+       st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (S.satisfiedBy W γ ∗ R) ⊢ Φ vs) →
+    st.sl W ρ ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wps W.pctx (es.map (fun e => e.runtime.subst γ)) Φ
 
 /-! #### Correctness Compatibility Lemmas -/
 
 theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
     correctExpr reg (.const c) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval _hagree _hbwf _hSwf _hwf _hag hΔreg hρreg hpost
   cases c with
   | int n =>
     simp only [compile] at heval
@@ -714,7 +691,7 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
 
 theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.Typ) :
     correctExpr reg (.var x vty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf _hSwf _hwf _hag hΔreg hρreg hpost
   simp only [compile] at heval
   obtain ⟨x', hbind, heval⟩ := VerifM.eval_bind_expectSome heval
   obtain ⟨hcheck, hcont⟩ := VerifM.eval_bind_expectEq heval
@@ -784,7 +761,7 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
 theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload : Expr)
     (ihPayload : correctExpr reg payload) :
     correctExpr reg (.inj tag arity payload) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
@@ -793,9 +770,9 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
     exact (VerifM.eval_fatal heval).elim
   · push Not at htag
     simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
-    have heval_p : (compile reg W.Θ Δ_spec S B Γ payload).eval st ρ _ := VerifM.eval_bind heval
-    refine SpatialContext.wp_bind_inj <| ihPayload W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    have heval_p : (compile reg W.Θ W.Δ_spec S B Γ payload).eval st ρ _ := VerifM.eval_bind heval
+    refine SpatialContext.wp_bind_inj <| ihPayload W R S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
     intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p
     obtain ⟨_hdecls_p, _hagreeOn_p, hΨ_p⟩ := hΨ_p
     obtain hΨ_p := VerifM.eval_ret hΨ_p
@@ -822,12 +799,12 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
 theorem compileCast_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.Typ)
     (ih : correctExpr reg e) :
     correctExpr reg (.cast e ty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   simp only [compile] at heval
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
   simp [Expr.runtime]
-  refine ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  refine ih W R S B Γ st ρ γ _ _ hW (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v ρ' st' se hΨ hse_wf heval_se
   obtain ⟨_, _, hΨ⟩ := hΨ
   cases hsub : TinyML.Typ.sub W.Θ e.ty ty with
@@ -847,13 +824,13 @@ theorem compileCast_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.Ty
 theorem compileAssert_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.assert e) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_assert <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_assert <| ih W R S B Γ st ρ γ _ _ hW
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_, _, hΨ_e⟩ := hΨ_e
   let φ := Formula.eq .bool (Term.unop .toBool se) (Term.const (.b true))
@@ -878,28 +855,28 @@ theorem compileAssert_correct (reg : Verifier.Registry) (e : Expr)
 
 theorem compileFix_correct (reg : Verifier.Registry) (self : Binder) (args : List Binder) (retTy : TinyML.Typ) (body : Expr) :
     correctExpr reg (.fix self args retTy body) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval _hagree _hbwf _hSwf _hwf _hag _hpost
   simp only [compile] at heval
   exact (VerifM.eval_fatal heval).elim
 
 theorem compilePrim_correct (reg : Verifier.Registry) (n : String)
     (inst : List (TinyML.TyVar × TinyML.Typ)) (ty : TinyML.Typ) :
     correctExpr reg (.prim n inst ty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _hagree _hbwf _hSwf _hΔwf _hΔvars _hΔspec _hρspec _hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval _hagree _hbwf _hSwf _hwf _hag _hpost
   simp only [compile] at heval
   exact (VerifM.eval_fatal heval).elim
 
 theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.ref .shared e) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_ref <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_ref <| ih W R S B Γ st ρ γ _ _ hW
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hwf_st₁ := VerifM.eval.wf hΨ_e
@@ -960,14 +937,14 @@ theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
 theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.ref .owned e) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_ref <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_ref <| ih W R S B Γ st ρ γ _ _ hW
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hdecl_eval := VerifM.eval_bind hΨ_e
@@ -1039,15 +1016,15 @@ theorem compileDerefShared_correct (reg : Verifier.Registry) (e : Expr) (ty : Ti
     (href : e.ty = .ref ty)
     (ih : correctExpr reg e) :
     correctExpr reg (.deref e ty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, href] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_deref <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_deref <| ih W R S B Γ st ρ γ _ _ hW
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e _hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hdecl_eval := VerifM.eval_bind hΨ_e
@@ -1104,15 +1081,15 @@ theorem compileDerefOwned_correct (reg : Verifier.Registry) (e : Expr) (ty : Tin
     (howned : e.ty = .owned ty)
     (ih : correctExpr reg e) :
     correctExpr reg (.deref e ty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, howned] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_deref <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_deref <| ih W R S B Γ st ρ γ _ _ hW
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_hdecls_e, _hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hfind_eval := VerifM.eval_bind hΨ_e
@@ -1171,7 +1148,7 @@ theorem compileDeref_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.T
       by_cases heq : ty' = ty
       · have href : e.ty = .ref ty := by simpa [heq] using hty
         exact compileDerefShared_correct reg e ty href ih
-      · intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
+      · intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
@@ -1179,12 +1156,12 @@ theorem compileDeref_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.T
       by_cases heq : ty' = ty
       · have howned : e.ty = .owned ty := by simpa [heq] using hty
         exact compileDerefOwned_correct reg e ty howned ih
-      · intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
+      · intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
   | prim _ | sum _ | arrow _ _ | array _ | ownedArray _ | vec _ | empty | value | tuple _ | tvar _ | named _ _ =>
-      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
@@ -1192,37 +1169,37 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
     (href : loc.ty = .ref val.ty)
     (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
     correctExpr reg (.store loc val) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, href] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_v : (compile reg W.Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
+  have heval_v : (compile reg W.Θ W.Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+      st.sl W ρ ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
         st.sl W ρ ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
-            (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))) :=
-    Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W γ ∗ R))) :=
+    Helpers.ctx_dup_flip W S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal W (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_)
+    ihVal W (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W γ ∗ R)) S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hwf hag hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
   have hagree_v : B.agreeOnLinked ρ_v.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
-  have heval_l : (compile reg W.Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
+  have heval_l : (compile reg W.Θ W.Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
   have hlocStart :
       st₁.sl W ρ_v ∗ TinyML.ValHasType W v_v val.ty ∗
-        (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl W ρ_v ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+        (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W γ ∗ R)) ⊢
+          st₁.sl W ρ_v ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
             (TinyML.ValHasType W v_v val.ty ∗ R)) :=
-    Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
-  have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
-  refine hlocStart.trans <| ihLoc W (TinyML.ValHasType W v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 hΔreg hρreg ?_
+    Helpers.ctx_push_flip W S B Γ st₁ ρ_v γ R v_v val.ty
+  have hspecInv_v := hag.step hdecls_v hagreeOn_v
+  refine hlocStart.trans <| ihLoc W (TinyML.ValHasType W v_v val.ty ∗ R) S B Γ st₁ ρ_v γ _ _ hW
+    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hwf hspecInv_v hΔreg hρreg ?_
   intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
   obtain hret := VerifM.eval_ret hΨ_l
@@ -1258,37 +1235,37 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
     (howned : loc.ty = .owned val.ty)
     (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
     correctExpr reg (.store loc val) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, howned] at heval
   simp only [Expr.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_v : (compile reg W.Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
+  have heval_v : (compile reg W.Θ W.Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+      st.sl W ρ ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
         st.sl W ρ ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
-            (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))) :=
-    Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W γ ∗ R))) :=
+    Helpers.ctx_dup_flip W S B Γ st ρ γ R
   refine SpatialContext.wp_bind_store <| (hstart.trans <|
-    ihVal W (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_)
+    ihVal W (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W γ ∗ R)) S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hwf hag hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
   have hagree_v : B.agreeOnLinked ρ_v.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
-  have heval_l : (compile reg W.Θ Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
+  have heval_l : (compile reg W.Θ W.Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
   have hlocStart :
       st₁.sl W ρ_v ∗ TinyML.ValHasType W v_v val.ty ∗
-        (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
-          st₁.sl W ρ_v ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+        (Bindings.typedSubst W B Γ γ ∗ (S.satisfiedBy W γ ∗ R)) ⊢
+          st₁.sl W ρ_v ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
             (TinyML.ValHasType W v_v val.ty ∗ R)) :=
-    Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_v γ R v_v val.ty
-  have hspecInv_v := specInvariants_mono hΔspec hρspec hdecls_v hagreeOn_v
-  refine hlocStart.trans <| ihLoc W (TinyML.ValHasType W v_v val.ty ∗ R) S B Γ st₁ ρ_v γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hΔwf hΔvars hspecInv_v.1 hspecInv_v.2 hΔreg hρreg ?_
+    Helpers.ctx_push_flip W S B Γ st₁ ρ_v γ R v_v val.ty
+  have hspecInv_v := hag.step hdecls_v hagreeOn_v
+  refine hlocStart.trans <| ihLoc W (TinyML.ValHasType W v_v val.ty ∗ R) S B Γ st₁ ρ_v γ _ _ hW
+    (VerifM.eval.decls_grow ρ_v heval_l) hagree_v hbwf_v hSwf hwf hspecInv_v hΔreg hρreg ?_
   intro v_l ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨_hdecls_l, _hagreeOn_l, hΨ_l⟩ := hΨ_l
   have hfind_eval := VerifM.eval_bind hΨ_l
@@ -1354,7 +1331,7 @@ theorem compileStore_correct (reg : Verifier.Registry) (loc val : Expr)
       by_cases heq : ty = val.ty
       · have href : loc.ty = .ref val.ty := by simpa [heq] using hty
         exact compileStoreShared_correct reg loc val href ihVal ihLoc
-      · intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
+      · intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
@@ -1362,12 +1339,12 @@ theorem compileStore_correct (reg : Verifier.Registry) (loc val : Expr)
       by_cases heq : ty = val.ty
       · have howned : loc.ty = .owned val.ty := by simpa [heq] using hty
         exact compileStoreOwned_correct reg loc val howned ihVal ihLoc
-      · intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
+      · intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _
         simp only [compile, hty] at heval
         obtain ⟨hannot, _⟩ := VerifM.eval_bind_expectEq heval
         exact False.elim (heq hannot)
   | prim _ | sum _ | arrow _ _ | array _ | ownedArray _ | vec _ | empty | value | tuple _ | tvar _ | named _ _ =>
-      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
@@ -1400,30 +1377,30 @@ owned branch acquires a fresh owned-array atom. -/
 theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.Ownership) (len init : Expr)
     (ihLen : correctExpr reg len) (ihInit : correctExpr reg init) :
     correctExpr reg (.arrayMake ownership len init) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   obtain ⟨hlenty, heval⟩ := VerifM.eval_bind_expectEq heval
-  have heval_init : (compile reg W.Θ Δ_spec S B Γ init).eval st ρ _ := VerifM.eval_bind heval
+  have heval_init : (compile reg W.Θ W.Δ_spec S B Γ init).eval st ρ _ := VerifM.eval_bind heval
   refine SpatialContext.wp_bind_arrayMake <| ?_
   -- Evaluate `init`.
-  have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
-  refine hstart.trans <| ihInit W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
-    S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_init)
-    hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  have hstart := Helpers.ctx_dup_flip W S B Γ st ρ γ R
+  refine hstart.trans <| ihInit W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R))
+    S B Γ st ρ γ _ _ hW (VerifM.eval.decls_grow ρ heval_init)
+    hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_init ρ_init st₁ s_init hΨ_init hsinit_wf heval_sinit
   obtain ⟨hdecls_init, hagreeOn_init, hΨ_init⟩ := hΨ_init
   have hagree_init : B.agreeOnLinked ρ_init.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_init hbwf
   have hbwf_init : B.wfIn st₁.decls := fun p hp => hdecls_init.consts _ (hbwf p hp)
-  have heval_len : (compile reg W.Θ Δ_spec S B Γ len).eval st₁ ρ_init _ := VerifM.eval_bind hΨ_init
-  have hlenStart := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_init γ R v_init init.ty
-  have hspecInv_init := specInvariants_mono hΔspec hρspec hdecls_init hagreeOn_init
+  have heval_len : (compile reg W.Θ W.Δ_spec S B Γ len).eval st₁ ρ_init _ := VerifM.eval_bind hΨ_init
+  have hlenStart := Helpers.ctx_push_flip W S B Γ st₁ ρ_init γ R v_init init.ty
+  have hspecInv_init := hag.step hdecls_init hagreeOn_init
   -- Evaluate `len`, carrying `init`'s typing.
-  refine hlenStart.trans <| ihLen W (TinyML.ValHasType W v_init init.ty ∗ R) S B Γ st₁ ρ_init γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ_init heval_len) hagree_init hbwf_init hSwf hΔwf hΔvars
-    hspecInv_init.1 hspecInv_init.2 hΔreg hρreg ?_
+  refine hlenStart.trans <| ihLen W (TinyML.ValHasType W v_init init.ty ∗ R) S B Γ st₁ ρ_init γ _ _ hW
+    (VerifM.eval.decls_grow ρ_init heval_len) hagree_init hbwf_init hSwf hwf
+    hspecInv_init hΔreg hρreg ?_
   intro v_len ρ_len st₂ slen hΨ_len hslen_wf heval_slen
   obtain ⟨hdecls_len, hagreeOn_len, hΨ_len⟩ := hΨ_len
   -- Discharge the nonnegative-length obligation.
@@ -1609,14 +1586,14 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
     correctExpr reg (.arrayLen arr) := by
   cases hty : arr.ty with
   | array elem =>
-      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+      intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
       unfold Expr.runtime
       simp only [Runtime.Expr.subst]
       simp only [compile, hty] at heval
-      have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st ρ _ :=
+      have heval_arr : (compile reg W.Θ W.Δ_spec S B Γ arr).eval st ρ _ :=
         VerifM.eval_bind heval
-      refine SpatialContext.wp_bind_arrayLen <| ihArr W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-        (VerifM.eval.decls_grow ρ heval_arr) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+      refine SpatialContext.wp_bind_arrayLen <| ihArr W R S B Γ st ρ γ _ _ hW
+        (VerifM.eval.decls_grow ρ heval_arr) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
       intro v_arr ρ_arr st₁ sa hΨ_arr hsa_wf heval_sa
       obtain ⟨_, _, hΨ_arr⟩ := hΨ_arr
       obtain hret := VerifM.eval_ret hΨ_arr
@@ -1648,14 +1625,14 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
           · iexact HR
       exact hwp
   | ownedArray elem =>
-      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+      intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
       unfold Expr.runtime
       simp only [Runtime.Expr.subst]
       simp only [compile, hty] at heval
-      have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st ρ _ :=
+      have heval_arr : (compile reg W.Θ W.Δ_spec S B Γ arr).eval st ρ _ :=
         VerifM.eval_bind heval
-      refine SpatialContext.wp_bind_arrayLen <| ihArr W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-        (VerifM.eval.decls_grow ρ heval_arr) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+      refine SpatialContext.wp_bind_arrayLen <| ihArr W R S B Γ st ρ γ _ _ hW
+        (VerifM.eval.decls_grow ρ heval_arr) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
       intro v_arr ρ_arr st₁ sa hΨ_arr hsa_wf heval_sa
       obtain ⟨_, _, hΨ_arr⟩ := hΨ_arr
       obtain hret := VerifM.eval_ret hΨ_arr
@@ -1682,7 +1659,7 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
         · iexact HR
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
-      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal heval).elim
 
@@ -1691,7 +1668,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     correctExpr reg (.arrayGet arr idx ty) := by
   cases hty : arr.ty with
   | array elemTy =>
-    intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
@@ -1700,23 +1677,23 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     obtain ⟨helem, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
     subst helem
-    have heval_idx : (compile reg W.Θ Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind heval
+    have heval_idx : (compile reg W.Θ W.Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_arrayGet <| ?_
-    have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
-    refine hstart.trans <| ihIdx W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_idx)
-      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    have hstart := Helpers.ctx_dup_flip W S B Γ st ρ γ R
+    refine hstart.trans <| ihIdx W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R))
+      S B Γ st ρ γ _ _ hW (VerifM.eval.decls_grow ρ heval_idx)
+      hagree hbwf hSwf hwf hag hΔreg hρreg ?_
     intro v_idx ρ_idx st₁ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
     have hagree_idx : B.agreeOnLinked ρ_idx.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_idx hbwf
     have hbwf_idx : B.wfIn st₁.decls := fun p hp => hdecls_idx.consts _ (hbwf p hp)
-    have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
-    have harrStart := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_idx γ R v_idx idx.ty
-    have hspecInv_idx := specInvariants_mono hΔspec hρspec hdecls_idx hagreeOn_idx
-    refine harrStart.trans <| ihArr W (TinyML.ValHasType W v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ_idx heval_arr) hagree_idx hbwf_idx hSwf hΔwf hΔvars
-      hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
+    have heval_arr : (compile reg W.Θ W.Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
+    have harrStart := Helpers.ctx_push_flip W S B Γ st₁ ρ_idx γ R v_idx idx.ty
+    have hspecInv_idx := hag.step hdecls_idx hagreeOn_idx
+    refine harrStart.trans <| ihArr W (TinyML.ValHasType W v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ _ _ hW
+      (VerifM.eval.decls_grow ρ_idx heval_arr) hagree_idx hbwf_idx hSwf hwf
+      hspecInv_idx hΔreg hρreg ?_
     intro v_arr ρ_arr st₂ sa hΨ_arr hsa_wf heval_sa
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
     have hsi_wf₂ : si.wfIn st₂.decls :=
@@ -1775,7 +1752,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
               · iexact HR))
     exact hwp
   | ownedArray elemTy =>
-    intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
@@ -1784,22 +1761,22 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     obtain ⟨helem, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
     subst ty
-    have heval_idx : (compile reg W.Θ Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind heval
+    have heval_idx : (compile reg W.Θ W.Δ_spec S B Γ idx).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_arrayGet <| ?_
-    have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
-    refine hstart.trans <| ihIdx W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_idx)
-      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    have hstart := Helpers.ctx_dup_flip W S B Γ st ρ γ R
+    refine hstart.trans <| ihIdx W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R))
+      S B Γ st ρ γ _ _ hW (VerifM.eval.decls_grow ρ heval_idx)
+      hagree hbwf hSwf hwf hag hΔreg hρreg ?_
     intro v_idx ρ_idx st₁ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
     have hagree_idx := Bindings.agreeOnLinked_env_agree hagree hagreeOn_idx hbwf
     have hbwf_idx : B.wfIn st₁.decls := fun p hp => hdecls_idx.consts _ (hbwf p hp)
-    have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
-    have harrStart := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_idx γ R v_idx idx.ty
-    have hspecInv_idx := specInvariants_mono hΔspec hρspec hdecls_idx hagreeOn_idx
-    refine harrStart.trans <| ihArr W (TinyML.ValHasType W v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ_idx heval_arr) hagree_idx hbwf_idx hSwf hΔwf hΔvars
-      hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
+    have heval_arr : (compile reg W.Θ W.Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
+    have harrStart := Helpers.ctx_push_flip W S B Γ st₁ ρ_idx γ R v_idx idx.ty
+    have hspecInv_idx := hag.step hdecls_idx hagreeOn_idx
+    refine harrStart.trans <| ihArr W (TinyML.ValHasType W v_idx idx.ty ∗ R) S B Γ st₁ ρ_idx γ _ _ hW
+      (VerifM.eval.decls_grow ρ_idx heval_arr) hagree_idx hbwf_idx hSwf hwf
+      hspecInv_idx hΔreg hρreg ?_
     intro v_arr ρ_arr st₂ sa hΨ_arr hsa_wf heval_sa
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
     have hsi_wf₂ := Term.wfIn_mono si hsi_wf hdecls_arr (VerifM.eval.wf hΨ_arr).namesDisjoint
@@ -1843,7 +1820,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
               · iexact HR))
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
-      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
@@ -1852,7 +1829,7 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     correctExpr reg (.arraySet arr idx val) := by
   cases hty : arr.ty with
   | array elemTy =>
-    intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
@@ -1860,42 +1837,42 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     replace heval := VerifM.eval_ret (VerifM.eval_bind heval)
     obtain ⟨helemTy, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
-    have heval_val : (compile reg W.Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
+    have heval_val : (compile reg W.Θ W.Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_arraySet <| ?_
     -- Evaluate `val`.
-    have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
-    refine hstart.trans <| ihVal W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_val)
-      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    have hstart := Helpers.ctx_dup_flip W S B Γ st ρ γ R
+    refine hstart.trans <| ihVal W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R))
+      S B Γ st ρ γ _ _ hW (VerifM.eval.decls_grow ρ heval_val)
+      hagree hbwf hSwf hwf hag hΔreg hρreg ?_
     intro v_val ρ_val st₁ sv hΨ_val hsv_wf heval_sv
     obtain ⟨hdecls_val, hagreeOn_val, hΨ_val⟩ := hΨ_val
     have hagree_val : B.agreeOnLinked ρ_val.env γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_val hbwf
     have hbwf_val : B.wfIn st₁.decls := fun p hp => hdecls_val.consts _ (hbwf p hp)
-    have heval_idx : (compile reg W.Θ Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
-    have hspecInv_val := specInvariants_mono hΔspec hρspec hdecls_val hagreeOn_val
+    have heval_idx : (compile reg W.Θ W.Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
+    have hspecInv_val := hag.step hdecls_val hagreeOn_val
     -- Evaluate `idx`, re-exposing the spec context and carrying `val`'s typing.
     have hstepB :=
-      (Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_val γ R v_val val.ty).trans
-        (Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st₁ ρ_val γ (TinyML.ValHasType W v_val val.ty ∗ R))
+      (Helpers.ctx_push_flip W S B Γ st₁ ρ_val γ R v_val val.ty).trans
+        (Helpers.ctx_dup_flip W S B Γ st₁ ρ_val γ (TinyML.ValHasType W v_val val.ty ∗ R))
     refine hstepB.trans <| ihIdx W
-      (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ (TinyML.ValHasType W v_val val.ty ∗ R)))
-      S B Γ st₁ ρ_val γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ_val heval_idx)
-      hagree_val hbwf_val hSwf hΔwf hΔvars hspecInv_val.1 hspecInv_val.2 hΔreg hρreg ?_
+      (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ (TinyML.ValHasType W v_val val.ty ∗ R)))
+      S B Γ st₁ ρ_val γ _ _ hW (VerifM.eval.decls_grow ρ_val heval_idx)
+      hagree_val hbwf_val hSwf hwf hspecInv_val hΔreg hρreg ?_
     intro v_idx ρ_idx st₂ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
     have hagree_idx : B.agreeOnLinked ρ_idx.env γ :=
       Bindings.agreeOnLinked_env_agree hagree_val hagreeOn_idx hbwf_val
     have hbwf_idx : B.wfIn st₂.decls := fun p hp => hdecls_idx.consts _ (hbwf_val p hp)
-    have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
-    have hspecInv_idx := specInvariants_mono hspecInv_val.1 hspecInv_val.2 hdecls_idx hagreeOn_idx
+    have heval_arr : (compile reg W.Θ W.Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
+    have hspecInv_idx := hspecInv_val.step hdecls_idx hagreeOn_idx
     -- Evaluate `arr`, carrying both `idx`'s and `val`'s typings.
-    have hstepC := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₂ ρ_idx γ
+    have hstepC := Helpers.ctx_push_flip W S B Γ st₂ ρ_idx γ
       (TinyML.ValHasType W v_val val.ty ∗ R) v_idx idx.ty
     refine hstepC.trans <| ihArr W
       (TinyML.ValHasType W v_idx idx.ty ∗ (TinyML.ValHasType W v_val val.ty ∗ R))
-      S B Γ st₂ ρ_idx γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ_idx heval_arr)
-      hagree_idx hbwf_idx hSwf hΔwf hΔvars hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
+      S B Γ st₂ ρ_idx γ _ _ hW (VerifM.eval.decls_grow ρ_idx heval_arr)
+      hagree_idx hbwf_idx hSwf hwf hspecInv_idx hΔreg hρreg ?_
     intro v_arr ρ_arr st₃ sa hΨ_arr hsa_wf heval_sa
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
     have hsi_wf₃ : si.wfIn st₃.decls :=
@@ -1933,7 +1910,7 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
               · iexact HR))
     exact hwp
   | ownedArray elemTy =>
-    intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+    intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
     unfold Expr.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
@@ -1941,37 +1918,37 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     replace heval := VerifM.eval_ret (VerifM.eval_bind heval)
     obtain ⟨helemTy, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
-    have heval_val : (compile reg W.Θ Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
+    have heval_val : (compile reg W.Θ W.Δ_spec S B Γ val).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_arraySet <| ?_
-    have hstart := Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st ρ γ R
-    refine hstart.trans <| ihVal W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ heval_val)
-      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    have hstart := Helpers.ctx_dup_flip W S B Γ st ρ γ R
+    refine hstart.trans <| ihVal W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R))
+      S B Γ st ρ γ _ _ hW (VerifM.eval.decls_grow ρ heval_val)
+      hagree hbwf hSwf hwf hag hΔreg hρreg ?_
     intro v_val ρ_val st₁ sv hΨ_val hsv_wf heval_sv
     obtain ⟨hdecls_val, hagreeOn_val, hΨ_val⟩ := hΨ_val
     have hagree_val := Bindings.agreeOnLinked_env_agree hagree hagreeOn_val hbwf
     have hbwf_val : B.wfIn st₁.decls := fun p hp => hdecls_val.consts _ (hbwf p hp)
-    have heval_idx : (compile reg W.Θ Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
-    have hspecInv_val := specInvariants_mono hΔspec hρspec hdecls_val hagreeOn_val
+    have heval_idx : (compile reg W.Θ W.Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
+    have hspecInv_val := hag.step hdecls_val hagreeOn_val
     have hstepB :=
-      (Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₁ ρ_val γ R v_val val.ty).trans
-        (Helpers.ctx_dup_flip W Δ_spec ρ_spec S B Γ st₁ ρ_val γ (TinyML.ValHasType W v_val val.ty ∗ R))
+      (Helpers.ctx_push_flip W S B Γ st₁ ρ_val γ R v_val val.ty).trans
+        (Helpers.ctx_dup_flip W S B Γ st₁ ρ_val γ (TinyML.ValHasType W v_val val.ty ∗ R))
     refine hstepB.trans <| ihIdx W
-      (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ (TinyML.ValHasType W v_val val.ty ∗ R)))
-      S B Γ st₁ ρ_val γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ_val heval_idx)
-      hagree_val hbwf_val hSwf hΔwf hΔvars hspecInv_val.1 hspecInv_val.2 hΔreg hρreg ?_
+      (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ (TinyML.ValHasType W v_val val.ty ∗ R)))
+      S B Γ st₁ ρ_val γ _ _ hW (VerifM.eval.decls_grow ρ_val heval_idx)
+      hagree_val hbwf_val hSwf hwf hspecInv_val hΔreg hρreg ?_
     intro v_idx ρ_idx st₂ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
     have hagree_idx := Bindings.agreeOnLinked_env_agree hagree_val hagreeOn_idx hbwf_val
     have hbwf_idx : B.wfIn st₂.decls := fun p hp => hdecls_idx.consts _ (hbwf_val p hp)
-    have heval_arr : (compile reg W.Θ Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
-    have hspecInv_idx := specInvariants_mono hspecInv_val.1 hspecInv_val.2 hdecls_idx hagreeOn_idx
-    have hstepC := Helpers.ctx_push_flip W Δ_spec ρ_spec S B Γ st₂ ρ_idx γ
+    have heval_arr : (compile reg W.Θ W.Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
+    have hspecInv_idx := hspecInv_val.step hdecls_idx hagreeOn_idx
+    have hstepC := Helpers.ctx_push_flip W S B Γ st₂ ρ_idx γ
       (TinyML.ValHasType W v_val val.ty ∗ R) v_idx idx.ty
     refine hstepC.trans <| ihArr W
       (TinyML.ValHasType W v_idx idx.ty ∗ (TinyML.ValHasType W v_val val.ty ∗ R))
-      S B Γ st₂ ρ_idx γ Δ_spec ρ_spec _ _ hW (VerifM.eval.decls_grow ρ_idx heval_arr)
-      hagree_idx hbwf_idx hSwf hΔwf hΔvars hspecInv_idx.1 hspecInv_idx.2 hΔreg hρreg ?_
+      S B Γ st₂ ρ_idx γ _ _ hW (VerifM.eval.decls_grow ρ_idx heval_arr)
+      hagree_idx hbwf_idx hSwf hwf hspecInv_idx hΔreg hρreg ?_
     intro v_arr ρ_arr st₃ sa hΨ_arr hsa_wf heval_sa
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
     have hsi_wf₃ := Term.wfIn_mono si hsi_wf hdecls_arr (VerifM.eval.wf hΨ_arr).namesDisjoint
@@ -2027,20 +2004,20 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
               · iexact HR))
   | prim _ | sum _ | arrow _ _ | ref _ | vec _ | owned _ | empty | value | tuple _ | tvar _
   | named _ _ =>
-      intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
+      intro W R S B Γ st ρ γ Ψ Φ hW heval _ _ _ _ _ _ _ _ _ _ _
       simp only [compile, hty] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
 theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Expr) (uty : TinyML.Typ)
     (ih : correctExpr reg e) :
     correctExpr reg (.unop op e uty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_unop <| ih W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_unop <| ih W R S B Γ st ρ γ _ _ hW
+    (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨_, _, hΨ_e⟩ := hΨ_e
   obtain ⟨ty, htypeOf, hΨ_e⟩ := VerifM.eval_bind_expectSome hΨ_e
@@ -2075,37 +2052,37 @@ theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Ex
 theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r : Expr) (bty : TinyML.Typ)
     (ihR : correctExpr reg r) (ihL : correctExpr reg l) :
     correctExpr reg (.binop op l r bty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_r : (compile reg W.Θ Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind heval
+  have heval_r : (compile reg W.Θ W.Δ_spec S B Γ r).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+      st.sl W ρ ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
         st.sl W ρ ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
-    Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
+    Helpers.ctx_dup W S B Γ st ρ γ R
   refine SpatialContext.wp_bind_binop <| hstart.trans <|
-    ihR W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    ihR W (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr
   obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
   have hagree_r : B.agreeOnLinked ρ_r.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
   have hbwf_r : B.wfIn st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
-  have heval_l : (compile reg W.Θ Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind hΨ_r
+  have heval_l : (compile reg W.Θ W.Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind hΨ_r
   have hleftStart :
       st₁.sl W ρ_r ∗ TinyML.ValHasType W vr r.ty ∗
-        (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
           st₁.sl W ρ_r ∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
               (TinyML.ValHasType W vr r.ty ∗ R)) :=
-    Helpers.ctx_push W Δ_spec ρ_spec S B Γ st₁ ρ_r γ R vr r.ty
-  have hspecInv_r := specInvariants_mono hΔspec hρspec hdecls_r hagreeOn_r
+    Helpers.ctx_push W S B Γ st₁ ρ_r γ R vr r.ty
+  have hspecInv_r := hag.step hdecls_r hagreeOn_r
   refine hleftStart.trans <|
-    ihL W (TinyML.ValHasType W vr r.ty ∗ R) S B Γ st₁ ρ_r γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hSwf hΔwf hΔvars hspecInv_r.1 hspecInv_r.2 hΔreg hρreg ?_
+    ihL W (TinyML.ValHasType W vr r.ty ∗ R) S B Γ st₁ ρ_r γ _ _ hW
+      (VerifM.eval.decls_grow ρ_r heval_l) hagree_r hbwf_r hSwf hwf hspecInv_r hΔreg hρreg ?_
   intro vl ρ_l st₂ sl hΨ_l hsl_wf heval_sl
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
   obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
@@ -2281,20 +2258,20 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
 theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Expr)
     (ihE : correctExpr reg e) (ihBody : correctExpr reg body) :
     correctExpr reg (.letIn b e body) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.letIn_subst]
-  have heval_e_outer : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
+  have heval_e_outer : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+      st.sl W ρ ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
         st.sl W ρ ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
-    Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
-  refine (hstart.trans <| ihE W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_).trans wp.letIn
+          (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
+    Helpers.ctx_dup W S B Γ st ρ γ R
+  refine (hstart.trans <| ihE W (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ _ _ hW
+    (VerifM.eval.decls_grow ρ heval_e_outer) hagree hbwf hSwf hwf hag hΔreg hρreg ?_).trans wp.letIn
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_e
   obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
   have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
@@ -2304,8 +2281,8 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
   | none =>
     simp [hname] at hΨ_e
     have hdrop :
-        st₁.sl W ρ_e ∗ (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
-          st₁.sl W ρ_e ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
+        st₁.sl W ρ_e ∗ (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+          st₁.sl W ρ_e ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
       iintro ⟨Howns, _Hv, #HS, #HT, HR⟩
       isplitl [Howns]
       · iexact Howns
@@ -2314,15 +2291,15 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
         · isplitl []
           · iexact HT
           · iexact HR
-    have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
-    have hbody := hdrop.trans <| ihBody W R S B Γ st₁ ρ_e γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hSwf hΔwf hΔvars hspecInv_e.1 hspecInv_e.2 hΔreg hρreg
+    have hspecInv_e := hag.step hdecls_e hagreeOn_e
+    have hbody := hdrop.trans <| ihBody W R S B Γ st₁ ρ_e γ _ _ hW
+      (VerifM.eval.decls_grow ρ_e hΨ_e) hagree_e hbwf_e hSwf hwf hspecInv_e hΔreg hρreg
       (fun v ρ' st' se hΨ hs hw =>
         let ⟨_, _, hΨ'⟩ := hΨ
         hpost v ρ' st' se hΨ' hs hw)
     have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ Runtime.Binder.none v_e
     have hbody' : st₁.sl W ρ_e ∗
-          (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+          (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
             wp W.pctx
               (Runtime.Expr.subst
                 (Runtime.Subst.updateBinder Runtime.Binder.none v_e Runtime.Subst.id)
@@ -2346,11 +2323,11 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
     set ρ_body := ρ_e.updateConst .value v.name v_e
     set γ_body : Runtime.Subst := Runtime.Subst.update γ x v_e
     suffices st₂.sl W ρ_body ∗
-        (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+        (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
           wp W.pctx (body.runtime.subst γ_body) Φ by
       have hsubst := Runtime.Expr.subst_remove'_updateBinder body.runtime γ (.named x) v_e
       have hbody' : st₂.sl W ρ_body ∗
-            (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+            (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
               wp W.pctx
                 (Runtime.Expr.subst
                   (Runtime.Subst.updateBinder (.named x) v_e Runtime.Subst.id)
@@ -2366,7 +2343,7 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
           using hbody'
     have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
       Env.agreeOn_update_fresh_const hfresh
-    have hΨ_body : (compile reg W.Θ Δ_spec (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
+    have hΨ_body : (compile reg W.Θ W.Δ_spec (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
       have hdecl_eval := VerifM.eval_bind hΨ_e
       have hdecl := VerifM.eval_decl hdecl_eval
       have h := hdecl v_e
@@ -2402,9 +2379,9 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
       rwa [hρ_body_lookup] at h
     have hres :
         st₂.sl W ρ_body ∗
-          (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+          (TinyML.ValHasType W v_e e.ty ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
             st₂.sl W ρ_body ∗
-              (SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.erase x S) γ_body ∗
+              (SpecMap.satisfiedBy W (Finmap.erase x S) γ_body ∗
                 Bindings.typedSubst W ((x, v) :: B) (Γ.extend x e.ty) γ_body ∗ R) := by
       iintro ⟨Howns, Hve, #HS, #HT, HR⟩
       isplitl [Howns]
@@ -2418,11 +2395,11 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
             · iexact HT
             · iexact Hve
           · iexact HR
-    have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
-    have hspecInv_body := specInvariants_mono hspecInv_e.1 hspecInv_e.2
+    have hspecInv_e := hag.step hdecls_e hagreeOn_e
+    have hspecInv_body := hspecInv_e.step
       (Signature.Subset.subset_addConst st₁.decls v) hagreeOn_body_e
-    refine hres.trans <| ihBody W R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ (SpecMap.wfIn_erase hSwf) hΔwf hΔvars hspecInv_body.1 hspecInv_body.2 hΔreg hρreg ?_
+    refine hres.trans <| ihBody W R (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) st₂ ρ_body γ_body _ _ hW
+      (VerifM.eval.decls_grow ρ_body hΨ_body) hagree_body hbwf₂ (SpecMap.wfIn_erase hSwf) hwf hspecInv_body hΔreg hρreg ?_
     intro v' ρ' st' se' hΨ hs hw
     obtain ⟨_, _, hΨ'⟩ := hΨ
     exact hpost v' ρ' st' se' hΨ' hs hw
@@ -2432,48 +2409,46 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
     ∀ (names : List Binder) (tys : List TinyML.Typ) (tl : Term .vallist)
       (vals : List Runtime.Val) (W : TinyML.World) (R : iProp) (S : SpecMap)
       (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env)
-      (γ : Runtime.Subst) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+      (γ : Runtime.Subst)
       (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
       W.pctx = reg.primCtx →
       VerifM.eval (compileProductBindersFrom S B Γ names tys tl) st ρ
-        (fun p st' ρ' => (compile reg W.Θ Δ_spec p.1 p.2.1 p.2.2 body).eval st' ρ' Ψ) →
+        (fun p st' ρ' => (compile reg W.Θ W.Δ_spec p.1 p.2.1 p.2.2 body).eval st' ρ' Ψ) →
       B.agreeOnLinked ρ.env γ →
       B.wfIn st.decls →
-      S.wfIn Δ_spec →
-      Δ_spec.wf →
-      Δ_spec.vars = [] →
-      Δ_spec.Subset st.decls →
-      VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
-      Verifier.Registry.symSubset reg Δ_spec →
-      Verifier.Registry.symAgree reg ρ_spec.env →
+      S.wfIn W.Δ_spec →
+      W.wf →
+      W.agrees st.decls ρ.env →
+      Verifier.Registry.symSubset reg W.Δ_spec →
+      Verifier.Registry.symAgree reg W.ρ_spec →
       tl.wfIn st.decls →
       Term.eval ρ.env tl = vals →
       (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
         st'.sl W ρ' ∗ TinyML.ValHasType W v body.ty ∗ R ⊢ Φ v) →
       st.sl W ρ ∗
           (TinyML.ValsHaveTypes W vals tys ∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+            (S.satisfiedBy W γ ∗
               Bindings.typedSubst W B Γ γ ∗ R)) ⊢
         wp W.pctx
           (body.runtime.subst (γ.updateAllBinder (names.map Binder.runtime) vals)) Φ
-  | [], [], tl, vals, W, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
-      hW, heval, hagree, hbwf, hSwf, hΔwf, hΔvars, hΔspec, hρspec, hΔreg, hρreg,
+  | [], [], tl, vals, W, R, S, B, Γ, st, ρ, γ, Ψ, Φ,
+      hW, heval, hagree, hbwf, hSwf, hwf, hag, hΔreg, hρreg,
       htl_wf, htl_eval, hpost => by
       simp only [compileProductBindersFrom] at heval
-      have hbody_eval : (compile reg W.Θ Δ_spec S B Γ body).eval st ρ Ψ := by
+      have hbody_eval : (compile reg W.Θ W.Δ_spec S B Γ body).eval st ρ Ψ := by
         simpa using VerifM.eval_ret heval
       cases vals with
       | nil =>
           have hbody_wp :=
-            ihBody W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW hbody_eval hagree hbwf hSwf
-              hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+            ihBody W R S B Γ st ρ γ Ψ Φ hW hbody_eval hagree hbwf hSwf
+              hwf hag hΔreg hρreg hpost
           simpa using
             ((show st.sl W ρ ∗
                 (TinyML.ValsHaveTypes W [] [] ∗
-                  (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                  (S.satisfiedBy W γ ∗
                     Bindings.typedSubst W B Γ γ ∗ R)) ⊢
                 st.sl W ρ ∗
-                  (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                  (S.satisfiedBy W γ ∗
                     Bindings.typedSubst W B Γ γ ∗ R) by
                 iintro ⟨Hsl, Hvals, Hctx⟩
                 ihave Hemp := (TinyML.ValsHaveTypes.nil W).1 $$ Hvals
@@ -2483,31 +2458,31 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
       | cons v vs =>
           exact (show st.sl W ρ ∗
               (TinyML.ValsHaveTypes W (v :: vs) [] ∗
-                (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                (S.satisfiedBy W γ ∗
                   Bindings.typedSubst W B Γ γ ∗ R)) ⊢
                 wp W.pctx (body.runtime.subst (γ.updateAllBinder ([] : List Runtime.Binder) (v :: vs))) Φ by
             iintro ⟨_Hsl, Hvals, _Hctx⟩
             ihave Hfalse := (TinyML.ValsHaveTypes.cons_nil W v vs).1 $$ Hvals
             iapply false_elim
             iexact Hfalse)
-  | [], ty :: tys, tl, vals, W, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
-      hW, heval, _hagree, _hbwf, _hSwf, _hΔwf, _hΔvars, _hΔspec, _hρspec, _hΔreg, _hρreg,
+  | [], ty :: tys, tl, vals, W, R, S, B, Γ, st, ρ, γ, Ψ, Φ,
+      hW, heval, _hagree, _hbwf, _hSwf, _hwf, _hag, _hΔreg, _hρreg,
       _htl_wf, _htl_eval, _hpost => by
       simp only [compileProductBindersFrom] at heval
       exact (VerifM.eval_fatal heval).elim
-  | b :: bs, [], tl, vals, W, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
-      hW, heval, _hagree, _hbwf, _hSwf, _hΔwf, _hΔvars, _hΔspec, _hρspec, _hΔreg, _hρreg,
+  | b :: bs, [], tl, vals, W, R, S, B, Γ, st, ρ, γ, Ψ, Φ,
+      hW, heval, _hagree, _hbwf, _hSwf, _hwf, _hag, _hΔreg, _hρreg,
       _htl_wf, _htl_eval, _hpost => by
       simp only [compileProductBindersFrom] at heval
       exact (VerifM.eval_fatal heval).elim
-  | b :: bs, ty :: tys, tl, vals, W, R, S, B, Γ, st, ρ, γ, Δ_spec, ρ_spec, Ψ, Φ,
-      hW, heval, hagree, hbwf, hSwf, hΔwf, hΔvars, hΔspec, hρspec, hΔreg, hρreg,
+  | b :: bs, ty :: tys, tl, vals, W, R, S, B, Γ, st, ρ, γ, Ψ, Φ,
+      hW, heval, hagree, hbwf, hSwf, hwf, hag, hΔreg, hρreg,
       htl_wf, htl_eval, hpost => by
       cases vals with
       | nil =>
           exact (show st.sl W ρ ∗
               (TinyML.ValsHaveTypes W [] (ty :: tys) ∗
-                (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                (S.satisfiedBy W γ ∗
                   Bindings.typedSubst W B Γ γ ∗ R)) ⊢
                 wp W.pctx
                   (body.runtime.subst (γ.updateAllBinder ((b :: bs).map Binder.runtime) [])) Φ by
@@ -2530,16 +2505,16 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
           | none =>
               simp [hname] at hcont
               have hrec := compileProductBindersFrom_correct reg body ihBody bs tys
-                (Term.unop UnOp.vtail tl) vs W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW
-                hcont hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg
+                (Term.unop UnOp.vtail tl) vs W R S B Γ st ρ γ Ψ Φ hW
+                hcont hagree hbwf hSwf hwf hag hΔreg hρreg
                 htail_wf htail_eval hpost
               refine (show st.sl W ρ ∗
                   (TinyML.ValsHaveTypes W (v :: vs) (ty :: tys) ∗
-                    (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                    (S.satisfiedBy W γ ∗
                       Bindings.typedSubst W B Γ γ ∗ R)) ⊢
                     st.sl W ρ ∗
                       (TinyML.ValsHaveTypes W vs tys ∗
-                        (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                        (S.satisfiedBy W γ ∗
                           Bindings.typedSubst W B Γ γ ∗ R)) by
                 iintro ⟨Hsl, Hvals, Hctx⟩
                 ihave Hpair := (TinyML.ValsHaveTypes.cons W v vs ty tys).1 $$ Hvals
@@ -2606,13 +2581,13 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
                 rwa [hρ_lookup] at h
               have hbwf₁ : Bindings.wfIn ((x, x') :: B) st₂.decls := by
                 simpa [st₂, st₁] using Bindings.wfIn_cons hbwf
-              have hspecInv := specInvariants_mono hΔspec hρspec
+              have hspecInv := hag.step
                 (Signature.Subset.subset_addConst st.decls x') hagreeOn_body
               have hrec := compileProductBindersFrom_correct reg body ihBody bs tys
                 (Term.unop UnOp.vtail tl) vs W R (Finmap.erase x S) ((x, x') :: B)
-                (Γ.extend x ty) st₂ ρ₁ (Runtime.Subst.update γ x v) Δ_spec ρ_spec Ψ Φ hW
-                hrec_eval hagree₁ hbwf₁ (SpecMap.wfIn_erase hSwf) hΔwf hΔvars
-                hspecInv.1 hspecInv.2 hΔreg hρreg
+                (Γ.extend x ty) st₂ ρ₁ (Runtime.Subst.update γ x v) Ψ Φ hW
+                hrec_eval hagree₁ hbwf₁ (SpecMap.wfIn_erase hSwf) hwf
+                hspecInv hΔreg hρreg
                 (by
                   have htail_wf₁ := Term.wfIn_mono (Term.unop UnOp.vtail tl) htail_wf
                     (Signature.Subset.subset_addConst st.decls x')
@@ -2625,11 +2600,11 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
               have hctx :
                   st.sl W ρ ∗
                     (TinyML.ValsHaveTypes W (v :: vs) (ty :: tys) ∗
-                      (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+                      (S.satisfiedBy W γ ∗
                         Bindings.typedSubst W B Γ γ ∗ R)) ⊢
                     st₂.sl W ρ₁ ∗
                       (TinyML.ValsHaveTypes W vs tys ∗
-                        (SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.erase x S)
+                        (SpecMap.satisfiedBy W (Finmap.erase x S)
                           (Runtime.Subst.update γ x v) ∗
                           Bindings.typedSubst W ((x, x') :: B) (Γ.extend x ty)
                             (Runtime.Subst.update γ x v) ∗ R)) := by
@@ -2664,24 +2639,24 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
 theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (e body : Expr)
     (ihE : correctExpr reg e) (ihBody : correctExpr reg body) :
     correctExpr reg (.letProd names e body) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval
-    hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval
+    hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [compile] at heval
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.letProd_subst]
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st ρ _ :=
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st ρ _ :=
     VerifM.eval_bind heval
   have hstart :
-      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+      st.sl W ρ ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
         st.sl W ρ ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
-    Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
+    Helpers.ctx_dup W S B Γ st ρ γ R
   refine SpatialContext.wp_bind_letProd <| hstart.trans <|
-    ihE W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)
-      S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec
+    ihE W (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)
+      S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hSwf hwf hag
       hΔreg hρreg ?_
   intro v_e ρ_e st₁ se hΨ_e hse_wf heval_se
   obtain ⟨hdecls_e, hagreeOn_e, hΨ_e⟩ := hΨ_e
@@ -2692,15 +2667,15 @@ theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (
       have hprod_body :
           (do
             let p ← compileProductBinders S B Γ names tys se
-            compile reg W.Θ Δ_spec p.1 p.2.1 p.2.2 body).eval st₁ ρ_e Ψ :=
+            compile reg W.Θ W.Δ_spec p.1 p.2.1 p.2.2 body).eval st₁ ρ_e Ψ :=
         VerifM.eval_ret hpure_eval
       have hprod_eval := VerifM.eval_bind hprod_body
       have hagree_e := Bindings.agreeOnLinked_env_agree hagree hagreeOn_e hbwf
       have hbwf_e : B.wfIn st₁.decls := fun p hp => hdecls_e.consts _ (hbwf p hp)
-      have hspecInv_e := specInvariants_mono hΔspec hρspec hdecls_e hagreeOn_e
+      have hspecInv_e := hag.step hdecls_e hagreeOn_e
       refine (show st₁.sl W ρ_e ∗
           (TinyML.ValHasType W v_e (.tuple tys) ∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗
+            (S.satisfiedBy W γ ∗
               Bindings.typedSubst W B Γ γ ∗ R)) ⊢
             wp W.pctx
               (Runtime.Expr.letProd (names.map Binder.runtime) (.val v_e)
@@ -2722,8 +2697,8 @@ theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (
         hnames_len)
       rw [hbody_subst]
       iapply (compileProductBindersFrom_correct reg body ihBody names tys
-        (Term.unop UnOp.toValList se) vs W R S B Γ st₁ ρ_e γ Δ_spec ρ_spec Ψ Φ hW
-        hprod_eval hagree_e hbwf_e hSwf hΔwf hΔvars hspecInv_e.1 hspecInv_e.2
+        (Term.unop UnOp.toValList se) vs W R S B Γ st₁ ρ_e γ Ψ Φ hW
+        hprod_eval hagree_e hbwf_e hSwf hwf hspecInv_e
         hΔreg hρreg ?_ ?_ hpost)
       · exact ⟨trivial, hse_wf⟩
       · simp [Term.eval, UnOp.eval, heval_se]
@@ -2744,26 +2719,26 @@ theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (
 theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr) (ty : TinyML.Typ)
     (ihCond : correctExpr reg cond) (ihThn : correctExpr reg thn) (ihEls : correctExpr reg els) :
     correctExpr reg (.ifThenElse cond thn els ty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  have heval_cond : (compile reg W.Θ Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind heval
+  have heval_cond : (compile reg W.Θ W.Δ_spec S B Γ cond).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
-      st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+      st.sl W ρ ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
         st.sl W ρ ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
-    Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
+          (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗
+            (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) :=
+    Helpers.ctx_dup W S B Γ st ρ γ R
   refine SpatialContext.wp_bind_if <| hstart.trans <|
-    ihCond W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    ihCond W (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_cond) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_c ρ_c st₁ sc hΨ_c hsc_wf heval_c
   obtain ⟨hdecls_c, hagreeOn_c, hΨ_c⟩ := hΨ_c
   have hagree_c := Bindings.agreeOnLinked_env_agree hagree hagreeOn_c hbwf
   have hbwf_c : B.wfIn st₁.decls := fun p hp => hdecls_c.consts _ (hbwf p hp)
-  have hspecInv_c := specInvariants_mono hΔspec hρspec hdecls_c hagreeOn_c
+  have hspecInv_c := hag.step hdecls_c hagreeOn_c
   obtain ⟨hcond_bool, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
   obtain ⟨hthn_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
   obtain ⟨hels_ty, hΨ_c⟩ := VerifM.eval_bind_expectEq hΨ_c
@@ -2785,9 +2760,9 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
   have hbool_cases_bool :
       st₁.sl W ρ_c ∗
           (TinyML.ValHasType W v_c .bool ∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+            (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
         st₁.sl W ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
+          (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
     iintro ⟨Howns, Hv, #HS, #HT, HR⟩
     ihave Hv_bool := (TinyML.ValHasType.bool W v_c).1 $$ Hv
     icases Hv_bool with ⟨%b, %hv⟩
@@ -2801,9 +2776,9 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
           · iexact HT
           · iexact HR
   have hbool_cases :
-      st₁.sl W ρ_c ∗ (TinyML.ValHasType W v_c cond.ty ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+      st₁.sl W ρ_c ∗ (TinyML.ValHasType W v_c cond.ty ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
         st₁.sl W ρ_c ∗ iprop(⌜v_c = .bool false ∨ v_c = .bool true⌝) ∗
-          (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
+          (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
     simpa [hcond_bool] using hbool_cases_bool
   refine hbool_cases.trans ?_
   istart
@@ -2811,21 +2786,21 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
   icases Hbool with %hbool
   rcases hbool with hfalse_val | htrue_val
   · subst hfalse_val
-    have heval_els : (compile reg W.Θ Δ_spec S B Γ els).eval st_els ρ_c Ψ :=
+    have heval_els : (compile reg W.Θ W.Δ_spec S B Γ els).eval st_els ρ_c Ψ :=
       hfalse_cont hwf_eq (by
         simp only [Term.isFalse, Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_c)
     have hwp :
-        st_els.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        st_els.sl W ρ_c ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
           wp W.pctx (.ifThenElse (.val (.bool false)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_false
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
-        ihEls W R S B Γ st_els ρ_c γ Δ_spec ρ_spec Ψ Φ hW heval_els hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
+        ihEls W R S B Γ st_els ρ_c γ Ψ Φ hW heval_els hagree_c hbwf_c hSwf hwf hspecInv_c hΔreg hρreg
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hels_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
-          st_els.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
+        st₁.sl W ρ_c ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+          st_els.sl W ρ_c ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
       simp [st_els, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -2839,21 +2814,21 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
     have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by
       rw [heval_c]
       simp
-    have heval_thn : (compile reg W.Θ Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
+    have heval_thn : (compile reg W.Θ W.Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
       htrue_cont hwf_ne (by
         simp only [Term.isFalse, Formula.eval, Term.eval, UnOp.eval, Const.denote]
         exact heval_ne)
     have hwp :
-        st_thn.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+        st_thn.sl W ρ_c ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
           wp W.pctx (.ifThenElse (.val (.bool true)) (thn.runtime.subst γ) (els.runtime.subst γ)) Φ :=
       SpatialContext.wp_if_true
         (thn := thn.runtime.subst γ) (els := els.runtime.subst γ) <|
-        ihThn W R S B Γ st_thn ρ_c γ Δ_spec ρ_spec Ψ Φ hW heval_thn hagree_c hbwf_c hSwf hΔwf hΔvars hspecInv_c.1 hspecInv_c.2 hΔreg hρreg
+        ihThn W R S B Γ st_thn ρ_c γ Ψ Φ hW heval_thn hagree_c hbwf_c hSwf hwf hspecInv_c hΔreg hρreg
           (fun v ρ' st' se hΨ hs hw =>
             by simpa [hthn_ty] using hpost v ρ' st' se hΨ hs hw)
     have hctx :
-        st₁.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
-          st_thn.sl W ρ_c ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
+        st₁.sl W ρ_c ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) ⊢
+          st_thn.sl W ρ_c ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R) := by
       simp [st_thn, TransState.sl]
     iapply (hctx.trans hwp)
     isplitl [Howns]
@@ -2867,14 +2842,14 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
 theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
     (ihEs : correctExprs reg es) :
     correctExpr reg (.tuple es) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
-  have heval_es : (compileExprs reg W.Θ Δ_spec S B Γ es).eval st ρ _ := VerifM.eval_bind heval
-  refine SpatialContext.wp_bind_tuple <| ihEs W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+  have heval_es : (compileExprs reg W.Θ W.Δ_spec S B Γ es).eval st ρ _ := VerifM.eval_bind heval
+  refine SpatialContext.wp_bind_tuple <| ihEs W R S B Γ st ρ γ _ _ hW
+    (VerifM.eval.decls_grow ρ heval_es) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro vs ρ' st' terms hΨ hwf_terms heval_terms
   obtain ⟨_, _, hΨ⟩ := hΨ
   obtain hΨ := VerifM.eval_ret hΨ
@@ -2885,7 +2860,7 @@ theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
     exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
   refine SpatialContext.wp_tuple ?_
   have hstep :
-      st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) ⊢
+      st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (S.satisfiedBy W γ ∗ R) ⊢
         st'.sl W ρ' ∗ TinyML.ValHasType W (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
     iintro ⟨Howns, Hvals, #HS, HR⟩
     isplitl [Howns]
@@ -2905,7 +2880,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     (fn : Expr) (args : List Expr) (aty : TinyML.Typ)
     (ihArgs : correctExprs reg args) :
     correctExpr reg (.app fn args aty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Runtime.Expr.subst, List.map_map]
@@ -2913,9 +2888,9 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
   | var f fty =>
     simp only [compile] at heval
     obtain ⟨spec, hlookup, heval⟩ := VerifM.eval_bind_expectSome heval
-    have heval_args : (compileExprs reg W.Θ Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind heval
+    have heval_args : (compileExprs reg W.Θ W.Δ_spec S B Γ args).eval st ρ _ := VerifM.eval_bind heval
     refine SpecMap.project
-      (P := st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) W Δ_spec ρ_spec S γ ?_ hlookup ?_
+      (P := st.sl W ρ ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) W S γ ?_ hlookup ?_
     · istart
       iintro ⟨_, #HS, _⟩
       iexact HS
@@ -2923,11 +2898,11 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       simp [Expr.runtime, Runtime.Expr.subst, hγf]
       refine SpatialContext.wp_bind_app ?_
       have hctx :
-          spec.isPrecondFor W Δ_spec ρ_spec fval ∗
-              (st.sl W ρ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
+          spec.isPrecondFor W fval ∗
+              (st.sl W ρ ∗ (S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ∗ R)) ⊢
             st.sl W ρ ∗
-              (S.satisfiedBy W Δ_spec ρ_spec γ ∗
-                Bindings.typedSubst W B Γ γ ∗ (spec.isPrecondFor W Δ_spec ρ_spec fval ∗ R)) := by
+              (S.satisfiedBy W γ ∗
+                Bindings.typedSubst W B Γ γ ∗ (spec.isPrecondFor W fval ∗ R)) := by
         istart
         iintro ⟨#Hspec, Howns, #HS, #HT, HR⟩
         isplitl [Howns]
@@ -2940,8 +2915,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
               · iexact Hspec
               · iexact HR
       refine hctx.trans <|
-        ihArgs W (spec.isPrecondFor W Δ_spec ρ_spec fval ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+        ihArgs W (spec.isPrecondFor W fval ∗ R) S B Γ st ρ γ _ _ hW
+          (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
       intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
       obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
       let typedArgs := (args.map Expr.ty).zip sargs
@@ -2949,19 +2924,19 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
         simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
       obtain ⟨hret_eq, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
       obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
-      have hΔspec_args : Δ_spec.Subset st_args.decls := hΔspec.trans hdecls_args
+      have hΔspec_args : W.Δ_spec.Subset st_args.decls := hag.subset.trans hdecls_args
       have hst_args_wf : st_args.decls.wf := (VerifM.eval.wf hΨ_args).namesDisjoint
-      have hwf_pred : spec.pred.wfIn ((Δ_spec.declVars (FiniteSubst.base Δ_spec).dom).declVars (Spec.argVars spec.args)) := by
+      have hwf_pred : spec.pred.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars (Spec.argVars spec.args)) := by
         simpa [FiniteSubst.base, Signature.declVars] using hSwf f spec hlookup
-      have hbase_wf : (FiniteSubst.base Δ_spec).wfIn Δ_spec st_args.decls :=
-        FiniteSubst.base_wfIn hΔspec_args hΔwf hst_args_wf hΔvars
+      have hbase_wf : (FiniteSubst.base W.Δ_spec).wfIn W.Δ_spec st_args.decls :=
+        FiniteSubst.base_wfIn hΔspec_args hwf.wf hst_args_wf hwf.vars
       have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
         intro p hp
         have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
         exact hsargs_wf _ hp''
-      have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base Δ_spec) spec typedArgs) st_args ρ_args
+      have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base W.Δ_spec) spec typedArgs) st_args ρ_args
           (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind hΨ_args
-      have hcall := Spec.call_correct W spec Δ_spec (FiniteSubst.base Δ_spec) typedArgs st_args ρ_args
+      have hcall := Spec.call_correct W spec W.Δ_spec (FiniteSubst.base W.Δ_spec) typedArgs st_args ρ_args
         (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
         hwf_pred
         hbase_wf htypedArgs_wf hcall_eval
@@ -3010,8 +2985,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
               (Spec.argsEnv ρ_args spec.args vs) := by
         rw [heval_sargs_map] at happly
         exact happly
-      have hagree_ρ_args : VerifM.Env.agreeOn Δ_spec ρ_spec ρ_args :=
-        VerifM.Env.agreeOn_trans hρspec (VerifM.Env.agreeOn_mono hΔspec hagreeOn_args)
+      have hagree_ρ_args : Env.agreeOn W.Δ_spec W.ρ_spec ρ_args.env :=
+        Env.agreeOn_trans hag.agree (Env.agreeOn_mono hag.subset hagreeOn_args)
       ispecialize Hspec $$ %ρ_args
       ispecialize Hspec $$ %Φ
       ispecialize Hspec $$ %vs
@@ -3028,14 +3003,14 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     simp only [compile] at heval
     obtain ⟨i, hilookup, heval⟩ := VerifM.eval_bind_expectSome heval
     obtain ⟨hret_eq, heval⟩ := VerifM.eval_bind_expectEq heval
-    have heval_args : (compileExprs reg W.Θ Δ_spec S B Γ args).eval st ρ _ :=
+    have heval_args : (compileExprs reg W.Θ W.Δ_spec S B Γ args).eval st ρ _ :=
       VerifM.eval_bind heval
     have hi_mem : i ∈ reg := Verifier.Registry.mem_of_lookup? hilookup
     have hbridge := Verifier.Registry.Sound.get hSound hi_mem
     simp only [Expr.runtime, Runtime.Expr.subst_val]
     refine SpatialContext.wp_bind_app ?_
-    refine ihArgs W R S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    refine ihArgs W R S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
     intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
     obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
     let σi : TinyML.TyVar → TinyML.Typ := fun v => (inst.lookup v).getD (.tvar v)
@@ -3043,22 +3018,22 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     let typedArgs := (args.map Expr.ty).zip sargs
     have hlen_sargs : sargs.length = vs.length := by
       simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
-    have hΔspec_args : Δ_spec.Subset st_args.decls := hΔspec.trans hdecls_args
+    have hΔspec_args : W.Δ_spec.Subset st_args.decls := hag.subset.trans hdecls_args
     have hst_args_wf : st_args.decls.wf := (VerifM.eval.wf hΨ_args).namesDisjoint
     have hwf_pred :
-        spec.pred.wfIn ((Δ_spec.declVars (FiniteSubst.base Δ_spec).dom).declVars
+        spec.pred.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars
           (Spec.argVars spec.args)) := by
       simpa [spec, FiniteSubst.base, Signature.declVars, Verifier.Intrinsic.specArgs] using
-        hbridge.specWf Δ_spec (hΔreg i hi_mem) hΔwf
-    have hbase_wf : (FiniteSubst.base Δ_spec).wfIn Δ_spec st_args.decls :=
-      FiniteSubst.base_wfIn hΔspec_args hΔwf hst_args_wf hΔvars
+        hbridge.specWf W.Δ_spec (hΔreg i hi_mem) hwf.wf
+    have hbase_wf : (FiniteSubst.base W.Δ_spec).wfIn W.Δ_spec st_args.decls :=
+      FiniteSubst.base_wfIn hΔspec_args hwf.wf hst_args_wf hwf.vars
     have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
       intro p hp
       have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
       exact hsargs_wf _ hp''
-    have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base Δ_spec) spec typedArgs) st_args ρ_args
+    have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base W.Δ_spec) spec typedArgs) st_args ρ_args
         (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind hΨ_args
-    have hcall := Spec.call_correct W spec Δ_spec (FiniteSubst.base Δ_spec) typedArgs st_args ρ_args
+    have hcall := Spec.call_correct W spec W.Δ_spec (FiniteSubst.base W.Δ_spec) typedArgs st_args ρ_args
       (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
       hwf_pred hbase_wf htypedArgs_wf hcall_eval
       (fun v st' ρ' t hΨ hwf heval => by
@@ -3113,8 +3088,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
             (Spec.argsEnv ρ_args spec.args vs) := by
       rw [heval_sargs_map] at happly
       exact happly
-    have hagree_ρ_args : VerifM.Env.agreeOn Δ_spec ρ_spec ρ_args :=
-      VerifM.Env.agreeOn_trans hρspec (VerifM.Env.agreeOn_mono hΔspec hagreeOn_args)
+    have hagree_ρ_args : Env.agreeOn W.Δ_spec W.ρ_spec ρ_args.env :=
+      Env.agreeOn_trans hag.agree (Env.agreeOn_mono hag.subset hagreeOn_args)
     have hρ_args_reg : ρ_args.env.respects i.folSym :=
       Env.respects_of_agreeOn_extendWithSym (hρreg i hi_mem) (hΔreg i hi_mem) hagree_ρ_args
     iapply (show
@@ -3136,16 +3111,16 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
 theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches : List (Binder × Expr)) (ty : TinyML.Typ)
     (ihScrut : correctExpr reg scrut) (ihBranches : correctBranches reg branches) :
     correctExpr reg (.match_ scrut branches ty) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [Expr.ty] at hpost
   unfold Expr.runtime
   simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
-  have heval_scrut : (compile reg W.Θ Δ_spec S B Γ scrut).eval st ρ _ := VerifM.eval_bind heval
+  have heval_scrut : (compile reg W.Θ W.Δ_spec S B Γ scrut).eval st ρ _ := VerifM.eval_bind heval
   refine SpatialContext.wp_bind_match <| BIBase.Entails.trans ?_ <|
-    ihScrut W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
-  · exact Helpers.ctx_dup W Δ_spec ρ_spec S B Γ st ρ γ R
+    ihScrut W (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_scrut) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
+  · exact Helpers.ctx_dup W S B Γ st ρ γ R
   intro v_scrut ρ_scrut st_scrut se_scrut hΨ_scrut hse_wf heval_se
   obtain ⟨hdecls_scrut, hagreeOn_scrut, hΨ_scrut⟩ := hΨ_scrut
   cases hscrut_ty : scrut.ty with
@@ -3162,12 +3137,12 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
       by_cases htys : ∀ br ∈ branches, br.2.ty = ty
       · have hΨ_scrut' :
             (do
-              let i ← VerifM.all (List.range (compileBranches reg W.Θ Δ_spec S B Γ se_scrut ts branches 0).length)
-              match (compileBranches reg W.Θ Δ_spec S B Γ se_scrut ts branches 0)[i]? with
+              let i ← VerifM.all (List.range (compileBranches reg W.Θ W.Δ_spec S B Γ se_scrut ts branches 0).length)
+              match (compileBranches reg W.Θ W.Δ_spec S B Γ se_scrut ts branches 0)[i]? with
               | some m => m
               | none => VerifM.fatal "match branch index out of range").eval st_scrut ρ_scrut Ψ := by
           simpa [if_pos hlen, if_pos htys] using hΨ_scrut
-        have hcb := compileBranches_length_get reg W.Θ Δ_spec S B Γ se_scrut ts branches 0
+        have hcb := compileBranches_length_get reg W.Θ W.Δ_spec S B Γ se_scrut ts branches 0
         have hactions_len := hcb.1
         have heval_all := VerifM.eval_bind hΨ_scrut'
         have hall := VerifM.eval_all heval_all
@@ -3179,7 +3154,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
           icases Hscrut_sum with ⟨%tag, %v_payload, %hval_eq, Hsum⟩
           ihave %htag_bound := TinyML.ValSumRel.bound $$ Hsum
           have htag_branches : tag < branches.length := hlen ▸ htag_bound
-          have htag_range : tag ∈ List.range (compileBranches reg W.Θ Δ_spec S B Γ se_scrut ts branches 0).length := by
+          have htag_range : tag ∈ List.range (compileBranches reg W.Θ W.Δ_spec S B Γ se_scrut ts branches 0).length := by
             rw [hactions_len]
             exact List.mem_range.mpr htag_branches
           have heval_tag := hall tag htag_range
@@ -3189,10 +3164,10 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
           have hget : ts[tag]? = some (ts[tag]?.getD .value) := by
             rw [List.getElem?_eq_getElem htag_bound]
             simp
-          have hspecInv_scrut := specInvariants_mono hΔspec hρspec hdecls_scrut hagreeOn_scrut
+          have hspecInv_scrut := hag.step hdecls_scrut hagreeOn_scrut
           have hbranch_wp := ihBranches W R S B Γ se_scrut ts.length ts 0
-            st_scrut ρ_scrut γ Δ_spec ρ_spec Ψ Φ hW
-            hagree_scrut hbwf_scrut hSwf hΔwf hΔvars hspecInv_scrut.1 hspecInv_scrut.2 hΔreg hρreg hse_wf
+            st_scrut ρ_scrut γ Ψ Φ hW
+            hagree_scrut hbwf_scrut hSwf hwf hspecInv_scrut hΔreg hρreg hse_wf
             (fun j hj v ρ' st' se hΨ hse_wf hse_eval => by
               iintro ⟨Hsl, Hv, #HS, HR⟩
               iapply (hpost v ρ' st' se hΨ hse_wf hse_eval)
@@ -3208,7 +3183,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
           have hbranch_entail :
               st_scrut.sl W ρ_scrut ∗
                   TinyML.ValSumRel W tag v_payload ts ∗
-                    (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+                    (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
                 wp W.pctx
                   ((Runtime.Expr.subst γ
                         (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime)).app
@@ -3230,7 +3205,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
           have hmatch_entail :
               st_scrut.sl W ρ_scrut ∗
                   TinyML.ValSumRel W tag v_payload ts ∗
-                    (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
+                    (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
                 wp W.pctx
                   ((Runtime.Expr.val (Runtime.Val.inj tag ts.length v_payload)).match_
                     (List.map (Runtime.Expr.subst γ ∘ fun p =>
@@ -3239,7 +3214,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
             SpatialContext.wp_match
               (R := st_scrut.sl W ρ_scrut ∗
                   TinyML.ValSumRel W tag v_payload ts ∗
-                    (S.satisfiedBy W Δ_spec ρ_spec γ ∗ B.typedSubst W Γ γ ∗ R))
+                    (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R))
               (branch :=
                 Runtime.Expr.subst γ
                   (Runtime.Expr.fix Runtime.Binder.none [branches[tag].1.runtime] branches[tag].2.runtime))
@@ -3264,7 +3239,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
 theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) (body : Expr)
     (ihBody : correctExpr reg body) :
     correctBranch reg (binder, body) := by
-  intro W R S B Γ sc n i ty_i st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost payload hsc_eval
+  intro W R S B Γ sc n i ty_i st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hsc_wf hpost payload hsc_eval
   simp only [compileBranch] at heval
   by_cases hty : binder.ty = ty_i
   · have hexpect := VerifM.eval_bind heval
@@ -3324,17 +3299,17 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
       have hagree₁ : B.agreeOnLinked ρ₁.env γ :=
         Bindings.agreeOnLinked_env_agree hagree hagreeOn_st hbwf
       have hbwf₁ : B.wfIn st₂.decls := hst₂_decls ▸ fun p hp => List.Mem.tail _ (hbwf p hp)
-      have heval_body'' : (compile reg W.Θ Δ_spec S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+      have heval_body'' : (compile reg W.Θ W.Δ_spec S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, hname] using heval_body'
-      have hspecInv₁ := specInvariants_mono hΔspec hρspec
+      have hspecInv₁ := hag.step
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
           st₂.sl W ρ₁ ∗
-              (S.satisfiedBy W Δ_spec ρ_spec γ ∗ Bindings.typedSubst W B (Γ.extendBinder binder ty_i) γ ∗
-                (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
+              (S.satisfiedBy W γ ∗ Bindings.typedSubst W B (Γ.extendBinder binder ty_i) γ ∗
+                (S.satisfiedBy W γ ∗ R)) ⊢
             wp W.pctx (body.runtime.subst γ) Φ :=
-        ihBody W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Δ_spec ρ_spec Ψ Φ hW
-          heval_body'' hagree₁ hbwf₁ hSwf hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
+        ihBody W (S.satisfiedBy W γ ∗ R) S B (Γ.extendBinder binder ty_i) st₂ ρ₁ γ Ψ Φ hW
+          heval_body'' hagree₁ hbwf₁ hSwf hwf (hst₂_decls ▸ hspecInv₁)
           hΔreg hρreg
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
       rw [Binder.runtime_of_name_none hname]
@@ -3383,19 +3358,19 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
         have h := Bindings.agreeOnLinked_cons (x := x) (v := xv) (γ := γ) hagree hagreeOn_B (hvty := rfl)
         rwa [hρ₁_lookup] at h
       have heval_body'' :
-          (compile reg W.Θ Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
+          (compile reg W.Θ W.Δ_spec (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
         simpa [ρ₁, xv, hint, TinyML.TyCtx.extendBinder, hname] using heval_body'
-      have hspecInv₁ := specInvariants_mono hΔspec hρspec
+      have hspecInv₁ := hag.step
         (Signature.Subset.subset_addConst st.decls xv) hagreeOn_st
       have hBodyWp :
           st₂.sl W ρ₁ ∗
-              (SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
+              (SpecMap.satisfiedBy W (Finmap.erase x S) (Runtime.Subst.update γ x payload) ∗
                 Bindings.typedSubst W ((x, xv) :: B) (Γ.extendBinder binder ty_i) (Runtime.Subst.update γ x payload) ∗
-                (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) ⊢
+                (S.satisfiedBy W γ ∗ R)) ⊢
             wp W.pctx (body.runtime.subst (Runtime.Subst.update γ x payload)) Φ :=
-        ihBody W (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
-          (Runtime.Subst.update γ x payload) Δ_spec ρ_spec Ψ Φ hW heval_body'' hagree₁ hbwf₂ (SpecMap.wfIn_erase hSwf)
-          hΔwf hΔvars (hst₂_decls ▸ hspecInv₁.1) hspecInv₁.2
+        ihBody W (S.satisfiedBy W γ ∗ R) (Finmap.erase x S) ((x, xv) :: B) (Γ.extendBinder binder ty_i) st₂ ρ₁
+          (Runtime.Subst.update γ x payload) Ψ Φ hW heval_body'' hagree₁ hbwf₂ (SpecMap.wfIn_erase hSwf)
+          hwf (hst₂_decls ▸ hspecInv₁)
           hΔreg hρreg
           (fun v ρ' st' se hΨ' hs hw => hpost v ρ' st' se hΨ' hs hw)
       rw [Binder.runtime_of_name_some hname]
@@ -3432,19 +3407,19 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
 theorem compileBranchesCons_correct (reg : Verifier.Registry) (b : Binder × Expr) (bs : List (Binder × Expr))
     (ihHead : correctBranch reg b) (ihTail : correctBranches reg bs) :
     correctBranches reg (b :: bs) := by
-  intro W R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hW hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost j hj
+  intro W R S B Γ sc n ts idx st ρ γ Ψ Φ hW hagree hbwf hSwf hwf hag hΔreg hρreg hsc_wf hpost j hj
   cases j with
   | zero =>
     simp only [Nat.add_zero, List.getElem_cons_zero]
     intro heval
-    exact ihHead W R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Δ_spec ρ_spec Ψ Φ hW
-      heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf (by simpa using hpost 0 hj)
+    exact ihHead W R S B Γ sc n idx (ts[idx]?.getD .value) st ρ γ Ψ Φ hW
+      heval hagree hbwf hSwf hwf hag hΔreg hρreg hsc_wf (by simpa using hpost 0 hj)
   | succ k =>
     have hk : k < bs.length := by simp at hj; omega
     have hidx : idx + (k + 1) = (idx + 1) + k := by omega
     simp only [hidx, List.getElem_cons_succ]
-    exact ihTail W R S B Γ sc n ts (idx + 1) st ρ γ Δ_spec ρ_spec Ψ Φ hW
-      hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf
+    exact ihTail W R S B Γ sc n ts (idx + 1) st ρ γ Ψ Φ hW
+      hagree hbwf hSwf hwf hag hΔreg hρreg hsc_wf
       (by
         intro j hj' v ρ' st' se hΨ hse_wf hse_eval htyped
         simpa [Nat.add_assoc] using hpost (j + 1) (by simpa using hj') v ρ' st' se hΨ hse_wf hse_eval htyped)
@@ -3453,13 +3428,13 @@ theorem compileBranchesCons_correct (reg : Verifier.Registry) (b : Binder × Exp
 theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : List Expr)
     (ihE : correctExpr reg e) (ihRest : correctExprs reg rest) :
     correctExprs reg (e :: rest) := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [compileExprs] at heval
   simp only [List.map, wps_cons]
-  have heval_rest : (compileExprs reg W.Θ Δ_spec S B Γ rest).eval st ρ _ := VerifM.eval_bind heval
+  have heval_rest : (compileExprs reg W.Θ W.Δ_spec S B Γ rest).eval st ρ _ := VerifM.eval_bind heval
   refine BIBase.Entails.trans ?_ <|
-    ihRest W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R)) S B Γ st ρ γ Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg ?_
+    ihRest W (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R)) S B Γ st ρ γ _ _ hW
+      (VerifM.eval.decls_grow ρ heval_rest) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   · iintro ⟨Hsl, #HS, #HT, HR⟩
     isplitl [Hsl]
     · iexact Hsl
@@ -3477,12 +3452,12 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
   have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
   have hbwf_vs : B.wfIn st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
-  have heval_e : (compile reg W.Θ Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind hΨ_vs
-  have hspecInv_vs := specInvariants_mono hΔspec hρspec hdecls_vs hagreeOn_vs
+  have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind hΨ_vs
+  have hspecInv_vs := hag.step hdecls_vs hagreeOn_vs
   refine BIBase.Entails.trans ?_ <|
-    ihE W (TinyML.ValsHaveTypes W vs (rest.map Expr.ty) ∗ (S.satisfiedBy W Δ_spec ρ_spec γ ∗ R))
-    S B Γ st_vs ρ_vs γ Δ_spec ρ_spec _ _ hW
-    (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hSwf hΔwf hΔvars hspecInv_vs.1 hspecInv_vs.2 hΔreg hρreg ?_
+    ihE W (TinyML.ValsHaveTypes W vs (rest.map Expr.ty) ∗ (S.satisfiedBy W γ ∗ R))
+    S B Γ st_vs ρ_vs γ _ _ hW
+    (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hSwf hwf hspecInv_vs hΔreg hρreg ?_
   · iintro ⟨Hsl, Hvs, #HS, #HT, #HSpare, HR⟩
     isplitl [Hsl]
     · iexact Hsl
@@ -3531,12 +3506,12 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
 
 theorem compileBranchesNil_correct (reg : Verifier.Registry) :
     correctBranches reg [] := by
-  intro W R S B Γ sc n ts idx st ρ γ Δ_spec ρ_spec Ψ Φ hW hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hsc_wf hpost j hj
+  intro W R S B Γ sc n ts idx st ρ γ Ψ Φ hW hagree hbwf hSwf hwf hag hΔreg hρreg hsc_wf hpost j hj
   exact absurd hj (Nat.not_lt_zero _)
 
 theorem compileExprsNil_correct (reg : Verifier.Registry) :
     correctExprs reg [] := by
-  intro W R S B Γ st ρ γ Δ_spec ρ_spec Ψ Φ hW heval hagree hbwf hSwf hΔwf hΔvars hΔspec hρspec hΔreg hρreg hpost
+  intro W R S B Γ st ρ γ Ψ Φ hW heval hagree hbwf hSwf hwf hag hΔreg hρreg hpost
   simp only [compileExprs] at heval
   simp only [List.map, wps]
   obtain heval := VerifM.eval_ret heval

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -277,7 +277,7 @@ mutual
         let sargs := (args.map Expr.ty).zip sterms
         VerifM.expectEq "app type annotation mismatch" spec.retTy aty
         VerifM.expectEq "app type annotation mismatch"
-          fty (Typed.arrowOfArgs (spec.args.map fun arg => Binder.named arg.1 arg.2) spec.retTy)
+          fty (.arrow (spec.args.map Prod.snd) spec.retTy)
         let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) spec sargs
         pure result
     | .app (.prim n inst _) args aty => do

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -47,7 +47,7 @@ def checkSpec (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signatu
     `Spec.implement_correct` and a successful `checkBody` evaluation, the
     compiled body's `wp` holds. -/
 theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (Θ : TinyML.TypeEnv) (S : SpecMap) (s : Spec)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (S : SpecMap) (s : Spec)
     (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (hswf : s.wfIn Δ_spec) (hSwf : S.wfIn Δ_spec)
@@ -68,14 +68,14 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
     (hargVars_lookup : List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs)
     (hbody_eval : VerifM.eval
-        (checkBody reg Θ Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
+        (checkBody reg W.Θ Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
-          st''.sl Θ ρ'' ∗ Q ∗
-            ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
-    st'.sl Θ ρ' ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗ Q ⊢
-      (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval) -∗
-        wp reg.primCtx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
+          st''.sl W ρ'' ∗ Q ∗
+            ((TinyML.ValHasType W (result.eval ρ''.env) s.retTy -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
+    st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗ Q ⊢
+      (S.satisfiedBy W Δ_spec ρ_spec γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval) -∗
+        wp W.pctx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
   simp only [checkBody] at hbody_eval
   obtain ⟨hargNames_len, _, hbs_eq⟩ := extractArgNames_spec hext
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_def ▸ hbs_eq
@@ -115,10 +115,10 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     · exact hargVars_sort
     · exact hargVars_lookup
   have hts :
-      TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ⊢
-        Bindings.typedSubst Θ B Γ γ_body := by
+      TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ⊢
+        Bindings.typedSubst W B Γ γ_body := by
     iintro #HvalsArg
-    iapply (Bindings.typedSubst_of_agreeOnLinked (Θ := Θ) hagree)
+    iapply (Bindings.typedSubst_of_agreeOnLinked (W := W) hagree)
     imodintro
     iintro %x %x' %t %hmem %hΓ
     set args' := argNames.zip (s.args.map Prod.snd)
@@ -134,26 +134,26 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     rw [hsnd]
     iassumption
   have hS'_sat :
-      S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ⊢
-        S'.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ_body := by
+      S.satisfiedBy W Δ_spec ρ_spec γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval ⊢
+        S'.satisfiedBy W Δ_spec ρ_spec γ_body := by
     have hinsert :
-        S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval ⊢
-          (S.insertBinder fb s).satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) :=
+        S.satisfiedBy W Δ_spec ρ_spec γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval ⊢
+          (S.insertBinder fb s).satisfiedBy W Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) :=
       SpecMap.satisfiedBy_insertBinder_updateBinder
     have herase :
-        (S.insertBinder fb s).satisfiedBy reg.primCtx Θ Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) ⊢
-          S'.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
+        (S.insertBinder fb s).satisfiedBy W Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) ⊢
+          S'.satisfiedBy W Δ_spec ρ_spec ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
       SpecMap.satisfiedBy_eraseAll_updateAllBinder hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
-      st'.sl Θ ρ' ∗ (S'.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst Θ B Γ γ_body ∗ Q) ⊢
-        wp reg.primCtx (body.runtime.subst γ_body) P := by
-    refine compile_correct reg hSound body Θ Q S' B Γ st' ρ' γ_body Δ_spec ρ_spec _ _
+      st'.sl W ρ' ∗ (S'.satisfiedBy W Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst W B Γ γ_body ∗ Q) ⊢
+        wp W.pctx (body.runtime.subst γ_body) P := by
+    refine compile_correct reg hSound body W Q S' B Γ st' ρ' γ_body Δ_spec ρ_spec _ _ hW
       (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hS'wf hΔwf hΔvars
       hΔspec hρspec hΔreg hρreg ?_
     intro v ρ'' st'' se hΨ hse_wf heval_se
     obtain ⟨_, _, hΨ⟩ := hΨ
-    by_cases hsub : TinyML.Typ.sub Θ body.ty s.retTy
+    by_cases hsub : TinyML.Typ.sub W.Θ body.ty s.retTy
     case neg =>
       simp [hsub] at hΨ
       exact (VerifM.eval_fatal hΨ).elim
@@ -161,9 +161,9 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     have hΨ' := VerifM.eval_ret hΨ
     dsimp only at hΨ'
     rw [← heval_se]
-    refine (show st''.sl Θ ρ'' ∗ TinyML.ValHasType Θ (se.eval ρ''.env) body.ty ∗ Q ⊢
-        st''.sl Θ ρ'' ∗ Q ∗
-          ((TinyML.ValHasType Θ (se.eval ρ''.env) s.retTy -∗ P (se.eval ρ''.env)) -∗
+    refine (show st''.sl W ρ'' ∗ TinyML.ValHasType W (se.eval ρ''.env) body.ty ∗ Q ⊢
+        st''.sl W ρ'' ∗ Q ∗
+          ((TinyML.ValHasType W (se.eval ρ''.env) s.retTy -∗ P (se.eval ρ''.env)) -∗
             P (se.eval ρ''.env)) from ?_).trans (hΨ' _ hse_wf)
     iintro ⟨Howns, Hty, HQ⟩
     iframe Howns HQ
@@ -181,7 +181,7 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     iexact Hvals
 
 theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (Θ : TinyML.TypeEnv) (S : SpecMap) (e : Expr) (s : Spec)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (hswf : s.wfIn Δ_spec) (hSwf : S.wfIn Δ_spec)
@@ -191,8 +191,8 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
     (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg ρ_spec.env) :
-    VerifM.eval (checkSpec reg Θ Δ_spec S e s) st ρ (fun _ _ _ => True) →
-    st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ wp reg.primCtx (e.runtime.subst γ) (fun v => s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec v) := by
+    VerifM.eval (checkSpec reg W.Θ Δ_spec S e s) st ρ (fun _ _ _ => True) →
+    st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ wp W.pctx (e.runtime.subst γ) (fun v => s.isPrecondFor W Δ_spec ρ_spec v) := by
   intro heval
   -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
   have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
@@ -240,27 +240,27 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
         omega
       have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
       simp only [] at hsub; rw [hsub]
-      have hbody' : TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+      have hbody' : TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
+          PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
           (Spec.argsEnv ρ_call s.args vs) ⊢
-          SpecMap.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec S γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval -∗
-            wp reg.primCtx (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
+          SpecMap.satisfiedBy W Δ_spec ρ_spec S γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval -∗
+            wp W.pctx (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
         iintro H
         icases H with ⟨Htyped', Hpred'⟩
         iintuitionistic Htyped'
         have hΔspec_persist : Δ_spec.Subset (TransState.persist st).decls := by
           simpa using hΔspec
-        ihave Hwand := Spec.implement_correct Θ s _ Δ_spec ρ_spec (TransState.persist st) ρ vs P
-          (TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
-            (S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ∗ s.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec fval) -∗
-              wp reg.primCtx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
+        ihave Hwand := Spec.implement_correct W s _ Δ_spec ρ_spec (TransState.persist st) ρ vs P
+          (TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
+            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval) -∗
+              wp W.pctx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
           hswf hΔspec_persist hρspec hΔwf hΔvars himpl
           (fun argVars st' ρ' Q hst_sub hρ_agree hargVars_mem hargVars_sort hargVars_lookup hbody_eval => by
             have hΔspec' : Δ_spec.Subset st'.decls := hΔspec_persist.trans hst_sub
             have hρspec' : VerifM.Env.agreeOn Δ_spec ρ_spec ρ' := by
               exact VerifM.Env.agreeOn_trans hρspec (VerifM.Env.agreeOn_mono hΔspec_persist hρ_agree)
             iintro ⟨Hsl, HQ⟩ Htyped''
-            iapply (checkBody_correct reg hSound Θ S s γ Δ_spec ρ_spec hswf hSwf hΔwf hΔvars fb argBinders body argNames
+            iapply (checkBody_correct reg hSound W hW S s γ Δ_spec ρ_spec hswf hSwf hΔwf hΔvars fb argBinders body argNames
               hext bs rfl fval vs P hΔspec' hρspec' hΔreg hρreg hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
             isplitl [Hsl]
             · iexact Hsl
@@ -276,7 +276,7 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
                 have hlen := hlen_typed
                 simp [List.length_map] at hlen
                 omega
-              iapply (PredTrans.apply_env_agree Θ (ρ := Spec.argsEnv ρ_call s.args vs)
+              iapply (PredTrans.apply_env_agree W (ρ := Spec.argsEnv ρ_call s.args vs)
                 (ρ' := Spec.argsEnv ρ_spec s.args vs) hswf
                 (Spec.argsEnv_agreeOn (Δ := Δ_spec) (ρ₁ := ρ_call) (ρ₂ := ρ_spec)
                   (VerifM.Env.agreeOn_symm hagree_call) s.args vs hlen_vals_call))

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -49,9 +49,8 @@ def checkSpec (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signatu
 theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx) (S : SpecMap) (s : Spec)
     (γ : Runtime.Subst)
-    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
-    (hswf : s.wfIn Δ_spec) (hSwf : S.wfIn Δ_spec)
-    (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (hswf : s.wfIn W.Δ_spec) (hSwf : S.wfIn W.Δ_spec)
+    (hwf : W.wf)
     (fb : Binder) (argBinders : List Binder) (body : Expr)
     (argNames : List String)
     (hext : extractArgNames argBinders s.args = Except.ok argNames)
@@ -60,28 +59,27 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     (vs : List Runtime.Val)
     (P : Runtime.Val → iProp)
     {argVars : List FOL.Const} {st' : TransState} {ρ' : VerifM.Env} {Q : iProp}
-    (hΔspec : Δ_spec.Subset st'.decls)
-    (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ')
-    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
-    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
+    (hag : W.agrees st'.decls ρ'.env)
+    (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
     (hargVars_mem : ∀ v ∈ argVars, v ∈ st'.decls.consts)
     (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
     (hargVars_lookup : List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs)
     (hbody_eval : VerifM.eval
-        (checkBody reg W.Θ Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
+        (checkBody reg W.Θ W.Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
           st''.sl W ρ'' ∗ Q ∗
             ((TinyML.ValHasType W (result.eval ρ''.env) s.retTy -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
     st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗ Q ⊢
-      (S.satisfiedBy W Δ_spec ρ_spec γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval) -∗
+      (S.satisfiedBy W γ ∗ s.isPrecondFor W fval) -∗
         wp W.pctx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
   simp only [checkBody] at hbody_eval
   obtain ⟨hargNames_len, _, hbs_eq⟩ := extractArgNames_spec hext
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_def ▸ hbs_eq
   set γ_body := γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs
   set S' : SpecMap := SpecMap.eraseAll argNames (S.insertBinder fb s)
-  have hS'wf : S'.wfIn Δ_spec :=
+  have hS'wf : S'.wfIn W.Δ_spec :=
     SpecMap.wfIn_eraseAll (SpecMap.wfIn_insertBinder hSwf hswf)
   set Γ := (argNames.zip (s.args.map Prod.snd)).foldl
     (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
@@ -134,23 +132,23 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     rw [hsnd]
     iassumption
   have hS'_sat :
-      S.satisfiedBy W Δ_spec ρ_spec γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval ⊢
-        S'.satisfiedBy W Δ_spec ρ_spec γ_body := by
+      S.satisfiedBy W γ ∗ s.isPrecondFor W fval ⊢
+        S'.satisfiedBy W γ_body := by
     have hinsert :
-        S.satisfiedBy W Δ_spec ρ_spec γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval ⊢
-          (S.insertBinder fb s).satisfiedBy W Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) :=
+        S.satisfiedBy W γ ∗ s.isPrecondFor W fval ⊢
+          (S.insertBinder fb s).satisfiedBy W (γ.updateBinder fb.runtime fval) :=
       SpecMap.satisfiedBy_insertBinder_updateBinder
     have herase :
-        (S.insertBinder fb s).satisfiedBy W Δ_spec ρ_spec (γ.updateBinder fb.runtime fval) ⊢
-          S'.satisfiedBy W Δ_spec ρ_spec ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
+        (S.insertBinder fb s).satisfiedBy W (γ.updateBinder fb.runtime fval) ⊢
+          S'.satisfiedBy W ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
       SpecMap.satisfiedBy_eraseAll_updateAllBinder hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
   have hbody_wp :
-      st'.sl W ρ' ∗ (S'.satisfiedBy W Δ_spec ρ_spec γ_body ∗ Bindings.typedSubst W B Γ γ_body ∗ Q) ⊢
+      st'.sl W ρ' ∗ (S'.satisfiedBy W γ_body ∗ Bindings.typedSubst W B Γ γ_body ∗ Q) ⊢
         wp W.pctx (body.runtime.subst γ_body) P := by
-    refine compile_correct reg hSound body W Q S' B Γ st' ρ' γ_body Δ_spec ρ_spec _ _ hW
-      (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hS'wf hΔwf hΔvars
-      hΔspec hρspec hΔreg hρreg ?_
+    refine compile_correct reg hSound body W Q S' B Γ st' ρ' γ_body _ _ hW
+      (VerifM.eval.decls_grow ρ' hcompile) hagree hbwf hS'wf hwf
+      hag hΔreg hρreg ?_
     intro v ρ'' st'' se hΨ hse_wf heval_se
     obtain ⟨_, _, hΨ⟩ := hΨ
     by_cases hsub : TinyML.Typ.sub W.Θ body.ty s.retTy
@@ -183,16 +181,14 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
 theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx) (S : SpecMap) (e : Expr) (s : Spec)
     (γ : Runtime.Subst)
-    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
-    (hswf : s.wfIn Δ_spec) (hSwf : S.wfIn Δ_spec)
-    (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (hswf : s.wfIn W.Δ_spec) (hSwf : S.wfIn W.Δ_spec)
+    (hwf : W.wf)
     (st : TransState) (ρ : VerifM.Env)
-    (hΔspec : Δ_spec.Subset st.decls)
-    (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
-    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
-    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env) :
-    VerifM.eval (checkSpec reg W.Θ Δ_spec S e s) st ρ (fun _ _ _ => True) →
-    st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ wp W.pctx (e.runtime.subst γ) (fun v => s.isPrecondFor W Δ_spec ρ_spec v) := by
+    (hag : W.agrees st.decls ρ.env)
+    (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg W.ρ_spec) :
+    VerifM.eval (checkSpec reg W.Θ W.Δ_spec S e s) st ρ (fun _ _ _ => True) →
+    st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (e.runtime.subst γ) (fun v => s.isPrecondFor W v) := by
   intro heval
   -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
   have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
@@ -243,25 +239,23 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       have hbody' : TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
           PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
           (Spec.argsEnv ρ_call s.args vs) ⊢
-          SpecMap.satisfiedBy W Δ_spec ρ_spec S γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval -∗
+          SpecMap.satisfiedBy W S γ ∗ s.isPrecondFor W fval -∗
             wp W.pctx (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
         iintro H
         icases H with ⟨Htyped', Hpred'⟩
         iintuitionistic Htyped'
-        have hΔspec_persist : Δ_spec.Subset (TransState.persist st).decls := by
-          simpa using hΔspec
-        ihave Hwand := Spec.implement_correct W s _ Δ_spec ρ_spec (TransState.persist st) ρ vs P
+        have hag_persist : W.agrees (TransState.persist st).decls ρ.env := by
+          simpa using hag
+        ihave Hwand := Spec.implement_correct W s _ (TransState.persist st) ρ vs P
           (TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
-            (S.satisfiedBy W Δ_spec ρ_spec γ ∗ s.isPrecondFor W Δ_spec ρ_spec fval) -∗
+            (S.satisfiedBy W γ ∗ s.isPrecondFor W fval) -∗
               wp W.pctx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
-          hswf hΔspec_persist hρspec hΔwf hΔvars himpl
+          hswf hwf hag_persist himpl
           (fun argVars st' ρ' Q hst_sub hρ_agree hargVars_mem hargVars_sort hargVars_lookup hbody_eval => by
-            have hΔspec' : Δ_spec.Subset st'.decls := hΔspec_persist.trans hst_sub
-            have hρspec' : VerifM.Env.agreeOn Δ_spec ρ_spec ρ' := by
-              exact VerifM.Env.agreeOn_trans hρspec (VerifM.Env.agreeOn_mono hΔspec_persist hρ_agree)
+            have hag' : W.agrees st'.decls ρ'.env := hag_persist.step hst_sub hρ_agree
             iintro ⟨Hsl, HQ⟩ Htyped''
-            iapply (checkBody_correct reg hSound W hW S s γ Δ_spec ρ_spec hswf hSwf hΔwf hΔvars fb argBinders body argNames
-              hext bs rfl fval vs P hΔspec' hρspec' hΔreg hρreg hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
+            iapply (checkBody_correct reg hSound W hW S s γ hswf hSwf hwf fb argBinders body argNames
+              hext bs rfl fval vs P hag' hΔreg hρreg hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
             isplitl [Hsl]
             · iexact Hsl
             · isplitl [Htyped'']
@@ -277,8 +271,8 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
                 simp [List.length_map] at hlen
                 omega
               iapply (PredTrans.apply_env_agree W (ρ := Spec.argsEnv ρ_call s.args vs)
-                (ρ' := Spec.argsEnv ρ_spec s.args vs) hswf
-                (Spec.argsEnv_agreeOn (Δ := Δ_spec) (ρ₁ := ρ_call) (ρ₂ := ρ_spec)
+                (ρ' := Spec.argsEnv ⟨W.ρ_spec⟩ s.args vs) hswf
+                (Spec.argsEnv_agreeOn (Δ := W.Δ_spec) (ρ₁ := ρ_call) (ρ₂ := ⟨W.ρ_spec⟩)
                   (VerifM.Env.agreeOn_symm hagree_call) s.args vs hlen_vals_call))
               iexact Hpred'
         iapply Hwand

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -361,7 +361,7 @@ def resultTy (i : Intrinsic) : TinyML.Typ :=
 
 /-- The intrinsic's full arrow (scheme) type. -/
 def arrowType (i : Intrinsic) : TinyML.Typ :=
-  i.argTysList.foldr .arrow i.resultTy
+  .arrow i.argTysList i.resultTy
 
 /-- The typing face of an intrinsic, consumed by the elaborator. -/
 def sig (i : Intrinsic) : Typed.PrimSig :=

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -553,11 +553,11 @@ class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Pr
     ∀ (Δ : Signature), (Signature.empty.extendWithSym i.folSym).Subset Δ → Δ.wf →
       PredTrans.wfIn (Δ.declVars (Spec.argVars i.specArgs)) i.spec.pred
   bridge :
-    ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ) (Θ : TinyML.TypeEnv)
+    ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ) (W : TinyML.World)
       (vs : List Runtime.Val) (ρ : VerifM.Env) (Φ : Runtime.Val → iProp),
     ρ.env.respects i.folSym →
-    TinyML.ValsHaveTypes Θ vs ((i.spec.instantiate σ).args.map Prod.snd) ∗
-      PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r (i.spec.instantiate σ).retTy -∗ Φ r)
+    TinyML.ValsHaveTypes W vs ((i.spec.instantiate σ).args.map Prod.snd) ∗
+      PredTrans.apply W (fun r => TinyML.ValHasType W r (i.spec.instantiate σ).retTy -∗ Φ r)
         (i.spec.instantiate σ).pred
         (Spec.argsEnv ρ (i.spec.instantiate σ).args vs) ⊢ i.toWp vs Φ
   wp_sound :

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -27,6 +27,10 @@ Defines `PredTrans` and `SpecPredicate`.
 def PredTrans := Assertion (Pred (Assertion Unit))
 abbrev SpecPredicate := MultiPred PredTrans
 
+instance : DecidableEq PredTrans := by
+  unfold PredTrans Pred
+  infer_instance
+
 -- ---------------------------------------------------------------------------
 -- Well-formedness
 -- ---------------------------------------------------------------------------

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -59,10 +59,10 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def PredTrans.apply (Θ : TinyML.TypeEnv) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
-  Assertion.pre Θ (fun post ρ' =>
+def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
+  Assertion.pre W (fun post ρ' =>
     BIBase.forall fun v : Runtime.Val =>
-      Assertion.post Θ (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+      Assertion.post W (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
   ) m ρ
 
 -- ---------------------------------------------------------------------------
@@ -106,17 +106,17 @@ theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
         (Signature.wf_declVar hwf'))
     h hsub hwf
 
-theorem PredTrans.apply_env_agree (Θ : TinyML.TypeEnv) {pt : PredTrans} {Φ : Runtime.Val → iProp}
+theorem PredTrans.apply_env_agree (W : TinyML.World) {pt : PredTrans} {Φ : Runtime.Val → iProp}
     {ρ ρ' : VerifM.Env} {Δ : Signature}
     (hwf : pt.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') :
-    PredTrans.apply Θ Φ pt ρ ⊢ PredTrans.apply Θ Φ pt ρ' := by
+    PredTrans.apply W Φ pt ρ ⊢ PredTrans.apply W Φ pt ρ' := by
   unfold PredTrans.apply at ⊢
-  apply Assertion.pre_env_agree Θ hwf hagree
+  apply Assertion.pre_env_agree W hwf hagree
   intro ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree_post
   apply forall_intro
   intro v
   exact (forall_elim v).trans <|
-    Assertion.post_env_agree Θ hwf_post
+    Assertion.post_env_agree W hwf_post
       (VerifM.Env.agreeOn_declVar hagree_post)
       (fun _ _ _ _ _ _ => .rfl)
 
@@ -124,15 +124,15 @@ theorem PredTrans.apply_env_agree (Θ : TinyML.TypeEnv) {pt : PredTrans} {Φ : R
 -- Correctness
 -- ---------------------------------------------------------------------------
 
-theorem PredTrans.call_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
+theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) R :
     pt.wfIn (Δ_base.declVars σ.dom) →
     σ.wfIn Δ_base st.decls →
     VerifM.eval (PredTrans.call σ pt) st ρ Ψ →
     (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
-      (st'.sl Θ ρ' ∗ R ⊢ Φ v)) →
-    st.sl Θ ρ ∗ R ⊢ PredTrans.apply Θ Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+      (st'.sl W ρ' ∗ R ⊢ Φ v)) →
+    st.sl W ρ ∗ R ⊢ PredTrans.apply W Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
   intro hwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind heval
@@ -141,7 +141,7 @@ theorem PredTrans.call_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base :
   let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun post ρ' =>
       BIBase.forall fun v : Runtime.Val =>
-        Assertion.post Θ (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+        Assertion.post W (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
   let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → VerifM.Env → Prop :=
     fun r st' ρ' =>
       match r with
@@ -149,12 +149,12 @@ theorem PredTrans.call_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base :
           let resVar ← VerifM.decl (some postName) Srt.value
           let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
           Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
-  have hpre : st.sl Θ ρ ∗ R ⊢ Assertion.pre Θ Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
-    exact Assertion.prove_correct Θ pt Δ_base σ retWf st ρ Ψcall Φpost R
+  have hpre : st.sl W ρ ∗ R ⊢ Assertion.pre W Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+    exact Assertion.prove_correct W pt Δ_base σ retWf st ρ Ψcall Φpost R
       (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree =>
         forall_intro fun v =>
           (forall_elim v).trans <|
-            Assertion.post_env_agree Θ hwf_post
+            Assertion.post_env_agree W hwf_post
               (VerifM.Env.agreeOn_declVar hagree)
               (fun _ _ _ _ _ _ => .rfl))
       hσwf hwf hb
@@ -179,7 +179,7 @@ theorem PredTrans.call_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base :
         have hwf₁' : Assertion.wfIn (fun _ _ => True) (Δ_base.declVars σ₂.dom) postBody := by
           simpa [σ₂, FiniteSubst.rename_source_eq] using hwf₁
         have hgrow := VerifM.eval.decls_grow (ρ₁.updateConst .value resVar.name v) hb3
-        have hassume := Assertion.assume_correct Θ postBody Δ_base σ₂ (fun _ _ => True)
+        have hassume := Assertion.assume_correct W postBody Δ_base σ₂ (fun _ _ => True)
           { st₁ with decls := st₁.decls.addConst resVar }
           (ρ₁.updateConst .value resVar.name v)
           (fun a st' ρ' =>
@@ -199,10 +199,10 @@ theorem PredTrans.call_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base :
               have := hagree.2.1 resVar (List.Mem.head _)
               simpa [Env.lookupConst, Env.updateConst] using this.symm)
         have hinterp_bi :
-            st₁.sl Θ ρ₁ ⊣⊢ st₁.sl Θ (ρ₁.updateConst .value resVar.name v) :=
-          SpatialContext.interp_env_agree Θ (VerifM.eval.wf hcont).ownsWf
+            st₁.sl W ρ₁ ⊣⊢ st₁.sl W (ρ₁.updateConst .value resVar.name v) :=
+          SpatialContext.interp_env_agree W (VerifM.eval.wf hcont).ownsWf
             (Env.agreeOn_update_fresh_const (c := resVar) hfresh_decls)
-        exact (sep_mono_left hinterp_bi.1).trans <| hassume.trans <| Assertion.post_env_agree Θ hwf₁'
+        exact (sep_mono_left hinterp_bi.1).trans <| hassume.trans <| Assertion.post_env_agree W hwf₁'
           (by
             simpa [σ₂, VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₁.decls)
@@ -212,7 +212,7 @@ theorem PredTrans.call_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base :
   simpa [PredTrans.apply, Φpost] using hpre
 
 
-theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
+theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
     (body : VerifM (Term .value))
     (st : TransState) (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (R : iProp) :
     pt.wfIn (Δ_base.declVars σ.dom) →
@@ -225,9 +225,9 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
       (fun result st'' ρ'' =>
         ∀ (S : iProp),
         result.wfIn st''.decls →
-        (st''.sl Θ ρ'' ∗ Q ∗ (Φ (result.eval ρ''.env) -∗ S) ⊢ S)) →
-      st'.sl Θ ρ' ∗ Q ⊢ R) →
-    st.sl Θ ρ ∗ PredTrans.apply Θ Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ⊢ R := by
+        (st''.sl W ρ'' ∗ Q ∗ (Φ (result.eval ρ''.env) -∗ S) ⊢ S)) →
+      st'.sl W ρ' ∗ Q ⊢ R) →
+    st.sl W ρ ∗ PredTrans.apply W Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ⊢ R := by
   intro hwf hσwf heval hbody
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind heval
@@ -237,10 +237,10 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
   let OuterQ : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun ⟨postName, postBody⟩ ρ' =>
       BIBase.forall fun v : Runtime.Val =>
-        Assertion.post Θ (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
+        Assertion.post W (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
   let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
-  have hpost := Assertion.assume_correct Θ pt Δ_base σ retWf
+  have hpost := Assertion.assume_correct W pt Δ_base σ retWf
     st ρ _ Φpost emp
     (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree => by
       refine wand_intro ?_
@@ -250,7 +250,7 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
       apply forall_intro
       intro v
       exact (forall_elim v).trans <|
-        Assertion.post_env_agree Θ hwf_post
+        Assertion.post_env_agree W hwf_post
           (Env.agreeOn_symm (Env.agreeOn_declVar hagree))
           (fun _ _ _ _ _ _ => .rfl))
     hσwf hwf hb_grow
@@ -258,7 +258,7 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
       apply BIBase.Entails.trans sep_comm.1
       apply BIBase.Entails.trans emp_sep.1
       have hcont_body := VerifM.eval_bind hcont
-      change st₁.sl Θ ρ₁ ⊢ OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) -∗ R
+      change st₁.sl W ρ₁ ⊢ OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) -∗ R
       refine wand_intro ?_
       refine hbody st₁ ρ₁ _ hdsub_st hagree_st ?_
       refine (VerifM.eval.decls_grow ρ₁ hcont_body).mono ?_
@@ -290,14 +290,14 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
         { st₂ with
           decls := st₂.decls.addConst resVar
           asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st₂.asserts }
-      have hpre := @Assertion.prove_correct _ Unit Θ postBody Δ_base σ₂ (fun _ _ => True)
+      have hpre := @Assertion.prove_correct _ Unit W postBody Δ_base σ₂ (fun _ _ => True)
         st₃
         (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
         _ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) (Φ (result.eval ρ₂.env) -∗ S)
         (fun _ _ _ _ _ _ => .rfl)
         hσ₂wf hwf_postBody' hb4
         (fun _ () st' ρ' hret _ _ => by
-          show st'.sl Θ ρ' ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+          show st'.sl W ρ' ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
             (Φ (result.eval ρ₂.env) -∗ S)
           exact sep_elim_right)
       have hag_rename :=
@@ -313,30 +313,30 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
         apply Env.agreeOn_mono
           (FiniteSubst.rename_source_subset_rev σ₁ Δ_base ⟨postName, .value⟩ resVar.name)
         exact Env.agreeOn_update (Env.agreeOn_remove hag_eval)
-      have hpost_transport : Assertion.post Θ (fun () _ => Φ (result.eval ρ₂.env)) postBody
+      have hpost_transport : Assertion.post W (fun () _ => Φ (result.eval ρ₂.env)) postBody
           (VerifM.Env.withEnv ρ₁ ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env))) ⊢
-          Assertion.post Θ (fun () _ => Φ (result.eval ρ₂.env)) postBody
+          Assertion.post W (fun () _ => Φ (result.eval ρ₂.env)) postBody
             (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
               (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
-        exact Assertion.post_env_agree Θ hwf_postBody'
+        exact Assertion.post_env_agree W hwf_postBody'
           (by
             simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv]
               using (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval')))
           (fun _ _ _ _ _ _ => .rfl)
-      have howns_agree : st₃.sl Θ ρ₂
+      have howns_agree : st₃.sl W ρ₂
             ⊢
-          st₃.sl Θ (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) := by
+          st₃.sl W (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) := by
         simpa using
-          (SpatialContext.interp_env_agree Θ (VerifM.eval.wf hrest).ownsWf
+          (SpatialContext.interp_env_agree W (VerifM.eval.wf hrest).ownsWf
             (Env.agreeOn_update_fresh_const hfresh_decls)).1
       have hpre_final :
-          st₂.sl Θ ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
-            Assertion.pre Θ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) postBody
+          st₂.sl W ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+            Assertion.pre W (fun () _ => Φ (result.eval ρ₂.env) -∗ S) postBody
               (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
                 (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
         have hinput :
-            st₂.sl Θ ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
-              st₃.sl Θ (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) ∗
+            st₂.sl W ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
+              st₃.sl W (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) ∗
                 (Φ (result.eval ρ₂.env) -∗ S) := by
           iintro ⟨Howns, Hwand⟩
           iframe Hwand
@@ -345,12 +345,12 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
         exact hinput.trans hpre
       have hpost_final :
           OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) ⊢
-            Assertion.post Θ (fun () _ => Φ (result.eval ρ₂.env)) postBody
+            Assertion.post W (fun () _ => Φ (result.eval ρ₂.env)) postBody
               (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
                 (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
         exact (forall_elim (result.eval ρ₂.env)).trans hpost_transport
       iintro ⟨Howns, HQ, Hwand⟩
-      iapply (Assertion.pre_post_combine Θ
+      iapply (Assertion.pre_post_combine W
         (ρ := VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
           (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env))
         (m := postBody)
@@ -368,16 +368,16 @@ theorem PredTrans.implement_correct (Θ : TinyML.TypeEnv) (pt : PredTrans) (Δ_b
         iexact HQ
       )
   have hpre :
-      PredTrans.apply Θ Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) =
-      Assertion.pre Θ OuterQ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := rfl
+      PredTrans.apply W Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) =
+      Assertion.pre W OuterQ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := rfl
   rw [hpre]
   exact BIBase.Entails.trans
     (by
-      have hpost' : st.sl Θ ρ ∗ emp ⊢
-          Assertion.post Θ Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+      have hpost' : st.sl W ρ ∗ emp ⊢
+          Assertion.post W Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
         simpa [VerifM.Env.withEnv] using hpost
       exact sep_comm.1.trans (sep_mono_right (sep_emp.2.trans hpost')))
-    (Assertion.pre_post_combine Θ
+    (Assertion.pre_post_combine W
       (ρ := VerifM.Env.withEnv ρ (σ.subst.eval ρ.env))
       (m := pt)
       (Φ := OuterQ)

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -495,7 +495,7 @@ theorem Program.prepare_correct (prims : Typed.Prims)
     exact VerifM.eval_ret heval
 
 theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
     (st : TransState) (ρ : VerifM.Env)
@@ -503,17 +503,18 @@ theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.R
     (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
     {Q : Unit → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.checkExpr reg Θ Δ_spec S d) st ρ Q) :
-    (□ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ Φ) →
-    □ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ wp reg.primCtx (d.body.runtime.subst γ) (fun _ => Φ) := by
+    (heval : VerifM.eval (ValDecl.checkExpr reg W.Θ Δ_spec S d) st ρ Q) :
+    (□ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ Φ) →
+    □ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun _ => Φ) := by
   intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind hinner
   have hcomp :=
-    compile_correct reg hSound d.body Θ iprop(□ st.sl Θ ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ Δ_spec ρ_spec
+    compile_correct reg hSound d.body W iprop(□ st.sl W ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ Δ_spec ρ_spec
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => Φ)
+    hW
     hcompile
     (fun _ _ h => by simp at h)
     (fun _ h => by simp at h)
@@ -544,7 +545,7 @@ theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.R
           · iexact Hspec
 
 theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Δ_spec : Signature) (Γfn : FunCtx)
     (ρ_spec : VerifM.Env)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
@@ -553,9 +554,9 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
     (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
     {Q : Spec → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.check reg Θ Δ_spec Γfn S d) st ρ Q) :
+    (heval : VerifM.eval (ValDecl.check reg W.Θ Δ_spec Γfn S d) st ρ Q) :
     ∃ spec, spec.wfIn Δ_spec ∧
-            (□ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ wp reg.primCtx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec v)) ∧
+            (□ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor W Δ_spec ρ_spec v)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.declMeta.spec with
@@ -591,7 +592,7 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
           exact ⟨spec, hswf,
             by
               have hcheck :=
-                checkSpec_correct reg hSound Θ S d.body spec γ Δ_spec ρ_spec
+                checkSpec_correct reg hSound W hW S d.body spec γ Δ_spec ρ_spec
                   hswf hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hcheckSpec
               refine BIBase.Entails.trans ?_ hcheck
               istart
@@ -602,7 +603,7 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
                  VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (Γfn : FunCtx)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Δ_spec : Signature) (Γfn : FunCtx)
     (ρ_spec : VerifM.Env)
     (S : SpecMap) (prog : Typed.Program (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
@@ -610,8 +611,8 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
     (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
     (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg ρ_spec.env) :
-    VerifM.eval (Program.check reg Θ Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
-    □ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ ⊢ pwp reg.primCtx ((Typed.Program.runtime prog).subst γ) := by
+    VerifM.eval (Program.check reg W.Θ Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
+    □ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ pwp W.pctx ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ st ρ with
   | nil =>
     intro _
@@ -623,9 +624,9 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
   | cons d ds ih =>
     intro heval
     have hpwp_unfold :
-        wp reg.primCtx (d.body.runtime.subst γ) (fun v =>
-          pwp reg.primCtx ((Typed.Program.runtime ds).subst (Runtime.Subst.updateBinder d.name.runtime v γ)))
-        ⊢ pwp reg.primCtx ((Typed.Program.runtime (d :: ds)).subst γ) := by
+        wp W.pctx (d.body.runtime.subst γ) (fun v =>
+          pwp W.pctx ((Typed.Program.runtime ds).subst (Runtime.Subst.updateBinder d.name.runtime v γ)))
+        ⊢ pwp W.pctx ((Typed.Program.runtime (d :: ds)).subst γ) := by
       simp only [Typed.Program.runtime, Typed.ValDecl.runtime,
         Runtime.Program.subst, Runtime.Decl.subst, List.map_cons]
       refine BIBase.Entails.trans (wp.mono fun v => ?_) pwp_cons
@@ -645,14 +646,14 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         have hbind := VerifM.eval_bind heval
         have ⟨_, hcont⟩ := VerifM.eval_seq hbind
         have hih := ih S γ hSwf st ρ hΔspec hρspec (VerifM.eval_ret hcont)
-        have hwp := ValDecl.checkExpr_correct reg hSound Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hbind hih
+        have hwp := ValDecl.checkExpr_correct reg hSound W hW Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hbind hih
         refine hwp.trans (wp.mono ?_)
         intro v; rw [hupd v]; exact .rfl
       | some _ =>
         -- unnamed, with spec
         simp only [hname, hspec] at heval
         obtain ⟨spec, _, hwp, hcont⟩ :=
-          ValDecl.check_correct reg hSound Θ Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg (VerifM.eval_bind heval)
+          ValDecl.check_correct reg hSound W hW Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg (VerifM.eval_bind heval)
         have hih := ih S γ hSwf st ρ hΔspec hρspec hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
@@ -684,7 +685,7 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
               (args.map (·.runtime))))
           apply SpatialContext.wp_func
           rw [hupd fval]
-          have heval' : VerifM.eval (Program.check reg Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) := by
+          have heval' : VerifM.eval (Program.check reg W.Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) := by
             convert heval
           have hih := ih (S.erase n) (γ.update n fval)
             (SpecMap.wfIn_erase hSwf) st ρ hΔspec hρspec heval'
@@ -698,9 +699,9 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         · -- named, no spec, not a function
           have hbind := VerifM.eval_bind heval
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          have hcont' : VerifM.eval (Program.check reg Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) :=
+          have hcont' : VerifM.eval (Program.check reg W.Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) :=
             VerifM.eval_ret hcont
-          have hwp := ValDecl.checkExpr_correct reg hSound Θ Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hbind
+          have hwp := ValDecl.checkExpr_correct reg hSound W hW Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hbind
             (Φ := iprop(emp)) (by istart; iintro _; iempintro)
           refine SpatialContext.wp_strengthen_persistent hwp ?_
           intro v
@@ -717,16 +718,16 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
       | some _ =>
         simp only [hname, hspec] at heval
         obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          ValDecl.check_correct reg hSound Θ Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg (VerifM.eval_bind heval)
-        have hcont' : VerifM.eval (Program.check reg Θ Δ_spec Γfn (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
+          ValDecl.check_correct reg hSound W hW Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg (VerifM.eval_bind heval)
+        have hcont' : VerifM.eval (Program.check reg W.Θ Δ_spec Γfn (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
           convert hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
         have hih := ih (S.insert n spec) (γ.update n v)
           (SpecMap.wfIn_insert hSwf hswf) st ρ hΔspec hρspec hcont'
-        have hstep : (□ st.sl Θ ρ ∗ S.satisfiedBy reg.primCtx Θ Δ_spec ρ_spec γ) ∗ spec.isPrecondFor reg.primCtx Θ Δ_spec ρ_spec v ⊢
-            pwp reg.primCtx ((Typed.Program.runtime ds).subst (γ.update n v)) := by
+        have hstep : (□ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ) ∗ spec.isPrecondFor W Δ_spec ρ_spec v ⊢
+            pwp W.pctx ((Typed.Program.runtime ds).subst (γ.update n v)) := by
           refine BIBase.Entails.trans ?_ hih
           istart
           iintro ⟨Hctx, Hpre⟩
@@ -804,7 +805,10 @@ theorem Program.verify_correct (reg : Verifier.Registry)
     have hρreg : Verifier.Registry.symAgree reg ρRel.env := by
       intro i hi
       exact hstable_setup ρRel hag_setup_rel i hi
-    have hcorrect := Program.check_correct reg hSound Θ stRel.decls spec0.functionMap ρRel
+    -- The meta-level world: the registry's operational context together with the
+    -- type environment the elaborator produced.
+    let W : TinyML.World := { pctx := reg.primCtx, Θ }
+    have hcorrect := Program.check_correct reg hSound W rfl stRel.decls spec0.functionMap ρRel
                        ∅ (pairs.map Prod.fst) Runtime.Subst.id
                        (SpecMap.empty_wfIn _)
                        hcheck_eval.1.namesDisjoint
@@ -816,8 +820,8 @@ theorem Program.verify_correct (reg : Verifier.Registry)
                        hρreg
                        hcheck_eval
     rw [Runtime.Program.subst_id] at hcorrect
-    have hctx0 : (⊢ □ stRel.sl Θ ρRel ∗
-        SpecMap.satisfiedBy reg.primCtx Θ stRel.decls ρRel (∅ : SpecMap) Runtime.Subst.id) := by
+    have hctx0 : (⊢ □ stRel.sl W ρRel ∗
+        SpecMap.satisfiedBy W stRel.decls ρRel (∅ : SpecMap) Runtime.Subst.id) := by
       istart
       isplitl []
       · simp [TransState.sl, howns]

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -457,13 +457,6 @@ def Program.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Sig
         | none => S
       Program.check reg Θ Δ_spec Γfn S' ds
 
-/-- Empty relation signature used before global relation assembly. -/
-def Δ_spec : Signature := Signature.empty
-
-/-- Initial verifier environment threaded through program verification.
-    Proper relation support must populate this with relation interpretations. -/
-def ρ_spec : VerifM.Env := VerifM.Env.empty
-
 def Program.verify (reg : Verifier.Registry) (prog : Untyped.Program (Spec.Body Untyped.Expr)) : Smt.Strategy Smt.Strategy.Outcome :=
   VerifM.strategy do
     let (Θ, typed) ← Program.prepare reg.sigs prog
@@ -495,32 +488,31 @@ theorem Program.prepare_correct (prims : Typed.Prims)
     exact VerifM.eval_ret heval
 
 theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : VerifM.Env)
-    (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
-    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
-    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
+    (hag : W.agrees st.decls ρ.env)
+    (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
     {Q : Unit → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.checkExpr reg W.Θ Δ_spec S d) st ρ Q) :
-    (□ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ Φ) →
-    □ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun _ => Φ) := by
+    (heval : VerifM.eval (ValDecl.checkExpr reg W.Θ W.Δ_spec S d) st ρ Q) :
+    (□ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ Φ) →
+    □ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun _ => Φ) := by
   intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind hinner
   have hcomp :=
-    compile_correct reg hSound d.body W iprop(□ st.sl W ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ Δ_spec ρ_spec
+    compile_correct reg hSound d.body W iprop(□ st.sl W ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => Φ)
     hW
     hcompile
     (fun _ _ h => by simp at h)
     (fun _ h => by simp at h)
-    hSwf hΔwf hΔvars
-    hΔspec
-    hρspec
+    hSwf hwf
+    hag
     hΔreg
     hρreg
     (fun _ _ _ _ _ _ _ => by
@@ -545,18 +537,17 @@ theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.R
           · iexact Hspec
 
 theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Δ_spec : Signature) (Γfn : FunCtx)
-    (ρ_spec : VerifM.Env)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Γfn : FunCtx)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : VerifM.Env)
-    (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
-    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
-    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env)
+    (hag : W.agrees st.decls ρ.env)
+    (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
     {Q : Spec → TransState → VerifM.Env → Prop}
-    (heval : VerifM.eval (ValDecl.check reg W.Θ Δ_spec Γfn S d) st ρ Q) :
-    ∃ spec, spec.wfIn Δ_spec ∧
-            (□ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor W Δ_spec ρ_spec v)) ∧
+    (heval : VerifM.eval (ValDecl.check reg W.Θ W.Δ_spec Γfn S d) st ρ Q) :
+    ∃ spec, spec.wfIn W.Δ_spec ∧
+            (□ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor W v)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.declMeta.spec with
@@ -580,20 +571,20 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
       | ok spec =>
         simp only [hcomplete] at h2
         have h3 := VerifM.eval_ret (VerifM.eval_bind h2)
-        cases hwf : Spec.checkWf spec Δ_spec with
+        cases hcheckWf : Spec.checkWf spec W.Δ_spec with
         | error msg =>
-          simp only [hwf] at h3
+          simp only [hcheckWf] at h3
           exact (VerifM.eval_fatal (VerifM.eval_bind h3)).elim
         | ok u =>
-          simp only [hwf] at h3
+          simp only [hcheckWf] at h3
           have h4 := VerifM.eval_ret (VerifM.eval_bind h3)
-          have hswf : spec.wfIn Δ_spec := Spec.checkWf_ok (by cases u; exact hwf)
+          have hswf : spec.wfIn W.Δ_spec := Spec.checkWf_ok (by cases u; exact hcheckWf)
           have ⟨hcheckSpec, hpure⟩ := VerifM.eval_seq h4
           exact ⟨spec, hswf,
             by
               have hcheck :=
-                checkSpec_correct reg hSound W hW S d.body spec γ Δ_spec ρ_spec
-                  hswf hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hcheckSpec
+                checkSpec_correct reg hSound W hW S d.body spec γ
+                  hswf hSwf hwf st ρ hag hΔreg hρreg hcheckSpec
               refine BIBase.Entails.trans ?_ hcheck
               istart
               iintro ⟨#Hsl, #Hspec⟩
@@ -603,16 +594,15 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
                  VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Δ_spec : Signature) (Γfn : FunCtx)
-    (ρ_spec : VerifM.Env)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Γfn : FunCtx)
     (S : SpecMap) (prog : Typed.Program (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
-    (hSwf : S.wfIn Δ_spec) (hΔwf : Δ_spec.wf) (hΔvars : Δ_spec.vars = [])
+    (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : VerifM.Env)
-    (hΔspec : Δ_spec.Subset st.decls) (hρspec : VerifM.Env.agreeOn Δ_spec ρ_spec ρ)
-    (hΔreg : Verifier.Registry.symSubset reg Δ_spec)
-    (hρreg : Verifier.Registry.symAgree reg ρ_spec.env) :
-    VerifM.eval (Program.check reg W.Θ Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
-    □ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ ⊢ pwp W.pctx ((Typed.Program.runtime prog).subst γ) := by
+    (hag : W.agrees st.decls ρ.env)
+    (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
+    (hρreg : Verifier.Registry.symAgree reg W.ρ_spec) :
+    VerifM.eval (Program.check reg W.Θ W.Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
+    □ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ pwp W.pctx ((Typed.Program.runtime prog).subst γ) := by
   induction prog generalizing S γ st ρ with
   | nil =>
     intro _
@@ -645,16 +635,16 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         simp only [hname, hspec] at heval
         have hbind := VerifM.eval_bind heval
         have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-        have hih := ih S γ hSwf st ρ hΔspec hρspec (VerifM.eval_ret hcont)
-        have hwp := ValDecl.checkExpr_correct reg hSound W hW Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hbind hih
+        have hih := ih S γ hSwf st ρ hag (VerifM.eval_ret hcont)
+        have hwp := ValDecl.checkExpr_correct reg hSound W hW S d γ hSwf hwf st ρ hag hΔreg hρreg hbind hih
         refine hwp.trans (wp.mono ?_)
         intro v; rw [hupd v]; exact .rfl
       | some _ =>
         -- unnamed, with spec
         simp only [hname, hspec] at heval
         obtain ⟨spec, _, hwp, hcont⟩ :=
-          ValDecl.check_correct reg hSound W hW Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg (VerifM.eval_bind heval)
-        have hih := ih S γ hSwf st ρ hΔspec hρspec hcont
+          ValDecl.check_correct reg hSound W hW Γfn S d γ hSwf hwf st ρ hag hΔreg hρreg (VerifM.eval_bind heval)
+        have hih := ih S γ hSwf st ρ hag hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
@@ -685,10 +675,10 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
               (args.map (·.runtime))))
           apply SpatialContext.wp_func
           rw [hupd fval]
-          have heval' : VerifM.eval (Program.check reg W.Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) := by
+          have heval' : VerifM.eval (Program.check reg W.Θ W.Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) := by
             convert heval
           have hih := ih (S.erase n) (γ.update n fval)
-            (SpecMap.wfIn_erase hSwf) st ρ hΔspec hρspec heval'
+            (SpecMap.wfIn_erase hSwf) st ρ hag heval'
           refine BIBase.Entails.trans ?_ hih
           istart
           iintro ⟨#Hsl, #Hspec⟩
@@ -699,14 +689,14 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         · -- named, no spec, not a function
           have hbind := VerifM.eval_bind heval
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          have hcont' : VerifM.eval (Program.check reg W.Θ Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) :=
+          have hcont' : VerifM.eval (Program.check reg W.Θ W.Δ_spec Γfn (S.erase n) ds) st ρ (fun _ _ _ => True) :=
             VerifM.eval_ret hcont
-          have hwp := ValDecl.checkExpr_correct reg hSound W hW Δ_spec ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg hbind
+          have hwp := ValDecl.checkExpr_correct reg hSound W hW S d γ hSwf hwf st ρ hag hΔreg hρreg hbind
             (Φ := iprop(emp)) (by istart; iintro _; iempintro)
           refine SpatialContext.wp_strengthen_persistent hwp ?_
           intro v
           rw [hupd v]
-          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) st ρ hΔspec hρspec hcont'
+          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) st ρ hag hcont'
           exact wand_intro (sep_elim_left.trans <| by
             refine BIBase.Entails.trans ?_ hih
             istart
@@ -718,15 +708,15 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
       | some _ =>
         simp only [hname, hspec] at heval
         obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          ValDecl.check_correct reg hSound W hW Δ_spec Γfn ρ_spec S d γ hSwf hΔwf hΔvars st ρ hΔspec hρspec hΔreg hρreg (VerifM.eval_bind heval)
-        have hcont' : VerifM.eval (Program.check reg W.Θ Δ_spec Γfn (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
+          ValDecl.check_correct reg hSound W hW Γfn S d γ hSwf hwf st ρ hag hΔreg hρreg (VerifM.eval_bind heval)
+        have hcont' : VerifM.eval (Program.check reg W.Θ W.Δ_spec Γfn (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
           convert hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
         have hih := ih (S.insert n spec) (γ.update n v)
-          (SpecMap.wfIn_insert hSwf hswf) st ρ hΔspec hρspec hcont'
-        have hstep : (□ st.sl W ρ ∗ S.satisfiedBy W Δ_spec ρ_spec γ) ∗ spec.isPrecondFor W Δ_spec ρ_spec v ⊢
+          (SpecMap.wfIn_insert hSwf hswf) st ρ hag hcont'
+        have hstep : (□ st.sl W ρ ∗ S.satisfiedBy W γ) ∗ spec.isPrecondFor W v ⊢
             pwp W.pctx ((Typed.Program.runtime ds).subst (γ.update n v)) := by
           refine BIBase.Entails.trans ?_ hih
           istart
@@ -805,23 +795,23 @@ theorem Program.verify_correct (reg : Verifier.Registry)
     have hρreg : Verifier.Registry.symAgree reg ρRel.env := by
       intro i hi
       exact hstable_setup ρRel hag_setup_rel i hi
-    -- The meta-level world: the registry's operational context together with the
-    -- type environment the elaborator produced.
-    let W : TinyML.World := { pctx := reg.primCtx, Θ }
-    have hcorrect := Program.check_correct reg hSound W rfl stRel.decls spec0.functionMap ρRel
+    -- The meta-level world: the registry's operational context, the type
+    -- environment the elaborator produced, and the specification model the
+    -- relational declarations left in the state.
+    let W : TinyML.World :=
+      { pctx := reg.primCtx, Θ, Δ_spec := stRel.decls, ρ_spec := ρRel.env }
+    have hcorrect := Program.check_correct reg hSound W rfl spec0.functionMap
                        ∅ (pairs.map Prod.fst) Runtime.Subst.id
                        (SpecMap.empty_wfIn _)
-                       hcheck_eval.1.namesDisjoint
-                       hvars
+                       ⟨hcheck_eval.1.namesDisjoint, hvars⟩
                        stRel ρRel
-                       (Signature.Subset.refl _)
-                       VerifM.Env.agreeOn_refl
+                       ⟨Signature.Subset.refl _, VerifM.Env.agreeOn_refl⟩
                        hΔreg
                        hρreg
                        hcheck_eval
     rw [Runtime.Program.subst_id] at hcorrect
     have hctx0 : (⊢ □ stRel.sl W ρRel ∗
-        SpecMap.satisfiedBy W stRel.decls ρRel (∅ : SpecMap) Runtime.Subst.id) := by
+        SpecMap.satisfiedBy W (∅ : SpecMap) Runtime.Subst.id) := by
       istart
       isplitl []
       · simp [TransState.sl, howns]

--- a/Mica/Verifier/SpecMaps.lean
+++ b/Mica/Verifier/SpecMaps.lean
@@ -19,23 +19,23 @@ variable [MicaGS HasLC.hasLC Sig]
 
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
-def SpecMap.satisfiedBy (pctx : TinyML.PrimCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+def SpecMap.satisfiedBy (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (S : SpecMap) (γ : Runtime.Subst) : iProp :=
   iprop(□ (∀ x s, ⌜S.lookup x = some s⌝ -∗
-    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor pctx Θ Δ_spec ρ_spec f))
+    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor W Δ_spec ρ_spec f))
 
-instance : Iris.BI.Persistent (SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec S γ) := by
+instance : Iris.BI.Persistent (SpecMap.satisfiedBy W Δ_spec ρ_spec S γ) := by
   unfold SpecMap.satisfiedBy; infer_instance
 
 theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp)
-    (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (S : SpecMap) (γ : Runtime.Subst) :
-  (P ⊢ S.satisfiedBy pctx Θ Δ_spec ρ_spec γ) →
+    (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (S : SpecMap) (γ : Runtime.Subst) :
+  (P ⊢ S.satisfiedBy W Δ_spec ρ_spec γ) →
   S.lookup x = some s →
-  (∀ fval, γ x = some fval → s.isPrecondFor pctx Θ Δ_spec ρ_spec fval ∗ P ⊢ Q) →
+  (∀ fval, γ x = some fval → s.isPrecondFor W Δ_spec ρ_spec fval ∗ P ⊢ Q) →
   (P ⊢ Q) := by
   intro hsat hlook hcont
   simp only [SpecMap.satisfiedBy] at hsat
-  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor pctx Θ Δ_spec ρ_spec fval) ∗ P := by
+  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor W Δ_spec ρ_spec fval) ∗ P := by
     refine (persistent_entails_right hsat).trans ?_
     istart
     iintro ⟨#Hall, HP⟩
@@ -134,11 +134,11 @@ omit [MicaGS HasLC.hasLC Sig] in
 
 /-- Generic preservation: if every `y` in the domain of `S'` has the same spec in `S` and
     its value is preserved from `γ` to `γ'`, then satisfiedness transfers. -/
-theorem SpecMap.satisfiedBy_preserved {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+theorem SpecMap.satisfiedBy_preserved {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
     {S S' : SpecMap} {γ γ' : Runtime.Subst}
     (h : ∀ y s, S'.lookup y = some s →
       S.lookup y = some s ∧ (∀ f, γ y = some f → γ' y = some f)) :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢ S'.satisfiedBy pctx Θ Δ_spec ρ_spec γ' := by
+    S.satisfiedBy W Δ_spec ρ_spec γ ⊢ S'.satisfiedBy W Δ_spec ρ_spec γ' := by
   simp only [SpecMap.satisfiedBy]
   iintro #HS
   imodintro
@@ -151,12 +151,12 @@ theorem SpecMap.satisfiedBy_preserved {Θ : TinyML.TypeEnv} {Δ_spec : Signature
   ipureintro; exact hγ f hγf
 
 /-- Generic insert: fresh precondition for `x ↦ fval` plus preservation elsewhere. -/
-theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap}
+theorem SpecMap.satisfiedBy_insert_of_preserved {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap}
     {γ γ' : Runtime.Subst} {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
     (hγ' : γ' x = some fval)
     (hγ : ∀ y f, y ≠ x → γ y = some f → γ' y = some f) :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ' := by
+    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.insert x spec S) γ' := by
   simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
   iintro ⟨#HS, #Hf⟩
   imodintro
@@ -175,16 +175,16 @@ theorem SpecMap.satisfiedBy_insert_of_preserved {Θ : TinyML.TypeEnv} {Δ_spec :
     iframe Hpre
     ipureintro; exact hγ y f hyx hγf
 
-theorem SpecMap.satisfiedBy_insert {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) γ :=
+    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.insert x spec S) γ :=
   SpecMap.satisfiedBy_insert_of_preserved hγ (fun _ _ _ hf => hf)
 
-theorem SpecMap.satisfiedBy_insert_update {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert_update {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec v ⊢
-      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (Finmap.insert x spec S) (γ.update x v) :=
+    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec v ⊢
+      SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.insert x spec S) (γ.update x v) :=
   SpecMap.satisfiedBy_insert_of_preserved
     (by simp [Runtime.Subst.update])
     (fun y f hyx hf => by simp [Runtime.Subst.update, beq_false_of_ne hyx, hf])
@@ -197,20 +197,20 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup; exact hs
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup; exact hS y s' hlookup
 
-theorem SpecMap.satisfiedBy_insertBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insertBinder {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
     (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval) :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (S.insertBinder b spec) γ := by
+    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec fval ⊢
+      SpecMap.satisfiedBy W Δ_spec ρ_spec (S.insertBinder b spec) γ := by
   rcases hb : b.name with _ | x
   · rw [SpecMap.insertBinder_none hb]; iintro ⟨HS, _⟩; iexact HS
   · obtain ⟨_, ty⟩ := b; cases hb
     rw [SpecMap.insertBinder_some rfl]; exact SpecMap.satisfiedBy_insert (hγ x ty rfl)
 
-theorem SpecMap.satisfiedBy_insertBinder_updateBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insertBinder_updateBinder {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ∗ spec.isPrecondFor pctx Θ Δ_spec ρ_spec v ⊢
-      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec v ⊢
+      SpecMap.satisfiedBy W Δ_spec ρ_spec (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.insertBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]; iintro ⟨HS, _⟩; iexact HS
@@ -231,11 +231,11 @@ theorem SpecMap.wfIn_eraseBinder {S : SpecMap} {b : Typed.Binder} {Δ : Signatur
   · rwa [SpecMap.eraseBinder_none hb]
   · rw [SpecMap.eraseBinder_some hb]; exact SpecMap.wfIn_erase hS
 
-theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
     {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
     {vs : List Runtime.Val} (hlen : keys.length = vs.length) :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢
-      (SpecMap.eraseAll keys S).satisfiedBy pctx Θ Δ_spec ρ_spec (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
+    S.satisfiedBy W Δ_spec ρ_spec γ ⊢
+      (SpecMap.eraseAll keys S).satisfiedBy W Δ_spec ρ_spec (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hy_notin : y ∉ keys := by
@@ -249,8 +249,8 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {Θ : TinyML.TypeEnv} {Δ_s
       findVal_none_of_not_mem keys vs y (by omega) hy_notin]
   exact hf
 
-theorem SpecMap.empty_satisfiedBy (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (γ : Runtime.Subst) :
-    ⊢ SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (∅ : SpecMap) γ := by
+theorem SpecMap.empty_satisfiedBy (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (γ : Runtime.Subst) :
+    ⊢ SpecMap.satisfiedBy W Δ_spec ρ_spec (∅ : SpecMap) γ := by
   simp only [SpecMap.satisfiedBy]
   imodintro
   iintro %x %s %h
@@ -261,10 +261,10 @@ theorem SpecMap.empty_wfIn (Δ : Signature) :
     SpecMap.wfIn (∅ : SpecMap) Δ := by
   intro f spec h; simp [Finmap.lookup_empty] at h
 
-theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+theorem SpecMap.satisfiedBy_erase {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
     {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢
-      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
+    S.satisfiedBy W Δ_spec ρ_spec γ ⊢
+      SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by
@@ -272,19 +272,19 @@ theorem SpecMap.satisfiedBy_erase {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {�
   exact ⟨by rwa [Finmap.lookup_erase_ne hyx] at hlookup,
     fun f hf => by simp [Runtime.Subst.update, hyx, hf]⟩
 
-theorem SpecMap.satisfiedBy_eraseBinder {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_eraseBinder {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢
-      SpecMap.satisfiedBy pctx Θ Δ_spec ρ_spec (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy W Δ_spec ρ_spec γ ⊢
+      SpecMap.satisfiedBy W Δ_spec ρ_spec (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.eraseBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]
   · rw [SpecMap.eraseBinder_some hb, Typed.Binder.runtime_of_name_some hb]
     exact SpecMap.satisfiedBy_erase
 
-theorem SpecMap.satisfiedBy_update_of_not_mem {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_update_of_not_mem {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} (hx : S.lookup x = none) :
-    S.satisfiedBy pctx Θ Δ_spec ρ_spec γ ⊢ S.satisfiedBy pctx Θ Δ_spec ρ_spec (γ.update x v) := by
+    S.satisfiedBy W Δ_spec ρ_spec γ ⊢ S.satisfiedBy W Δ_spec ρ_spec (γ.update x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)

--- a/Mica/Verifier/SpecMaps.lean
+++ b/Mica/Verifier/SpecMaps.lean
@@ -19,23 +19,23 @@ variable [MicaGS HasLC.hasLC Sig]
 
 abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
 
-def SpecMap.satisfiedBy (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+def SpecMap.satisfiedBy (W : TinyML.World)
     (S : SpecMap) (γ : Runtime.Subst) : iProp :=
   iprop(□ (∀ x s, ⌜S.lookup x = some s⌝ -∗
-    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor W Δ_spec ρ_spec f))
+    ∃ f, ⌜γ x = some f⌝ ∗ s.isPrecondFor W f))
 
-instance : Iris.BI.Persistent (SpecMap.satisfiedBy W Δ_spec ρ_spec S γ) := by
+instance : Iris.BI.Persistent (SpecMap.satisfiedBy W S γ) := by
   unfold SpecMap.satisfiedBy; infer_instance
 
 theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp)
-    (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (S : SpecMap) (γ : Runtime.Subst) :
-  (P ⊢ S.satisfiedBy W Δ_spec ρ_spec γ) →
+    (W : TinyML.World) (S : SpecMap) (γ : Runtime.Subst) :
+  (P ⊢ S.satisfiedBy W γ) →
   S.lookup x = some s →
-  (∀ fval, γ x = some fval → s.isPrecondFor W Δ_spec ρ_spec fval ∗ P ⊢ Q) →
+  (∀ fval, γ x = some fval → s.isPrecondFor W fval ∗ P ⊢ Q) →
   (P ⊢ Q) := by
   intro hsat hlook hcont
   simp only [SpecMap.satisfiedBy] at hsat
-  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor W Δ_spec ρ_spec fval) ∗ P := by
+  have hstep : P ⊢ (∃ fval, ⌜γ x = some fval⌝ ∗ s.isPrecondFor W fval) ∗ P := by
     refine (persistent_entails_right hsat).trans ?_
     istart
     iintro ⟨#Hall, HP⟩
@@ -134,11 +134,11 @@ omit [MicaGS HasLC.hasLC Sig] in
 
 /-- Generic preservation: if every `y` in the domain of `S'` has the same spec in `S` and
     its value is preserved from `γ` to `γ'`, then satisfiedness transfers. -/
-theorem SpecMap.satisfiedBy_preserved {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+theorem SpecMap.satisfiedBy_preserved {W : TinyML.World}
     {S S' : SpecMap} {γ γ' : Runtime.Subst}
     (h : ∀ y s, S'.lookup y = some s →
       S.lookup y = some s ∧ (∀ f, γ y = some f → γ' y = some f)) :
-    S.satisfiedBy W Δ_spec ρ_spec γ ⊢ S'.satisfiedBy W Δ_spec ρ_spec γ' := by
+    S.satisfiedBy W γ ⊢ S'.satisfiedBy W γ' := by
   simp only [SpecMap.satisfiedBy]
   iintro #HS
   imodintro
@@ -151,12 +151,12 @@ theorem SpecMap.satisfiedBy_preserved {W : TinyML.World} {Δ_spec : Signature} {
   ipureintro; exact hγ f hγf
 
 /-- Generic insert: fresh precondition for `x ↦ fval` plus preservation elsewhere. -/
-theorem SpecMap.satisfiedBy_insert_of_preserved {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap}
+theorem SpecMap.satisfiedBy_insert_of_preserved {W : TinyML.World} {S : SpecMap}
     {γ γ' : Runtime.Subst} {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
     (hγ' : γ' x = some fval)
     (hγ : ∀ y f, y ≠ x → γ y = some f → γ' y = some f) :
-    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.insert x spec S) γ' := by
+    S.satisfiedBy W γ ∗ spec.isPrecondFor W fval ⊢
+      SpecMap.satisfiedBy W (Finmap.insert x spec S) γ' := by
   simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
   iintro ⟨#HS, #Hf⟩
   imodintro
@@ -175,16 +175,16 @@ theorem SpecMap.satisfiedBy_insert_of_preserved {W : TinyML.World} {Δ_spec : Si
     iframe Hpre
     ipureintro; exact hγ y f hyx hγf
 
-theorem SpecMap.satisfiedBy_insert {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
-    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.insert x spec S) γ :=
+    S.satisfiedBy W γ ∗ spec.isPrecondFor W fval ⊢
+      SpecMap.satisfiedBy W (Finmap.insert x spec S) γ :=
   SpecMap.satisfiedBy_insert_of_preserved hγ (fun _ _ _ hf => hf)
 
-theorem SpecMap.satisfiedBy_insert_update {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insert_update {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec v ⊢
-      SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.insert x spec S) (γ.update x v) :=
+    S.satisfiedBy W γ ∗ spec.isPrecondFor W v ⊢
+      SpecMap.satisfiedBy W (Finmap.insert x spec S) (γ.update x v) :=
   SpecMap.satisfiedBy_insert_of_preserved
     (by simp [Runtime.Subst.update])
     (fun y f hyx hf => by simp [Runtime.Subst.update, beq_false_of_ne hyx, hf])
@@ -197,20 +197,20 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
   · subst hyx; rw [Finmap.lookup_insert] at hlookup; simp at hlookup; subst hlookup; exact hs
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup; exact hS y s' hlookup
 
-theorem SpecMap.satisfiedBy_insertBinder {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insertBinder {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
     (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval) :
-    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec fval ⊢
-      SpecMap.satisfiedBy W Δ_spec ρ_spec (S.insertBinder b spec) γ := by
+    S.satisfiedBy W γ ∗ spec.isPrecondFor W fval ⊢
+      SpecMap.satisfiedBy W (S.insertBinder b spec) γ := by
   rcases hb : b.name with _ | x
   · rw [SpecMap.insertBinder_none hb]; iintro ⟨HS, _⟩; iexact HS
   · obtain ⟨_, ty⟩ := b; cases hb
     rw [SpecMap.insertBinder_some rfl]; exact SpecMap.satisfiedBy_insert (hγ x ty rfl)
 
-theorem SpecMap.satisfiedBy_insertBinder_updateBinder {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_insertBinder_updateBinder {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
-    S.satisfiedBy W Δ_spec ρ_spec γ ∗ spec.isPrecondFor W Δ_spec ρ_spec v ⊢
-      SpecMap.satisfiedBy W Δ_spec ρ_spec (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy W γ ∗ spec.isPrecondFor W v ⊢
+      SpecMap.satisfiedBy W (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.insertBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]; iintro ⟨HS, _⟩; iexact HS
@@ -231,11 +231,11 @@ theorem SpecMap.wfIn_eraseBinder {S : SpecMap} {b : Typed.Binder} {Δ : Signatur
   · rwa [SpecMap.eraseBinder_none hb]
   · rw [SpecMap.eraseBinder_some hb]; exact SpecMap.wfIn_erase hS
 
-theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {W : TinyML.World}
     {keys : List String} {S : SpecMap} {γ : Runtime.Subst}
     {vs : List Runtime.Val} (hlen : keys.length = vs.length) :
-    S.satisfiedBy W Δ_spec ρ_spec γ ⊢
-      (SpecMap.eraseAll keys S).satisfiedBy W Δ_spec ρ_spec (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
+    S.satisfiedBy W γ ⊢
+      (SpecMap.eraseAll keys S).satisfiedBy W (γ.updateAllBinder (keys.map Runtime.Binder.named) vs) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hy_notin : y ∉ keys := by
@@ -249,8 +249,8 @@ theorem SpecMap.satisfiedBy_eraseAll_updateAllBinder {W : TinyML.World} {Δ_spec
       findVal_none_of_not_mem keys vs y (by omega) hy_notin]
   exact hf
 
-theorem SpecMap.empty_satisfiedBy (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (γ : Runtime.Subst) :
-    ⊢ SpecMap.satisfiedBy W Δ_spec ρ_spec (∅ : SpecMap) γ := by
+theorem SpecMap.empty_satisfiedBy (W : TinyML.World) (γ : Runtime.Subst) :
+    ⊢ SpecMap.satisfiedBy W (∅ : SpecMap) γ := by
   simp only [SpecMap.satisfiedBy]
   imodintro
   iintro %x %s %h
@@ -261,10 +261,10 @@ theorem SpecMap.empty_wfIn (Δ : Signature) :
     SpecMap.wfIn (∅ : SpecMap) Δ := by
   intro f spec h; simp [Finmap.lookup_empty] at h
 
-theorem SpecMap.satisfiedBy_erase {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env}
+theorem SpecMap.satisfiedBy_erase {W : TinyML.World}
     {S : SpecMap} {γ : Runtime.Subst} {x : TinyML.Var} {v : Runtime.Val} :
-    S.satisfiedBy W Δ_spec ρ_spec γ ⊢
-      SpecMap.satisfiedBy W Δ_spec ρ_spec (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
+    S.satisfiedBy W γ ⊢
+      SpecMap.satisfiedBy W (Finmap.erase x S) (Runtime.Subst.update γ x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by
@@ -272,19 +272,19 @@ theorem SpecMap.satisfiedBy_erase {W : TinyML.World} {Δ_spec : Signature} {ρ_s
   exact ⟨by rwa [Finmap.lookup_erase_ne hyx] at hlookup,
     fun f hf => by simp [Runtime.Subst.update, hyx, hf]⟩
 
-theorem SpecMap.satisfiedBy_eraseBinder {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_eraseBinder {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
     {b : Typed.Binder} {v : Runtime.Val} :
-    S.satisfiedBy W Δ_spec ρ_spec γ ⊢
-      SpecMap.satisfiedBy W Δ_spec ρ_spec (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
+    S.satisfiedBy W γ ⊢
+      SpecMap.satisfiedBy W (S.eraseBinder b) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
   · rw [SpecMap.eraseBinder_none hb, Typed.Binder.runtime_of_name_none hb]
     simp [Runtime.Subst.updateBinder]
   · rw [SpecMap.eraseBinder_some hb, Typed.Binder.runtime_of_name_some hb]
     exact SpecMap.satisfiedBy_erase
 
-theorem SpecMap.satisfiedBy_update_of_not_mem {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {S : SpecMap} {γ : Runtime.Subst}
+theorem SpecMap.satisfiedBy_update_of_not_mem {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
     {x : TinyML.Var} {v : Runtime.Val} (hx : S.lookup x = none) :
-    S.satisfiedBy W Δ_spec ρ_spec γ ⊢ S.satisfiedBy W Δ_spec ρ_spec (γ.update x v) := by
+    S.satisfiedBy W γ ⊢ S.satisfiedBy W (γ.update x v) := by
   apply SpecMap.satisfiedBy_preserved
   intro y s hlookup
   have hyx : y ≠ x := fun heq => by subst heq; rw [hx] at hlookup; exact absurd hlookup (by simp)

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -30,6 +30,7 @@ structure Spec where
   args    : List (String × TinyML.Typ)
   retTy   : TinyML.Typ
   pred    : PredTrans
+  deriving DecidableEq
 
 namespace Spec
 

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -70,14 +70,14 @@ def argsEnv (ρ : VerifM.Env) : List (String × TinyML.Typ) → List Runtime.Val
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
 
-def isPrecondFor (pctx : TinyML.PrimCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+def isPrecondFor (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (f : Runtime.Val) (s : Spec) : iProp :=
   iprop(□ ∀ (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
-      TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
-        PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+      TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
+        PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
           (argsEnv ρ s.args vs) -∗
-        wp pctx (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
+        wp W.pctx (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
     context extended with all argument variables. -/
@@ -132,20 +132,20 @@ def implement (Δ_base : Signature) (s : Spec) (body : List FOL.Const → VerifM
 /-! ## Precondition Proofs -/
 section Precondition
 
-instance : Iris.BI.Persistent (isPrecondFor pctx Θ Δ_spec ρ_spec f s) := by
+instance : Iris.BI.Persistent (isPrecondFor W Δ_spec ρ_spec f s) := by
   unfold isPrecondFor
   infer_instance
 
 /-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
-theorem isPrecondFor_intro (pctx : TinyML.PrimCtx) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (s : Spec)
+theorem isPrecondFor_intro (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (s : Spec)
     (f : Runtime.Val) :
     iprop(□ ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
       (⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
-        TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-        PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+        TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
+        PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
           (argsEnv ρ s.args vs)) -∗
-        wp pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor pctx Θ Δ_spec ρ_spec f := by
+        wp W.pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor W Δ_spec ρ_spec f := by
   unfold isPrecondFor
   iintro #H
   imodintro
@@ -155,25 +155,25 @@ theorem isPrecondFor_intro (pctx : TinyML.PrimCtx) (Θ : TinyML.TypeEnv) (Δ_spe
   iframe
 
 /-- Löb-style rule for spec preconditions on `fix`: to prove
-    `s.isPrecondFor Θ (.fix f args e)`, assume it as the recursive hypothesis and
+    `s.isPrecondFor W (.fix f args e)`, assume it as the recursive hypothesis and
     prove the `wp` of the body (after the usual fix-substitution). -/
-theorem isPrecondFor_fix {pctx : TinyML.PrimCtx} {Θ : TinyML.TypeEnv} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {s : Spec}
+theorem isPrecondFor_fix {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {s : Spec}
     {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {R : iProp}
     (hargs : args.length = s.args.length)
-    (h : R ⊢ □ (s.isPrecondFor pctx Θ Δ_spec ρ_spec (.fix f args e) -∗
+    (h : R ⊢ □ (s.isPrecondFor W Δ_spec ρ_spec (.fix f args e) -∗
         ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
-          TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) -∗
-          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+          TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
+          PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
               (argsEnv ρ s.args vs) -∗
-          wp pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
-    R ⊢ s.isPrecondFor pctx Θ Δ_spec ρ_spec (.fix f args e) := by
-  refine (SpatialContext.wp_fix' (pctx := pctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
+          wp W.pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
+    R ⊢ s.isPrecondFor W Δ_spec ρ_spec (.fix f args e) := by
+  refine (SpatialContext.wp_fix' (pctx := W.pctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
       iprop(∃ ρ : VerifM.Env,
         ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
-          TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-          PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ P r) s.pred
+          TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
+          PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
             (argsEnv ρ s.args vs))) ?_ (h.trans ?_)).trans ?_
   · intro vs P
     istart
@@ -261,17 +261,17 @@ section CallCorrectness
 omit [MicaGS HasLC.hasLC Sig] in
 /-- Correctness of `declareArgs`: after processing all arguments, the resulting
     substitution is well-formed, types match, and the env agrees with `argsEnv`. -/
-theorem declareArgs_correct (Θ : TinyML.TypeEnv) :
+theorem declareArgs_correct (W : TinyML.World) :
     ∀ (args : List (String × TinyML.Typ)) (sargs : List (TinyML.Typ × Term .value))
       (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
       (Ψ : FiniteSubst → TransState → VerifM.Env → Prop),
     σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
-    VerifM.eval (Spec.declareArgs Θ σ args sargs) st ρ Ψ →
+    VerifM.eval (Spec.declareArgs W.Θ σ args sargs) st ρ Ψ →
     ∃ σ' st' ρ', Ψ σ' st' ρ' ∧
       σ'.wfIn Δ_base st'.decls ∧
       st'.owns = st.owns ∧
-      @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
+      @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
       ((Δ_base.declVars σ.dom).declVars (Spec.argVars args)).Subset
         (Δ_base.declVars σ'.dom) ∧
       VerifM.Env.agreeOn ((Δ_base.declVars σ.dom).declVars (Spec.argVars args))
@@ -300,7 +300,7 @@ theorem declareArgs_correct (Θ : TinyML.TypeEnv) :
     | cons sarg_hd sargs_rest =>
       obtain ⟨targ, sarg⟩ := sarg_hd
       simp only [Spec.declareArgs] at heval
-      by_cases hsub_ty : TinyML.Typ.sub Θ targ ty = true
+      by_cases hsub_ty : TinyML.Typ.sub W.Θ targ ty = true
       · simp [hsub_ty] at heval
         have hdecl := VerifM.eval_decl
           (VerifM.eval_bind (VerifM.eval_ret (VerifM.eval_bind heval)))
@@ -370,7 +370,7 @@ theorem declareArgs_correct (Θ : TinyML.TypeEnv) :
       · simp [hsub_ty] at heval
         exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
-theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (Δ_base : Signature)
+theorem call_correct (W : TinyML.World) (s : Spec) (Δ_base : Signature)
     (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
     (st : TransState) (ρ : VerifM.Env)
     (Ψ : (TinyML.Typ × Term .value) → TransState → VerifM.Env → Prop)
@@ -378,41 +378,41 @@ theorem call_correct (Θ : TinyML.TypeEnv) (s : Spec) (Δ_base : Signature)
     s.pred.wfIn ((Δ_base.declVars σ.dom).declVars (Spec.argVars s.args)) →
     σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
-    VerifM.eval (Spec.call Θ σ s sargs) st ρ Ψ →
+    VerifM.eval (Spec.call W.Θ σ s sargs) st ρ Ψ →
     (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
-      st'.sl Θ ρ' ∗ R ∗ TinyML.ValHasType Θ v s.retTy ⊢ Φ v) →
-    @TinyML.Typ.SubList Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
-    (st.sl Θ ρ ∗ R ⊢ PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+      st'.sl W ρ' ∗ R ∗ TinyML.ValHasType W v s.retTy ⊢ Φ v) →
+    @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
+    (st.sl W ρ ∗ R ⊢ PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
       (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) s.args
         (sargs.map fun p => p.2.eval ρ.env))) := by
   intro hwf hσwf hsargs heval hΨ
   simp only [Spec.call] at heval
   have hb_grow := VerifM.eval.decls_grow ρ (VerifM.eval_bind heval)
   obtain ⟨σ', st', ρ', ⟨hdsub, hragree, hΨ'⟩, hσ'wf, howns, hsublist, hdom_sub, hagree⟩ :=
-    declareArgs_correct Θ s.args sargs Δ_base σ st ρ _ hσwf hsargs hb_grow
+    declareArgs_correct W s.args sargs Δ_base σ st ρ _ hσwf hsargs hb_grow
   refine ⟨hsublist, ?_⟩
   have hwf'' : s.pred.wfIn (Δ_base.declVars σ'.dom) :=
     PredTrans.wfIn_mono hwf hdom_sub hσ'wf.srcWf
-  have hcall := PredTrans.call_correct Θ s.pred Δ_base σ' st' ρ'
-    _ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) R
+  have hcall := PredTrans.call_correct W s.pred Δ_base σ' st' ρ'
+    _ (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) R
     hwf'' hσ'wf (VerifM.eval_bind hΨ')
     (fun v st'' ρ'' t hΨ'' htwf hteval => by
       apply wand_intro
       iintro ⟨⟨Howns, HR⟩, Hty⟩
       iintuitionistic Hty
-      ihave Hpure := (TinyML.typeConstraints_hold (ty := s.retTy) (t := t) (ρ := ρ''.env) (Θ := Θ) (v := v) hteval) $$ Hty
+      ihave Hpure := (TinyML.typeConstraints_hold (ty := s.retTy) (t := t) (ρ := ρ''.env) (W := W) (v := v) hteval) $$ Hty
       ipure Hpure
       obtain ⟨st₃, hst₃_decls, hst₃_owns, _, hret⟩ :=
         VerifM.eval_assumeAll (VerifM.eval_bind hΨ'')
           (fun φ hφ => TinyML.typeConstraints_wfIn htwf φ hφ)
           (fun φ hφ => Hpure φ hφ)
-      ihave Harg : (st₃.sl Θ ρ'' ∗ R ∗ TinyML.ValHasType Θ v s.retTy) $$ [HR Howns Hty]
+      ihave Harg : (st₃.sl W ρ'' ∗ R ∗ TinyML.ValHasType W v s.retTy) $$ [HR Howns Hty]
       · iframe HR Hty
         simp [TransState.sl, hst₃_owns]; iassumption
       iapply (hΨ v st₃ ρ'' t (VerifM.eval_ret hret) (hst₃_decls ▸ htwf) hteval) $$ Harg)
-  exact (sep_mono_left (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf hragree).1).trans <|
-    (by simpa [howns] using hcall : st.sl Θ ρ' ∗ R ⊢ _).trans <|
-    PredTrans.apply_env_agree Θ hwf hagree
+  exact (sep_mono_left (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf hragree).1).trans <|
+    (by simpa [howns] using hcall : st.sl W ρ' ∗ R ⊢ _).trans <|
+    PredTrans.apply_env_agree W hwf hagree
 
 end CallCorrectness
 
@@ -437,13 +437,13 @@ def DeclareImplArgs.Result (args : List (String × TinyML.Typ)) (vs : List Runti
     (∀ v ∈ implVars, v.sort = .value) ∧
     Terms.Eval ρ'.env (implVars.map (fun av => .const (.uninterpreted av.name .value))) vs
 
-theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
+theorem declareImplArgs_correct (W : TinyML.World) :
     ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
       (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
       (Ψ : (FiniteSubst × List FOL.Const) → TransState → VerifM.Env → Prop),
     σ.wfIn Δ_base st.decls →
     VerifM.eval (Spec.declareImplArgs σ args) st ρ Ψ →
-    TinyML.ValsHaveTypes Θ vs (args.map Prod.snd) ⊢
+    TinyML.ValsHaveTypes W vs (args.map Prod.snd) ⊢
       ⌜Spec.DeclareImplArgs.Result args vs Δ_base σ st ρ Ψ⌝ := by
   intro args
   induction args with
@@ -469,9 +469,9 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
     obtain ⟨name, ty⟩ := arg
     cases vs with
     | nil =>
-      exact (TinyML.ValsHaveTypes.nil_cons Θ ty (rest.map Prod.snd)).1.trans false_elim
+      exact (TinyML.ValsHaveTypes.nil_cons W ty (rest.map Prod.snd)).1.trans false_elim
     | cons v vs' =>
-      refine (TinyML.ValsHaveTypes.cons Θ v vs' ty (rest.map Prod.snd)).1.trans ?_
+      refine (TinyML.ValsHaveTypes.cons W v vs' ty (rest.map Prod.snd)).1.trans ?_
       iintro Hvs
       icases Hvs with ⟨Hv, Hvs_rest⟩
       simp only [Spec.declareImplArgs] at heval
@@ -497,7 +497,7 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
         simp [ρ₁]
       ihave %htyped_formulas := TinyML.typeConstraints_hold (ty := ty)
           (t := .const (.uninterpreted argVar.name .value))
-          (ρ := ρ₁.env) (Θ := Θ) (v := v) hvar_eval $$ Hv
+          (ρ := ρ₁.env) (W := W) (v := v) hvar_eval $$ Hv
       obtain ⟨st₂, hst₂_decls, hst₂_owns, _, hdecl₂⟩ :=
         VerifM.eval_assumeAll (VerifM.eval_bind hdecl)
           (fun φ hφ => TinyML.typeConstraints_wfIn hvar_wf φ hφ)
@@ -554,7 +554,7 @@ theorem declareImplArgs_correct (Θ : TinyML.TypeEnv) :
           simpa [Term.eval, Const.denote, Env.lookupConst] using h1.symm
         exact h1'.trans hvar_eval
 
-theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
+theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
     (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (st : TransState) (ρ : VerifM.Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
     s.wfIn Δ_spec →
@@ -572,10 +572,10 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
       VerifM.eval (body argVars) st' ρ'
         (fun result st'' ρ'' =>
           ∀ (S : iProp), result.wfIn st''.decls →
-            st''.sl Θ ρ'' ∗ Q ∗ ((TinyML.ValHasType Θ (result.eval ρ''.env) s.retTy -∗ Φ (result.eval ρ''.env)) -∗ S) ⊢ S) →
-      st'.sl Θ ρ' ∗ Q ⊢ R) →
-    st.sl Θ ρ ∗ TinyML.ValsHaveTypes Θ vs (s.args.map Prod.snd) ∗
-      PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+            st''.sl W ρ'' ∗ Q ∗ ((TinyML.ValHasType W (result.eval ρ''.env) s.retTy -∗ Φ (result.eval ρ''.env)) -∗ S) ⊢ S) →
+      st'.sl W ρ' ∗ Q ⊢ R) →
+    st.sl W ρ ∗ TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
+      PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
         (Spec.argsEnv ρ_spec s.args vs) ⊢ R := by
   intro hswf hΔspec hρspec hΔwf hΔvars heval hbody
   simp only [Spec.implement] at heval
@@ -584,7 +584,7 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
   icases H with ⟨Howns, Hvals, Happ⟩
   iintuitionistic Hvals
   ihave %hlen_vals := TinyML.ValsHaveTypes.length_eq $$ Hvals
-  ihave Hdecl := declareImplArgs_correct Θ s.args vs Δ_spec (FiniteSubst.base Δ_spec) st ρ _
+  ihave Hdecl := declareImplArgs_correct W s.args vs Δ_spec (FiniteSubst.base Δ_spec) st ρ _
       (FiniteSubst.base_wfIn hΔspec hΔwf (VerifM.eval.wf heval).namesDisjoint hΔvars)
       hb $$ Hvals
   ipure Hdecl
@@ -603,11 +603,11 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
         simp [List.length_map] at hlen_vals
         omega)
   have hst'_wf : st'.decls.wf := (VerifM.eval.wf hΨ).namesDisjoint
-  iapply (show st'.sl Θ ρ' ∗
-        PredTrans.apply Θ (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) s.pred
+  iapply (show st'.sl W ρ' ∗
+        PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
           (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) ⊢ R from
-    PredTrans.implement_correct Θ s.pred Δ_spec σ' (body argVars) st' ρ'
-      (fun r => TinyML.ValHasType Θ r s.retTy -∗ Φ r) R
+    PredTrans.implement_correct W s.pred Δ_spec σ' (body argVars) st' ρ'
+      (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) R
       (PredTrans.wfIn_mono hswf hdom_sub hσ'wf.srcWf)
       hσ'wf hΨ
       (fun st'' ρ'' Q hdsub' hragree' hbody_eval => by
@@ -624,12 +624,12 @@ theorem implement_correct (Θ : TinyML.TypeEnv) (s : Spec) (body : List FOL.Cons
           exact Term.const_wfIn_of_mem hst'_wf (hmem_decls _ hav)
         · exact hbody_eval))
   isplitr [Happ]
-  · iapply (show st.sl Θ ρ' ⊢ st'.sl Θ ρ' by simp [howns, TransState.sl])
-    iapply (show st.sl Θ ρ ⊢ st.sl Θ ρ' by
+  · iapply (show st.sl W ρ' ⊢ st'.sl W ρ' by simp [howns, TransState.sl])
+    iapply (show st.sl W ρ ⊢ st.sl W ρ' by
       simpa [TransState.sl] using
-        (SpatialContext.interp_env_agree Θ (VerifM.eval.wf heval).ownsWf hragree).1)
+        (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf hragree).1)
     iexact Howns
-  · iapply (PredTrans.apply_env_agree Θ hswf (VerifM.Env.agreeOn_trans hag_base (by
+  · iapply (PredTrans.apply_env_agree W hswf (VerifM.Env.agreeOn_trans hag_base (by
         simpa [FiniteSubst.base, Signature.declVars] using VerifM.Env.agreeOn_symm hagree)))
     iexact Happ
 

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -70,10 +70,10 @@ def argsEnv (ρ : VerifM.Env) : List (String × TinyML.Typ) → List Runtime.Val
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
 
-def isPrecondFor (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env)
+def isPrecondFor (W : TinyML.World)
     (f : Runtime.Val) (s : Spec) : iProp :=
   iprop(□ ∀ (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
-      ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
+      ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ.env⌝ -∗
       TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
         PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
           (argsEnv ρ s.args vs) -∗
@@ -132,20 +132,20 @@ def implement (Δ_base : Signature) (s : Spec) (body : List FOL.Const → VerifM
 /-! ## Precondition Proofs -/
 section Precondition
 
-instance : Iris.BI.Persistent (isPrecondFor W Δ_spec ρ_spec f s) := by
+instance : Iris.BI.Persistent (isPrecondFor W f s) := by
   unfold isPrecondFor
   infer_instance
 
 /-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
-theorem isPrecondFor_intro (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : VerifM.Env) (s : Spec)
+theorem isPrecondFor_intro (W : TinyML.World) (s : Spec)
     (f : Runtime.Val) :
     iprop(□ ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-      (⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
+      (⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ.env⌝ ∗
         TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
         PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
           (argsEnv ρ s.args vs)) -∗
-        wp W.pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor W Δ_spec ρ_spec f := by
+        wp W.pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor W f := by
   unfold isPrecondFor
   iintro #H
   imodintro
@@ -157,21 +157,21 @@ theorem isPrecondFor_intro (W : TinyML.World) (Δ_spec : Signature) (ρ_spec : V
 /-- Löb-style rule for spec preconditions on `fix`: to prove
     `s.isPrecondFor W (.fix f args e)`, assume it as the recursive hypothesis and
     prove the `wp` of the body (after the usual fix-substitution). -/
-theorem isPrecondFor_fix {W : TinyML.World} {Δ_spec : Signature} {ρ_spec : VerifM.Env} {s : Spec}
+theorem isPrecondFor_fix {W : TinyML.World} {s : Spec}
     {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {R : iProp}
     (hargs : args.length = s.args.length)
-    (h : R ⊢ □ (s.isPrecondFor W Δ_spec ρ_spec (.fix f args e) -∗
+    (h : R ⊢ □ (s.isPrecondFor W (.fix f args e) -∗
         ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ -∗
+          ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ.env⌝ -∗
           TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
           PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
               (argsEnv ρ s.args vs) -∗
           wp W.pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
-    R ⊢ s.isPrecondFor W Δ_spec ρ_spec (.fix f args e) := by
+    R ⊢ s.isPrecondFor W (.fix f args e) := by
   refine (SpatialContext.wp_fix' (pctx := W.pctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
       iprop(∃ ρ : VerifM.Env,
-        ⌜VerifM.Env.agreeOn Δ_spec ρ_spec ρ⌝ ∗
+        ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ.env⌝ ∗
           TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
           PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
             (argsEnv ρ s.args vs))) ?_ (h.trans ?_)).trans ?_
@@ -555,14 +555,11 @@ theorem declareImplArgs_correct (W : TinyML.World) :
         exact h1'.trans hvar_eval
 
 theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
-    (Δ_spec : Signature) (ρ_spec : VerifM.Env)
     (st : TransState) (ρ : VerifM.Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
-    s.wfIn Δ_spec →
-    Δ_spec.Subset st.decls →
-    VerifM.Env.agreeOn Δ_spec ρ_spec ρ →
-    Δ_spec.wf →
-    Δ_spec.vars = [] →
-    VerifM.eval (Spec.implement Δ_spec s body) st ρ (fun _ _ _ => True) →
+    s.wfIn W.Δ_spec →
+    W.wf →
+    W.agrees st.decls ρ.env →
+    VerifM.eval (Spec.implement W.Δ_spec s body) st ρ (fun _ _ _ => True) →
     (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : VerifM.Env) (Q : iProp),
       st.decls.Subset st'.decls →
       VerifM.Env.agreeOn st.decls ρ ρ' →
@@ -576,28 +573,28 @@ theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const �
       st'.sl W ρ' ∗ Q ⊢ R) →
     st.sl W ρ ∗ TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
       PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
-        (Spec.argsEnv ρ_spec s.args vs) ⊢ R := by
-  intro hswf hΔspec hρspec hΔwf hΔvars heval hbody
+        (Spec.argsEnv ⟨W.ρ_spec⟩ s.args vs) ⊢ R := by
+  intro hswf hwf hag heval hbody
   simp only [Spec.implement] at heval
   have hb := VerifM.eval_bind heval
   iintro H
   icases H with ⟨Howns, Hvals, Happ⟩
   iintuitionistic Hvals
   ihave %hlen_vals := TinyML.ValsHaveTypes.length_eq $$ Hvals
-  ihave Hdecl := declareImplArgs_correct W s.args vs Δ_spec (FiniteSubst.base Δ_spec) st ρ _
-      (FiniteSubst.base_wfIn hΔspec hΔwf (VerifM.eval.wf heval).namesDisjoint hΔvars)
+  ihave Hdecl := declareImplArgs_correct W s.args vs W.Δ_spec (FiniteSubst.base W.Δ_spec) st ρ _
+      (FiniteSubst.base_wfIn hag.subset hwf.wf (VerifM.eval.wf heval).namesDisjoint hwf.vars)
       hb $$ Hvals
   ipure Hdecl
   obtain ⟨σ', argVars, st', ρ', hΨ, hσ'wf, hdsub, hragree, howns, hdom_sub, hagree,
     hmem_decls, hsorts, hlookups⟩ := Hdecl
   have hag_base :
-      VerifM.Env.agreeOn (Δ_spec.declVars (Spec.argVars s.args))
-        (Spec.argsEnv ρ_spec s.args vs)
-            (Spec.argsEnv (VerifM.Env.withEnv ρ ((FiniteSubst.base Δ_spec).subst.eval ρ.env)) s.args vs) :=
-    Spec.argsEnv_agreeOn (Δ := Δ_spec)
-      (ρ₁ := ρ_spec)
-      (ρ₂ := VerifM.Env.withEnv ρ ((FiniteSubst.base Δ_spec).subst.eval ρ.env))
-      (by simpa [FiniteSubst.base, VerifM.Env.withEnv] using hρspec)
+      VerifM.Env.agreeOn (W.Δ_spec.declVars (Spec.argVars s.args))
+        (Spec.argsEnv ⟨W.ρ_spec⟩ s.args vs)
+            (Spec.argsEnv (VerifM.Env.withEnv ρ ((FiniteSubst.base W.Δ_spec).subst.eval ρ.env)) s.args vs) :=
+    Spec.argsEnv_agreeOn (Δ := W.Δ_spec)
+      (ρ₁ := ⟨W.ρ_spec⟩)
+      (ρ₂ := VerifM.Env.withEnv ρ ((FiniteSubst.base W.Δ_spec).subst.eval ρ.env))
+      (by simpa [FiniteSubst.base, VerifM.Env.withEnv] using hag.agree)
       s.args vs
       (by
         simp [List.length_map] at hlen_vals
@@ -606,7 +603,7 @@ theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const �
   iapply (show st'.sl W ρ' ∗
         PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
           (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) ⊢ R from
-    PredTrans.implement_correct W s.pred Δ_spec σ' (body argVars) st' ρ'
+    PredTrans.implement_correct W s.pred W.Δ_spec σ' (body argVars) st' ρ'
       (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) R
       (PredTrans.wfIn_mono hswf hdom_sub hσ'wf.srcWf)
       hσ'wf hΨ

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -173,10 +173,10 @@ theorem Builtins.holdsFor.agree {Δ : Signature} {ρ ρ' : Env}
 end VerifM
 
 /-- Semantic interpretation of a verifier context item. -/
-def CtxItem.interp [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+def CtxItem.interp [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
     (ρ : VerifM.Env) : CtxItem → iProp
   | .pure φ => ⌜φ.eval ρ.env⌝
-  | .spatial a => a.interp Θ ρ.env
+  | .spatial a => a.interp W ρ.env
 
 def CtxItem.purePart (i : CtxItem) (ρ : VerifM.Env) : Prop :=
   match i with
@@ -196,9 +196,9 @@ theorem CtxItem.facts_wfIn {i : CtxItem} {Δ : Signature} (h : i.wfIn Δ) :
   | spatial a => exact SpatialAtom.facts_wfIn h
 
 /-- An item's interpretation implies its pure facts. -/
-theorem CtxItem.interp_facts [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+theorem CtxItem.interp_facts [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
     (ρ : VerifM.Env) (i : CtxItem) :
-    i.interp Θ ρ ⊢ ⌜∀ φ ∈ i.facts, φ.eval ρ.env⌝ ∗ i.interp Θ ρ := by
+    i.interp W ρ ⊢ ⌜∀ φ ∈ i.facts, φ.eval ρ.env⌝ ∗ i.interp W ρ := by
   cases i with
   | pure φ =>
     istart
@@ -208,15 +208,15 @@ theorem CtxItem.interp_facts [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
       simp [facts]
     · iexact H
   | spatial a =>
-    exact SpatialAtom.interp_facts Θ a
+    exact SpatialAtom.interp_facts W a
 
-def TransState.sl [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+def TransState.sl [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
     (st : TransState) (ρ : VerifM.Env) : iProp :=
-  SpatialContext.interp Θ ρ.env st.owns
+  SpatialContext.interp W ρ.env st.owns
 
-@[simp] theorem TransState.sl_eq [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+@[simp] theorem TransState.sl_eq [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
     (st : TransState) (ρ : VerifM.Env) :
-    st.sl Θ ρ = SpatialContext.interp Θ ρ.env st.owns := rfl
+    st.sl W ρ = SpatialContext.interp W ρ.env st.owns := rfl
 
 /-- Drop the non-persistent spatial part of the verifier state. -/
 def TransState.persist (st : TransState) : TransState :=
@@ -228,9 +228,9 @@ def TransState.persist (st : TransState) : TransState :=
 @[simp] theorem TransState.persist_asserts (st : TransState) :
     st.persist.asserts = st.asserts := rfl
 
-theorem TransState.sl_entails_persist [MicaGS HasLC.hasLC Sig] (Θ : TinyML.TypeEnv)
+theorem TransState.sl_entails_persist [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
     (st : TransState) (ρ : VerifM.Env) :
-    st.sl Θ ρ ⊢ □ st.persist.sl Θ ρ := by
+    st.sl W ρ ⊢ □ st.persist.sl W ρ := by
   istart
   iintro _
   imodintro

--- a/Tests/functions/nary_functions.ml
+++ b/Tests/functions/nary_functions.ml
@@ -1,0 +1,12 @@
+(* TEST: --print-ocaml --no-check roundtrip *)
+
+open Mica
+
+(* Unary and multi-argument function expressions elaborate to n-ary core arrows. *)
+let unary (x : int) : int = x
+
+let multi (x : int) (y : int) : int = x + y
+
+let apply_two (f : int -> int -> int) (x : int) (y : int) : int = f x y
+
+let result : int = apply_two multi (unary 1) 2

--- a/Tests/functions/partial_application.ml
+++ b/Tests/functions/partial_application.ml
@@ -1,0 +1,8 @@
+(* TEST: no-compile *)
+
+open Mica
+
+let add (x : int) (y : int) : int = x + y
+
+(* TinyML applications are n-ary; the runtime has no partial application. *)
+let add_one = add 1

--- a/Tests/functions/partial_application.out
+++ b/Tests/functions/partial_application.out
@@ -1,0 +1,2 @@
+Status: failed: arity mismatch: expected 2, got 1
+[1]

--- a/Tests/functions/zero_argument_type.ml
+++ b/Tests/functions/zero_argument_type.ml
@@ -1,0 +1,6 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* The frontend rejects zero-argument function expressions. *)
+let zero = fun : int -> 0

--- a/Tests/functions/zero_argument_type.out
+++ b/Tests/functions/zero_argument_type.out
@@ -1,0 +1,2 @@
+parse error: Tests/functions/zero_argument_type.ml:6:12: function expressions require at least one argument
+[1]


### PR DESCRIPTION
This PR bundles several structural improvements to the internals of the verifier:

- decidable equality for the specifications type `Spec`
- forcing function arrows to be n-ary (and disallowing partial application)
- a new notion of a "world", the fixed portion determined at the beginning of the verifier run containing, for example, the type environment and the available spec-level functions 