### PR TITLE
Flatten verifier environment wrapper

### DIFF
--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -17,8 +17,8 @@ namespace Intrinsics
 /-- Apply a `.ret (s, .assert φ ...)` spec at a value, discharging the asserted
     `φ` as a pure side condition. -/
 theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runtime.Val → iProp)
-    (s : String) (ρ : VerifM.Env) (φ : Formula) (v : Runtime.Val)
-    (hφ : φ.eval (ρ.updateConst .value s v).env) :
+    (s : String) (ρ : Env) (φ : Formula) (v : Runtime.Val)
+    (hφ : φ.eval (ρ.updateConst .value s v)) :
     PredTrans.apply W Φ (.ret (s, .assert φ (.ret ()))) ρ ⊢ Φ v := by
   simp only [PredTrans.apply, Assertion.pre, Assertion.post]
   refine (forall_elim v).trans ?_
@@ -37,9 +37,9 @@ def withPre : Option Formula → PredTrans → PredTrans
 /-- Eliminate `withPre`: applying the wrapped predicate yields the precondition
     as a pure fact (vacuous for `none`) alongside the unwrapped application. -/
 theorem withPre_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runtime.Val → iProp)
-    (pre : Option Formula) (post : PredTrans) (ρ : VerifM.Env) :
+    (pre : Option Formula) (post : PredTrans) (ρ : Env) :
     PredTrans.apply W Φ (withPre pre post) ρ ⊢
-      iprop(⌜∀ φ, pre = some φ → φ.eval ρ.env⌝ ∗ PredTrans.apply W Φ post ρ) := by
+      iprop(⌜∀ φ, pre = some φ → φ.eval ρ⌝ ∗ PredTrans.apply W Φ post ρ) := by
   cases pre with
   | none =>
     simp only [withPre]
@@ -67,40 +67,37 @@ theorem valsHaveTypes_off_shape [MicaGS HasLC.hasLC Sig] {W : TinyML.World}
 /-- Respect for an arity-one symbol survives the argument-binding fold; each
     step rebinds a `value` constant, which never touches the unary table. -/
 private theorem respects_argsEnv_one {s : FOL.Symbol .one} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
+    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : Env},
+      ρ.respects (some s) → (Spec.argsEnv ρ args vs).respects (some s)
   | [], _, _, h => h
   | _ :: _, [], _, h => h
   | (_, _) :: rest, _ :: vs, ρ, h => by
       simp only [Spec.argsEnv]
       refine respects_argsEnv_one rest vs ?_
-      rw [VerifM.Env.updateConst_env]
       simpa only [Env.respects, Env.updateConst_unary] using h
 
 /-- Respect for an arity-two symbol survives the argument-binding fold; each
     step rebinds a `value` constant, which never touches the binary table. -/
 private theorem respects_argsEnv_two {s : FOL.Symbol .two} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
+    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : Env},
+      ρ.respects (some s) → (Spec.argsEnv ρ args vs).respects (some s)
   | [], _, _, h => h
   | _ :: _, [], _, h => h
   | (_, _) :: rest, _ :: vs, ρ, h => by
       simp only [Spec.argsEnv]
       refine respects_argsEnv_two rest vs ?_
-      rw [VerifM.Env.updateConst_env]
       simpa only [Env.respects, Env.updateConst_binary] using h
 
 /-- Respect for an arity-three symbol survives the argument-binding fold; each
     step rebinds a `value` constant, which never touches the ternary table. -/
 private theorem respects_argsEnv_three {s : FOL.Symbol .three} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : VerifM.Env},
-      ρ.env.respects (some s) → (Spec.argsEnv ρ args vs).env.respects (some s)
+    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : Env},
+      ρ.respects (some s) → (Spec.argsEnv ρ args vs).respects (some s)
   | [], _, _, h => h
   | _ :: _, [], _, h => h
   | (_, _) :: rest, _ :: vs, ρ, h => by
       simp only [Spec.argsEnv]
       refine respects_argsEnv_three rest vs ?_
-      rw [VerifM.Env.updateConst_env]
       simpa only [Env.respects, Env.updateConst_ternary] using h
 
 /-! ## `specWf`: predicate-transformer well-formedness -/
@@ -521,9 +518,8 @@ structure Zero.Lawful (b : Zero) where
       refine (sep_mono_left (TinyML.ValsHaveTypes.nil W).1).trans ?_
       refine emp_sep.1.trans ?_
       refine (assert_ret_apply W _ "ret" _ _ (b.res.inject b.f) ?_).trans ?_
-      · have hconst : (ρ.updateConst .value "ret" (b.res.inject b.f)).env.lookupConst
+      · have hconst : (ρ.updateConst .value "ret" (b.res.inject b.f)).lookupConst
             .value b.name = b.res.inject b.f := by
-          rw [VerifM.Env.updateConst_env]
           rw [Env.lookupConst_updateConst_ne l.nameFresh]
           simpa [Env.respects, Zero.sym] using hρ
         simpa [Zero.opTerm, Term.eval, Const.denote] using hconst.symm
@@ -698,9 +694,9 @@ structure Unary.Lawful (b : Unary) where
       ihave Hsplit := withPre_apply W _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x := by
-        refine l.domSound ρ.env x fun p hp => ?_
+        refine l.domSound ρ x fun p hp => ?_
         have h := hpre (p "a") (by rw [hp]; rfl)
-        simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
+        simpa [Spec.argsEnv, ] using h
       ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x)) (b.res.typ.subst σ)) $$ [Hrel]
       · iapply (l.resL.intro σ W (b.f x))
         iapply (l.semWellTyped σ W x hdom)
@@ -712,13 +708,13 @@ structure Unary.Lawful (b : Unary) where
       · have hassert : (Formula.eq .value (.var .value "ret")
             (b.opTerm (.var .value "a"))).eval
             ((Spec.argsEnv ρ b.toIntrinsic.specArgs [b.arg.inject x]).updateConst
-              .value "ret" (b.res.inject (b.f x))).env := by
+              .value "ret" (b.res.inject (b.f x))) := by
           have hargs := respects_argsEnv_one b.toIntrinsic.specArgs [b.arg.inject x] hρ
-          have hun : (Spec.argsEnv ρ b.toIntrinsic.specArgs [b.arg.inject x]).env.unary
+          have hun : (Spec.argsEnv ρ b.toIntrinsic.specArgs [b.arg.inject x]).unary
               .value .value b.name = b.sym.interp := by
             simpa [Env.respects, Unary.sym] using hargs
           show b.res.inject (b.f x) =
-            (Spec.argsEnv ρ b.toIntrinsic.specArgs [b.arg.inject x]).env.unary
+            (Spec.argsEnv ρ b.toIntrinsic.specArgs [b.arg.inject x]).unary
               .value .value b.name (b.arg.inject x)
           simp [hun, Unary.sym, l.argL.project_inject]
         refine (sep_mono_left
@@ -922,9 +918,9 @@ structure Binary.Lawful (b : Binary) where
       ihave Hsplit := withPre_apply W _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x y := by
-        refine l.domSound ρ.env x y fun p hp => ?_
+        refine l.domSound ρ x y fun p hp => ?_
         have h := hpre (p "a" "b") (by rw [hp]; rfl)
-        simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
+        simpa [Spec.argsEnv, ] using h
       ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x y))
           (b.res.typ.subst σ)) $$ [Hrel1 Hrel2]
       · iapply (l.resL.intro σ W (b.f x y))
@@ -941,16 +937,16 @@ structure Binary.Lawful (b : Binary) where
             (b.opTerm (.var .value "a") (.var .value "b"))).eval
             ((Spec.argsEnv ρ b.toIntrinsic.specArgs
               [b.arg₁.inject x, b.arg₂.inject y]).updateConst
-              .value "ret" (b.res.inject (b.f x y))).env := by
+              .value "ret" (b.res.inject (b.f x y))) := by
           have hargs := respects_argsEnv_two b.toIntrinsic.specArgs
             [b.arg₁.inject x, b.arg₂.inject y] hρ
           have hbin : (Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg₁.inject x, b.arg₂.inject y]).env.binary .value .value .value b.name
+              [b.arg₁.inject x, b.arg₂.inject y]).binary .value .value .value b.name
               = fun a c => b.sym.interp (a, c) := by
             simpa [Env.respects, Binary.sym] using hargs
           show b.res.inject (b.f x y) =
             (Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg₁.inject x, b.arg₂.inject y]).env.binary
+              [b.arg₁.inject x, b.arg₂.inject y]).binary
               .value .value .value b.name (b.arg₁.inject x) (b.arg₂.inject y)
           simp [hbin, Binary.sym, l.argL₁.project_inject, l.argL₂.project_inject]
         refine (sep_mono_left
@@ -1170,9 +1166,9 @@ structure Ternary.Lawful (b : Ternary) where
       ihave Hsplit := withPre_apply W _ _ _ _ $$ Hpred
       icases Hsplit with ⟨%hpre, Hpost⟩
       have hdom : b.dom x y z := by
-        refine l.domSound ρ.env x y z fun p hp => ?_
+        refine l.domSound ρ x y z fun p hp => ?_
         have h := hpre (p "a" "b" "c") (by rw [hp]; rfl)
-        simpa [Spec.argsEnv, VerifM.Env.updateConst_env] using h
+        simpa [Spec.argsEnv, ] using h
       ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x y z))
           (b.res.typ.subst σ)) $$ [Hrel1 Hrel2 Hrel3]
       · iapply (l.resL.intro σ W (b.f x y z))
@@ -1192,17 +1188,17 @@ structure Ternary.Lawful (b : Ternary) where
             (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))).eval
             ((Spec.argsEnv ρ b.toIntrinsic.specArgs
               [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z]).updateConst
-              .value "ret" (b.res.inject (b.f x y z))).env := by
+              .value "ret" (b.res.inject (b.f x y z))) := by
           have hargs := respects_argsEnv_three b.toIntrinsic.specArgs
             [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z] hρ
           have hter : (Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z]).env.ternary
+              [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z]).ternary
               .value .value .value .value b.name
               = fun a c d => b.sym.interp (a, c, d) := by
             simpa [Env.respects, Ternary.sym] using hargs
           show b.res.inject (b.f x y z) =
             (Spec.argsEnv ρ b.toIntrinsic.specArgs
-              [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z]).env.ternary
+              [b.arg₁.inject x, b.arg₂.inject y, b.arg₃.inject z]).ternary
               .value .value .value .value b.name
               (b.arg₁.inject x) (b.arg₂.inject y) (b.arg₃.inject z)
           simp [hter, Ternary.sym, l.argL₁.project_inject, l.argL₂.project_inject,

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -76,26 +76,26 @@ instance [DecidableEq α] : DecidableEq (Assertion α) := Assertion.decideEq
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Assertion.pre (W : TinyML.World) (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
+def Assertion.pre (W : TinyML.World) (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
   (match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ.env⌝ ∗ Assertion.pre W Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ.env; Assertion.pre W Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ⌝ ∗ Assertion.pre W Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ; Assertion.pre W Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => ∃ (v : x.sort.denote), p.eval W ρ v ∗ Assertion.pre W Φ k (ρ.updateConst x.sort x.name v)
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.pre W Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.pre W Φ ke ρ)))
+      iprop((⌜φ.eval ρ⌝ -∗ Assertion.pre W Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ⌝ -∗ Assertion.pre W Φ ke ρ)))
 
-def Assertion.post (W : TinyML.World) {α} (Φ : α → VerifM.Env → iProp) (m : Assertion α) (ρ : VerifM.Env) : iProp :=
+def Assertion.post (W : TinyML.World) {α} (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ.env⌝ -∗ Assertion.post W Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ.env; Assertion.post W Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ⌝ -∗ Assertion.post W Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ; Assertion.post W Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => iprop(∀ (v : x.sort.denote),
       p.eval W ρ v -∗ Assertion.post W Φ k (ρ.updateConst x.sort x.name v))
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ.env⌝ -∗ Assertion.post W Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ.env⌝ -∗ Assertion.post W Φ ke ρ))
+      iprop((⌜φ.eval ρ⌝ -∗ Assertion.post W Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ⌝ -∗ Assertion.post W Φ ke ρ))
 
 
 -- ---------------------------------------------------------------------------
@@ -165,9 +165,9 @@ theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Pro
 -- ---------------------------------------------------------------------------
 
 theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : α → Signature → Prop}
-    {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
-    (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
+    (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     Assertion.pre W Φ m ρ ⊢ Assertion.pre W Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
@@ -185,7 +185,7 @@ theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : �
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.pre]
     rw [← Term.eval_env_agree htwf hagree]
-    exact ih hkwf (VerifM.Env.agreeOn_declVar hagree)
+    exact ih hkwf (Env.agreeOn_declVar hagree)
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.pre]
@@ -195,7 +195,7 @@ theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : �
     iapply (sep_mono
       (show p.eval W ρ w ⊢ p.eval W ρ' w by
         simp [(Atom.eval_env_agree W hpwf hagree)])
-      (ih hkwf (VerifM.Env.agreeOn_declVar hagree)))
+      (ih hkwf (Env.agreeOn_declVar hagree)))
     iexact Hsep
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
@@ -204,7 +204,7 @@ theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : �
     · apply BI.and_elim_l.trans
       iintro Hkt
       iintro Hφ
-      have hφ : BIBase.Entails (⌜φ.eval ρ'.env⌝ : iProp) ⌜φ.eval ρ.env⌝ := by
+      have hφ : BIBase.Entails (⌜φ.eval ρ'⌝ : iProp) ⌜φ.eval ρ⌝ := by
         iintro %hφ
         ipureintro
         exact (Formula.eval_env_agree hφwf hagree).mpr hφ
@@ -215,7 +215,7 @@ theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : �
     · apply BI.and_elim_r.trans
       iintro Hke
       iintro Hnφ
-      have hnφ : BIBase.Entails (⌜¬ φ.eval ρ'.env⌝ : iProp) ⌜¬ φ.eval ρ.env⌝ := by
+      have hnφ : BIBase.Entails (⌜¬ φ.eval ρ'⌝ : iProp) ⌜¬ φ.eval ρ⌝ := by
         iintro %hnφ
         ipureintro
         exact mt (Formula.eval_env_agree hφwf hagree).mp hnφ
@@ -225,9 +225,9 @@ theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : �
       iapply Hnφ
 
 theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : α → Signature → Prop}
-    {Φ : α → VerifM.Env → iProp} {ρ ρ' : VerifM.Env} {Δ : Signature}
-    (hwf : m.wfIn retWf Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ')
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
+    (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     Assertion.post W Φ m ρ ⊢ Assertion.post W Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
@@ -236,7 +236,7 @@ theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : 
     simp only [Assertion.post]
     iintro H
     iintro %hφ
-    have hφ' : φ.eval ρ.env := (Formula.eval_env_agree hφwf hagree).mpr hφ
+    have hφ' : φ.eval ρ := (Formula.eval_env_agree hφwf hagree).mpr hφ
     iapply (ih hkwf hagree)
     iapply H
     ipureintro
@@ -245,13 +245,13 @@ theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : 
     obtain ⟨htwf, hkwf⟩ := hwf
     simp only [Assertion.post]
     rw [← Term.eval_env_agree htwf hagree]
-    exact ih hkwf (VerifM.Env.agreeOn_declVar hagree)
+    exact ih hkwf (Env.agreeOn_declVar hagree)
   | pred v p k ih =>
     obtain ⟨hpwf, hkwf⟩ := hwf
     simp only [Assertion.post]
     iintro H
     iintro %w Hw
-    iapply (ih hkwf (VerifM.Env.agreeOn_declVar hagree))
+    iapply (ih hkwf (Env.agreeOn_declVar hagree))
     iapply H
     iapply (show p.eval W ρ' w ⊢ p.eval W ρ w by simp [(Atom.eval_env_agree W hpwf hagree)])
     iexact Hw
@@ -262,7 +262,7 @@ theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : 
     · apply BI.and_elim_l.trans
       iintro Hkt
       iintro %hφ
-      have hφ' : φ.eval ρ.env := (Formula.eval_env_agree hφwf hagree).mpr hφ
+      have hφ' : φ.eval ρ := (Formula.eval_env_agree hφwf hagree).mpr hφ
       iapply (iht hktwf hagree)
       iapply Hkt
       ipureintro
@@ -270,7 +270,7 @@ theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : 
     · apply BI.and_elim_r.trans
       iintro Hke
       iintro %hnφ
-      have hnφ' : ¬ φ.eval ρ.env := mt (Formula.eval_env_agree hφwf hagree).mp hnφ
+      have hnφ' : ¬ φ.eval ρ := mt (Formula.eval_env_agree hφwf hagree).mp hnφ
       iapply (ihe hkewf hagree)
       iapply Hke
       ipureintro
@@ -279,10 +279,10 @@ theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : 
 /-- Combining caller-side `pre` with verifier-side `post`. -/
 theorem Assertion.pre_post_combine (W : TinyML.World) {α : Type}
     {m : Assertion α}
-    {Φ : α → VerifM.Env → iProp} {Ψ : α → VerifM.Env → iProp}
-    {ρ : VerifM.Env}
+    {Φ : α → Env → iProp} {Ψ : α → Env → iProp}
+    {ρ : Env}
     {R : iProp}
-    (hR : ∀ (a : α) (ρ0 : VerifM.Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
+    (hR : ∀ (a : α) (ρ0 : Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
     : (Assertion.pre W Φ m ρ ∗ Assertion.post W Ψ m ρ) ⊢ R := by
   induction m generalizing ρ R with
   | ret a =>
@@ -300,7 +300,7 @@ theorem Assertion.pre_post_combine (W : TinyML.World) {α : Type}
       exact hφ
   | let_ v t k ih =>
     simp only [Assertion.pre, Assertion.post]
-    simpa using ih (ρ := ρ.updateConst v.sort v.name (t.eval ρ.env)) (R := R) hR
+    simpa using ih (ρ := ρ.updateConst v.sort v.name (t.eval ρ)) (R := R) hR
   | pred v p k ih =>
     simp only [Assertion.pre, Assertion.post]
     istart
@@ -313,7 +313,7 @@ theorem Assertion.pre_post_combine (W : TinyML.World) {α : Type}
       iexact Hpre1
   | ite φ kt ke iht ihe =>
     simp only [Assertion.pre, Assertion.post]
-    by_cases hφ : φ.eval ρ.env
+    by_cases hφ : φ.eval ρ
     · istart
       iintro ⟨Hpre, Hpost⟩
       iapply (iht (ρ := ρ) (R := R) hR)
@@ -401,16 +401,16 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
 
 theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
-    (st : TransState) (ρ : VerifM.Env)
-    (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    (st : TransState) (ρ : Env)
+    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     σ.wfIn Δ_base st.decls →
     m.wfIn retWf (Δ_base.declVars σ.dom) →
     VerifM.eval (Assertion.assume σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
       retWf a (Δ_base.declVars σ'.dom) →
-      st'.sl W ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
-    st.sl W ρ ∗ R ⊢ Assertion.post W Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
+      st'.sl W ρ' ∗ R ⊢ Φ a ((σ'.subst.eval ρ'))) →
+    st.sl W ρ ∗ R ⊢ Assertion.post W Φ m ((σ.subst.eval ρ)) := by
   intro hσwf hwf heval hpost
   induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
@@ -436,12 +436,12 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
       have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
         st.freshConst_fresh (some v.name) v.sort
       have hv'_fresh_range : v'.name ∉ σ.range.allNames := hσwf.fresh_range hv'_fresh_decls
-      set u := t.eval (σ.subst.eval ρ.env)
+      set u := t.eval (σ.subst.eval ρ)
       specialize hdecl u
       have hb2 := VerifM.eval_bind hdecl
       have hassume := VerifM.eval_assumePure hb2
         (FiniteSubst.decl_eq_wfIn (c := v') hσwf htwf hv'_fresh_decls)
-        (FiniteSubst.decl_eq_eval (c := v') (ρ := ρ.env) hσwf htwf hv'_fresh_decls)
+        (FiniteSubst.decl_eq_eval (c := v') (ρ := ρ) hσwf htwf hv'_fresh_decls)
       set σ' := σ.rename v v'.name
       have hσ'wf : σ'.wfIn Δ_base (st.decls.addConst v') := by
         simpa [σ'] using
@@ -456,9 +456,9 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
           (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
       exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.post_env_agree W hkwf'
         (by
-          simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+          simpa [σ', Env.agreeOn, Env.updateConst] using
             (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
-              (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
+              (v := v) (name' := v'.name) (ρ := ρ) (u := u) hσwf hv'_fresh_range))
         hΦ
   | pred v p k ih =>
       obtain ⟨hpwf, hkwf⟩ := hwf
@@ -486,27 +486,25 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
         Atom.toItem_wfIn
           (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
             (Signature.wf_addConst hσwf.useWf hv'_fresh_decls)) hvar_wf
-      have hpu' : p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+      have hpu' : p.eval W ((σ.subst.eval ρ)) u ⊢
           (p.subst σ.subst).eval W (ρ.updateConst v.sort v'.name u)
             ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
-              (ρ.updateConst v.sort v'.name u).env) := by
+              (ρ.updateConst v.sort v'.name u)) := by
         have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
-            (ρ.updateConst v.sort v'.name u).env) = u := by
+            (ρ.updateConst v.sort v'.name u)) = u := by
           simp [Term.eval, Const.denote, Env.updateConst]
         rw [hconst]
         rw [Atom.eval_subst W hpwf hσwf.subst hσwf.rangeWf]
-        have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ.env)
+        have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ)
           (τ := v.sort) (name' := v'.name) (u := u) hσwf hv'_fresh_range
         have heval_agree :
-            p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) =
-              p.eval W ((ρ.updateConst v.sort v'.name u).withEnv
-                (σ.subst.eval (ρ.updateConst v.sort v'.name u).env)) :=
+            p.eval W ((σ.subst.eval ρ)) =
+              p.eval W (σ.subst.eval (ρ.updateConst v.sort v'.name u)) :=
           Atom.eval_env_agree W (p := p)
-            (ρ := ρ.withEnv (σ.subst.eval ρ.env))
-            (ρ' := (ρ.updateConst v.sort v'.name u).withEnv
-              (σ.subst.eval (ρ.updateConst v.sort v'.name u).env))
+            (ρ := (σ.subst.eval ρ))
+            (ρ' := σ.subst.eval (ρ.updateConst v.sort v'.name u))
             (Δ := Δ_base.declVars σ.dom) hpwf (by
-              simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv_env] using hagree)
+              simpa [Env.agreeOn, ] using hagree)
         rw [heval_agree]
         exact .rfl
       set item := (p.subst σ.subst).toItem (.const (.uninterpreted v'.name v.sort))
@@ -519,15 +517,15 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
         simpa [σ', FiniteSubst.rename_source_eq] using hkwf
       cases hitem : item with
       | pure φ =>
-        have hφ_entail : p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-            ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ := by
+        have hφ_entail : p.eval W ((σ.subst.eval ρ)) u ⊢
+            ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ := by
           simpa [item, hitem] using
             (hpu'.trans (Atom.eval_purePart W (p := p.subst σ.subst)
               (t := .const (.uninterpreted v'.name v.sort))
               (ρ := (ρ.updateConst v.sort v'.name u))))
-        ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u).env⌝ $$ [Hpu]
+        ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ $$ [Hpu]
         · iapply hφ_entail
-          simp [VerifM.Env.withEnv]
+          simp []
         icases Hφ with %hφ
         have hb2' : (VerifM.acquire (.pure φ)).eval
             { st with decls := st.decls.addConst v' } (ρ.updateConst v.sort v'.name u)
@@ -552,9 +550,9 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
               iexact HR)
         iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree W hkwf'
           (by
-            simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+            simpa [σ', Env.agreeOn, Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
-                (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
+                (v := v) (name' := v'.name) (ρ := ρ) (u := u) hσwf hv'_fresh_range))
           hΦ)
         iexact Howns
       | spatial a =>
@@ -565,19 +563,19 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
         have hitem_wf' : (.spatial a : CtxItem).wfIn (st.decls.addConst v') := by
           simpa [item, hitem] using hitem_wf
         have hitem_interp :
-            p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
+            p.eval W ((σ.subst.eval ρ)) u ⊢
               CtxItem.interp W (ρ.updateConst v.sort v'.name u) item := by
           simpa [item] using
             (hpu'.trans (Atom.toItem_eval W (p := p.subst σ.subst)
               (t := .const (.uninterpreted v'.name v.sort))
               (ρ := (ρ.updateConst v.sort v'.name u))).2)
         have hspatial_interp :
-            p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) u ⊢
-              SpatialAtom.interp W (ρ.updateConst v.sort v'.name u).env a := by
+            p.eval W ((σ.subst.eval ρ)) u ⊢
+              SpatialAtom.interp W (ρ.updateConst v.sort v'.name u) a := by
           simpa [item, hitem, CtxItem.interp] using hitem_interp
-        ihave Ha : SpatialAtom.interp W (ρ.updateConst v.sort v'.name u).env a $$ [Hpu]
+        ihave Ha : SpatialAtom.interp W (ρ.updateConst v.sort v'.name u) a $$ [Hpu]
         · iapply hspatial_interp
-          simp [VerifM.Env.withEnv]
+          simp []
         ihave Hfacts := SpatialAtom.interp_facts W a $$ Ha
         icases Hfacts with ⟨%hfacts, Ha⟩
         obtain ⟨st'', hdecls'', howns'', hassume⟩ :=
@@ -592,9 +590,9 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
             (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
         iapply (hih.trans <| Assertion.post_env_agree W hkwf'
           (by
-            simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+            simpa [σ', Env.agreeOn, Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
-                (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
+                (v := v) (name' := v'.name) (ρ := ρ) (u := u) hσwf hv'_fresh_range))
           hΦ)
         simp only [TransState.sl_eq, howns'', TransState.addItem, SpatialContext.interp]
         icases Howns with ⟨HS, HR⟩
@@ -631,16 +629,16 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
 
 theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
-    (st : TransState) (ρ : VerifM.Env)
-    (Ψ : (FiniteSubst × α) → TransState → VerifM.Env → Prop) (Φ : α → VerifM.Env → iProp) (R : iProp)
-    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → VerifM.Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
+    (st : TransState) (ρ : Env)
+    (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
+    (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
     σ.wfIn Δ_base st.decls →
     m.wfIn retWf (Δ_base.declVars σ.dom) →
     VerifM.eval (Assertion.prove σ m) st ρ Ψ →
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
       retWf a (Δ_base.declVars σ'.dom) →
-      st'.sl W ρ' ∗ R ⊢ Φ a (ρ'.withEnv (σ'.subst.eval ρ'.env))) →
-    st.sl W ρ ∗ R ⊢ Assertion.pre W Φ m (ρ.withEnv (σ.subst.eval ρ.env)) := by
+      st'.sl W ρ' ∗ R ⊢ Φ a ((σ'.subst.eval ρ'))) →
+    st.sl W ρ ∗ R ⊢ Assertion.pre W Φ m ((σ.subst.eval ρ)) := by
   intro hσwf hwf heval hpost
   induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
@@ -652,7 +650,7 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base :
         (FiniteSubst.subst_wfIn_formula hσwf hφwf)
       have hφ_holds := (FiniteSubst.eval_subst_formula hσwf hφwf).mp hassert.1
       show st.sl W ρ ∗ R ⊢
-        (⌜φ.eval (σ.subst.eval ρ.env)⌝ ∗ Assertion.pre W Φ k (ρ.withEnv (σ.subst.eval ρ.env)) : iProp)
+        (⌜φ.eval (σ.subst.eval ρ)⌝ ∗ Assertion.pre W Φ k ((σ.subst.eval ρ)) : iProp)
       istart
       iintro ⟨Howns, HR⟩
       isplitr [Howns HR]
@@ -670,12 +668,12 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base :
       have hv'_fresh_decls : v'.name ∉ st.decls.allNames :=
         st.freshConst_fresh (some v.name) v.sort
       have hv'_fresh_range : v'.name ∉ σ.range.allNames := hσwf.fresh_range hv'_fresh_decls
-      set u := t.eval (σ.subst.eval ρ.env)
+      set u := t.eval (σ.subst.eval ρ)
       specialize hdecl u
       have hb2 := VerifM.eval_bind hdecl
       have hassume := VerifM.eval_assumePure hb2
         (FiniteSubst.decl_eq_wfIn (c := v') hσwf htwf hv'_fresh_decls)
-        (FiniteSubst.decl_eq_eval (c := v') (ρ := ρ.env) hσwf htwf hv'_fresh_decls)
+        (FiniteSubst.decl_eq_eval (c := v') (ρ := ρ) hσwf htwf hv'_fresh_decls)
       set σ' := σ.rename v v'.name
       have hσ'wf : σ'.wfIn Δ_base (st.decls.addConst v') := by
         simpa [σ'] using
@@ -690,9 +688,9 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base :
           (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
       exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.pre_env_agree W hkwf'
         (by
-          simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+          simpa [σ', Env.agreeOn, Env.updateConst] using
             (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
-              (v := v) (name' := v'.name) (ρ := ρ.env) (u := u) hσwf hv'_fresh_range))
+              (v := v) (name' := v'.name) (ρ := ρ) (u := u) hσwf hv'_fresh_range))
         hΦ
   | pred v p k ih =>
       obtain ⟨hpwf, hkwf⟩ := hwf
@@ -712,25 +710,25 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base :
           istart
           iintro H
           icases H with ⟨Hpred, Howns, HR⟩
-          iexists (t.eval ρ'.env)
+          iexists (t.eval ρ')
           isplitr [Howns HR]
           · have hpred_subst :
-                (p.subst σ.subst).eval W ρ' (t.eval ρ'.env) ⊢
-                  p.eval W (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) := by
-              simpa [VerifM.Env.withEnv] using
-                (show (p.subst σ.subst).eval W ρ' (t.eval ρ'.env) ⊢
-                    p.eval W (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) by
+                (p.subst σ.subst).eval W ρ' (t.eval ρ') ⊢
+                  p.eval W ((σ.subst.eval ρ')) (t.eval ρ') := by
+              simpa [] using
+                (show (p.subst σ.subst).eval W ρ' (t.eval ρ') ⊢
+                    p.eval W ((σ.subst.eval ρ')) (t.eval ρ') by
                   rw [Atom.eval_subst W hpwf hσwf.subst hσwf.rangeWf]
                   exact BIBase.Entails.rfl)
             have hagree_subst :
-                VerifM.Env.agreeOn (Δ_base.declVars σ.dom)
-                  (ρ.withEnv (σ.subst.eval ρ.env))
-                  (ρ'.withEnv (σ.subst.eval ρ'.env)) := by
+                Env.agreeOn (Δ_base.declVars σ.dom)
+                  ((σ.subst.eval ρ))
+                  ((σ.subst.eval ρ')) := by
               exact FiniteSubst.eval_agreeOn hσwf hagree
             have hpred_transport :
-                p.eval W (ρ'.withEnv (σ.subst.eval ρ'.env)) (t.eval ρ'.env) ⊢
-                  p.eval W (ρ.withEnv (σ.subst.eval ρ.env)) (t.eval ρ'.env) := by
-              rw [Atom.eval_env_agree W hpwf (VerifM.Env.agreeOn_symm hagree_subst)]
+                p.eval W ((σ.subst.eval ρ')) (t.eval ρ') ⊢
+                  p.eval W ((σ.subst.eval ρ)) (t.eval ρ') := by
+              rw [Atom.eval_env_agree W hpwf (Env.agreeOn_symm hagree_subst)]
               exact BIBase.Entails.rfl
             iapply hpred_transport
             iapply hpred_subst
@@ -742,11 +740,11 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base :
               st'.freshConst_fresh (some v.name) v.sort
             have hv'_fresh_range : v'.name ∉ σ.range.allNames :=
               hσwf_st'.fresh_range hv'_fresh_decls
-            specialize hdecl (t.eval ρ'.env)
+            specialize hdecl (t.eval ρ')
             have hb3 := VerifM.eval_bind hdecl
             have hassume := VerifM.eval_assumePure hb3
               (Formula.eq_wfIn_addConst_of_fresh (c := v') hwfst' htwf hv'_fresh_decls)
-              (Formula.eq_eval_updateConst_of_fresh (c := v') (ρ := ρ'.env) htwf hv'_fresh_decls)
+              (Formula.eq_eval_updateConst_of_fresh (c := v') (ρ := ρ') htwf hv'_fresh_decls)
             set σ' := σ.rename v v'.name
             have hσ'wf : σ'.wfIn Δ_base (st'.decls.addConst v') := by
               simpa [σ'] using
@@ -755,33 +753,33 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base :
             have hkwf' : k.wfIn retWf (Δ_base.declVars σ'.dom) := by
               simpa [σ', FiniteSubst.rename_source_eq] using hkwf
             have hih := ih Δ_base σ' { st' with decls := st'.decls.addConst v', asserts := _ :: st'.asserts }
-              (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) Ψ hσ'wf hkwf' hassume hpost
-            have hinterp_bi : st'.sl W ρ' ⊣⊢ st'.sl W (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) :=
+              (ρ'.updateConst v.sort v'.name (t.eval ρ')) Ψ hσ'wf hkwf' hassume hpost
+            have hinterp_bi : st'.sl W ρ' ⊣⊢ st'.sl W (ρ'.updateConst v.sort v'.name (t.eval ρ')) :=
               SpatialContext.interp_env_agree W (VerifM.eval.wf hq).ownsWf
                 (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
             have hframe : st'.sl W ρ' ∗ R ⊢
-                st'.sl W (ρ'.updateConst v.sort v'.name (t.eval ρ'.env)) ∗ R :=
+                st'.sl W (ρ'.updateConst v.sort v'.name (t.eval ρ')) ∗ R :=
               sep_mono_left hinterp_bi.1
             iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree W hkwf'
               (by
                 have hrename := (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st'.decls)
-                    (v := v) (name' := v'.name) (ρ := ρ'.env) (u := t.eval ρ'.env)
+                    (v := v) (name' := v'.name) (ρ := ρ') (u := t.eval ρ')
                     hσwf_st' hv'_fresh_range)
                 have hsubst_agree : _root_.Env.agreeOn (Δ_base.declVars σ.dom)
-                    (σ.subst.eval ρ'.env) (σ.subst.eval ρ.env) := by
+                    (σ.subst.eval ρ') (σ.subst.eval ρ) := by
                   exact _root_.Env.agreeOn_symm (FiniteSubst.eval_agreeOn hσwf (by
-                    simpa [VerifM.Env.agreeOn] using hagree))
+                    simpa [Env.agreeOn] using hagree))
                 have hsubst_update : _root_.Env.agreeOn ((Δ_base.declVars σ.dom).declVar v)
-                    ((σ.subst.eval ρ'.env).updateConst v.sort v.name (t.eval ρ'.env))
-                    ((σ.subst.eval ρ.env).updateConst v.sort v.name (t.eval ρ'.env)) :=
+                    ((σ.subst.eval ρ').updateConst v.sort v.name (t.eval ρ'))
+                    ((σ.subst.eval ρ).updateConst v.sort v.name (t.eval ρ')) :=
                   _root_.Env.agreeOn_declVar hsubst_agree
                 have hsubst_update' : _root_.Env.agreeOn (Δ_base.declVars (σ.rename v v'.name).dom)
-                    ((σ.subst.eval ρ'.env).updateConst v.sort v.name (t.eval ρ'.env))
-                    ((σ.subst.eval ρ.env).updateConst v.sort v.name (t.eval ρ'.env)) :=
+                    ((σ.subst.eval ρ').updateConst v.sort v.name (t.eval ρ'))
+                    ((σ.subst.eval ρ).updateConst v.sort v.name (t.eval ρ')) :=
                   _root_.Env.agreeOn_mono
                     (FiniteSubst.rename_source_subset_rev σ Δ_base v v'.name) hsubst_update
                 have htrans := _root_.Env.agreeOn_trans hrename hsubst_update'
-                simpa [σ', VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using htrans)
+                simpa [σ', Env.agreeOn, Env.updateConst] using htrans)
               hΦ)
             isplitl [Howns]
             · simp [TransState.sl]

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -61,18 +61,18 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Atom.eval (W : TinyML.World) {τ : Srt} (p : Atom τ) (ρ : VerifM.Env) : τ.denote → iProp :=
+def Atom.eval (W : TinyML.World) {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
   match p with
-  | isint t  => λ v => ⌜.int v = t.eval ρ.env⌝
-  | isbool t => λ v => ⌜.bool v = t.eval ρ.env⌝
-  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ.env⌝
+  | isint t  => λ v => ⌜.int v = t.eval ρ⌝
+  | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
+  | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
   | own l ty => λ v => ∃ loc : Runtime.Location,
-      ⌜l.eval ρ.env = .loc loc⌝ ∗ loc ↦ [v] ∗ TinyML.ValHasType W v ty
+      ⌜l.eval ρ = .loc loc⌝ ∗ loc ↦ [v] ∗ TinyML.ValHasType W v ty
   | arr a ty => λ v => ∃ loc : Runtime.Location, ∃ vs : List Runtime.Val,
-      ⌜a.eval ρ.env = .array vs.length loc⌝ ∗ ⌜v = .vec vs⌝ ∗ loc ↦ vs ∗
+      ⌜a.eval ρ = .array vs.length loc⌝ ∗ ⌜v = .vec vs⌝ ∗ loc ↦ vs ∗
         TinyML.ValHasType W (.vec vs) (.vec ty)
   | rel name arg => λ v =>
-    ⌜(SpecFn.isDefined name arg).eval ρ.env ∧ (SpecFn.call name arg).eval ρ.env = v⌝
+    ⌜(SpecFn.isDefined name arg).eval ρ ∧ (SpecFn.call name arg).eval ρ = v⌝
 
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
@@ -141,7 +141,7 @@ def Atom.resolve (a : Atom τ) (C : List Formula) : Option (Term τ) :=
   C.findSome? (·.matchAtom a)
 
 theorem Atom.resolve_correct (W : TinyML.World) {a : Atom τ} {C : List Formula} {t : Term τ}
-    (h : a.resolve C = some t) (ρ : VerifM.Env) (hC : ∀ φ ∈ C, φ.eval ρ.env) :
+    (h : a.resolve C = some t) (ρ : Env) (hC : ∀ φ ∈ C, φ.eval ρ) :
     ⊢ (a.toItem t).interp W ρ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
   rw [Formula.matchAtom_correct hφ_match]
@@ -215,8 +215,8 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | rel name t =>
     exact ⟨Formula.wfIn_mono _ h.1 hmono hwf, Term.wfIn_mono _ h.2 hmono hwf⟩
 
-theorem Atom.eval_env_agree (W : TinyML.World) {p : Atom τ} {ρ ρ' : VerifM.Env} {Δ : Signature}
-    (hwf : p.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') : p.eval W ρ = p.eval W ρ' := by
+theorem Atom.eval_env_agree (W : TinyML.World) {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
+    (hwf : p.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') : p.eval W ρ = p.eval W ρ' := by
   cases p with
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
@@ -253,8 +253,8 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     simp only [Atom.toItem, CtxItem.wfIn, Formula.wfIn]
     exact ⟨hp.1, hp.2, ht⟩
 
-theorem Atom.toItem_eval (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
-    CtxItem.interp W ρ (p.toItem t) ⊣⊢ p.eval W ρ (t.eval ρ.env) := by
+theorem Atom.toItem_eval (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : Env} :
+    CtxItem.interp W ρ (p.toItem t) ⊣⊢ p.eval W ρ (t.eval ρ) := by
   cases p with
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
@@ -268,8 +268,8 @@ theorem Atom.toItem_eval (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : Ve
   | rel name arg =>
     simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval]
 
-theorem Atom.eval_purePart (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : VerifM.Env} :
-    p.eval W ρ (t.eval ρ.env) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
+theorem Atom.eval_purePart (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : Env} :
+    p.eval W ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
   cases p with
   | isint v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
@@ -292,33 +292,33 @@ theorem Atom.eval_purePart (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : 
 -- ---------------------------------------------------------------------------
 
 -- @agent: change eval_subst to a bi-entailment in the future.
-theorem Atom.eval_subst (W : TinyML.World) {p : Atom τ} {σ : Subst} {ρ : VerifM.Env} {Δ Δ' : Signature}
+theorem Atom.eval_subst (W : TinyML.World) {p : Atom τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hwfΔ' : Δ'.wf) :
-    (p.subst σ).eval W ρ = p.eval W (ρ.withEnv (σ.eval ρ.env)) := by
+    (p.subst σ).eval W ρ = p.eval W ((σ.eval ρ)) := by
   cases p with
   | isint t =>
     funext v
-    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
+    simp only [Atom.subst, Atom.eval, ]
     rw [Term.eval_subst hp hσ hwfΔ']
   | isbool t =>
     funext v
-    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
+    simp only [Atom.subst, Atom.eval, ]
     rw [Term.eval_subst hp hσ hwfΔ']
   | isinj tag arity t =>
     funext v
-    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
+    simp only [Atom.subst, Atom.eval, ]
     rw [Term.eval_subst hp hσ hwfΔ']
   | own l ty =>
     funext v
-    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
+    simp only [Atom.subst, Atom.eval, ]
     rw [Term.eval_subst hp hσ hwfΔ']
   | arr a ty =>
     funext v
-    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env]
+    simp only [Atom.subst, Atom.eval, ]
     rw [Term.eval_subst hp hσ hwfΔ']
   | rel name t =>
     funext v
-    simp only [Atom.subst, Atom.eval, VerifM.Env.withEnv_env, SpecFn.isDefined,
+    simp only [Atom.subst, Atom.eval, SpecFn.isDefined,
       SpecFn.call, Formula.eval, Term.eval, UnPred.eval]
     rw [Term.eval_subst hp.2.2 hσ hwfΔ']
     simp [Subst.eval]
@@ -363,26 +363,26 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .arr _ _ => []
   | .rel _ _ => []
 
-theorem Atom.candidates_correct (W : TinyML.World) {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : VerifM.Env}
-    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ.env) : ⊢ (a.toItem t).interp W ρ := by
+theorem Atom.candidates_correct (W : TinyML.World) {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : Env}
+    (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : ⊢ (a.toItem t).interp W ρ := by
   cases a with
   | isint v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ.env <;> simp_all
+    cases hv : v.eval ρ <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isbool v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ.env <;> simp_all
+    cases hv : v.eval ρ <;> simp_all
     · exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | isinj tag arity v =>
     simp [candidates] at hmem; obtain ⟨rfl, rfl⟩ := hmem
     simp [Formula.eval, UnPred.eval, Term.eval, UnOp.eval, Const.denote] at h
     simp [toItem, CtxItem.interp, Formula.eval, Term.eval, UnOp.eval]
-    cases hv : v.eval ρ.env <;> simp_all
+    cases hv : v.eval ρ <;> simp_all
     exact (pure_intro (PROP := iProp) trivial).trans true_emp.1
   | own l ty => simp [candidates] at hmem
   | arr a ty => simp [candidates] at hmem
@@ -423,7 +423,7 @@ def VerifM.tryCandidates : List (Formula × Term τ) → VerifM (Option (Term τ
 
 private theorem VerifM.eval_tryCandidates (W : TinyML.World)
     {candidates : List (Formula × Term τ)} {a : Atom τ}
-    {st : TransState} {ρ : VerifM.Env} {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env} {Q : Option (Term τ) → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.tryCandidates candidates) st ρ Q)
     (hcands : ∀ p ∈ candidates, p ∈ a.candidates)
     (hpwf : a.wfIn st.decls) :
@@ -493,8 +493,8 @@ omit [MicaGS HasLC.hasLC Sig] in
 /-- Correctness of `findMatchIn`: on a `some (n, v)` result, `remove ctx n`
     extracts an atom of kind `k` whose key the solver has proved equal to `tq`. -/
 theorem VerifM.eval_findMatchIn {k : SpatialAtom.Kind} {tq : Term .value} {ty : TinyML.Typ}
-    {ctx : SpatialContext} {st : TransState} {ρ : VerifM.Env}
-    {Q : Option (Nat × Term .value) → TransState → VerifM.Env → Prop}
+    {ctx : SpatialContext} {st : TransState} {ρ : Env}
+    {Q : Option (Nat × Term .value) → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.findMatchIn k tq ty ctx) st ρ Q)
     (htq : tq.wfIn st.decls) (hctx : ctx.wfIn st.decls) :
     ∃ result,
@@ -502,7 +502,7 @@ theorem VerifM.eval_findMatchIn {k : SpatialAtom.Kind} {tq : Term .value} {ty : 
       (∀ n v, result = some (n, v) →
         ∃ t rest,
           SpatialContext.remove ctx n = some (k.atom t v ty, rest) ∧
-          Term.eval ρ.env tq = Term.eval ρ.env t) := by
+          Term.eval ρ tq = Term.eval ρ t) := by
   induction ctx generalizing Q with
   | nil =>
     simp only [VerifM.findMatchIn] at h
@@ -520,7 +520,7 @@ theorem VerifM.eval_findMatchIn {k : SpatialAtom.Kind} {tq : Term .value} {ty : 
           (∀ n v', result = some (n, v') →
             ∃ t' rest',
               SpatialContext.remove (a :: ctx) n = some (k.atom t' v' ty, rest') ∧
-              Term.eval ρ.env tq = Term.eval ρ.env t') := by
+              Term.eval ρ tq = Term.eval ρ t') := by
       intro hrec
       have hb' := VerifM.eval_bind hrec
       obtain ⟨result', hres', hsome'⟩ := ih hb' hcons.2
@@ -553,7 +553,7 @@ theorem VerifM.eval_findMatchIn {k : SpatialAtom.Kind} {tq : Term .value} {ty : 
         intros n' v' hnv
         simp at hnv
         obtain ⟨rfl, rfl⟩ := hnv
-        have heq : Term.eval ρ.env tq = Term.eval ρ.env a.key := by
+        have heq : Term.eval ρ tq = Term.eval ρ a.key := by
           simpa [Formula.eval] using hb_sound hbtrue
         simp only [Bool.and_eq_true, beq_iff_eq] at hmatch
         refine ⟨a.key, ctx, ?_, heq⟩
@@ -568,14 +568,14 @@ theorem VerifM.eval_findMatchIn {k : SpatialAtom.Kind} {tq : Term .value} {ty : 
     caller receives its interpretation at key `tq` separately. -/
 theorem VerifM.eval_findMatch (W : TinyML.World) {k : SpatialAtom.Kind}
     {tq : Term .value} {ty : TinyML.Typ}
-    {st : TransState} {ρ : VerifM.Env}
-    {Q : Option (Term .value) → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env}
+    {Q : Option (Term .value) → TransState → Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.findMatch k tq ty) st ρ Q)
     (htq : tq.wfIn st.decls)
     (hsome : ∀ v st', Q (some v) st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp W ρ.env (k.atom tq v ty) ∗ st'.sl W ρ ∗ R ⊢ Φ)
+        SpatialAtom.interp W ρ (k.atom tq v ty) ∗ st'.sl W ρ ∗ R ⊢ Φ)
     (hnone : Q none st ρ → st.sl W ρ ∗ R ⊢ Φ) :
     st.sl W ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatch at h
@@ -603,7 +603,7 @@ theorem VerifM.eval_findMatch (W : TinyML.World) {k : SpatialAtom.Kind}
     have ⟨hk3, _, _, _⟩ := VerifM.eval_ctx hb3
     have hk3' := hk3 hrest_wf
     have hQ : Q (some v) { st with owns := rest } ρ := VerifM.eval_ret hk3'
-    have hsplit := SpatialContext.interp_remove W ρ.env st.owns n _ _ hrem
+    have hsplit := SpatialContext.interp_remove W ρ st.owns n _ _ hrem
     have hcong := SpatialAtom.congr W (k := k) (t := t) (t' := tq) (v := v) (v' := v)
       (ty := ty) heq.symm rfl
     -- goal: st.owns.interp ρ ∗ R ⊢ Φ
@@ -626,14 +626,14 @@ def VerifM.findMatchForce (k : SpatialAtom.Kind) (tq : Term .value) (ty : TinyML
     required, since the `none` branch is discharged by the fatal error. -/
 theorem VerifM.eval_findMatchForce (W : TinyML.World) {k : SpatialAtom.Kind}
     {tq : Term .value} {ty : TinyML.Typ}
-    {st : TransState} {ρ : VerifM.Env}
-    {Q : Term .value → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env}
+    {Q : Term .value → TransState → Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.findMatchForce k tq ty) st ρ Q)
     (htq : tq.wfIn st.decls)
     (hsome : ∀ v st', Q v st' ρ →
         st'.decls = st.decls → v.wfIn st.decls →
-        SpatialAtom.interp W ρ.env (k.atom tq v ty) ∗ st'.sl W ρ ∗ R ⊢ Φ) :
+        SpatialAtom.interp W ρ (k.atom tq v ty) ∗ st'.sl W ρ ∗ R ⊢ Φ) :
     st.sl W ρ ∗ R ⊢ Φ := by
   unfold VerifM.findMatchForce at h
   have hb := VerifM.eval_bind h
@@ -659,12 +659,12 @@ def VerifM.acquire (item : CtxItem) : VerifM Unit := do
 omit [MicaGS HasLC.hasLC Sig] in
 /-- Correctness of `acquire`: the resulting state extends the input state by
     the item; its pure facts must hold in the current environment. -/
-theorem VerifM.eval_acquire {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_acquire {item : CtxItem} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.acquire item) st ρ Q)
     (hwf : item.wfIn st.decls)
     (hpure : item.purePart ρ)
-    (hfacts : ∀ φ ∈ item.facts, φ.eval ρ.env) :
+    (hfacts : ∀ φ ∈ item.facts, φ.eval ρ) :
     ∃ st', st'.decls = st.decls ∧ st'.owns = (st.addItem item).owns ∧ Q () st' ρ := by
   unfold VerifM.acquire at h
   have hb := VerifM.eval_bind h
@@ -682,13 +682,13 @@ theorem VerifM.eval_acquire {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
     extended by the atom, whose pure facts are justified from its
     interpretation. -/
 theorem VerifM.eval_acquireSpatial (W : TinyML.World) {a : SpatialAtom}
-    {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop} {R Φ : iProp}
+    {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop} {R Φ : iProp}
     (h : VerifM.eval (VerifM.acquire (.spatial a)) st ρ Q)
     (hwf : a.wfIn st.decls)
     (hk : ∀ st', Q () st' ρ → st'.decls = st.decls → st'.owns = a :: st.owns →
       st'.sl W ρ ∗ R ⊢ Φ) :
-    SpatialAtom.interp W ρ.env a ∗ st.sl W ρ ∗ R ⊢ Φ := by
+    SpatialAtom.interp W ρ a ∗ st.sl W ρ ∗ R ⊢ Φ := by
   istart
   iintro ⟨Ha, Howns, HR⟩
   ihave Hfacts := SpatialAtom.interp_facts W a $$ Ha
@@ -724,8 +724,8 @@ def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
       | none => VerifM.tryCandidates a.candidates
 
 /-- Helper: resolution of a pure atom via formula matching or SMT candidates. -/
-private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
-    {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
+private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom τ} {st : TransState} {ρ : Env}
+    {Q : Option (Term τ) → TransState → Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (do
       match ← VerifM.ctxPure (pred.resolve ·) with
@@ -733,10 +733,10 @@ private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom τ} {st
       | none => VerifM.tryCandidates pred.candidates) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st' ρ', Q .none st' ρ' → st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl W ρ' ∗ R ⊢ Φ)
+      Env.agreeOn st.decls ρ ρ' → st'.sl W ρ' ∗ R ⊢ Φ)
     (hsome : ∀ v st' ρ', Q (.some v) st' ρ' → st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
-      Atom.eval W pred ρ' (v.eval ρ'.env) ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
+      Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
+      Atom.eval W pred ρ' (v.eval ρ') ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
     st.sl W ρ ∗ R ⊢ Φ := by
     have hb1 := VerifM.eval_bind h
     have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
@@ -745,10 +745,10 @@ private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom τ} {st
       simp [hres] at hctx_q
       have hq := VerifM.eval_ret hctx_q
       have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
-      have hpred : ⊢ Atom.eval W pred ρ (t.eval ρ.env) :=
+      have hpred : ⊢ Atom.eval W pred ρ (t.eval ρ) :=
         (Atom.resolve_correct W hres ρ hholds.asserts).trans (Atom.toItem_eval W).1
       exact (sep_intro_valid_left hpred).trans
-        (hsome t st ρ hq (Signature.Subset.refl _) VerifM.Env.agreeOn_refl htwf)
+        (hsome t st ρ hq (Signature.Subset.refl _) Env.agreeOn_refl htwf)
     | none =>
       simp [hres] at hctx_q
       obtain ⟨result, hq, hresult_eval, hresult_wf⟩ :=
@@ -756,25 +756,25 @@ private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom τ} {st
       cases hr : result with
       | none =>
         have hqnone : Q .none st ρ := by simpa [hr] using hq
-        exact hnone st ρ hqnone (Signature.Subset.refl _) VerifM.Env.agreeOn_refl
+        exact hnone st ρ hqnone (Signature.Subset.refl _) Env.agreeOn_refl
       | some t =>
         have htwf : t.wfIn st.decls := hresult_wf t hr
         have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
-        have hpred : ⊢ Atom.eval W pred ρ (t.eval ρ.env) :=
+        have hpred : ⊢ Atom.eval W pred ρ (t.eval ρ) :=
           (hresult_eval t hr).trans (Atom.toItem_eval W).1
         exact (sep_intro_valid_left hpred).trans
-          (hsome t st ρ hqsome (Signature.Subset.refl _) VerifM.Env.agreeOn_refl htwf)
+          (hsome t st ρ hqsome (Signature.Subset.refl _) Env.agreeOn_refl htwf)
 
-theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom τ} {st : TransState} {ρ : VerifM.Env}
-    {Q : Option (Term τ) → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom τ} {st : TransState} {ρ : Env}
+    {Q : Option (Term τ) → TransState → Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)
     (hwf : pred.wfIn st.decls)
     (hnone : ∀ st' ρ', Q .none st' ρ' → st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' → st'.sl W ρ' ∗ R ⊢ Φ)
+      Env.agreeOn st.decls ρ ρ' → st'.sl W ρ' ∗ R ⊢ Φ)
     (hsome : ∀ v st' ρ', Q (.some v) st' ρ' → st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
-      Atom.eval W pred ρ' (v.eval ρ'.env) ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
+      Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
+      Atom.eval W pred ρ' (v.eval ρ') ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
     st.sl W ρ ∗ R ⊢ Φ := by
   match pred, hwf, hsome, h with
   | .own l ty, hwf, hsome, h =>
@@ -783,28 +783,28 @@ theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom τ} {st : TransState
     · intros v st' hqsome hdecls hvwf
       have hsub : st.decls.Subset st'.decls := by rw [hdecls]; exact Signature.Subset.refl _
       have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
-      have hsome' := hsome v st' ρ hqsome hsub VerifM.Env.agreeOn_refl hvwf'
-      have heq : SpatialAtom.interp W ρ.env (SpatialAtom.Kind.ref.atom l v ty) ⊢
-          Atom.eval W (Atom.own l ty) ρ (v.eval ρ.env) := by
+      have hsome' := hsome v st' ρ hqsome hsub Env.agreeOn_refl hvwf'
+      have heq : SpatialAtom.interp W ρ (SpatialAtom.Kind.ref.atom l v ty) ⊢
+          Atom.eval W (Atom.own l ty) ρ (v.eval ρ) := by
         simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
     · intros hqnone
-      exact hnone st ρ hqnone (Signature.Subset.refl _) VerifM.Env.agreeOn_refl
+      exact hnone st ρ hqnone (Signature.Subset.refl _) Env.agreeOn_refl
   | .arr a ty, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
     refine VerifM.eval_findMatch W (R := R) (Φ := Φ) h hwf ?_ ?_
     · intros v st' hqsome hdecls hvwf
       have hsub : st.decls.Subset st'.decls := by rw [hdecls]; exact Signature.Subset.refl _
       have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
-      have hsome' := hsome v st' ρ hqsome hsub VerifM.Env.agreeOn_refl hvwf'
-      have heq : SpatialAtom.interp W ρ.env (SpatialAtom.Kind.array.atom a v ty) ⊢
-          Atom.eval W (Atom.arr a ty) ρ (v.eval ρ.env) := by
+      have hsome' := hsome v st' ρ hqsome hsub Env.agreeOn_refl hvwf'
+      have heq : SpatialAtom.interp W ρ (SpatialAtom.Kind.array.atom a v ty) ⊢
+          Atom.eval W (Atom.arr a ty) ρ (v.eval ρ) := by
         simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
     · intros hqnone
-      exact hnone st ρ hqnone (Signature.Subset.refl _) VerifM.Env.agreeOn_refl
+      exact hnone st ρ hqnone (Signature.Subset.refl _) Env.agreeOn_refl
   | .isint t, hwf, hsome, h =>
     simp only [VerifM.resolve] at h
     exact VerifM.eval_resolve_pure W (pred := .isint t) h hwf hnone hsome
@@ -822,12 +822,12 @@ theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom τ} {st : TransState
     | false =>
       simp at hafter
       exact hnone st ρ (VerifM.eval_ret hafter)
-        (Signature.Subset.refl _) VerifM.Env.agreeOn_refl
+        (Signature.Subset.refl _) Env.agreeOn_refl
     | true =>
       simp at hafter
-      have hdef : (SpecFn.isDefined name t).eval ρ.env := hok_sound rfl
+      have hdef : (SpecFn.isDefined name t).eval ρ := hok_sound rfl
       have hqsome : Q (some (SpecFn.call name t)) st ρ := VerifM.eval_ret hafter
-      have hpred : ⊢ Atom.eval W (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ.env) :=
+      have hpred : ⊢ Atom.eval W (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ) :=
         pure_intro (PROP := iProp) ⟨hdef, rfl⟩
       exact (sep_intro_valid_left hpred).trans (hsome (SpecFn.call name t) st ρ hqsome
-        (Signature.Subset.refl _) VerifM.Env.agreeOn_refl hwf.2)
+        (Signature.Subset.refl _) Env.agreeOn_refl hwf.2)

--- a/Mica/Verifier/BoundedQuantifier.lean
+++ b/Mica/Verifier/BoundedQuantifier.lean
@@ -47,8 +47,8 @@ theorem declare_correct (L : SpecFn) (f : TinyML.Var) (axs : List Axiom)
     (R : Srt.value.denote → Srt.value.denote → Prop)
     (F : Srt.value.denote → Srt.value.denote)
     (D : Srt.value.denote → Prop)
-    (Δ : Signature) (Γ : FunCtx) (st : TransState) (ρ : VerifM.Env)
-    {Q : Unit → TransState → VerifM.Env → Prop}
+    (Δ : Signature) (Γ : FunCtx) (st : TransState) (ρ : Env)
+    {Q : Unit → TransState → Env → Prop}
     (hrelFresh : relName L ∉ Δ.allNames)
     (hfunFresh : funcName L ∉ Δ.allNames)
     (hdefFresh : defName L ∉ Δ.allNames)
@@ -56,20 +56,20 @@ theorem declare_correct (L : SpecFn) (f : TinyML.Var) (axs : List Axiom)
     (hdecls : st.decls = Δ) (howns : st.owns = []) (hvars : st.decls.vars = [])
     (hwfext : (((Δ.addBinaryRel (rel L)).addUnary (func L)).addUnaryRel (defined L)).wf)
     (hΓwf : FunCtx.wfIn Γ Δ)
-    (hsplit : FunCtx.splitCompatible Γ ρ.env)
-    (hdet : Relation.BinaryRelDet Γ ρ.env ρ.env)
+    (hsplit : FunCtx.splitCompatible Γ ρ)
+    (hdet : Relation.BinaryRelDet Γ ρ ρ)
     (haxwf : ∀ ax ∈ axs, ax.formula.wfIn
       (((Δ.addBinaryRel (rel L)).addUnary (func L)).addUnaryRel (defined L)))
-    (haxeval : ∀ ax ∈ axs, ax.formula.eval (Skolemize.relSplitEnv ρ.env L R D F))
+    (haxeval : ∀ ax ∈ axs, ax.formula.eval (Skolemize.relSplitEnv ρ L R D F))
     (heval : VerifM.eval (declare L axs) st ρ Q) :
     ∃ st' ρ',
       st'.decls = ((Δ.addBinaryRel (rel L)).addUnary (func L)).addUnaryRel (defined L) ∧
       st'.owns = [] ∧ st'.decls.vars = [] ∧ st'.decls.wf ∧
       st.decls.Subset st'.decls ∧
-      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      Env.agreeOn st.decls ρ ρ' ∧
       FunCtx.wfIn (Γ ++ [(f, L)]) st'.decls ∧
-      FunCtx.splitCompatible (Γ ++ [(f, L)]) ρ'.env ∧
-      Relation.BinaryRelDet (Γ ++ [(f, L)]) ρ'.env ρ'.env ∧
+      FunCtx.splitCompatible (Γ ++ [(f, L)]) ρ' ∧
+      Relation.BinaryRelDet (Γ ++ [(f, L)]) ρ' ρ' ∧
       Q () st' ρ' := by
   simp only [declare] at heval
   obtain ⟨_, h1⟩ := VerifM.eval_declBinaryRelExact (VerifM.eval_bind heval)
@@ -81,22 +81,21 @@ theorem declare_correct (L : SpecFn) (f : TinyML.Var) (axs : List Axiom)
   set st3 : TransState :=
     { st with decls := ((st.decls.addBinaryRel (rel L)).addUnary
         (func L)).addUnaryRel (defined L) }
-  set ρ3 : VerifM.Env :=
+  set ρ3 : Env :=
     ((ρ.updateBinaryRel .value .value (relName L) R).updateUnary
         .value .value (funcName L) F).updateUnaryRel
       .value (defName L) D
   have hst3 : st3.decls = Δext := by
     simp only [st3, Δext, hdecls]
-  have hρ3 : ρ3.env = Skolemize.relSplitEnv ρ.env L R D F := by
-    simp only [ρ3, VerifM.Env.updateUnaryRel_env, VerifM.Env.updateUnary_env,
-      VerifM.Env.updateBinaryRel_env, Skolemize.relSplitEnv]
+  have hρ3 : ρ3 = Skolemize.relSplitEnv ρ L R D F := by
+    rfl
   have hsub : Δ.Subset Δext :=
     ((Signature.Subset.subset_addBinaryRel _ _).trans
       (Signature.Subset.subset_addUnary _ _)).trans
       (Signature.Subset.subset_addUnaryRel _ _)
   obtain ⟨st4, hst4, howns4, _, hQ4⟩ :=
     VerifM.eval_assumeAxioms h4 (fun ax hax => hst3 ▸ haxwf ax hax)
-      (fun ax hax => hρ3 ▸ haxeval ax hax)
+      (fun ax hax => by simpa [Skolemize.relSplitEnv] using haxeval ax hax)
   have howns4' : st4.owns = [] := by rw [howns4]; exact howns
   have hvars4 : st4.decls.vars = [] := by
     rw [hst4, hst3]
@@ -104,7 +103,7 @@ theorem declare_correct (L : SpecFn) (f : TinyML.Var) (axs : List Axiom)
     rw [← hdecls]
     exact hvars
   have hwf4 : st4.decls.wf := by rw [hst4, hst3]; exact hwfext
-  have hagree : Env.agreeOn Δ ρ.env ρ3.env := by
+  have hagree : Env.agreeOn Δ ρ ρ3 := by
     rw [hρ3]
     exact Skolemize.relSplitEnv_agreeOn hrelFresh hfunFresh hdefFresh
   have hΓwf' : FunCtx.wfIn (Γ ++ [(f, L)]) st4.decls := by
@@ -121,7 +120,7 @@ theorem declare_correct (L : SpecFn) (f : TinyML.Var) (axs : List Axiom)
         exact ⟨hsub.unary _ hu, hsub.unaryRel _ hr⟩
       · simp at hnew; obtain ⟨_, rfl⟩ := hnew
         exact ⟨List.Mem.head _, List.Mem.head _⟩
-  have hsplit' : FunCtx.splitCompatible (Γ ++ [(f, L)]) ρ3.env := by
+  have hsplit' : FunCtx.splitCompatible (Γ ++ [(f, L)]) ρ3 := by
     intro g rel hgr x y
     rcases List.mem_append.mp hgr with hold | hnew
     · obtain ⟨hu, hr⟩ := hΓwf.split g rel hold
@@ -130,8 +129,8 @@ theorem declare_correct (L : SpecFn) (f : TinyML.Var) (axs : List Axiom)
       exact hsplit g rel hold x y
     · simp at hnew; obtain ⟨_, rfl⟩ := hnew
       rw [hρ3]
-      exact Skolemize.relSplitEnv_graph rel ρ.env hgraph x y
-  have hdet' : Relation.BinaryRelDet (Γ ++ [(f, L)]) ρ3.env ρ3.env := by
+      exact Skolemize.relSplitEnv_graph rel ρ hgraph x y
+  have hdet' : Relation.BinaryRelDet (Γ ++ [(f, L)]) ρ3 ρ3 := by
     intro g rel hgr x y₁ y₂ hy₁ hy₂
     rcases List.mem_append.mp hgr with hold | hnew
     · obtain ⟨hu, hr⟩ := hΓwf.split g rel hold
@@ -140,13 +139,13 @@ theorem declare_correct (L : SpecFn) (f : TinyML.Var) (axs : List Axiom)
       exact hdet g rel hold x y₁ y₂ hy₁ hy₂
     · simp at hnew; obtain ⟨_, rfl⟩ := hnew
       rw [hρ3] at hy₁ hy₂
-      obtain ⟨_, heq₁⟩ := (Skolemize.relSplitEnv_graph rel ρ.env hgraph x y₁).mp hy₁
-      obtain ⟨_, heq₂⟩ := (Skolemize.relSplitEnv_graph rel ρ.env hgraph x y₂).mp hy₂
+      obtain ⟨_, heq₁⟩ := (Skolemize.relSplitEnv_graph rel ρ hgraph x y₁).mp hy₁
+      obtain ⟨_, heq₂⟩ := (Skolemize.relSplitEnv_graph rel ρ hgraph x y₂).mp hy₂
       exact heq₁.symm.trans heq₂
   have hsub4 : st.decls.Subset st4.decls := by
     rw [hst4, hst3, hdecls]
     exact hsub
-  have hagree4 : VerifM.Env.agreeOn st.decls ρ ρ3 := by
+  have hagree4 : Env.agreeOn st.decls ρ ρ3 := by
     rw [hdecls]
     exact hagree
   exact ⟨st4, ρ3, by rw [hst4, hst3], howns4', hvars4, hwf4, hsub4,
@@ -885,21 +884,21 @@ relation-assembly invariants: the generic triple declaration
 (`SpecFn.declare_correct`) instantiated with the canonical interpretations,
 whose graph shape holds by construction. -/
 theorem declare_correct (s : Lifting) (body : Skolemize.DefVal) (Δ : Signature) (Γ : FunCtx)
-    (st : TransState) (ρ : VerifM.Env) {Q : Unit → TransState → VerifM.Env → Prop}
+    (st : TransState) (ρ : Env) {Q : Unit → TransState → Env → Prop}
     (hv : Valid s Δ)
     (hbody : body.wfIn ((Δ.declVar ⟨s.arg, .value⟩).declVar ⟨s.idx, .int⟩))
     (hdecls : st.decls = Δ) (howns : st.owns = []) (hvars : st.decls.vars = [])
     (hwf : Δ.wf) (hΓwf : FunCtx.wfIn Γ Δ)
-    (hsplit : FunCtx.splitCompatible Γ ρ.env)
-    (hdet : Relation.BinaryRelDet Γ ρ.env ρ.env)
+    (hsplit : FunCtx.splitCompatible Γ ρ)
+    (hdet : Relation.BinaryRelDet Γ ρ ρ)
     (heval : VerifM.eval (s.declare body) st ρ Q) :
     ∃ st' ρ',
       st'.decls = s.extendSignature Δ ∧ st'.owns = [] ∧ st'.decls.vars = [] ∧
       st'.decls.wf ∧ st.decls.Subset st'.decls ∧
-      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      Env.agreeOn st.decls ρ ρ' ∧
       FunCtx.wfIn (Γ ++ [(s.name, s.name)]) st'.decls ∧
-      FunCtx.splitCompatible (Γ ++ [(s.name, s.name)]) ρ'.env ∧
-      Relation.BinaryRelDet (Γ ++ [(s.name, s.name)]) ρ'.env ρ'.env ∧
+      FunCtx.splitCompatible (Γ ++ [(s.name, s.name)]) ρ' ∧
+      Relation.BinaryRelDet (Γ ++ [(s.name, s.name)]) ρ' ρ' ∧
       Q () st' ρ' := by
   have hf : Skolemize.InfoFresh Δ s.name s.arg :=
     { relFresh := hv.relFresh, funFresh := hv.funFresh, defFresh := hv.defFresh,
@@ -933,14 +932,14 @@ theorem declare_correct (s : Lifting) (body : Skolemize.DefVal) (Δ : Signature)
     s.axioms_wfIn hwfext hbodyext (List.Mem.head _) (List.Mem.head _)
       hargext hidxext hv.idxNeArg
   have haxeval : ∀ ax ∈ s.axioms body,
-      ax.formula.eval (Skolemize.relSplitEnv ρ.env s.name
-        (s.relinterp body ρ.env) (s.definterp body ρ.env) (s.funcinterp body ρ.env)) :=
+      ax.formula.eval (Skolemize.relSplitEnv ρ s.name
+        (s.relinterp body ρ) (s.definterp body ρ) (s.funcinterp body ρ)) :=
     s.axioms_eval (Δ := Δ)
       (s.matrix_wfIn hwf hbody hv.argFresh hv.idxFresh hv.idxNeArg)
       (s.defMatrix_wfIn hwf hbody hv.argFresh hv.idxFresh hv.idxNeArg)
       hv.relFresh hv.funFresh hv.defFresh
   exact SpecFn.declare_correct s.name s.name (s.axioms body)
-    (s.relinterp body ρ.env) (s.funcinterp body ρ.env) (s.definterp body ρ.env) Δ Γ st ρ
+    (s.relinterp body ρ) (s.funcinterp body ρ) (s.definterp body ρ) Δ Γ st ρ
     hv.relFresh hv.funFresh hv.defFresh (fun _ _ => Iff.rfl)
     hdecls howns hvars hwfext hΓwf hsplit hdet haxwf haxeval heval
 

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -64,21 +64,21 @@ theorem compileUnop_wfIn {op : TinyML.UnOp} {s : Term .value} {Δ : Signature}
   all_goals first | exact hs | (have : (Term.unop UnOp.toValList s).wfIn _ := ⟨trivial, hs⟩; exact vtailN_wfIn this _)
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem compileUnop_eval {op : TinyML.UnOp} {s : Term .value} {ρ : VerifM.Env}
+theorem compileUnop_eval {op : TinyML.UnOp} {s : Term .value} {ρ : Env}
     {v w : Runtime.Val} {t : Term .value}
-    (hs : s.eval ρ.env = v) (heval : TinyML.evalUnOp op v = some w)
+    (hs : s.eval ρ = v) (heval : TinyML.evalUnOp op v = some w)
     (hcomp : compileUnop op s = some t) :
-    t.eval ρ.env = w := by
+    t.eval ρ = w := by
   subst hs
   cases op with
   | proj n =>
     simp only [compileUnop, Option.some.injEq] at hcomp; subst hcomp
-    cases h : s.eval ρ.env <;> simp_all [TinyML.evalUnOp]
-    exact vhead_vtailN_eval heval _ ρ.env (by simp [Term.eval, UnOp.eval, h])
+    cases h : s.eval ρ <;> simp_all [TinyML.evalUnOp]
+    exact vhead_vtailN_eval heval _ ρ (by simp [Term.eval, UnOp.eval, h])
   | neg | not =>
     simp only [compileUnop, Option.some.injEq] at hcomp
     subst hcomp
-    cases h : s.eval ρ.env <;>
+    cases h : s.eval ρ <;>
     simp_all [TinyML.evalUnOp, Term.eval, UnOp.eval]
 
 omit [MicaGS HasLC.hasLC Sig] in
@@ -93,18 +93,18 @@ omit [MicaGS HasLC.hasLC Sig] in
 /-- If `evalBinOp op v1 v2 = some w` and the input terms evaluate to `v1`, `v2`,
     then the compiled SMT term evaluates to `w`.
     Pair/store return `none` from `compileOp` so those cases are vacuous via `hcomp`. -/
-theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : VerifM.Env}
+theorem compileOp_eval {op : TinyML.BinOp} {sl sr : Term .value} {ρ : Env}
     {v1 v2 w : Runtime.Val} {t : Term .value}
-    (hsl : sl.eval ρ.env = v1) (hsr : sr.eval ρ.env = v2)
+    (hsl : sl.eval ρ = v1) (hsr : sr.eval ρ = v2)
     (heval : TinyML.evalBinOp op v1 v2 = some w)
     (hcomp : compileOp op sl sr = some t) :
-    t.eval ρ.env = w := by
+    t.eval ρ = w := by
   subst hsl hsr
   cases op <;>
     simp only [compileOp, Option.some.injEq] at hcomp <;>
     (try simp at hcomp) <;>
     subst hcomp <;>
-    (cases h1 : sl.eval ρ.env <;> cases h2 : sr.eval ρ.env) <;>
+    (cases h1 : sl.eval ρ <;> cases h2 : sr.eval ρ) <;>
     simp_all [TinyML.evalBinOp, Term.eval, UnOp.eval, BinOp.eval, Const.denote,
               Bool.cond_eq_ite, ge_iff_le, Bool.beq_eq_decide_eq]
 
@@ -136,8 +136,8 @@ def compileProductBinders (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
 omit [MicaGS HasLC.hasLC Sig] in
 theorem compileProductBindersFrom_length {S : SpecMap} {B : Bindings} {Γ : TinyML.TyCtx}
     {names : List Binder} {tys : List TinyML.Typ} {tl : Term .vallist}
-    {st : TransState} {ρ : VerifM.Env}
-    {Ψ : SpecMap × Bindings × TinyML.TyCtx → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env}
+    {Ψ : SpecMap × Bindings × TinyML.TyCtx → TransState → Env → Prop}
     (htl_wf : tl.wfIn st.decls)
     (heval : VerifM.eval (compileProductBindersFrom S B Γ names tys tl) st ρ Ψ) :
     names.length = tys.length := by
@@ -167,7 +167,7 @@ theorem compileProductBindersFrom_length {S : SpecMap} {B : Bindings} {Γ : Tiny
               have hdecl_eval := VerifM.eval_bind hcont
               have hdecl := VerifM.eval_decl hdecl_eval
               let x' := st.freshConst (some x) .value
-              have hafter_decl := hdecl ((Term.unop UnOp.vhead tl).eval ρ.env)
+              have hafter_decl := hdecl ((Term.unop UnOp.vhead tl).eval ρ)
               have hassume := VerifM.eval_assumePure (VerifM.eval_bind hafter_decl)
               have hstwf : st.decls.wf := (VerifM.eval.wf hdecl_eval).namesDisjoint
               have hfresh : x'.name ∉ st.decls.allNames := by
@@ -183,12 +183,12 @@ theorem compileProductBindersFrom_length {S : SpecMap} {B : Bindings} {Γ : Tiny
               have hholds :
                   (Formula.eq .value (.const (.uninterpreted x'.name .value))
                     (Term.unop UnOp.vhead tl)).eval
-                      (ρ.updateConst .value x'.name ((Term.unop UnOp.vhead tl).eval ρ.env)).env := by
-                have hagree_head : Env.agreeOn st.decls ρ.env
-                    (ρ.updateConst .value x'.name ((Term.unop UnOp.vhead tl).eval ρ.env)).env :=
+                      (ρ.updateConst .value x'.name ((Term.unop UnOp.vhead tl).eval ρ)) := by
+                have hagree_head : Env.agreeOn st.decls ρ
+                    (ρ.updateConst .value x'.name ((Term.unop UnOp.vhead tl).eval ρ)) :=
                   Env.agreeOn_update_fresh_const hfresh
                 have hhead_same := Term.eval_env_agree hhead_wf hagree_head
-                simpa [Formula.eval, Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
+                simpa [Formula.eval, Term.eval, Const.denote, Env.updateConst, Env.updateConst]
                   using hhead_same
               have hrec_eval := hassume hwf hholds
               have hsub : st.decls.Subset (st.decls.addConst x') :=
@@ -478,7 +478,7 @@ namespace Helpers
 
 theorem ctx_dup (W : TinyML.World)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
+    (st : TransState) (ρ : Env) (γ : Runtime.Subst) (R : iProp) :
     st.sl W ρ ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
       st.sl W ρ ∗
         (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗
@@ -488,7 +488,7 @@ theorem ctx_dup (W : TinyML.World)
 
 theorem ctx_dup_flip (W : TinyML.World)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp) :
+    (st : TransState) (ρ : Env) (γ : Runtime.Subst) (R : iProp) :
     st.sl W ρ ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
       st.sl W ρ ∗
         (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗
@@ -498,7 +498,7 @@ theorem ctx_dup_flip (W : TinyML.World)
 
 theorem ctx_push (W : TinyML.World)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
+    (st : TransState) (ρ : Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
     st.sl W ρ ∗ TinyML.ValHasType W v ty ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢
       st.sl W ρ ∗
@@ -509,7 +509,7 @@ theorem ctx_push (W : TinyML.World)
 
 theorem ctx_push_flip (W : TinyML.World)
     (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst) (R : iProp)
+    (st : TransState) (ρ : Env) (γ : Runtime.Subst) (R : iProp)
     (v : Runtime.Val) (ty : TinyML.Typ) :
     st.sl W ρ ∗ TinyML.ValHasType W v ty ∗ (B.typedSubst W Γ γ ∗ (S.satisfiedBy W γ ∗ R)) ⊢
       st.sl W ρ ∗
@@ -526,81 +526,81 @@ end Helpers
 /-! #### Correctness Statements -/
 
 def correctExpr (reg : Verifier.Registry) (e : Expr) : Prop :=
-  ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-  (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
+  ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env) (γ : Runtime.Subst)
+  (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp),
     W.pctx = reg.primCtx →
     VerifM.eval (compile reg W.Θ W.Δ_spec S B Γ e) st ρ Ψ →
-    B.agreeOnLinked ρ.env γ →
+    B.agreeOnLinked ρ γ →
     B.wfIn st.decls →
     S.wfIn W.Δ_spec →
     W.wf →
-    W.agrees st.decls ρ.env →
+    W.agrees st.decls ρ →
     Verifier.Registry.symSubset reg W.Δ_spec →
     Verifier.Registry.symAgree reg W.ρ_spec →
-    (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
+    (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
       st'.sl W ρ' ∗ TinyML.ValHasType W v e.ty ∗ R ⊢ Φ v) →
     st.sl W ρ ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (e.runtime.subst γ) Φ
 
 def correctBranch (reg : Verifier.Registry) (branch : Binder × Expr) : Prop :=
   ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n i : Nat) (ty_i : TinyML.Typ)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-      (Ψ : Term .value → TransState → VerifM.Env → Prop)
+    (st : TransState) (ρ : Env) (γ : Runtime.Subst)
+      (Ψ : Term .value → TransState → Env → Prop)
     (Φ : Runtime.Val → iProp),
     W.pctx = reg.primCtx →
     VerifM.eval (compileBranch reg W.Θ W.Δ_spec S B Γ sc n i ty_i branch) st ρ Ψ →
-    B.agreeOnLinked ρ.env γ →
+    B.agreeOnLinked ρ γ →
     B.wfIn st.decls →
     S.wfIn W.Δ_spec →
     W.wf →
-    W.agrees st.decls ρ.env →
+    W.agrees st.decls ρ →
     Verifier.Registry.symSubset reg W.Δ_spec →
     Verifier.Registry.symAgree reg W.ρ_spec →
     sc.wfIn st.decls →
     (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl W ρ' ∗ TinyML.ValHasType W v branch.2.ty ∗ (S.satisfiedBy W γ ∗ R) ⊢ Φ v) →
-    ∀ payload, sc.eval ρ.env = Runtime.Val.inj i n payload →
+      se.eval ρ' = v → st'.sl W ρ' ∗ TinyML.ValHasType W v branch.2.ty ∗ (S.satisfiedBy W γ ∗ R) ⊢ Φ v) →
+    ∀ payload, sc.eval ρ = Runtime.Val.inj i n payload →
       st.sl W ρ ∗ TinyML.ValHasType W payload ty_i ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (.app ((Runtime.Expr.fix .none [branch.1.runtime] branch.2.runtime).subst γ) [.val payload]) Φ
 
 def correctBranches (reg : Verifier.Registry) (branches : List (Binder × Expr)) : Prop :=
   ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
     (sc : Term .value) (n : Nat) (ts : List TinyML.Typ) (idx : Nat)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-      (Ψ : Term .value → TransState → VerifM.Env → Prop)
+    (st : TransState) (ρ : Env) (γ : Runtime.Subst)
+      (Ψ : Term .value → TransState → Env → Prop)
     (Φ : Runtime.Val → iProp),
     W.pctx = reg.primCtx →
-    B.agreeOnLinked ρ.env γ →
+    B.agreeOnLinked ρ γ →
     B.wfIn st.decls →
     S.wfIn W.Δ_spec →
     W.wf →
-    W.agrees st.decls ρ.env →
+    W.agrees st.decls ρ →
     Verifier.Registry.symSubset reg W.Δ_spec →
     Verifier.Registry.symAgree reg W.ρ_spec →
     sc.wfIn st.decls →
     (∀ (j : Nat) (hj : j < branches.length) v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls →
-      se.eval ρ'.env = v → st'.sl W ρ' ∗ TinyML.ValHasType W v (branches[j]).2.ty ∗ (S.satisfiedBy W γ ∗ R) ⊢ Φ v) →
+      se.eval ρ' = v → st'.sl W ρ' ∗ TinyML.ValHasType W v (branches[j]).2.ty ∗ (S.satisfiedBy W γ ∗ R) ⊢ Φ v) →
     ∀ (j : Nat) (hj : j < branches.length),
       VerifM.eval (compileBranch reg W.Θ W.Δ_spec S B Γ sc n (idx + j) (ts[idx + j]?.getD .value) branches[j]) st ρ Ψ →
-      ∀ payload, sc.eval ρ.env = Runtime.Val.inj (idx + j) n payload →
+      ∀ payload, sc.eval ρ = Runtime.Val.inj (idx + j) n payload →
         st.sl W ρ ∗ TinyML.ValHasType W payload (ts[idx + j]?.getD .value) ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wp W.pctx (.app ((Runtime.Expr.fix .none [(branches[j]).1.runtime] (branches[j]).2.runtime).subst γ) [.val payload]) Φ
 
 def correctExprs (reg : Verifier.Registry) (es : List Expr) : Prop :=
   ∀ (W : TinyML.World) (R : iProp) (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
-    (st : TransState) (ρ : VerifM.Env) (γ : Runtime.Subst)
-      (Ψ : List (Term .value) → TransState → VerifM.Env → Prop)
+    (st : TransState) (ρ : Env) (γ : Runtime.Subst)
+      (Ψ : List (Term .value) → TransState → Env → Prop)
     (Φ : List Runtime.Val → iProp),
     W.pctx = reg.primCtx →
     VerifM.eval (compileExprs reg W.Θ W.Δ_spec S B Γ es) st ρ Ψ →
-    B.agreeOnLinked ρ.env γ →
+    B.agreeOnLinked ρ γ →
     B.wfIn st.decls →
     S.wfIn W.Δ_spec →
     W.wf →
-    W.agrees st.decls ρ.env →
+    W.agrees st.decls ρ →
     Verifier.Registry.symSubset reg W.Δ_spec →
     Verifier.Registry.symAgree reg W.ρ_spec →
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
-      Terms.Eval ρ'.env terms vs →
+      Terms.Eval ρ' terms vs →
        st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (S.satisfiedBy W γ ∗ R) ⊢ Φ vs) →
     st.sl W ρ ∗ (S.satisfiedBy W γ ∗ B.typedSubst W Γ γ ∗ R) ⊢ wps W.pctx (es.map (fun e => e.runtime.subst γ)) Φ
 
@@ -713,12 +713,12 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
       simp only at hsort; subst hsort
       exact Term.const_wfIn_of_mem hwfst h
   have htyped {t : TinyML.Typ} (hΓ : Γ x = some t) :
-      B.typedSubst W Γ γ ⊢ TinyML.ValHasType W (ρ.env.consts .value x'.name) t := by
+      B.typedSubst W Γ γ ⊢ TinyML.ValHasType W (ρ.consts .value x'.name) t := by
     unfold Bindings.typedSubst
     iintro #Hts
     ispecialize Hts $$ %x %x' %t %hbind %hΓ
     icases Hts with ⟨%v, %hγv, Hvty⟩
-    have hv : v = ρ.env.consts .value x'.name := by
+    have hv : v = ρ.consts .value x'.name := by
       rw [hγ] at hγv
       exact Option.some.inj hγv.symm
     subst hv
@@ -728,19 +728,19 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
   | none =>
     have hvty : vty = .value := by simpa [hΓx] using hcheck.symm
     subst hvty
-    have hvalue : ⊢ TinyML.ValHasType W (ρ.env.consts .value x'.name) .value := by
-      iapply (TinyML.ValHasType.value W (ρ.env.consts .value x'.name)).2
+    have hvalue : ⊢ TinyML.ValHasType W (ρ.consts .value x'.name) .value := by
+      iapply (TinyML.ValHasType.value W (ρ.consts .value x'.name)).2
       ipureintro
       trivial
     have hprep :
         st.sl W ρ ∗ (B.typedSubst W Γ γ ∗ R) ⊢
-          st.sl W ρ ∗ TinyML.ValHasType W (ρ.env.consts .value x'.name) .value ∗ R := by
+          st.sl W ρ ∗ TinyML.ValHasType W (ρ.consts .value x'.name) .value ∗ R := by
       exact sep_mono_right (sep_mono_left (true_intro.trans hvalue))
     have hpost' :
-        st.sl W ρ ∗ TinyML.ValHasType W (ρ.env.consts .value x'.name) .value ∗ R ⊢
-          Φ (ρ.env.consts .value x'.name) := by
+        st.sl W ρ ∗ TinyML.ValHasType W (ρ.consts .value x'.name) .value ∗ R ⊢
+          Φ (ρ.consts .value x'.name) := by
       simpa [hΓx] using
-        (hpost (ρ.env.consts .value x'.name) ρ st (Term.const (.uninterpreted x'.name .value))
+        (hpost (ρ.consts .value x'.name) ρ st (Term.const (.uninterpreted x'.name .value))
           hΨ hwfv (by simp [Term.eval, Const.denote]))
     exact SpatialContext.wp_val <| (sep_mono_right sep_elim_right).trans <| hprep.trans <| hpost'
   | some t =>
@@ -748,13 +748,13 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
     have htv : t = vty := by simpa [hΓx] using hcheck
     have hprep :
         st.sl W ρ ∗ (B.typedSubst W Γ γ ∗ R) ⊢
-          st.sl W ρ ∗ TinyML.ValHasType W (ρ.env.consts .value x'.name) vty ∗ R := by
+          st.sl W ρ ∗ TinyML.ValHasType W (ρ.consts .value x'.name) vty ∗ R := by
       rw [← htv]
       exact sep_mono_right (sep_mono_left (htyped hΓ))
     have hpost' :
-        st.sl W ρ ∗ TinyML.ValHasType W (ρ.env.consts .value x'.name) vty ∗ R ⊢
-          Φ (ρ.env.consts .value x'.name) :=
-      hpost (ρ.env.consts .value x'.name) ρ st (Term.const (.uninterpreted x'.name .value))
+        st.sl W ρ ∗ TinyML.ValHasType W (ρ.consts .value x'.name) vty ∗ R ⊢
+          Φ (ρ.consts .value x'.name) :=
+      hpost (ρ.consts .value x'.name) ρ st (Term.const (.uninterpreted x'.name .value))
         hΨ hwfv (by simp [Term.eval, Const.denote])
     exact SpatialContext.wp_val <| (sep_mono_right sep_elim_right).trans <| hprep.trans <| hpost'
 
@@ -897,7 +897,7 @@ theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
       have hdecl_eval := VerifM.eval_bind hΨ_e
       have hdecl := VerifM.eval_decl hdecl_eval (.loc loc)
       have hret := VerifM.eval_ret hdecl
-      set ρ_e' : VerifM.Env := ρ_e.updateConst .value c.name (.loc loc)
+      set ρ_e' : Env := ρ_e.updateConst .value c.name (.loc loc)
       set st₂ : TransState := {
         decls := st₁.decls.addConst c
         asserts := st₁.asserts
@@ -908,8 +908,8 @@ theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
           simpa [st₂] using
             (Term.const_wfIn_addConst_of_fresh (Δ := st₁.decls) (c := c)
               hwf_st₁.namesDisjoint hfresh)
-      have hval_eval : Term.eval ρ_e'.env (Term.const (.uninterpreted c.name .value)) = .loc loc := by
-        simp [Term.eval, Const.denote, ρ_e', VerifM.Env.updateConst, Env.updateConst]
+      have hval_eval : Term.eval ρ_e' (Term.const (.uninterpreted c.name .value)) = .loc loc := by
+        simp [Term.eval, Const.denote, ρ_e', Env.updateConst, Env.updateConst]
       have hlocTy : locinv loc (fun w => TinyML.ValHasType W w e.ty) ⊢
           TinyML.ValHasType W (.loc loc) (.ref e.ty) := by
         refine Entails.trans ?_ (TinyML.ValHasType.ref W (.loc loc) e.ty).2
@@ -957,12 +957,12 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
   have hwp :
       st₁.sl W ρ_e ∗ TinyML.ValHasType W v_e e.ty ∗ R ⊢ wp W.pctx (.ref (.val v_e)) Φ := by
     refine SpatialContext.wp_ref W
-      (ctx := st₁.owns) (ρ := ρ_e.env) (R := R) (Δ := st₁.decls)
+      (ctx := st₁.owns) (ρ := ρ_e) (R := R) (Δ := st₁.decls)
       (vt := se) (ty := e.ty) (name := c.name)
       (newctx := SpatialContext.insert (.pointsTo sl se e.ty) st₁.owns)
       hwf_st₁.ownsWf hse_wf heval_se hc_fresh rfl ?_
     intro loc
-    set ρ₂ : VerifM.Env := ρ_e.updateConst .value c.name (.loc loc)
+    set ρ₂ : Env := ρ_e.updateConst .value c.name (.loc loc)
     set st₂ : TransState := { st₁ with decls := st₁.decls.addConst c }
     have hdecl_loc := hdecl (.loc loc)
     have hsl_wf : sl.wfIn st₂.decls := by
@@ -974,9 +974,9 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
         (TransState.freshConst.wf _ hwf_st₁).namesDisjoint
     have hatom_wf : (SpatialAtom.pointsTo sl se e.ty).wfIn st₂.decls := ⟨hsl_wf, hse_wf₂⟩
     have hassumed := VerifM.eval_assumeSpatial (VerifM.eval_bind hdecl_loc) hatom_wf
-    have hsl_eval : sl.eval ρ₂.env = .loc loc := by
-      simp [sl, ρ₂, c, Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
-    have htyped : ∀ φ ∈ TinyML.typeConstraints (.owned e.ty) sl, φ.eval ρ₂.env := by
+    have hsl_eval : sl.eval ρ₂ = .loc loc := by
+      simp [sl, ρ₂, c, Term.eval, Const.denote, Env.updateConst, Env.updateConst]
+    have htyped : ∀ φ ∈ TinyML.typeConstraints (.owned e.ty) sl, φ.eval ρ₂ := by
       intro φ hφ
       simp only [TinyML.typeConstraints, List.mem_singleton] at hφ
       subst hφ
@@ -998,7 +998,7 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
     iapply (hpost (.loc loc) ρ₂ st₃ sl hret hsl_wf₃ hsl_eval)
     isplitl [Hsl]
     · simp [TransState.sl_eq, howns₃, SpatialContext.insert]
-      rw [show ρ₂.env = ρ_e.env.updateConst .value c.name (.loc loc) by rfl]
+      rw [show ρ₂ = ρ_e.updateConst .value c.name (.loc loc) by rfl]
       iexact Hsl
     · isplitl []
       · iapply hlocTy
@@ -1052,12 +1052,12 @@ theorem compileDerefShared_correct (reg : Verifier.Registry) (e : Expr) (ty : Ti
     · iintro %w #Hw
       have hdecl_w := hdecl w
       have hassume_eval := VerifM.eval_bind hdecl_w
-      set ρ₂ : VerifM.Env := ρ_e.updateConst .value c.name w
+      set ρ₂ : Env := ρ_e.updateConst .value c.name w
       set st₂ : TransState := { st₁ with decls := st₁.decls.addConst c }
-      have hsv_eval : sv.eval ρ₂.env = w := by
-        simp [sv, ρ₂, Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
+      have hsv_eval : sv.eval ρ₂ = w := by
+        simp [sv, ρ₂, Term.eval, Const.denote, Env.updateConst, Env.updateConst]
       ihave Hcheck := TinyML.typeConstraints_hold (ty := ty) (t := sv)
-        (ρ := ρ₂.env) (W := W) (v := w) hsv_eval $$ Hw
+        (ρ := ρ₂) (W := W) (v := w) hsv_eval $$ Hw
       ipure Hcheck
       obtain ⟨st₃, hst₃_decls, hst₃_owns, _, heval_ret⟩ := VerifM.eval_assumeAll hassume_eval
         (fun φ hφ => TinyML.typeConstraints_wfIn hc_wf φ hφ)
@@ -1108,20 +1108,20 @@ theorem compileDerefOwned_correct (reg : Verifier.Registry) (e : Expr) (ty : Tin
     rw [hdecls]
     exact hv_wf
   have hwp :
-      SpatialAtom.interp W ρ_e.env (.pointsTo se v ty) ∗ st₂.sl W ρ_e ∗
+      SpatialAtom.interp W ρ_e (.pointsTo se v ty) ∗ st₂.sl W ρ_e ∗
         (TinyML.ValHasType W v_e (.owned ty) ∗ R) ⊢ wp W.pctx (.deref (.val v_e)) Φ := by
     simp only [SpatialAtom.interp]
     istart
     iintro ⟨Hatom, Howns, _Howned, HR⟩
     icases Hatom with ⟨%loc, %hse_loc, Hpt, #HstoredTy⟩
-    have hse_loc_orig : se.eval ρ_e.env = .loc loc := hse_loc
+    have hse_loc_orig : se.eval ρ_e = .loc loc := hse_loc
     rw [heval_se] at hse_loc
     rw [hse_loc]
-    iapply (wp.deref (l := loc) (v := v.eval ρ_e.env))
+    iapply (wp.deref (l := loc) (v := v.eval ρ_e))
     isplitl [Hpt]
     · iexact Hpt
     · iintro Hpt
-      iapply (hpost (v.eval ρ_e.env) ρ_e { st₂ with owns := .pointsTo se v ty :: st₂.owns }
+      iapply (hpost (v.eval ρ_e) ρ_e { st₂ with owns := .pointsTo se v ty :: st₂.owns }
         v hret hv_wf' rfl)
       isplitl [Hpt HstoredTy Howns]
       · simp [TransState.sl_eq]
@@ -1187,7 +1187,7 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
       (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hwf hag hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
-  have hagree_v : B.agreeOnLinked ρ_v.env γ :=
+  have hagree_v : B.agreeOnLinked ρ_v γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
   have heval_l : (compile reg W.Θ W.Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
@@ -1253,7 +1253,7 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
       (VerifM.eval.decls_grow ρ heval_v) hagree hbwf hSwf hwf hag hΔreg hρreg ?_)
   intro v_v ρ_v st₁ sv hΨ_v hsv_wf heval_sv
   obtain ⟨hdecls_v, hagreeOn_v, hΨ_v⟩ := hΨ_v
-  have hagree_v : B.agreeOnLinked ρ_v.env γ :=
+  have hagree_v : B.agreeOnLinked ρ_v γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_v hbwf
   have hbwf_v : B.wfIn st₁.decls := fun p hp => hdecls_v.consts _ (hbwf p hp)
   have heval_l : (compile reg W.Θ W.Δ_spec S B Γ loc).eval st₁ ρ_v _ := VerifM.eval_bind hΨ_v
@@ -1271,7 +1271,7 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
   have hfind_eval := VerifM.eval_bind hΨ_l
   have hsv_wf_l : sv.wfIn st₂.decls :=
     Term.wfIn_mono sv hsv_wf _hdecls_l (VerifM.eval.wf hΨ_l).namesDisjoint
-  have heval_sv_l : sv.eval ρ_l.env = v_v := by
+  have heval_sv_l : sv.eval ρ_l = v_v := by
     rw [← Term.eval_env_agree hsv_wf _hagreeOn_l]
     exact heval_sv
   rw [howned]
@@ -1288,17 +1288,17 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
   have hunit_wf : (Term.const .unit).wfIn ({ st₃ with owns := .pointsTo sl sv val.ty :: st₃.owns }).decls := by
     simp [Term.wfIn, Const.wfIn]
   have hwp :
-      SpatialAtom.interp W ρ_l.env (.pointsTo sl old val.ty) ∗ st₃.sl W ρ_l ∗
+      SpatialAtom.interp W ρ_l (.pointsTo sl old val.ty) ∗ st₃.sl W ρ_l ∗
         (TinyML.ValHasType W v_l (.owned val.ty) ∗ (TinyML.ValHasType W v_v val.ty ∗ R)) ⊢
           wp W.pctx (.store (.val v_l) (.val v_v)) Φ := by
     simp only [SpatialAtom.interp]
     istart
     iintro ⟨Hatom, Howns, _Howned, #HnewTy, HR⟩
     icases Hatom with ⟨%lref, %hsl_loc, Hold, _HoldTy⟩
-    have hsl_loc_orig : sl.eval ρ_l.env = .loc lref := hsl_loc
+    have hsl_loc_orig : sl.eval ρ_l = .loc lref := hsl_loc
     rw [heval_sl] at hsl_loc
     rw [hsl_loc]
-    iapply (wp.store (l := lref) (old := old.eval ρ_l.env) (v := v_v))
+    iapply (wp.store (l := lref) (old := old.eval ρ_l) (v := v_v))
     isplitl [Hold]
     · iexact Hold
     · iintro Hnew
@@ -1351,15 +1351,15 @@ theorem compileStore_correct (reg : Verifier.Registry) (loc val : Expr)
 omit [MicaGS HasLC.hasLC Sig] in
 /-- Peel the two bounds assertions guarding an array access. -/
 private theorem VerifM.eval_assertBounds {si sa : Term .value} {α : Type}
-    {k : VerifM α} {st : TransState} {ρ : VerifM.Env}
-    {Q : α → TransState → VerifM.Env → Prop}
+    {k : VerifM α} {st : TransState} {ρ : Env}
+    {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (do
       VerifM.assert (.binpred .le (.const (.i 0)) (.unop .toInt si))
       VerifM.assert (.binpred .lt (.unop .toInt si) (.unop .arrayLengthOf sa))
       k) st ρ Q)
     (hsi : si.wfIn st.decls) (hsa : sa.wfIn st.decls) :
-    0 ≤ Term.eval ρ.env (.unop .toInt si) ∧
-    Term.eval ρ.env (.unop .toInt si) < Term.eval ρ.env (.unop .arrayLengthOf sa) ∧
+    0 ≤ Term.eval ρ (.unop .toInt si) ∧
+    Term.eval ρ (.unop .toInt si) < Term.eval ρ (.unop .arrayLengthOf sa) ∧
     VerifM.eval k st ρ Q := by
   have hwf1 : (Formula.binpred .le (.const (.i 0)) (.unop .toInt si)).wfIn st.decls := by
     simpa [Formula.wfIn, Term.wfIn, Const.wfIn, UnOp.wfIn, BinPred.wfIn] using hsi
@@ -1391,7 +1391,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
     hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro v_init ρ_init st₁ s_init hΨ_init hsinit_wf heval_sinit
   obtain ⟨hdecls_init, hagreeOn_init, hΨ_init⟩ := hΨ_init
-  have hagree_init : B.agreeOnLinked ρ_init.env γ :=
+  have hagree_init : B.agreeOnLinked ρ_init γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_init hbwf
   have hbwf_init : B.wfIn st₁.decls := fun p hp => hdecls_init.consts _ (hbwf p hp)
   have heval_len : (compile reg W.Θ W.Δ_spec S B Γ len).eval st₁ ρ_init _ := VerifM.eval_bind hΨ_init
@@ -1439,13 +1439,13 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
       -- freshly allocated array value `.array n.toNat l`.
       have hbody := hdecl (.array n.toNat l)
       have hassume_eval := VerifM.eval_bind hbody
-      set ρ' : VerifM.Env := ρ_len.updateConst .value c.name (.array n.toNat l)
+      set ρ' : Env := ρ_len.updateConst .value c.name (.array n.toNat l)
       set st_c : TransState := { st₂ with decls := st₂.decls.addConst c } with hst_c_def
-      have hsa_eval : sa.eval ρ'.env = .array n.toNat l := by
-        simp [sa, ρ', Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
-      have hslen_eval' : slen.eval ρ'.env = .int n :=
+      have hsa_eval : sa.eval ρ' = .array n.toNat l := by
+        simp [sa, ρ', Term.eval, Const.denote, Env.updateConst, Env.updateConst]
+      have hslen_eval' : slen.eval ρ' = .int n :=
         (Term.eval_env_agree hslen_wf
-          (VerifM.Env.agreeOn_update_fresh (c := c)
+          (Env.agreeOn_update_fresh_const (c := c)
             (u := Runtime.Val.array n.toNat l) hc_fresh)).symm.trans (heval_slen.trans hv_len)
       -- The length equation assumed after allocation.
       have hstc_wf : (st₂.decls.addConst c).wf :=
@@ -1456,7 +1456,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
           (CtxItem.pure (Formula.eq Srt.int (.unop .arrayLengthOf sa) (.unop .toInt slen))).wfIn st_c.decls := by
         refine ⟨⟨trivial, hc_wf⟩, ⟨trivial, hslen_wf_c⟩⟩
       have heqφ_hold :
-          (Formula.eq Srt.int (.unop .arrayLengthOf sa) (.unop .toInt slen)).eval ρ'.env := by
+          (Formula.eq Srt.int (.unop .arrayLengthOf sa) (.unop .toInt slen)).eval ρ' := by
         simp [Formula.eval, Term.eval, UnOp.eval, hsa_eval, hslen_eval']
         omega
       have hassumeAll := VerifM.eval_assume hassume_eval heqφ_wf heqφ_hold
@@ -1467,7 +1467,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
         · ipureintro; rfl
         · iexact Hinv_l
       ihave %htyped_formulas := (TinyML.typeConstraints_hold
-        (ty := TinyML.Typ.array init.ty) (t := sa) (ρ := ρ'.env) (W := W)
+        (ty := TinyML.Typ.array init.ty) (t := sa) (ρ := ρ') (W := W)
         (v := .array n.toNat l) hsa_eval) $$ HarrTy
       obtain ⟨st_final, hst_final_decls, hst_final_owns, _, heval_ret⟩ :=
         VerifM.eval_assumeAll hassumeAll_eval
@@ -1496,22 +1496,22 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
       (Q := Φ) hv_len hn)
     iintro %l Hpt
     have hbody := hdecl (.array n.toNat l)
-    set ρ' : VerifM.Env := ρ_len.updateConst .value c.name (.array n.toNat l)
+    set ρ' : Env := ρ_len.updateConst .value c.name (.array n.toNat l)
     set st_c : TransState := { st₂ with decls := st₂.decls.addConst c }
-    have hsa_eval : sa.eval ρ'.env = .array n.toNat l := by
-      simp [sa, ρ', Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
-    have hslen_eval' : slen.eval ρ'.env = .int n :=
+    have hsa_eval : sa.eval ρ' = .array n.toNat l := by
+      simp [sa, ρ', Term.eval, Const.denote, Env.updateConst, Env.updateConst]
+    have hslen_eval' : slen.eval ρ' = .int n :=
       (Term.eval_env_agree hslen_wf
-        (VerifM.Env.agreeOn_update_fresh (c := c) (u := Runtime.Val.array n.toNat l) hc_fresh)).symm.trans
+        (Env.agreeOn_update_fresh_const (c := c) (u := Runtime.Val.array n.toNat l) hc_fresh)).symm.trans
         (heval_slen.trans hv_len)
     have hsinit_wf₂ : s_init.wfIn st₂.decls :=
       Term.wfIn_mono s_init hsinit_wf hdecls_len hst₂_wf.namesDisjoint
-    have hsinit_eval_len : s_init.eval ρ_len.env = v_init := by
+    have hsinit_eval_len : s_init.eval ρ_len = v_init := by
       rw [Term.eval_env_agree hsinit_wf (Env.agreeOn_symm hagreeOn_len)]
       exact heval_sinit
-    have hsinit_eval' : s_init.eval ρ'.env = v_init :=
+    have hsinit_eval' : s_init.eval ρ' = v_init :=
       (Term.eval_env_agree hsinit_wf₂
-        (VerifM.Env.agreeOn_update_fresh (c := c) (u := Runtime.Val.array n.toNat l) hc_fresh)).symm.trans
+        (Env.agreeOn_update_fresh_const (c := c) (u := Runtime.Val.array n.toNat l) hc_fresh)).symm.trans
         hsinit_eval_len
     have hstc_wf : (st₂.decls.addConst c).wf := Signature.wf_addConst hst₂_wf.namesDisjoint hc_fresh
     have hslen_wf_c := Term.wfIn_mono slen hslen_wf (Signature.Subset.subset_addConst _ _) hstc_wf
@@ -1519,7 +1519,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
     have heq_wf : (CtxItem.pure
         (.eq .int (.unop .arrayLengthOf sa) (.unop .toInt slen))).wfIn st_c.decls :=
       ⟨⟨trivial, hc_wf⟩, ⟨trivial, hslen_wf_c⟩⟩
-    have heq_hold : Formula.eval ρ'.env
+    have heq_hold : Formula.eval ρ'
         (.eq .int (.unop .arrayLengthOf sa) (.unop .toInt slen)) := by
       simp [Formula.eval, Term.eval, UnOp.eval, hsa_eval, hslen_eval']
       omega
@@ -1530,7 +1530,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
       ⟨trivial, ⟨trivial, ⟨trivial, hslen_wf_c⟩, hsinit_wf_c⟩⟩
     have hatom_wf : (SpatialAtom.arrayPointsTo sa contents init.ty).wfIn st_c.decls :=
       ⟨hc_wf, hcontents_wf⟩
-    have hcontents_eval : contents.eval ρ'.env = .vec (List.replicate n.toNat v_init) := by
+    have hcontents_eval : contents.eval ρ' = .vec (List.replicate n.toNat v_init) := by
       simp [contents, Term.eval, UnOp.eval, BinOp.eval, hslen_eval', hsinit_eval', hn]
     ihave #HvecTy : iprop(TinyML.ValHasType W (.vec (List.replicate n.toNat v_init)) (.vec init.ty)) $$ [Hinit]
     · iapply TinyML.ValHasType.vec_replicate
@@ -1538,7 +1538,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
     ihave %helements := TinyML.elementConstraints_hold (ty := init.ty) hcontents_eval $$ HvecTy
     -- Acquire the owned-array atom; all snapshot facts hold by construction.
     have hfacts : ∀ ψ ∈ (CtxItem.spatial (.arrayPointsTo sa contents init.ty)).facts,
-        ψ.eval ρ'.env := by
+        ψ.eval ρ' := by
       intro ψ hψ
       simp only [CtxItem.facts, SpatialAtom.facts, List.mem_cons] at hψ
       rcases hψ with rfl | hψ
@@ -1552,7 +1552,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
       ipureintro; rfl
     ihave HarrTy := hArrTy
     ihave %htyped := TinyML.typeConstraints_hold (ty := .ownedArray init.ty) (t := sa)
-      (ρ := ρ'.env) (W := W) hsa_eval $$ HarrTy
+      (ρ := ρ') (W := W) hsa_eval $$ HarrTy
     obtain ⟨st_final, hdecls_final, howns_final, _, heval_ret⟩ :=
       VerifM.eval_assumeAll (VerifM.eval_bind hq_a)
         (fun ψ hψ => by rw [hdecls_a]; exact TinyML.typeConstraints_wfIn hc_wf ψ hψ)
@@ -1560,11 +1560,11 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
     have hret := VerifM.eval_ret heval_ret
     have hsa_wf_final : sa.wfIn st_final.decls := by
       rw [hdecls_final, hdecls_a]; exact hc_wf
-    have hsl_agree : SpatialContext.interp W ρ_len.env st₂.owns ⊢
-        SpatialContext.interp W ρ'.env st₂.owns := by
-      rw [show ρ'.env = ρ_len.env.updateConst .value c.name (.array n.toNat l) by rfl]
+    have hsl_agree : SpatialContext.interp W ρ_len st₂.owns ⊢
+        SpatialContext.interp W ρ' st₂.owns := by
+      rw [show ρ' = ρ_len.updateConst .value c.name (.array n.toNat l) by rfl]
       exact (SpatialContext.interp_env_agree W hst₂_wf.ownsWf
-        (Env.agreeOn_update_fresh_const (ρ := ρ_len.env) (c := c)
+        (Env.agreeOn_update_fresh_const (ρ := ρ_len) (c := c)
           (u := Runtime.Val.array n.toNat l) hc_fresh)).1
     iapply (hpost (.array n.toNat l) ρ' st_final sa hret hsa_wf_final hsa_eval)
     isplitl [Hpt Howns]
@@ -1608,7 +1608,7 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
         iintro ⟨Howns, Harr, HR⟩
         ihave Harr' := (TinyML.ValHasType.array W v_arr elem).1 $$ Harr
         icases Harr' with ⟨%len, %loc, %hv_arr, _⟩
-        have ht_eval : t.eval ρ_arr.env = Runtime.Val.int len := by
+        have ht_eval : t.eval ρ_arr = Runtime.Val.int len := by
           simp [t, Term.eval, UnOp.eval, heval_sa, hv_arr]
         have hgoal :
             st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R ⊢
@@ -1643,7 +1643,7 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
       iintro ⟨Howns, Harr, HR⟩
       ihave Harr' := (TinyML.ValHasType.ownedArray W v_arr elem).1 $$ Harr
       icases Harr' with ⟨%len, %loc, %hv_arr⟩
-      have ht_eval : t.eval ρ_arr.env = Runtime.Val.int len := by
+      have ht_eval : t.eval ρ_arr = Runtime.Val.int len := by
         simp [t, Term.eval, UnOp.eval, heval_sa, hv_arr]
       have hgoal :
           st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R ⊢
@@ -1685,7 +1685,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
       hagree hbwf hSwf hwf hag hΔreg hρreg ?_
     intro v_idx ρ_idx st₁ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
-    have hagree_idx : B.agreeOnLinked ρ_idx.env γ :=
+    have hagree_idx : B.agreeOnLinked ρ_idx γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_idx hbwf
     have hbwf_idx : B.wfIn st₁.decls := fun p hp => hdecls_idx.consts _ (hbwf p hp)
     have heval_arr : (compile reg W.Θ W.Δ_spec S B Γ arr).eval st₁ ρ_idx _ := VerifM.eval_bind hΨ_idx
@@ -1698,7 +1698,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
     have hsi_wf₂ : si.wfIn st₂.decls :=
       Term.wfIn_mono si hsi_wf hdecls_arr (VerifM.eval.wf hΨ_arr).namesDisjoint
-    have hsi_ρ_arr : si.eval ρ_arr.env = v_idx := by
+    have hsi_ρ_arr : si.eval ρ_arr = v_idx := by
       rw [Term.eval_env_agree hsi_wf (Env.agreeOn_symm hagreeOn_arr)]; exact heval_si
     obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₂ hsa_wf
     have hdecl_eval := VerifM.eval_bind hcont2
@@ -1717,7 +1717,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
       rw [hty, hidxty]
       simpa [TransState.sl_eq] using
         (SpatialContext.wp_arrayGet_inv (W := W)
-          (ctx := st₂.owns) (ρ := ρ_arr.env) (arr := sa) (idx := si)
+          (ctx := st₂.owns) (ρ := ρ_arr) (arr := sa) (idx := si)
           (elemTy := elemTy) (varr := v_arr) (vidx := v_idx) (Q := Φ) (R := R)
           heval_sa hsi_ρ_arr hi hlt (by
             intro w
@@ -1725,12 +1725,12 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
             iintro ⟨Howns, #Hw, HR⟩
             have hdecl_w := hdecl w
             have hassume_eval := VerifM.eval_bind hdecl_w
-            set ρ₂ : VerifM.Env := ρ_arr.updateConst .value c.name w
+            set ρ₂ : Env := ρ_arr.updateConst .value c.name w
             set st_c : TransState := { st₂ with decls := st₂.decls.addConst c }
-            have hsv_eval : sv.eval ρ₂.env = w := by
-              simp [sv, ρ₂, Term.eval, Const.denote, VerifM.Env.updateConst, Env.updateConst]
+            have hsv_eval : sv.eval ρ₂ = w := by
+              simp [sv, ρ₂, Term.eval, Const.denote, Env.updateConst, Env.updateConst]
             ihave Hcheck := TinyML.typeConstraints_hold (ty := elemTy) (t := sv)
-              (ρ := ρ₂.env) (W := W) (v := w) hsv_eval $$ Hw
+              (ρ := ρ₂) (W := W) (v := w) hsv_eval $$ Hw
             ipure Hcheck
             obtain ⟨st₃, hst₃_decls, hst₃_owns, _, heval_ret⟩ := VerifM.eval_assumeAll hassume_eval
               (fun φ hφ => TinyML.typeConstraints_wfIn hc_wf φ hφ)
@@ -1741,7 +1741,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
               simp [TransState.sl_eq, st_c, hst₃_owns]
               exact (SpatialContext.interp_env_agree W (VerifM.eval.wf hdecl_eval).ownsWf
                 (Env.agreeOn_update_fresh_const (c := c) hc_fresh)).1
-            have hsl_agree' : SpatialContext.interp W ρ_arr.env st₂.owns ⊢ st₃.sl W ρ₂ := by
+            have hsl_agree' : SpatialContext.interp W ρ_arr st₂.owns ⊢ st₃.sl W ρ₂ := by
               simpa [TransState.sl_eq] using hsl_agree
             iapply (hpost w ρ₂ st₃ sv hΨ_ret hsv_wf hsv_eval)
             isplitl [Howns]
@@ -1780,7 +1780,7 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     intro v_arr ρ_arr st₂ sa hΨ_arr hsa_wf heval_sa
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
     have hsi_wf₂ := Term.wfIn_mono si hsi_wf hdecls_arr (VerifM.eval.wf hΨ_arr).namesDisjoint
-    have hsi_eval : si.eval ρ_arr.env = v_idx := by
+    have hsi_eval : si.eval ρ_arr = v_idx := by
       rw [Term.eval_env_agree hsi_wf (Env.agreeOn_symm hagreeOn_arr)]; exact heval_si
     obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₂ hsa_wf
     have hfind := VerifM.eval_bind hcont2
@@ -1799,10 +1799,10 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
         (Q := Φ) (R := R) heval_sa hsi_eval hi hlt rfl (by
           -- Acquire the restored atom, then conclude with the postcondition.
           have hstep := VerifM.eval_acquireSpatial W
-            (R := TinyML.ValHasType W (Term.eval ρ_arr.env result) elemTy ∗ R)
-            (Φ := Φ (Term.eval ρ_arr.env result)) (VerifM.eval_bind hQ) hatom_wf
+            (R := TinyML.ValHasType W (Term.eval ρ_arr result) elemTy ∗ R)
+            (Φ := Φ (Term.eval ρ_arr result)) (VerifM.eval_bind hQ) hatom_wf
             (fun st₄ hq₄ hdecls₄ _howns₄ =>
-              hpost (Term.eval ρ_arr.env result) ρ_arr st₄ result (VerifM.eval_ret hq₄)
+              hpost (Term.eval ρ_arr result) ρ_arr st₄ result (VerifM.eval_ret hq₄)
                 (by rw [hdecls₄, hdecls]
                     exact ⟨trivial, ⟨trivial, hcontents_wf⟩, ⟨trivial, hsi_wf₂⟩⟩)
                 rfl)
@@ -1846,7 +1846,7 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
       hagree hbwf hSwf hwf hag hΔreg hρreg ?_
     intro v_val ρ_val st₁ sv hΨ_val hsv_wf heval_sv
     obtain ⟨hdecls_val, hagreeOn_val, hΨ_val⟩ := hΨ_val
-    have hagree_val : B.agreeOnLinked ρ_val.env γ :=
+    have hagree_val : B.agreeOnLinked ρ_val γ :=
       Bindings.agreeOnLinked_env_agree hagree hagreeOn_val hbwf
     have hbwf_val : B.wfIn st₁.decls := fun p hp => hdecls_val.consts _ (hbwf p hp)
     have heval_idx : (compile reg W.Θ W.Δ_spec S B Γ idx).eval st₁ ρ_val _ := VerifM.eval_bind hΨ_val
@@ -1861,7 +1861,7 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
       hagree_val hbwf_val hSwf hwf hspecInv_val hΔreg hρreg ?_
     intro v_idx ρ_idx st₂ si hΨ_idx hsi_wf heval_si
     obtain ⟨hdecls_idx, hagreeOn_idx, hΨ_idx⟩ := hΨ_idx
-    have hagree_idx : B.agreeOnLinked ρ_idx.env γ :=
+    have hagree_idx : B.agreeOnLinked ρ_idx γ :=
       Bindings.agreeOnLinked_env_agree hagree_val hagreeOn_idx hbwf_val
     have hbwf_idx : B.wfIn st₂.decls := fun p hp => hdecls_idx.consts _ (hbwf_val p hp)
     have heval_arr : (compile reg W.Θ W.Δ_spec S B Γ arr).eval st₂ ρ_idx _ := VerifM.eval_bind hΨ_idx
@@ -1877,7 +1877,7 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     obtain ⟨hdecls_arr, hagreeOn_arr, hΨ_arr⟩ := hΨ_arr
     have hsi_wf₃ : si.wfIn st₃.decls :=
       Term.wfIn_mono si hsi_wf hdecls_arr (VerifM.eval.wf hΨ_arr).namesDisjoint
-    have hsi_ρ_arr : si.eval ρ_arr.env = v_idx := by
+    have hsi_ρ_arr : si.eval ρ_arr = v_idx := by
       rw [Term.eval_env_agree hsi_wf (Env.agreeOn_symm hagreeOn_arr)]; exact heval_si
     -- Discharge the two bounds obligations.
     obtain ⟨hi, hlt, hcont2⟩ := VerifM.eval_assertBounds hΨ_arr hsi_wf₃ hsa_wf
@@ -1893,11 +1893,11 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
       rw [hty, hidxty, ← helemTy]
       simpa [TransState.sl_eq] using
         (SpatialContext.wp_arraySet_inv (W := W)
-          (ctx := st₃.owns) (ρ := ρ_arr.env) (arr := sa) (idx := si)
+          (ctx := st₃.owns) (ρ := ρ_arr) (arr := sa) (idx := si)
           (elemTy := elemTy) (varr := v_arr) (vidx := v_idx) (val := v_val)
           (Q := Φ) (R := R) heval_sa hsi_ρ_arr hi hlt (by
             have hgoal' :
-                SpatialContext.interp W ρ_arr.env st₃.owns ∗
+                SpatialContext.interp W ρ_arr st₃.owns ∗
                   TinyML.ValHasType W .unit .unit ∗ R ⊢ Φ .unit := by
               simpa [TransState.sl_eq] using hgoal
             istart
@@ -1956,9 +1956,9 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
       Term.wfIn_mono sv hsv_wf (hdecls_idx.trans hdecls_arr) (VerifM.eval.wf hΨ_arr).namesDisjoint
     have hsv_wf₂ : sv.wfIn st₂.decls :=
       Term.wfIn_mono sv hsv_wf hdecls_idx (VerifM.eval.wf hΨ_idx).namesDisjoint
-    have hsi_eval : si.eval ρ_arr.env = v_idx := by
+    have hsi_eval : si.eval ρ_arr = v_idx := by
       rw [Term.eval_env_agree hsi_wf (Env.agreeOn_symm hagreeOn_arr)]; exact heval_si
-    have hsv_eval : sv.eval ρ_arr.env = v_val := by
+    have hsv_eval : sv.eval ρ_arr = v_val := by
       rw [Term.eval_env_agree hsv_wf₂ (Env.agreeOn_symm hagreeOn_arr)]
       rw [Term.eval_env_agree hsv_wf (Env.agreeOn_symm hagreeOn_idx)]
       exact heval_sv
@@ -2033,7 +2033,7 @@ theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Ex
   istart
   iintro ⟨Howns, Hex, HR⟩
   icases Hex with ⟨%w, %heval_op, Hwty⟩
-  have ht_eval : t.eval ρ_e.env = w :=
+  have ht_eval : t.eval ρ_e = w :=
     compileUnop_eval heval_se heval_op hcompUnop
   have hq : st₁.sl W ρ_e ∗ TinyML.ValHasType W w ty ∗ R ⊢ Φ w :=
     by simpa [hty_eq] using
@@ -2068,7 +2068,7 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
       (VerifM.eval.decls_grow ρ heval_r) hagree hbwf hSwf hwf hag hΔreg hρreg ?_
   intro vr ρ_r st₁ sr hΨ_r hsr_wf heval_sr
   obtain ⟨hdecls_r, hagreeOn_r, hΨ_r⟩ := hΨ_r
-  have hagree_r : B.agreeOnLinked ρ_r.env γ :=
+  have hagree_r : B.agreeOnLinked ρ_r γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_r hbwf
   have hbwf_r : B.wfIn st₁.decls := fun p hp => hdecls_r.consts _ (hbwf p hp)
   have heval_l : (compile reg W.Θ W.Δ_spec S B Γ l).eval st₁ ρ_r _ := VerifM.eval_bind hΨ_r
@@ -2088,7 +2088,7 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
   obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
   obtain ⟨hty_eq, hΨ_l'⟩ := VerifM.eval_bind_expectEq hΨ_l
   simp only [Expr.ty] at hpost
-  have hsr_ρ_l : sr.eval ρ_l.env = vr := by
+  have hsr_ρ_l : sr.eval ρ_l = vr := by
     rw [Term.eval_env_agree hsr_wf (Env.agreeOn_symm hagreeOn_l)]
     exact heval_sr
   by_cases hdivmod : op = .div ∨ op = .mod
@@ -2240,7 +2240,7 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
     istart
     iintro ⟨Howns, Hex, HR⟩
     icases Hex with ⟨%w, %heval_op, Hwty⟩
-    have ht_eval : t.eval ρ_l.env = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
+    have ht_eval : t.eval ρ_l = w := compileOp_eval heval_sl hsr_ρ_l heval_op hcompOp
     have hq : st₂.sl W ρ_l ∗ TinyML.ValHasType W w ty ∗ R ⊢ Φ w := by
       simpa [hty_eq] using
         (hpost w ρ_l st₂ t hΨ_ndiv (compileOp_wfIn hsl_wf hwf_sr_l hcompOp) ht_eval)
@@ -2334,14 +2334,14 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
                   (Runtime.Expr.subst (γ.remove' (.named x)) body.runtime))
                 Φ :=
         hsubst.symm ▸ this
-      have hinterp_eq : SpatialContext.interp W ρ_e.env st₁.owns ⊢ SpatialContext.interp W ρ_body.env st₁.owns :=
+      have hinterp_eq : SpatialContext.interp W ρ_e st₁.owns ⊢ SpatialContext.interp W ρ_body st₁.owns :=
         (SpatialContext.interp_env_agree W (VerifM.eval.wf hΨ_e).ownsWf
           (Env.agreeOn_update_fresh_const hfresh)).1
       rw [Binder.runtime_of_name_some hname]
       exact (sep_mono_left hinterp_eq).trans <|
         by simpa [st₂, γ_body, base, Runtime.Subst.updateBinder, Runtime.Subst.update, Runtime.Subst.id]
           using hbody'
-    have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e.env ρ_body.env :=
+    have hagreeOn_body_e : Env.agreeOn st₁.decls ρ_e ρ_body :=
       Env.agreeOn_update_fresh_const hfresh
     have hΨ_body : (compile reg W.Θ W.Δ_spec (Finmap.erase x S) ((x, v) :: B) (Γ.extend x e.ty) body).eval st₂ ρ_body Ψ := by
       have hdecl_eval := VerifM.eval_bind hΨ_e
@@ -2354,12 +2354,12 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
         simpa [v] using
           (Formula.eq_wfIn_addConst_of_fresh (Δ := st₁.decls) (c := v) hstwf hse_wf hfresh)
       · simp only [Formula.eval, Term.eval, Const.denote]
-        have : v_e = Term.eval ρ_body.env se := by
+        have : v_e = Term.eval ρ_body se := by
           rw [Term.eval_env_agree hse_wf (Env.agreeOn_symm hagreeOn_body_e)]
           exact heval_e.symm
         simpa [ρ_body, Env.updateConst] using this
     have hbwf₂ : Bindings.wfIn ((x, v) :: B) st₂.decls := Bindings.wfIn_cons hbwf_e
-    have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ_body.env ρ.env := by
+    have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ_body ρ := by
       refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
       · intro y hy
         cases hy
@@ -2372,9 +2372,9 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
       · intro z hz; cases hz
       · intro z hz; cases hz
       · intro z hz; cases hz
-    have hρ_body_lookup : ρ_body.env.consts .value v.name = v_e := by
-      simp [ρ_body, VerifM.Env.updateConst, Env.updateConst]
-    have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body.env γ_body := by
+    have hρ_body_lookup : ρ_body.consts .value v.name = v_e := by
+      simp [ρ_body, Env.updateConst, Env.updateConst]
+    have hagree_body : Bindings.agreeOnLinked ((x, v) :: B) ρ_body γ_body := by
       have h := Bindings.agreeOnLinked_cons (x := x) (γ := γ) hagree hρ_agree (hvty := (rfl : v.sort = .value))
       rwa [hρ_body_lookup] at h
     have hres :
@@ -2408,22 +2408,22 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
     (ihBody : correctExpr reg body) :
     ∀ (names : List Binder) (tys : List TinyML.Typ) (tl : Term .vallist)
       (vals : List Runtime.Val) (W : TinyML.World) (R : iProp) (S : SpecMap)
-      (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : VerifM.Env)
+      (B : Bindings) (Γ : TinyML.TyCtx) (st : TransState) (ρ : Env)
       (γ : Runtime.Subst)
-      (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp),
+      (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp),
       W.pctx = reg.primCtx →
       VerifM.eval (compileProductBindersFrom S B Γ names tys tl) st ρ
         (fun p st' ρ' => (compile reg W.Θ W.Δ_spec p.1 p.2.1 p.2.2 body).eval st' ρ' Ψ) →
-      B.agreeOnLinked ρ.env γ →
+      B.agreeOnLinked ρ γ →
       B.wfIn st.decls →
       S.wfIn W.Δ_spec →
       W.wf →
-      W.agrees st.decls ρ.env →
+      W.agrees st.decls ρ →
       Verifier.Registry.symSubset reg W.Δ_spec →
       Verifier.Registry.symAgree reg W.ρ_spec →
       tl.wfIn st.decls →
-      Term.eval ρ.env tl = vals →
-      (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ'.env se = v →
+      Term.eval ρ tl = vals →
+      (∀ v ρ' st' se, Ψ se st' ρ' → se.wfIn st'.decls → Term.eval ρ' se = v →
         st'.sl W ρ' ∗ TinyML.ValHasType W v body.ty ∗ R ⊢ Φ v) →
       st.sl W ρ ∗
           (TinyML.ValsHaveTypes W vals tys ∗
@@ -2497,9 +2497,9 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
           obtain ⟨hbty, hcont⟩ := VerifM.eval_expectEq hexpect
           have hhead_wf : (Term.unop UnOp.vhead tl).wfIn st.decls := ⟨trivial, htl_wf⟩
           have htail_wf : (Term.unop UnOp.vtail tl).wfIn st.decls := ⟨trivial, htl_wf⟩
-          have hhead_eval : (Term.unop UnOp.vhead tl).eval ρ.env = v := by
+          have hhead_eval : (Term.unop UnOp.vhead tl).eval ρ = v := by
             simp [Term.eval, UnOp.eval, htl_eval]
-          have htail_eval : (Term.unop UnOp.vtail tl).eval ρ.env = vs := by
+          have htail_eval : (Term.unop UnOp.vtail tl).eval ρ = vs := by
             simp [Term.eval, UnOp.eval, htl_eval]
           cases hname : b.name with
           | none =>
@@ -2547,21 +2547,21 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
                     hstwf hhead_wf hfresh)
               have hformula_eval :
                   (Formula.eq .value (.const (.uninterpreted x'.name .value))
-                    (Term.unop UnOp.vhead tl)).eval ρ₁.env := by
-                have hagree_head : Env.agreeOn st.decls ρ.env ρ₁.env :=
+                    (Term.unop UnOp.vhead tl)).eval ρ₁ := by
+                have hagree_head : Env.agreeOn st.decls ρ ρ₁ :=
                   Env.agreeOn_update_fresh_const hfresh
                 have hhead_same := Term.eval_env_agree hhead_wf hagree_head
-                have hval_same : v = (Term.unop UnOp.vhead tl).eval ρ₁.env := by
+                have hval_same : v = (Term.unop UnOp.vhead tl).eval ρ₁ := by
                   exact hhead_eval.symm.trans hhead_same
-                simpa [Formula.eval, Term.eval, Const.denote, ρ₁, VerifM.Env.updateConst,
+                simpa [Formula.eval, Term.eval, Const.denote, ρ₁, Env.updateConst,
                   Env.updateConst] using hval_same
               have hrec_eval := hassume hformula_wf hformula_eval
               set st₂ : TransState := { st₁ with
                 asserts := (Formula.eq .value (.const (.uninterpreted x'.name .value))
                   (Term.unop UnOp.vhead tl)) :: st₁.asserts }
-              have hagreeOn_body : Env.agreeOn st.decls ρ.env ρ₁.env :=
+              have hagreeOn_body : Env.agreeOn st.decls ρ ρ₁ :=
                 Env.agreeOn_update_fresh_const hfresh
-              have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁.env ρ.env := by
+              have hρ_agree : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁ ρ := by
                 refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
                 · intro y hy; cases hy
                 · intro y' hy'
@@ -2572,9 +2572,9 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
                 · intro z hz; cases hz
                 · intro z hz; cases hz
                 · intro z hz; cases hz
-              have hρ_lookup : ρ₁.env.consts .value x'.name = v := by
-                simp [ρ₁, VerifM.Env.updateConst, Env.updateConst]
-              have hagree₁ : Bindings.agreeOnLinked ((x, x') :: B) ρ₁.env
+              have hρ_lookup : ρ₁.consts .value x'.name = v := by
+                simp [ρ₁, Env.updateConst, Env.updateConst]
+              have hagree₁ : Bindings.agreeOnLinked ((x, x') :: B) ρ₁
                   (Runtime.Subst.update γ x v) := by
                 have h := Bindings.agreeOnLinked_cons (x := x) (v := x') (γ := γ)
                   hagree hρ_agree (hvty := (rfl : x'.sort = .value))
@@ -2611,8 +2611,8 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
                 iintro ⟨Hsl, Hvals, #HS, #HT, HR⟩
                 ihave Hpair := (TinyML.ValsHaveTypes.cons W v vs ty tys).1 $$ Hvals
                 icases Hpair with ⟨Hv, Hvs⟩
-                have hinterp_eq : SpatialContext.interp W ρ.env st.owns ⊢
-                    SpatialContext.interp W ρ₁.env st.owns :=
+                have hinterp_eq : SpatialContext.interp W ρ st.owns ⊢
+                    SpatialContext.interp W ρ₁ st.owns :=
                   (SpatialContext.interp_env_agree W (VerifM.eval.wf hdecl_eval).ownsWf
                     (Env.agreeOn_update_fresh_const hfresh)).1
                 isplitl [Hsl]
@@ -2811,7 +2811,7 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
         · iexact HT
         · iexact HR
   · subst htrue_val
-    have heval_ne : sc.eval ρ_c.env ≠ Runtime.Val.bool false := by
+    have heval_ne : sc.eval ρ_c ≠ Runtime.Val.bool false := by
       rw [heval_c]
       simp
     have heval_thn : (compile reg W.Θ W.Δ_spec S B Γ thn).eval st_thn ρ_c Ψ :=
@@ -2853,7 +2853,7 @@ theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
   intro vs ρ' st' terms hΨ hwf_terms heval_terms
   obtain ⟨_, _, hΨ⟩ := hΨ
   obtain hΨ := VerifM.eval_ret hΨ
-  have heval_tuple : (Term.unop .ofValList (Terms.toValList terms)).eval ρ'.env = Runtime.Val.tuple vs := by
+  have heval_tuple : (Term.unop .ofValList (Terms.toValList terms)).eval ρ' = Runtime.Val.tuple vs := by
     simp [Term.eval, UnOp.eval, Terms.toValList_eval heval_terms]
   have hwf_tuple : (Term.unop UnOp.ofValList (Terms.toValList terms)).wfIn st'.decls := by
     simp only [Term.wfIn]
@@ -2964,17 +2964,17 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
         rw [← Hlen]; exact hlen_sargs.symm
       have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
         simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
-      have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args.env) = vs := by
+      have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
         have hsnd :
             List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
           simpa using
             (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
               (Nat.le_of_eq hlen_typed.symm))
         calc
-          typedArgs.map (fun p => p.2.eval ρ_args.env)
-              = sargs.map (fun t => t.eval ρ_args.env) := by
+          typedArgs.map (fun p => p.2.eval ρ_args)
+              = sargs.map (fun t => t.eval ρ_args) := by
                   simpa [typedArgs, List.map_map] using
-                    congrArg (List.map (fun t => t.eval ρ_args.env)) hsnd
+                    congrArg (List.map (fun t => t.eval ρ_args)) hsnd
           _ = vs := Terms.Eval.map_eval heval_sargs
       have hlen_vs : vs.length = (spec.args.map Prod.snd).length := by
         have := hsub_ty'.length_eq
@@ -2985,7 +2985,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
               (Spec.argsEnv ρ_args spec.args vs) := by
         rw [heval_sargs_map] at happly
         exact happly
-      have hagree_ρ_args : Env.agreeOn W.Δ_spec W.ρ_spec ρ_args.env :=
+      have hagree_ρ_args : Env.agreeOn W.Δ_spec W.ρ_spec ρ_args :=
         Env.agreeOn_trans hag.agree (Env.agreeOn_mono hag.subset hagreeOn_args)
       ispecialize Hspec $$ %ρ_args
       ispecialize Hspec $$ %Φ
@@ -3070,17 +3070,17 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
           (List.map_fst_zip (l₁ := args.map Expr.ty) (l₂ := sargs)
             (Nat.le_of_eq hlen_typed))
       simpa [hfst] using hsub_ty
-    have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args.env) = vs := by
+    have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
       have hsnd :
           List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
         simpa using
           (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
             (Nat.le_of_eq hlen_typed.symm))
       calc
-        typedArgs.map (fun p => p.2.eval ρ_args.env)
-            = sargs.map (fun t => t.eval ρ_args.env) := by
+        typedArgs.map (fun p => p.2.eval ρ_args)
+            = sargs.map (fun t => t.eval ρ_args) := by
                 simpa [typedArgs, List.map_map] using
-                  congrArg (List.map (fun t => t.eval ρ_args.env)) hsnd
+                  congrArg (List.map (fun t => t.eval ρ_args)) hsnd
         _ = vs := Terms.Eval.map_eval heval_sargs
     have happly' :
         st_args.sl W ρ_args ∗ R ⊢
@@ -3088,9 +3088,9 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
             (Spec.argsEnv ρ_args spec.args vs) := by
       rw [heval_sargs_map] at happly
       exact happly
-    have hagree_ρ_args : Env.agreeOn W.Δ_spec W.ρ_spec ρ_args.env :=
+    have hagree_ρ_args : Env.agreeOn W.Δ_spec W.ρ_spec ρ_args :=
       Env.agreeOn_trans hag.agree (Env.agreeOn_mono hag.subset hagreeOn_args)
-    have hρ_args_reg : ρ_args.env.respects i.folSym :=
+    have hρ_args_reg : ρ_args.respects i.folSym :=
       Env.respects_of_agreeOn_extendWithSym (hρreg i hi_mem) (hΔreg i hi_mem) hagree_ρ_args
     iapply (show
         TinyML.ValsHaveTypes W vs (spec.args.map Prod.snd) ∗
@@ -3178,7 +3178,7 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
                   iexact Hv
                 · iexact HR)
             tag htag_branches (by simpa [Nat.zero_add] using heval_tag)
-          have hsc_eval : se_scrut.eval ρ_scrut.env = Runtime.Val.inj tag ts.length v_payload := by
+          have hsc_eval : se_scrut.eval ρ_scrut = Runtime.Val.inj tag ts.length v_payload := by
             exact heval_se.trans hval_eq
           have hbranch_entail :
               st_scrut.sl W ρ_scrut ∗
@@ -3264,21 +3264,21 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
         (.unop (.ofInj i n) (.const (.uninterpreted xv.name .value)))).wfIn st₁.decls := by
       refine ⟨Term.wfIn_mono sc hsc_wf (Signature.Subset.subset_addConst _ _)
         (Signature.wf_addConst hstwf hxv_fresh), trivial, hxv_wf⟩
-    have hsc_eval_ρ₁ : sc.eval ρ₁.env = sc.eval ρ.env :=
+    have hsc_eval_ρ₁ : sc.eval ρ₁ = sc.eval ρ :=
       Term.eval_env_agree hsc_wf (Env.agreeOn_symm (Env.agreeOn_update_fresh_const hxv_fresh))
-    have hformula_eval : Formula.eval ρ₁.env
+    have hformula_eval : Formula.eval ρ₁
         (Formula.eq .value sc (.unop (.ofInj i n) (.const (.uninterpreted xv.name .value)))) := by
       simp [Formula.eval, Term.eval, UnOp.eval]
       rw [hsc_eval_ρ₁, hsc_eval]
       simp [ρ₁, Env.updateConst]
     have heval_assumeAll := hassume hformula_wf hformula_eval
-    have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁.env = payload := by
+    have hxv_eval : (Term.const (.uninterpreted xv.name .value)).eval ρ₁ = payload := by
       simp [Term.eval, Const.denote, ρ₁, Env.updateConst]
     have hassume_bind₂ := VerifM.eval_bind heval_assumeAll
-    have hinterp_eq : SpatialContext.interp W ρ.env st.owns ⊢ SpatialContext.interp W ρ₁.env st.owns :=
+    have hinterp_eq : SpatialContext.interp W ρ st.owns ⊢ SpatialContext.interp W ρ₁ st.owns :=
       (SpatialContext.interp_env_agree W (VerifM.eval.wf heval_decl).ownsWf
         (Env.agreeOn_update_fresh_const hxv_fresh)).1
-    have hagreeOn_st : Env.agreeOn st.decls ρ.env ρ₁.env :=
+    have hagreeOn_st : Env.agreeOn st.decls ρ ρ₁ :=
       Env.agreeOn_update_fresh_const hxv_fresh
     -- Extract the type-constraints Prop from the iProp `ValHasType W payload ty_i`
     -- assumption, then dispatch into iproof mode to build the final entailment.
@@ -3287,7 +3287,7 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
     iintuitionistic Hpay
     ihave Hcheck := TinyML.typeConstraints_hold (ty := ty_i)
         (t := Term.const (.uninterpreted xv.name .value))
-        (ρ := ρ₁.env) (W := W) (v := payload) hxv_eval $$ Hpay
+        (ρ := ρ₁) (W := W) (v := payload) hxv_eval $$ Hpay
     ipure Hcheck
     obtain ⟨st₂, hst₂_decls, hst₂_owns, _, heval_body'⟩ := VerifM.eval_assumeAll hassume_bind₂
       (fun φ hφ => TinyML.typeConstraints_wfIn hxv_wf φ hφ)
@@ -3296,7 +3296,7 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
     cases hname : binder.name with
     | none =>
       simp [hname] at heval_body'
-      have hagree₁ : B.agreeOnLinked ρ₁.env γ :=
+      have hagree₁ : B.agreeOnLinked ρ₁ γ :=
         Bindings.agreeOnLinked_env_agree hagree hagreeOn_st hbwf
       have hbwf₁ : B.wfIn st₂.decls := hst₂_decls ▸ fun p hp => List.Mem.tail _ (hbwf p hp)
       have heval_body'' : (compile reg W.Θ W.Δ_spec S B (Γ.extendBinder binder ty_i) body).eval st₂ ρ₁ Ψ := by
@@ -3339,7 +3339,7 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
             · iexact HR
     | some x =>
       simp [hname, TinyML.TyCtx.extendBinder] at heval_body'
-      have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁.env ρ.env := by
+      have hagreeOn_B : Env.agreeOn (Signature.ofConsts (B.map Prod.snd)) ρ₁ ρ := by
         refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
         · intro w hw
           cases hw
@@ -3352,9 +3352,9 @@ theorem compileSingleBranch_correct (reg : Verifier.Registry) (binder : Binder) 
         · intro z hz; cases hz
         · intro z hz; cases hz
       have hbwf₂ : Bindings.wfIn ((x, xv) :: B) st₂.decls := hst₂_decls ▸ Bindings.wfIn_cons hbwf
-      have hρ₁_lookup : ρ₁.env.consts .value xv.name = payload := by
-        simp [ρ₁, VerifM.Env.updateConst, Env.updateConst]
-      have hagree₁ : Bindings.agreeOnLinked ((x, xv) :: B) ρ₁.env (Runtime.Subst.update γ x payload) := by
+      have hρ₁_lookup : ρ₁.consts .value xv.name = payload := by
+        simp [ρ₁, Env.updateConst, Env.updateConst]
+      have hagree₁ : Bindings.agreeOnLinked ((x, xv) :: B) ρ₁ (Runtime.Subst.update γ x payload) := by
         have h := Bindings.agreeOnLinked_cons (x := x) (v := xv) (γ := γ) hagree hagreeOn_B (hvty := rfl)
         rwa [hρ₁_lookup] at h
       have heval_body'' :
@@ -3449,7 +3449,7 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
             · iexact HR
   intro vs ρ_vs st_vs rest_terms hΨ_vs hwf_rest heval_rest
   obtain ⟨hdecls_vs, hagreeOn_vs, hΨ_vs⟩ := hΨ_vs
-  have hagree_vs : B.agreeOnLinked ρ_vs.env γ :=
+  have hagree_vs : B.agreeOnLinked ρ_vs γ :=
     Bindings.agreeOnLinked_env_agree hagree hagreeOn_vs hbwf
   have hbwf_vs : B.wfIn st_vs.decls := fun p hp => hdecls_vs.consts _ (hbwf p hp)
   have heval_e : (compile reg W.Θ W.Δ_spec S B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind hΨ_vs
@@ -3480,7 +3480,7 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
     rcases ht with rfl | ht
     · exact hse_wf
     · exact Term.wfIn_mono _ (hwf_rest t ht) hdecls_e hwfst'
-  have heval_cons : Terms.Eval ρ'.env (se :: rest_terms) (v :: vs) :=
+  have heval_cons : Terms.Eval ρ' (se :: rest_terms) (v :: vs) :=
     Terms.Eval.cons heval_se
       (Terms.Eval.env_agree
         (fun t ht => hwf_rest t ht)

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -58,19 +58,19 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     (fval : Runtime.Val)
     (vs : List Runtime.Val)
     (P : Runtime.Val → iProp)
-    {argVars : List FOL.Const} {st' : TransState} {ρ' : VerifM.Env} {Q : iProp}
-    (hag : W.agrees st'.decls ρ'.env)
+    {argVars : List FOL.Const} {st' : TransState} {ρ' : Env} {Q : iProp}
+    (hag : W.agrees st'.decls ρ')
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
     (hargVars_mem : ∀ v ∈ argVars, v ∈ st'.decls.consts)
     (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
-    (hargVars_lookup : List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs)
+    (hargVars_lookup : List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs)
     (hbody_eval : VerifM.eval
         (checkBody reg W.Θ W.Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
           st''.sl W ρ'' ∗ Q ∗
-            ((TinyML.ValHasType W (result.eval ρ''.env) s.retTy -∗ P (result.eval ρ''.env)) -∗ S) ⊢ S)) :
+            ((TinyML.ValHasType W (result.eval ρ'') s.retTy -∗ P (result.eval ρ'')) -∗ S) ⊢ S)) :
     st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗ Q ⊢
       (S.satisfiedBy W γ ∗ s.isPrecondFor W fval) -∗
         wp W.pctx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
@@ -99,14 +99,14 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
   have hlen_avs : argNames.length = argVars.length := by
     have := hargVars_lookup.length_eq
     omega
-  have hagree : Bindings.agreeOnLinked B ρ'.env γ_body := by
-    show Bindings.agreeOnLinked (Bindings.empty ++ (argNames.zip argVars).reverse) ρ'.env
+  have hagree : Bindings.agreeOnLinked B ρ' γ_body := by
+    show Bindings.agreeOnLinked (Bindings.empty ++ (argNames.zip argVars).reverse) ρ'
       ((γ.updateBinder fb.runtime fval).updateAllBinder bs vs)
     rw [show Bindings.empty ++ (argNames.zip argVars).reverse =
         (argNames.zip argVars).reverse ++ Bindings.empty from by simp [Bindings.empty]]
     rw [hbs_runtime]
     apply Bindings.agreeOnLinked_updateAllBinder Bindings.empty argNames argVars vs
-      (γ.updateBinder fb.runtime fval) ρ'.env
+      (γ.updateBinder fb.runtime fval) ρ'
     · intro x x' h; simp [Bindings.empty] at h
     · exact hlen_avs
     · exact hlen_nv
@@ -124,7 +124,7 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       simp [args']; exact List.map_fst_zip (by simp; omega)
     have hsnd : args'.map Prod.snd = s.args.map Prod.snd := by
       simp [args']; exact List.map_snd_zip (by simp; omega)
-    iapply (valHasType_lookup_zip_reverse args' argVars vs ρ'.env TinyML.TyCtx.empty x x' t
+    iapply (valHasType_lookup_zip_reverse args' argVars vs ρ' TinyML.TyCtx.empty x x' t
       (by rw [hfst]; exact hlen_avs)
       (by rw [hfst]; exact hlen_nv)
       (by rw [hfst]; simp [B, Bindings.empty] at hmem; exact hmem)
@@ -159,10 +159,10 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     have hΨ' := VerifM.eval_ret hΨ
     dsimp only at hΨ'
     rw [← heval_se]
-    refine (show st''.sl W ρ'' ∗ TinyML.ValHasType W (se.eval ρ''.env) body.ty ∗ Q ⊢
+    refine (show st''.sl W ρ'' ∗ TinyML.ValHasType W (se.eval ρ'') body.ty ∗ Q ⊢
         st''.sl W ρ'' ∗ Q ∗
-          ((TinyML.ValHasType W (se.eval ρ''.env) s.retTy -∗ P (se.eval ρ''.env)) -∗
-            P (se.eval ρ''.env)) from ?_).trans (hΨ' _ hse_wf)
+          ((TinyML.ValHasType W (se.eval ρ'') s.retTy -∗ P (se.eval ρ'')) -∗
+            P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
     iintro ⟨Howns, Hty, HQ⟩
     iframe Howns HQ
     iintro Hwand
@@ -183,8 +183,8 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     (γ : Runtime.Subst)
     (hswf : s.wfIn W.Δ_spec) (hSwf : S.wfIn W.Δ_spec)
     (hwf : W.wf)
-    (st : TransState) (ρ : VerifM.Env)
-    (hag : W.agrees st.decls ρ.env)
+    (st : TransState) (ρ : Env)
+    (hag : W.agrees st.decls ρ)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec) :
     VerifM.eval (checkSpec reg W.Θ W.Δ_spec S e s) st ρ (fun _ _ _ => True) →
@@ -244,7 +244,7 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
         iintro H
         icases H with ⟨Htyped', Hpred'⟩
         iintuitionistic Htyped'
-        have hag_persist : W.agrees (TransState.persist st).decls ρ.env := by
+        have hag_persist : W.agrees (TransState.persist st).decls ρ := by
           simpa using hag
         ihave Hwand := Spec.implement_correct W s _ (TransState.persist st) ρ vs P
           (TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
@@ -252,7 +252,7 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
               wp W.pctx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
           hswf hwf hag_persist himpl
           (fun argVars st' ρ' Q hst_sub hρ_agree hargVars_mem hargVars_sort hargVars_lookup hbody_eval => by
-            have hag' : W.agrees st'.decls ρ'.env := hag_persist.step hst_sub hρ_agree
+            have hag' : W.agrees st'.decls ρ' := hag_persist.step hst_sub hρ_agree
             iintro ⟨Hsl, HQ⟩ Htyped''
             iapply (checkBody_correct reg hSound W hW S s γ hswf hSwf hwf fb argBinders body argNames
               hext bs rfl fval vs P hag' hΔreg hρreg hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
@@ -271,9 +271,9 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
                 simp [List.length_map] at hlen
                 omega
               iapply (PredTrans.apply_env_agree W (ρ := Spec.argsEnv ρ_call s.args vs)
-                (ρ' := Spec.argsEnv ⟨W.ρ_spec⟩ s.args vs) hswf
-                (Spec.argsEnv_agreeOn (Δ := W.Δ_spec) (ρ₁ := ρ_call) (ρ₂ := ⟨W.ρ_spec⟩)
-                  (VerifM.Env.agreeOn_symm hagree_call) s.args vs hlen_vals_call))
+                (ρ' := Spec.argsEnv W.ρ_spec s.args vs) hswf
+                (Spec.argsEnv_agreeOn (Δ := W.Δ_spec) (ρ₁ := ρ_call) (ρ₂ := W.ρ_spec)
+                  (Env.agreeOn_symm hagree_call) s.args vs hlen_vals_call))
               iexact Hpred'
         iapply Hwand
         iexact Htyped'

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -554,8 +554,8 @@ class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Pr
       PredTrans.wfIn (Δ.declVars (Spec.argVars i.specArgs)) i.spec.pred
   bridge :
     ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ) (W : TinyML.World)
-      (vs : List Runtime.Val) (ρ : VerifM.Env) (Φ : Runtime.Val → iProp),
-    ρ.env.respects i.folSym →
+      (vs : List Runtime.Val) (ρ : Env) (Φ : Runtime.Val → iProp),
+    ρ.respects i.folSym →
     TinyML.ValsHaveTypes W vs ((i.spec.instantiate σ).args.map Prod.snd) ∗
       PredTrans.apply W (fun r => TinyML.ValHasType W r (i.spec.instantiate σ).retTy -∗ Φ r)
         (i.spec.instantiate σ).pred
@@ -876,12 +876,12 @@ namespace Intrinsic
     leaves owns and asserts untouched, and produces a post-decl environment
     that respects `i.folSym` (when present), agreeing with the original on
     the original signature. -/
-theorem eval_declFOLSym (i : Intrinsic) {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem eval_declFOLSym (i : Intrinsic) {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (heval : VerifM.eval i.declFOLSym st ρ Q) :
-    ∃ ρ' : VerifM.Env,
-      VerifM.Env.agreeOn st.decls ρ ρ' ∧
-      ρ'.env.respects i.folSym ∧
+    ∃ ρ' : Env,
+      Env.agreeOn st.decls ρ ρ' ∧
+      ρ'.respects i.folSym ∧
       Q () { st with decls := st.decls.extendWithSym i.folSym } ρ' := by
   cases i with
   | mk arity name path reduce wp spec typing folSym axioms =>
@@ -890,59 +890,59 @@ theorem eval_declFOLSym (i : Intrinsic) {st : TransState} {ρ : VerifM.Env}
       cases folSym with
       | none =>
         simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
-        refine ⟨ρ, VerifM.Env.agreeOn_refl, by simp [Env.respects], ?_⟩
+        refine ⟨ρ, Env.agreeOn_refl, by simp [Env.respects], ?_⟩
         exact VerifM.eval_ret heval
       | some s =>
         simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
         obtain ⟨hfresh, hcont⟩ := VerifM.eval_declConstExact heval
         refine ⟨ρ.updateConst .value s.name (s.interp ()),
-                VerifM.Env.agreeOn_update_fresh (c := ⟨s.name, .value⟩) hfresh,
+                Env.agreeOn_update_fresh_const (c := ⟨s.name, .value⟩) hfresh,
                 ?_, ?_⟩
-        · simp [Env.respects, VerifM.Env.updateConst, Env.lookupConst, Env.updateConst]
+        · simp [Env.respects, Env.updateConst, Env.lookupConst, Env.updateConst]
         · exact hcont (s.interp ())
     | one =>
       cases folSym with
       | none =>
         simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
-        refine ⟨ρ, VerifM.Env.agreeOn_refl, by simp [Env.respects], ?_⟩
+        refine ⟨ρ, Env.agreeOn_refl, by simp [Env.respects], ?_⟩
         exact VerifM.eval_ret heval
       | some s =>
         simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
         obtain ⟨hfresh, hcont⟩ := VerifM.eval_declUnaryExact heval
         refine ⟨ρ.updateUnary .value .value s.name s.interp,
-                VerifM.Env.agreeOn_update_fresh_unary (u := ⟨s.name, .value, .value⟩) hfresh,
+                Env.agreeOn_update_fresh_unary (u := ⟨s.name, .value, .value⟩) hfresh,
                 ?_, ?_⟩
-        · simp [Env.respects, VerifM.Env.updateUnary, Env.updateUnary]
+        · simp [Env.respects, Env.updateUnary, Env.updateUnary]
         · exact hcont s.interp
     | two =>
       cases folSym with
       | none =>
         simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
-        refine ⟨ρ, VerifM.Env.agreeOn_refl, by simp [Env.respects], ?_⟩
+        refine ⟨ρ, Env.agreeOn_refl, by simp [Env.respects], ?_⟩
         exact VerifM.eval_ret heval
       | some s =>
         simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
         obtain ⟨hfresh, hcont⟩ := VerifM.eval_declBinaryExact heval
         refine ⟨ρ.updateBinary .value .value .value s.name (fun a b => s.interp (a, b)),
-                VerifM.Env.agreeOn_update_fresh_binary (b := ⟨s.name, .value, .value, .value⟩) hfresh,
+                Env.agreeOn_update_fresh_binary (b := ⟨s.name, .value, .value, .value⟩) hfresh,
                 ?_, ?_⟩
-        · simp [Env.respects, VerifM.Env.updateBinary, Env.updateBinary]
+        · simp [Env.respects, Env.updateBinary, Env.updateBinary]
         · exact hcont (fun a b => s.interp (a, b))
     | three =>
       cases folSym with
       | none =>
         simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
-        refine ⟨ρ, VerifM.Env.agreeOn_refl, by simp [Env.respects], ?_⟩
+        refine ⟨ρ, Env.agreeOn_refl, by simp [Env.respects], ?_⟩
         exact VerifM.eval_ret heval
       | some s =>
         simp only [declFOLSym, Signature.extendWithSym] at heval ⊢
         obtain ⟨hfresh, hcont⟩ := VerifM.eval_declTernaryExact heval
         refine ⟨ρ.updateTernary .value .value .value .value s.name
                   (fun a b c => s.interp (a, b, c)),
-                VerifM.Env.agreeOn_update_fresh_ternary
+                Env.agreeOn_update_fresh_ternary
                   (t := ⟨s.name, .value, .value, .value, .value⟩) hfresh,
                 ?_, ?_⟩
-        · simp [Env.respects, VerifM.Env.updateTernary, Env.updateTernary]
+        · simp [Env.respects, Env.updateTernary, Env.updateTernary]
         · exact hcont (fun a b c => s.interp (a, b, c))
 
 end Intrinsic
@@ -952,8 +952,8 @@ namespace Registry
 /-- Effect of the declaration pass on a registry. It declares every registered
     FOL symbol before any intrinsic axiom is assumed. -/
 theorem eval_declFOLSyms (R : Registry)
-    {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (heval : VerifM.eval (declFOLSyms R) st ρ Q) :
     ∃ st' ρ',
       st.decls.Subset st'.decls ∧
@@ -961,15 +961,15 @@ theorem eval_declFOLSyms (R : Registry)
       st'.decls.vars = st.decls.vars ∧
       st'.owns = st.owns ∧
       st'.asserts = st.asserts ∧
-      (∀ ρ'' : VerifM.Env, VerifM.Env.agreeOn st'.decls ρ' ρ'' →
-        ∀ d ∈ R, ρ''.env.respects d.folSym) ∧
-      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      (∀ ρ'' : Env, Env.agreeOn st'.decls ρ' ρ'' →
+        ∀ d ∈ R, ρ''.respects d.folSym) ∧
+      Env.agreeOn st.decls ρ ρ' ∧
       Q () st' ρ' := by
   induction R generalizing st ρ Q with
   | nil =>
     simp only [declFOLSyms] at heval
     refine ⟨st, ρ, Signature.Subset.refl _, ?_, rfl, rfl, rfl, ?_,
-            VerifM.Env.agreeOn_refl, VerifM.eval_ret heval⟩
+            Env.agreeOn_refl, VerifM.eval_ret heval⟩
     · exact Signature.Subset.refl _
     · intro _ _ d hd
       cases hd
@@ -982,16 +982,16 @@ theorem eval_declFOLSyms (R : Registry)
       ih hcont
     have hsub1 : st.decls.Subset st1.decls := Signature.subset_extendWithSym _ _
     have hiStable :
-        ∀ ρ'' : VerifM.Env, VerifM.Env.agreeOn st'.decls ρ' ρ'' →
-          ρ''.env.respects i.folSym := by
+        ∀ ρ'' : Env, Env.agreeOn st'.decls ρ' ρ'' →
+          ρ''.respects i.folSym := by
       intro ρ'' hag
       refine Env.respects_of_agreeOn_extendWithSym (Δ := st1.decls) hiRespect ?_ ?_
       · exact Signature.extendWithSym_mono (Signature.empty_subset _) _
-      · exact VerifM.Env.agreeOn_trans hag2 (VerifM.Env.agreeOn_mono hsub2 hag)
+      · exact Env.agreeOn_trans hag2 (Env.agreeOn_mono hsub2 hag)
     have hvars1 : st1.decls.vars = st.decls.vars := by
       simp [st1]
     refine ⟨st', ρ', hsub1.trans hsub2, ?_, hvars2.trans hvars1, howns2, hass2, ?_,
-            VerifM.Env.agreeOn_trans hag1 (VerifM.Env.agreeOn_mono hsub1 hag2), hQ⟩
+            Env.agreeOn_trans hag1 (Env.agreeOn_mono hsub1 hag2), hQ⟩
     · exact hdep2
     · intro ρ'' hag d hd
       cases hd with
@@ -1002,12 +1002,12 @@ theorem eval_declFOLSyms (R : Registry)
     full registry fragment, so axiom dependencies need not follow list order. -/
 theorem eval_assumeAxioms_in (full todo : Registry)
     (hSound : SoundIn full todo)
-    {st : TransState} {ρ : VerifM.Env}
+    {st : TransState} {ρ : Env}
     (hSig : (Intrinsic.sigOf full).Subset st.decls)
     (hRespect :
-      ∀ ρ' : VerifM.Env, VerifM.Env.agreeOn st.decls ρ ρ' →
-        ∀ d ∈ full, ρ'.env.respects d.folSym)
-    {Q : Unit → TransState → VerifM.Env → Prop}
+      ∀ ρ' : Env, Env.agreeOn st.decls ρ ρ' →
+        ∀ d ∈ full, ρ'.respects d.folSym)
+    {Q : Unit → TransState → Env → Prop}
     (heval : VerifM.eval (assumeAxioms todo) st ρ Q) :
     ∃ st',
       st'.decls = st.decls ∧
@@ -1024,16 +1024,16 @@ theorem eval_assumeAxioms_in (full todo : Registry)
     rcases hSound with ⟨hiSound, hrestSound⟩
     have hwfAxioms : ∀ a ∈ i.axioms, a.formula.wfIn st.decls := fun a ha =>
       hiSound.axiomWf hSig (VerifM.eval.wf h1).namesDisjoint a ha
-    have hevalAxioms : ∀ a ∈ i.axioms, a.formula.eval ρ.env :=
-      hiSound.proof ρ.env (fun d hd => hRespect ρ VerifM.Env.agreeOn_refl d hd)
+    have hevalAxioms : ∀ a ∈ i.axioms, a.formula.eval ρ :=
+      hiSound.proof ρ (fun d hd => hRespect ρ Env.agreeOn_refl d hd)
     obtain ⟨st1, hdecls1, howns1, hass1, hcont⟩ :=
       VerifM.eval_assumeAxioms h1 hwfAxioms hevalAxioms
     have hSig1 : (Intrinsic.sigOf full).Subset st1.decls := by
       rw [hdecls1]
       exact hSig
     have hRespect1 :
-        ∀ ρ' : VerifM.Env, VerifM.Env.agreeOn st1.decls ρ ρ' →
-          ∀ d ∈ full, ρ'.env.respects d.folSym := by
+        ∀ ρ' : Env, Env.agreeOn st1.decls ρ ρ' →
+          ∀ d ∈ full, ρ'.respects d.folSym := by
       intro ρ' hag d hd
       exact hRespect ρ' (by rwa [hdecls1] at hag) d hd
     obtain ⟨st', hdecls2, howns2, ⟨extra2, hass2⟩, hQ⟩ :=
@@ -1047,8 +1047,8 @@ theorem eval_assumeAxioms_in (full todo : Registry)
     signature. -/
 theorem eval_introduceRegistry (R : Registry)
     (hSound : Sound R)
-    {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (heval : VerifM.eval (introduceRegistry R) st ρ Q) :
     ∃ st' ρ',
       st.decls.Subset st'.decls ∧
@@ -1056,9 +1056,9 @@ theorem eval_introduceRegistry (R : Registry)
       st'.decls.vars = st.decls.vars ∧
       st'.owns = st.owns ∧
       (∃ extra, st'.asserts = extra ++ st.asserts) ∧
-      (∀ ρ'' : VerifM.Env, VerifM.Env.agreeOn st'.decls ρ' ρ'' →
-        ∀ d ∈ R, ρ''.env.respects d.folSym) ∧
-      VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      (∀ ρ'' : Env, Env.agreeOn st'.decls ρ' ρ'' →
+        ∀ d ∈ R, ρ''.respects d.folSym) ∧
+      Env.agreeOn st.decls ρ ρ' ∧
       Q () st' ρ' := by
   unfold introduceRegistry at heval
   have hdecls := VerifM.eval_bind heval

--- a/Mica/Verifier/Monad.lean
+++ b/Mica/Verifier/Monad.lean
@@ -219,7 +219,7 @@ def VerifM.translate :
 
 /-! ### Eval_rec: postcondition-based semantics (raw) -/
 
-private def VerifM.eval_rec : VerifM α → TransState → VerifM.Env → (α → TransState → VerifM.Env → Prop) → Prop
+private def VerifM.eval_rec : VerifM α → TransState → Env → (α → TransState → Env → Prop) → Prop
   | .ret a, st, ρ, P => P a st ρ
   | .bind m k, st, ρ, P => m.eval_rec st ρ (fun r st' ρ' => (k r).eval_rec st' ρ' P)
   | .decl hint t, st, ρ, P =>
@@ -243,9 +243,9 @@ private def VerifM.eval_rec : VerifM α → TransState → VerifM.Env → (α �
         (ρ.updateTernary τ₁ τ₂ τ₃ τ₄ t.name f)
   | .assume item, st, ρ, P =>
       match item with
-      | .pure φ => φ.wfIn st.decls → φ.eval ρ.env → P () { st with asserts := φ :: st.asserts } ρ
+      | .pure φ => φ.wfIn st.decls → φ.eval ρ → P () { st with asserts := φ :: st.asserts } ρ
       | .spatial a => a.wfIn st.decls → P () { st with owns := a :: st.owns } ρ
-  | .check _ φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ.env) ∧ P b st ρ
+  | .check _ φ, st, ρ, P => φ.wfIn st.decls → ∃ b, (b = true → φ.eval ρ) ∧ P b st ρ
   | .fatal _, _, _, _ => False
   | .failed _, _, _, _ => False
   | .all items, st, ρ, P => ∀ a ∈ items, P a st ρ
@@ -256,80 +256,80 @@ private def VerifM.eval_rec : VerifM α → TransState → VerifM.Env → (α �
   | .seq m m2, st, ρ, P =>
       m.eval_rec st ρ (fun () _ _ => True) ∧ m2.eval_rec st ρ P
 
-private theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : VerifM.Env) (st : TransState) (h : m.eval_rec st ρ P)
-    (hPQ : ∀ a st' (ρ' : VerifM.Env),
-      st.decls.Subset st'.decls → VerifM.Env.agreeOn st.decls ρ ρ' → P a st' ρ' → Q a st' ρ') :
+private theorem VerifM.eval_rec.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : m.eval_rec st ρ P)
+    (hPQ : ∀ a st' (ρ' : Env),
+      st.decls.Subset st'.decls → Env.agreeOn st.decls ρ ρ' → P a st' ρ' → Q a st' ρ') :
     m.eval_rec st ρ Q := by
   induction m generalizing st ρ with
-  | ret => exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) h
+  | ret => exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) h
   | bind m k ihm ihk =>
     exact ihm ρ st h fun r st' ρ' hsub hag hr =>
       ihk r ρ' st' hr fun a st'' ρ'' hsub' hag' hp =>
-        hPQ a st'' ρ'' (hsub.trans hsub') (VerifM.Env.agreeOn_trans hag (VerifM.Env.agreeOn_mono hsub hag')) hp
+        hPQ a st'' ρ'' (hsub.trans hsub') (Env.agreeOn_trans hag (Env.agreeOn_mono hsub hag')) hp
   | decl hint t =>
     intro u
     refine hPQ _ _ _ (Signature.Subset.subset_addConst _ _) ?_ (h u)
-    exact VerifM.Env.agreeOn_update_fresh
+    exact Env.agreeOn_update_fresh_const
       (c := ⟨Fresh.freshNumbers (hint.getD "_v") st.decls.allNames, t⟩)
       (Fresh.freshNumbers_not_mem (hint.getD "_v") st.decls.allNames)
   | declUnaryRel hint τ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addUnaryRel _ _) ?_ (h f)
-    exact VerifM.Env.agreeOn_update_fresh_unaryRel
+    exact Env.agreeOn_update_fresh_unaryRel
       (u := st.freshUnaryRel hint τ)
       (st.freshUnaryRel_fresh hint τ)
   | declBinaryRel hint τ₁ τ₂ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addBinaryRel _ _) ?_ (h f)
-    exact VerifM.Env.agreeOn_update_fresh_binaryRel
+    exact Env.agreeOn_update_fresh_binaryRel
       (b := st.freshBinaryRel hint τ₁ τ₂)
       (st.freshBinaryRel_fresh hint τ₁ τ₂)
   | declUnary hint τ₁ τ₂ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addUnary _ _) ?_ (h f)
-    exact VerifM.Env.agreeOn_update_fresh_unary
+    exact Env.agreeOn_update_fresh_unary
       (u := st.freshUnary hint τ₁ τ₂)
       (st.freshUnary_fresh hint τ₁ τ₂)
   | declBinary hint τ₁ τ₂ τ₃ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addBinary _ _) ?_ (h f)
-    exact VerifM.Env.agreeOn_update_fresh_binary
+    exact Env.agreeOn_update_fresh_binary
       (b := st.freshBinary hint τ₁ τ₂ τ₃)
       (st.freshBinary_fresh hint τ₁ τ₂ τ₃)
   | declTernary hint τ₁ τ₂ τ₃ τ₄ =>
     simp only [VerifM.eval_rec] at h ⊢
     intro f
     refine hPQ _ _ _ (Signature.Subset.subset_addTernary _ _) ?_ (h f)
-    exact VerifM.Env.agreeOn_update_fresh_ternary
+    exact Env.agreeOn_update_fresh_ternary
       (t := st.freshTernary hint τ₁ τ₂ τ₃ τ₄)
       (st.freshTernary_fresh hint τ₁ τ₂ τ₃ τ₄)
   | assume item =>
     cases item with
     | pure φ =>
       intro hwf hφ
-      exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h hwf hφ)
+      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf hφ)
     | spatial a =>
       intro hwf
-      exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h hwf)
+      exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h hwf)
   | check =>
     intro hwf
     obtain ⟨b, hb, hp⟩ := h hwf
-    exact ⟨b, hb, hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) hp⟩
+    exact ⟨b, hb, hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) hp⟩
   | fatal => exact h.elim
   | failed => exact h.elim
   | all items =>
     intro a ha
-    exact hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) (h a ha)
+    exact hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) (h a ha)
   | any items =>
     obtain ⟨a, ha, hp⟩ := h
-    exact ⟨a, ha, hPQ _ _ _ (Signature.Subset.refl _) (VerifM.Env.agreeOn_refl) hp⟩
+    exact ⟨a, ha, hPQ _ _ _ (Signature.Subset.refl _) (Env.agreeOn_refl) hp⟩
   | ctx f =>
     intro howns
-    exact hPQ _ _ _ (Signature.Subset.refl _) VerifM.Env.agreeOn_refl (h howns)
+    exact hPQ _ _ _ (Signature.Subset.refl _) Env.agreeOn_refl (h howns)
   | seq m m2 ihm ihf =>
     exact ⟨ihm ρ st h.1 fun () _ _ _ _ ha => trivial,
            ihf ρ st h.2 hPQ⟩
@@ -339,13 +339,13 @@ private theorem VerifM.eval_rec.mono {m : VerifM α} (h : m.eval_rec st ρ P) (h
   h.mono' ρ st fun a st' ρ' _ _ => hPQ a st' ρ'
 
 private theorem VerifM.eval_rec.decls_grow {m : VerifM α} ρ (h : m.eval_rec st ρ P) :
-    m.eval_rec st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
+    m.eval_rec st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
   h.mono' ρ st fun _ _ _ hsub hag hp => ⟨hsub, hag, hp⟩
 
 /-! ### Adequacy: translate success implies eval -/
 
 
-private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: VerifM.Env)
+private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (ρ: Env)
     (h : VerifM.eval_rec m st ρ P) (g : st.holdsFor ρ) (hwf : st.wf) :
     VerifM.eval_rec m st ρ (fun a st' ρ' => st'.holdsFor ρ' ∧ st'.wf ∧ P a st' ρ') := by
   induction m generalizing st ρ with
@@ -362,8 +362,8 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     specialize (h u)
     let w := Fresh.freshNumbers (hint.getD "_v") st.decls.allNames
     have hfresh := Fresh.freshNumbers_not_mem (hint.getD "_v") st.decls.allNames
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateConst t w u) := by
-      exact VerifM.Env.agreeOn_update_fresh (c := ⟨w, t⟩) hfresh
+    have hagree : Env.agreeOn st.decls ρ (ρ.updateConst t w u) := by
+      exact Env.agreeOn_update_fresh_const (c := ⟨w, t⟩) hfresh
     refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩, TransState.freshConst.wf _ hwf, h⟩
     intro φ hφ
     exact (Formula.eval_env_agree (hwf.assertsWf φ hφ) hagree).mp (g.asserts φ hφ)
@@ -374,8 +374,8 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     specialize h f
     let u := st.freshUnaryRel hint τ
     have hfresh := st.freshUnaryRel_fresh hint τ
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnaryRel τ u.name f) := by
-      exact VerifM.Env.agreeOn_update_fresh_unaryRel (u := u) hfresh
+    have hagree : Env.agreeOn st.decls ρ (ρ.updateUnaryRel τ u.name f) := by
+      exact Env.agreeOn_update_fresh_unaryRel (u := u) hfresh
     refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
       TransState.addUnaryRel.wf st _ hwf hfresh, h⟩
     intro φ hφ
@@ -387,8 +387,8 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     specialize h f
     let b := st.freshBinaryRel hint τ₁ τ₂
     have hfresh := st.freshBinaryRel_fresh hint τ₁ τ₂
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinaryRel τ₁ τ₂ b.name f) := by
-      exact VerifM.Env.agreeOn_update_fresh_binaryRel (b := b) hfresh
+    have hagree : Env.agreeOn st.decls ρ (ρ.updateBinaryRel τ₁ τ₂ b.name f) := by
+      exact Env.agreeOn_update_fresh_binaryRel (b := b) hfresh
     refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
       TransState.addBinaryRel.wf st _ hwf hfresh, h⟩
     intro φ hφ
@@ -400,8 +400,8 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     specialize h f
     let u := st.freshUnary hint τ₁ τ₂
     have hfresh := st.freshUnary_fresh hint τ₁ τ₂
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateUnary τ₁ τ₂ u.name f) := by
-      exact VerifM.Env.agreeOn_update_fresh_unary (u := u) hfresh
+    have hagree : Env.agreeOn st.decls ρ (ρ.updateUnary τ₁ τ₂ u.name f) := by
+      exact Env.agreeOn_update_fresh_unary (u := u) hfresh
     refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
       TransState.addUnary.wf st _ hwf hfresh, h⟩
     intro φ hφ
@@ -413,8 +413,8 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     specialize h f
     let b := st.freshBinary hint τ₁ τ₂ τ₃
     have hfresh := st.freshBinary_fresh hint τ₁ τ₂ τ₃
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateBinary τ₁ τ₂ τ₃ b.name f) := by
-      exact VerifM.Env.agreeOn_update_fresh_binary (b := b) hfresh
+    have hagree : Env.agreeOn st.decls ρ (ρ.updateBinary τ₁ τ₂ τ₃ b.name f) := by
+      exact Env.agreeOn_update_fresh_binary (b := b) hfresh
     refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
       TransState.addBinary.wf st _ hwf hfresh, h⟩
     intro φ hφ
@@ -426,8 +426,8 @@ private theorem VerifM.eval_rec_preserves_wf (m : VerifM α) (st : TransState) (
     specialize h f
     let t := st.freshTernary hint τ₁ τ₂ τ₃ τ₄
     have hfresh := st.freshTernary_fresh hint τ₁ τ₂ τ₃ τ₄
-    have hagree : VerifM.Env.agreeOn st.decls ρ (ρ.updateTernary τ₁ τ₂ τ₃ τ₄ t.name f) := by
-      exact VerifM.Env.agreeOn_update_fresh_ternary (t := t) hfresh
+    have hagree : Env.agreeOn st.decls ρ (ρ.updateTernary τ₁ τ₂ τ₃ τ₄ t.name f) := by
+      exact Env.agreeOn_update_fresh_ternary (t := t) hfresh
     refine ⟨⟨?_, g.builtins.agree hwf.builtins hagree⟩,
       TransState.addTernary.wf st _ hwf hfresh, h⟩
     intro φ hφ
@@ -516,7 +516,7 @@ private theorem translateAny_eval (items : List α) (st : TransState)
       simp only [ScopedM.eval_ret] at hk1
       exact absurd hk1.1 (by simp)
 
-private theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: VerifM.Env)
+private theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ: Env)
     (f : TransCont (Except VerifError α))
     (hf : ∀ e st', ¬∃ Δ, ScopedM.eval (f (.error e) st') st'.toFlatCtx (.ok ()) Δ)
     (Δ : FlatCtx)
@@ -605,7 +605,7 @@ private theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ:
           rcases hproof with ⟨hunsat, _⟩ | hfalse
           · have hunsat' : ¬Smt.State.satisfiable st.decls (Formula.not φ :: st.asserts) := by
               simp only [FlatCtx.addAssert] at hunsat; exact hunsat
-            exact Smt.State.satisfiable.to_impl' st.decls st.asserts hunsat' ρ.env g.asserts
+            exact Smt.State.satisfiable.to_impl' st.decls st.asserts hunsat' ρ g.asserts
           · simp [ScopedM.eval_ret] at hfalse
     | high =>
       apply ScopedM.eval_assert at hxx
@@ -617,7 +617,7 @@ private theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ:
             (Formula.not φ :: guardFormula :: st.asserts) := by
           simp only [FlatCtx.addAssert] at hunsat; exact hunsat
         refine Smt.State.satisfiable.to_impl' st.decls (guardFormula :: st.asserts)
-          hunsat' ρ.env ?_
+          hunsat' ρ ?_
         intro ψ hψ
         cases hψ with
         | head => exact g.builtins.guard
@@ -664,20 +664,20 @@ private theorem VerifM.translate_eval_rec (m : VerifM α) (st : TransState) (ρ:
 
 /-- The main verification predicate. Requires `st` to be well-formed and satisfy `ρ`,
     and guarantees the same for every reachable `st'`. -/
-def VerifM.eval (m : VerifM α) (st : TransState) (ρ : VerifM.Env) (Q : α → TransState → VerifM.Env → Prop) : Prop :=
+def VerifM.eval (m : VerifM α) (st : TransState) (ρ : Env) (Q : α → TransState → Env → Prop) : Prop :=
   st.wf ∧ st.holdsFor ρ ∧
   m.eval_rec st ρ (fun a st' ρ' => st'.wf ∧ st'.holdsFor ρ' ∧ Q a st' ρ')
 
 /-! ### Structural properties -/
 
-theorem VerifM.eval.wf {m : VerifM α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
+theorem VerifM.eval.wf {m : VerifM α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
     (h : m.eval st ρ Q) : st.wf := h.1
 
-theorem VerifM.eval.holdsFor {m : VerifM α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
+theorem VerifM.eval.holdsFor {m : VerifM α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
     (h : m.eval st ρ Q) : st.holdsFor ρ := h.2.1
 
-theorem VerifM.eval.mono' {m : VerifM α} (ρ : VerifM.Env) (st : TransState) (h : m.eval st ρ P)
-    (hPQ : ∀ a st' (ρ' : VerifM.Env), st.decls.Subset st'.decls → VerifM.Env.agreeOn st.decls ρ ρ' →
+theorem VerifM.eval.mono' {m : VerifM α} (ρ : Env) (st : TransState) (h : m.eval st ρ P)
+    (hPQ : ∀ a st' (ρ' : Env), st.decls.Subset st'.decls → Env.agreeOn st.decls ρ ρ' →
       st'.wf → st'.holdsFor ρ' → P a st' ρ' → Q a st' ρ') :
     m.eval st ρ Q :=
   ⟨h.1, h.2.1, h.2.2.mono' ρ st fun a st' ρ' hsub hag ⟨hwf', hg', hp⟩ =>
@@ -688,12 +688,12 @@ theorem VerifM.eval.mono {m : VerifM α} (h : m.eval st ρ P) (hPQ : ∀ a st' �
   h.mono' ρ st fun a st' ρ' _ _ _ _ => hPQ a st' ρ'
 
 theorem VerifM.eval.decls_grow {m : VerifM α} ρ (h : m.eval st ρ P) :
-    m.eval st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
+    m.eval st ρ (fun a st' ρ' => st.decls.Subset st'.decls ∧ Env.agreeOn st.decls ρ ρ' ∧ P a st' ρ') :=
   h.mono' ρ st fun _ _ _ hsub hag _ _ hp => ⟨hsub, hag, hp⟩
 
 /-! ### Inversion lemmas for VerifM.eval (forward direction) -/
 
-theorem VerifM.eval_ret {a : α} {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_ret {a : α} {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (.ret a) st ρ Q) : Q a st ρ :=
   h.2.2.2.2
 
@@ -711,23 +711,23 @@ theorem VerifM.eval_bind {m : VerifM α} {k : α → VerifM β} {st ρ} :
 
 
 
-theorem VerifM.eval_failed {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_failed {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (.failed msg) st ρ Q) : False :=
   h.2.2
 
-theorem VerifM.eval_fatal {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_fatal {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (.fatal msg) st ρ Q) : False :=
   h.2.2
 
-theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ : VerifM.Env}
-    {Q : FOL.Const → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_decl {hint : Option String} {t : Srt} {st : TransState} {ρ : Env}
+    {Q : FOL.Const → TransState → Env → Prop}
     (h : VerifM.eval (.decl hint t) st ρ Q) :
     let c := st.freshConst hint t
     ∀ u, Q c { st with decls := st.decls.addConst c } (ρ.updateConst t c.name u) :=
   fun u => (h.2.2 u).2.2
 
-theorem VerifM.eval_declUnaryRel {hint : Option String} {τ : Srt} {st : TransState} {ρ : VerifM.Env}
-    {Q : FOL.UnaryRel → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declUnaryRel {hint : Option String} {τ : Srt} {st : TransState} {ρ : Env}
+    {Q : FOL.UnaryRel → TransState → Env → Prop}
     (h : VerifM.eval (.declUnaryRel hint τ) st ρ Q) :
     let u := st.freshUnaryRel hint τ
     u.name ∉ st.decls.allNames ∧
@@ -735,7 +735,7 @@ theorem VerifM.eval_declUnaryRel {hint : Option String} {τ : Srt} {st : TransSt
   ⟨st.freshUnaryRel_fresh hint τ, fun f => (h.2.2 f).2.2⟩
 
 theorem VerifM.eval_declBinaryRel {hint : Option String} {τ₁ τ₂ : Srt} {st : TransState}
-    {ρ : VerifM.Env} {Q : FOL.BinaryRel → TransState → VerifM.Env → Prop}
+    {ρ : Env} {Q : FOL.BinaryRel → TransState → Env → Prop}
     (h : VerifM.eval (.declBinaryRel hint τ₁ τ₂) st ρ Q) :
     let b := st.freshBinaryRel hint τ₁ τ₂
     b.name ∉ st.decls.allNames ∧
@@ -743,7 +743,7 @@ theorem VerifM.eval_declBinaryRel {hint : Option String} {τ₁ τ₂ : Srt} {st
   ⟨st.freshBinaryRel_fresh hint τ₁ τ₂, fun f => (h.2.2 f).2.2⟩
 
 theorem VerifM.eval_declUnary {hint : Option String} {τ₁ τ₂ : Srt} {st : TransState}
-    {ρ : VerifM.Env} {Q : FOL.Unary → TransState → VerifM.Env → Prop}
+    {ρ : Env} {Q : FOL.Unary → TransState → Env → Prop}
     (h : VerifM.eval (.declUnary hint τ₁ τ₂) st ρ Q) :
     let u := st.freshUnary hint τ₁ τ₂
     u.name ∉ st.decls.allNames ∧
@@ -751,7 +751,7 @@ theorem VerifM.eval_declUnary {hint : Option String} {τ₁ τ₂ : Srt} {st : T
   ⟨st.freshUnary_fresh hint τ₁ τ₂, fun f => (h.2.2 f).2.2⟩
 
 theorem VerifM.eval_declBinary {hint : Option String} {τ₁ τ₂ τ₃ : Srt} {st : TransState}
-    {ρ : VerifM.Env} {Q : FOL.Binary → TransState → VerifM.Env → Prop}
+    {ρ : Env} {Q : FOL.Binary → TransState → Env → Prop}
     (h : VerifM.eval (.declBinary hint τ₁ τ₂ τ₃) st ρ Q) :
     let b := st.freshBinary hint τ₁ τ₂ τ₃
     b.name ∉ st.decls.allNames ∧
@@ -759,8 +759,8 @@ theorem VerifM.eval_declBinary {hint : Option String} {τ₁ τ₂ τ₃ : Srt} 
   ⟨st.freshBinary_fresh hint τ₁ τ₂ τ₃, fun f => (h.2.2 f).2.2⟩
 
 theorem VerifM.eval_declTernary {hint : Option String} {τ₁ τ₂ τ₃ τ₄ : Srt}
-    {st : TransState} {ρ : VerifM.Env}
-    {Q : FOL.Ternary → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env}
+    {Q : FOL.Ternary → TransState → Env → Prop}
     (h : VerifM.eval (.declTernary hint τ₁ τ₂ τ₃ τ₄) st ρ Q) :
     let t := st.freshTernary hint τ₁ τ₂ τ₃ τ₄
     t.name ∉ st.decls.allNames ∧
@@ -768,23 +768,23 @@ theorem VerifM.eval_declTernary {hint : Option String} {τ₁ τ₂ τ₃ τ₄ 
       (ρ.updateTernary τ₁ τ₂ τ₃ τ₄ t.name f) :=
   ⟨st.freshTernary_fresh hint τ₁ τ₂ τ₃ τ₄, fun f => (h.2.2 f).2.2⟩
 
-theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_assumePure {φ : Formula} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (.assume (.pure φ)) st ρ Q) :
-    φ.wfIn st.decls → φ.eval ρ.env → Q () { st with asserts := φ :: st.asserts } ρ :=
+    φ.wfIn st.decls → φ.eval ρ → Q () { st with asserts := φ :: st.asserts } ρ :=
   fun hwf hφ => (h.2.2 hwf hφ).2.2
 
-theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_assumeSpatial {a : SpatialAtom} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (.assume (.spatial a)) st ρ Q) :
     a.wfIn st.decls → Q () { st with owns := a :: st.owns } ρ :=
   fun hwf => (h.2.2 hwf).2.2
 
-theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (.assume item) st ρ Q) :
     item.wfIn st.decls →
-    (match item with | .pure φ => φ.eval ρ.env | .spatial _ => True) →
+    (match item with | .pure φ => φ.eval ρ | .spatial _ => True) →
     Q () (st.addItem item) ρ :=
   by
     cases item with
@@ -795,19 +795,19 @@ theorem VerifM.eval_assume {item : CtxItem} {st : TransState} {ρ : VerifM.Env}
       simp [TransState.addItem]
       exact VerifM.eval_assumeSpatial h
 
-theorem VerifM.eval_check {e : Effort} {φ : Formula} {st : TransState} {ρ : VerifM.Env}
-    {Q : Bool → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_check {e : Effort} {φ : Formula} {st : TransState} {ρ : Env}
+    {Q : Bool → TransState → Env → Prop}
     (h : VerifM.eval (.check e φ) st ρ Q) :
     φ.wfIn st.decls →
-    ∃ b, (b = true → φ.eval ρ.env) ∧ Q b st ρ :=
+    ∃ b, (b = true → φ.eval ρ) ∧ Q b st ρ :=
   fun hwf =>
     let ⟨b, hb, _, _, hq⟩ := h.2.2 hwf
     ⟨b, hb, hq⟩
 
-theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.assert φ) st ρ Q) :
-    φ.wfIn st.decls → φ.eval ρ.env ∧ Q () st ρ := by
+    φ.wfIn st.decls → φ.eval ρ ∧ Q () st ρ := by
   intro hwf
   simp only [VerifM.assert] at h
   have hb := VerifM.eval_bind h
@@ -821,8 +821,8 @@ theorem VerifM.eval_assert {φ : Formula} {st : TransState} {ρ : VerifM.Env}
     exact (VerifM.eval_failed hq).elim
 
 theorem VerifM.eval_expectEq [DecidableEq α] [Repr α]
-    {msg : String} {actual expected : α} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+    {msg : String} {actual expected : α} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.expectEq msg actual expected) st ρ Q) :
     actual = expected ∧ Q () st ρ := by
   unfold VerifM.expectEq at h
@@ -833,8 +833,8 @@ theorem VerifM.eval_expectEq [DecidableEq α] [Repr α]
     exact (VerifM.eval_fatal h).elim
 
 theorem VerifM.eval_expectSome
-    {msg : String} {x : Option α} {st : TransState} {ρ : VerifM.Env}
-    {Q : α → TransState → VerifM.Env → Prop}
+    {msg : String} {x : Option α} {st : TransState} {ρ : Env}
+    {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.expectSome msg x) st ρ Q) :
     ∃ y, x = some y ∧ Q y st ρ := by
   unfold VerifM.expectSome at h
@@ -846,8 +846,8 @@ theorem VerifM.eval_expectSome
     simp [hx] at h
     exact ⟨y, rfl, VerifM.eval_ret h⟩
 
-theorem VerifM.eval_declConstExact {c : FOL.Const} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declConstExact {c : FOL.Const} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.declConstExact c) st ρ Q) :
     c.name ∉ st.decls.allNames ∧
     ∀ v, Q () { st with decls := st.decls.addConst c } (ρ.updateConst c.sort c.name v) := by
@@ -867,8 +867,8 @@ theorem VerifM.eval_declConstExact {c : FOL.Const} {st : TransState} {ρ : Verif
     rw [hceq] at hq
     exact hq
 
-theorem VerifM.eval_declUnaryRelExact {u : FOL.UnaryRel} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declUnaryRelExact {u : FOL.UnaryRel} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.declUnaryRelExact u) st ρ Q) :
     u.name ∉ st.decls.allNames ∧
     ∀ f, Q () { st with decls := st.decls.addUnaryRel u } (ρ.updateUnaryRel u.arg u.name f) := by
@@ -886,8 +886,8 @@ theorem VerifM.eval_declUnaryRelExact {u : FOL.UnaryRel} {st : TransState} {ρ :
   rw [hueq] at hq
   exact hq
 
-theorem VerifM.eval_declBinaryRelExact {b : FOL.BinaryRel} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declBinaryRelExact {b : FOL.BinaryRel} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.declBinaryRelExact b) st ρ Q) :
     b.name ∉ st.decls.allNames ∧
     ∀ f, Q () { st with decls := st.decls.addBinaryRel b } (ρ.updateBinaryRel b.arg1 b.arg2 b.name f) := by
@@ -905,8 +905,8 @@ theorem VerifM.eval_declBinaryRelExact {b : FOL.BinaryRel} {st : TransState} {ρ
   rw [hbeq] at hq
   exact hq
 
-theorem VerifM.eval_declUnaryExact {u : FOL.Unary} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declUnaryExact {u : FOL.Unary} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.declUnaryExact u) st ρ Q) :
     u.name ∉ st.decls.allNames ∧
     ∀ f, Q () { st with decls := st.decls.addUnary u } (ρ.updateUnary u.arg u.ret u.name f) := by
@@ -924,8 +924,8 @@ theorem VerifM.eval_declUnaryExact {u : FOL.Unary} {st : TransState} {ρ : Verif
   rw [hueq] at hq
   exact hq
 
-theorem VerifM.eval_declBinaryExact {b : FOL.Binary} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declBinaryExact {b : FOL.Binary} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.declBinaryExact b) st ρ Q) :
     b.name ∉ st.decls.allNames ∧
     ∀ f, Q () { st with decls := st.decls.addBinary b } (ρ.updateBinary b.arg1 b.arg2 b.ret b.name f) := by
@@ -943,8 +943,8 @@ theorem VerifM.eval_declBinaryExact {b : FOL.Binary} {st : TransState} {ρ : Ver
   rw [hbeq] at hq
   exact hq
 
-theorem VerifM.eval_declTernaryExact {t : FOL.Ternary} {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_declTernaryExact {t : FOL.Ternary} {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.declTernaryExact t) st ρ Q) :
     t.name ∉ st.decls.allNames ∧
     ∀ f, Q () { st with decls := st.decls.addTernary t }
@@ -965,7 +965,7 @@ theorem VerifM.eval_declTernaryExact {t : FOL.Ternary} {st : TransState} {ρ : V
 
 theorem VerifM.eval_bind_expectEq [DecidableEq α] [Repr α]
     {msg : String} {actual expected : α} {β : Type _} {k : Unit → VerifM β}
-    {st : TransState} {ρ : VerifM.Env} {Q : β → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env} {Q : β → TransState → Env → Prop}
     (h : VerifM.eval ((VerifM.expectEq msg actual expected).bind k) st ρ Q) :
     actual = expected ∧ VerifM.eval (k ()) st ρ Q := by
   have hb := VerifM.eval_bind h
@@ -974,28 +974,28 @@ theorem VerifM.eval_bind_expectEq [DecidableEq α] [Repr α]
 
 theorem VerifM.eval_bind_expectSome
     {msg : String} {x : Option α} {β : Type _} {k : α → VerifM β}
-    {st : TransState} {ρ : VerifM.Env} {Q : β → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env} {Q : β → TransState → Env → Prop}
     (h : VerifM.eval ((VerifM.expectSome msg x).bind k) st ρ Q) :
     ∃ y, x = some y ∧ VerifM.eval (k y) st ρ Q := by
   have hb := VerifM.eval_bind h
   obtain ⟨y, hx, hk⟩ := VerifM.eval_expectSome hb
   exact ⟨y, hx, hk⟩
 
-theorem VerifM.eval_all {items : List α} {st : TransState} {ρ : VerifM.Env}
-    {Q : α → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_all {items : List α} {st : TransState} {ρ : Env}
+    {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (.all items) st ρ Q) :
     ∀ a ∈ items, Q a st ρ :=
   fun a ha => (h.2.2 a ha).2.2
 
-theorem VerifM.eval_any {items : List α} {st : TransState} {ρ : VerifM.Env}
-    {Q : α → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_any {items : List α} {st : TransState} {ρ : Env}
+    {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (.any items) st ρ Q) :
     ∃ a ∈ items, Q a st ρ :=
   let ⟨a, ha, _, _, hq⟩ := h.2.2; ⟨a, ha, hq⟩
 
 
 theorem VerifM.eval_ctx {f : TransState → α × SpatialContext}
-    {st : TransState} {ρ : VerifM.Env} {Q : α → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env} {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (.ctx f) st ρ Q) :
     let (a, owns') := f st
     (owns'.wfIn st.decls → Q a { st with owns := owns' } ρ)
@@ -1004,8 +1004,8 @@ theorem VerifM.eval_ctx {f : TransState → α × SpatialContext}
     ∧ st.asserts.wfIn st.decls :=
   ⟨fun howns => (h.2.2 howns).2.2, h.1.ownsWf, h.2.1, h.1.assertsWf⟩
 
-theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : VerifM.Env}
-    {Q : α → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : Env}
+    {Q : α → TransState → Env → Prop}
     (h : VerifM.eval (.ctx (fun st => (f st.asserts, st.owns))) st ρ Q) :
     Q (f st.asserts) st ρ
     ∧ st.holdsFor ρ
@@ -1013,16 +1013,16 @@ theorem VerifM.eval_ctxPure {f : List Formula → α} {st : TransState} {ρ : Ve
   let ⟨hq, howns, hg, hwf⟩ := VerifM.eval_ctx h
   ⟨hq howns, hg, hwf⟩
 
-theorem VerifM.eval_persist {st : TransState} {ρ : VerifM.Env}
-    {Q : Unit → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_persist {st : TransState} {ρ : Env}
+    {Q : Unit → TransState → Env → Prop}
     (h : VerifM.eval VerifM.persist st ρ Q) :
     Q () (TransState.persist st) ρ := by
   let ⟨hq, howns, _, _⟩ := VerifM.eval_ctx h
   apply hq
   simp [TransState.persist]
 
-theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : VerifM.Env}
-    {Q : β → TransState → VerifM.Env → Prop}
+theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ : Env}
+    {Q : β → TransState → Env → Prop}
     (h : VerifM.eval (.seq m m2) st ρ Q) :
     VerifM.eval m st ρ (fun () _ _ => True) ∧ VerifM.eval m2 st ρ Q := by
   obtain ⟨hwf, hholds, hm, hm2⟩ := h
@@ -1031,10 +1031,10 @@ theorem VerifM.eval_seq {m : VerifM Unit} {m2 : VerifM β} {st : TransState} {ρ
    ⟨hwf, hholds, hm2⟩⟩
 
 theorem VerifM.eval_assumeAll {φs : List Formula}
-    {st : TransState} {ρ : VerifM.Env} {P : Unit → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env} {P : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.assumeAll φs) st ρ P) :
     (∀ φ ∈ φs, φ.wfIn st.decls) →
-    (∀ φ ∈ φs, φ.eval ρ.env) →
+    (∀ φ ∈ φs, φ.eval ρ) →
     ∃ st', st'.decls = st.decls ∧ st'.owns = st.owns ∧
            st'.asserts = φs.reverse ++ st.asserts ∧ P () st' ρ := by
   induction φs generalizing st with
@@ -1057,10 +1057,10 @@ theorem VerifM.eval_assumeAll {φs : List Formula}
     rw [hass]; simp [List.reverse_cons, List.append_assoc]
 
 theorem VerifM.eval_assumeAxioms {axs : List Axiom}
-    {st : TransState} {ρ : VerifM.Env} {P : Unit → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env} {P : Unit → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.assumeAxioms axs) st ρ P) :
     (∀ a ∈ axs, a.formula.wfIn st.decls) →
-    (∀ a ∈ axs, a.formula.eval ρ.env) →
+    (∀ a ∈ axs, a.formula.eval ρ) →
     ∃ st', st'.decls = st.decls ∧ st'.owns = st.owns ∧
            st'.asserts = (Axiom.asserts axs).reverse ++ st.asserts ∧ P () st' ρ := by
   intro hwf heval
@@ -1084,7 +1084,7 @@ theorem VerifM.topCont_error_propagates :
   simp only [topCont, ScopedM.eval_ret] at h
   exact absurd h.1 (by cases e <;> simp)
 
-theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : VerifM.Env)
+theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : Env)
     (f : TransCont (Except VerifError α))
     (hf : ∀ e st', ¬∃ Δ, ScopedM.eval (f (.error e) st') st'.toFlatCtx (.ok ()) Δ)
     (Δ : FlatCtx)
@@ -1094,7 +1094,7 @@ theorem VerifM.translate_eval (m : VerifM α) (st : TransState) (ρ : VerifM.Env
   ⟨hwf, g, (eval_rec_preserves_wf m st ρ (translate_eval_rec m st ρ f hf Δ h g hwf) g hwf).mono
     fun _ _ _ ⟨hg', hwf', hΔ'⟩ => ⟨hwf', hg', hΔ'⟩⟩
 
-theorem VerifM.eval_of_translate (m : VerifM Unit) (st : TransState) (ρ : VerifM.Env) (Δ : FlatCtx)
+theorem VerifM.eval_of_translate (m : VerifM Unit) (st : TransState) (ρ : Env) (Δ : FlatCtx)
     (h : ScopedM.eval (m.translate st topCont) st.toFlatCtx (.ok ()) Δ)
     (g : st.holdsFor ρ) (hwf : st.wf) :
     VerifM.eval m st ρ (fun _ _ _ => True) :=

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -59,7 +59,7 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : VerifM.Env) : iProp :=
+def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : Env) : iProp :=
   Assertion.pre W (fun post ρ' =>
     BIBase.forall fun v : Runtime.Val =>
       Assertion.post W (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
@@ -107,8 +107,8 @@ theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
     h hsub hwf
 
 theorem PredTrans.apply_env_agree (W : TinyML.World) {pt : PredTrans} {Φ : Runtime.Val → iProp}
-    {ρ ρ' : VerifM.Env} {Δ : Signature}
-    (hwf : pt.wfIn Δ) (hagree : VerifM.Env.agreeOn Δ ρ ρ') :
+    {ρ ρ' : Env} {Δ : Signature}
+    (hwf : pt.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
     PredTrans.apply W Φ pt ρ ⊢ PredTrans.apply W Φ pt ρ' := by
   unfold PredTrans.apply at ⊢
   apply Assertion.pre_env_agree W hwf hagree
@@ -117,7 +117,7 @@ theorem PredTrans.apply_env_agree (W : TinyML.World) {pt : PredTrans} {Φ : Runt
   intro v
   exact (forall_elim v).trans <|
     Assertion.post_env_agree W hwf_post
-      (VerifM.Env.agreeOn_declVar hagree_post)
+      (Env.agreeOn_declVar hagree_post)
       (fun _ _ _ _ _ _ => .rfl)
 
 -- ---------------------------------------------------------------------------
@@ -125,37 +125,37 @@ theorem PredTrans.apply_env_agree (W : TinyML.World) {pt : PredTrans} {Φ : Runt
 -- ---------------------------------------------------------------------------
 
 theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
-    (st : TransState) (ρ : VerifM.Env)
-    (Ψ : Term .value → TransState → VerifM.Env → Prop) (Φ : Runtime.Val → iProp) R :
+    (st : TransState) (ρ : Env)
+    (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp) R :
     pt.wfIn (Δ_base.declVars σ.dom) →
     σ.wfIn Δ_base st.decls →
     VerifM.eval (PredTrans.call σ pt) st ρ Ψ →
-    (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
+    (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
       (st'.sl W ρ' ∗ R ⊢ Φ v)) →
-    st.sl W ρ ∗ R ⊢ PredTrans.apply W Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+    st.sl W ρ ∗ R ⊢ PredTrans.apply W Φ pt ((σ.subst.eval ρ)) := by
   intro hwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind heval
   let retWf : (String × Assertion Unit) → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
+  let Φpost : (String × Assertion Unit) → Env → iProp :=
     fun post ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post W (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
-  let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → VerifM.Env → Prop :=
+  let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → Env → Prop :=
     fun r st' ρ' =>
       match r with
       | (σ₁, postName, postBody) => (do
           let resVar ← VerifM.decl (some postName) Srt.value
           let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
           Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
-  have hpre : st.sl W ρ ∗ R ⊢ Assertion.pre W Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
+  have hpre : st.sl W ρ ∗ R ⊢ Assertion.pre W Φpost pt ((σ.subst.eval ρ)) := by
     exact Assertion.prove_correct W pt Δ_base σ retWf st ρ Ψcall Φpost R
       (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree =>
         forall_intro fun v =>
           (forall_elim v).trans <|
             Assertion.post_env_agree W hwf_post
-              (VerifM.Env.agreeOn_declVar hagree)
+              (Env.agreeOn_declVar hagree)
               (fun _ _ _ _ _ _ => .rfl))
       hσwf hwf hb
       (fun σ₁ ⟨postName, postBody⟩ st₁ ρ₁ hcont hσ₁wf hwf₁ => by
@@ -184,7 +184,7 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Si
           (ρ₁.updateConst .value resVar.name v)
           (fun a st' ρ' =>
             { st₁ with decls := st₁.decls.addConst resVar }.decls.Subset st'.decls ∧
-              VerifM.Env.agreeOn { st₁ with decls := st₁.decls.addConst resVar }.decls
+              Env.agreeOn { st₁ with decls := st₁.decls.addConst resVar }.decls
                 (ρ₁.updateConst .value resVar.name v) ρ' ∧
               (Pure.pure (Term.const (.uninterpreted resVar.name .value)) : VerifM (Term .value)).eval st' ρ' Ψ)
           (fun () _ => Φ v) R
@@ -204,41 +204,41 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Si
             (Env.agreeOn_update_fresh_const (c := resVar) hfresh_decls)
         exact (sep_mono_left hinterp_bi.1).trans <| hassume.trans <| Assertion.post_env_agree W hwf₁'
           (by
-            simpa [σ₂, VerifM.Env.agreeOn, VerifM.Env.withEnv_env, VerifM.Env.updateConst] using
+            simpa [σ₂, Env.agreeOn, Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₁.decls)
                 (v := ⟨postName, .value⟩) (name' := resVar.name)
-                (ρ := ρ₁.env) (u := v) hσ₁wf hfresh_range))
+                (ρ := ρ₁) (u := v) hσ₁wf hfresh_range))
           (fun _ _ _ _ _ _ => .rfl))
   simpa [PredTrans.apply, Φpost] using hpre
 
 
 theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
     (body : VerifM (Term .value))
-    (st : TransState) (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (R : iProp) :
+    (st : TransState) (ρ : Env) (Φ : Runtime.Val → iProp) (R : iProp) :
     pt.wfIn (Δ_base.declVars σ.dom) →
     σ.wfIn Δ_base st.decls →
     VerifM.eval (PredTrans.implement σ pt body) st ρ (fun _ _ _ => True) →
     (∀ st' ρ' (Q : iProp),
       st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' →
+      Env.agreeOn st.decls ρ ρ' →
       VerifM.eval body st' ρ'
       (fun result st'' ρ'' =>
         ∀ (S : iProp),
         result.wfIn st''.decls →
-        (st''.sl W ρ'' ∗ Q ∗ (Φ (result.eval ρ''.env) -∗ S) ⊢ S)) →
+        (st''.sl W ρ'' ∗ Q ∗ (Φ (result.eval ρ'') -∗ S) ⊢ S)) →
       st'.sl W ρ' ∗ Q ⊢ R) →
-    st.sl W ρ ∗ PredTrans.apply W Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) ⊢ R := by
+    st.sl W ρ ∗ PredTrans.apply W Φ pt ((σ.subst.eval ρ)) ⊢ R := by
   intro hwf hσwf heval hbody
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind heval
   have hb_grow := VerifM.eval.decls_grow ρ hb
   let retWf : (String × Assertion Unit) → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let OuterQ : (String × Assertion Unit) → VerifM.Env → iProp :=
+  let OuterQ : (String × Assertion Unit) → Env → iProp :=
     fun ⟨postName, postBody⟩ ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post W (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
-  let Φpost : (String × Assertion Unit) → VerifM.Env → iProp :=
+  let Φpost : (String × Assertion Unit) → Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
   have hpost := Assertion.assume_correct W pt Δ_base σ retWf
     st ρ _ Φpost emp
@@ -258,7 +258,7 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base
       apply BIBase.Entails.trans sep_comm.1
       apply BIBase.Entails.trans emp_sep.1
       have hcont_body := VerifM.eval_bind hcont
-      change st₁.sl W ρ₁ ⊢ OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) -∗ R
+      change st₁.sl W ρ₁ ⊢ OuterQ (postName, postBody) ((σ₁.subst.eval ρ₁)) -∗ R
       refine wand_intro ?_
       refine hbody st₁ ρ₁ _ hdsub_st hagree_st ?_
       refine (VerifM.eval.decls_grow ρ₁ hcont_body).mono ?_
@@ -272,11 +272,11 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base
         st₂.freshConst_fresh (some postName) .value
       have hfresh_range : resVar.name ∉ σ₁.range.allNames :=
         hσ₁wf₂.fresh_range hfresh_decls
-      specialize hdecl (result.eval ρ₂.env)
+      specialize hdecl (result.eval ρ₂)
       have hb3 := VerifM.eval_bind hdecl
       have hassume := VerifM.eval_assumePure hb3
         (Formula.eq_wfIn_addConst_of_fresh (c := resVar) hwfst₂ hwf_result hfresh_decls)
-        (Formula.eq_eval_updateConst_of_fresh (c := resVar) (ρ := ρ₂.env) hwf_result hfresh_decls)
+        (Formula.eq_eval_updateConst_of_fresh (c := resVar) (ρ := ρ₂) hwf_result hfresh_decls)
       set σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
       have hσ₂wf : σ₂.wfIn Δ_base (st₂.decls.addConst resVar) := by
         simpa [σ₂] using
@@ -292,70 +292,66 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base
           asserts := Formula.eq Srt.value (Term.const (.uninterpreted resVar.name .value)) result :: st₂.asserts }
       have hpre := @Assertion.prove_correct _ Unit W postBody Δ_base σ₂ (fun _ _ => True)
         st₃
-        (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
-        _ (fun () _ => Φ (result.eval ρ₂.env) -∗ S) (Φ (result.eval ρ₂.env) -∗ S)
+        (ρ₂.updateConst .value resVar.name (result.eval ρ₂))
+        _ (fun () _ => Φ (result.eval ρ₂) -∗ S) (Φ (result.eval ρ₂) -∗ S)
         (fun _ _ _ _ _ _ => .rfl)
         hσ₂wf hwf_postBody' hb4
         (fun _ () st' ρ' hret _ _ => by
-          show st'.sl W ρ' ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
-            (Φ (result.eval ρ₂.env) -∗ S)
+          show st'.sl W ρ' ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
+            (Φ (result.eval ρ₂) -∗ S)
           exact sep_elim_right)
       have hag_rename :=
         FiniteSubst.rename_agreeOn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₂.decls)
           (v := ⟨postName, .value⟩) (name' := resVar.name)
-          (ρ := ρ₂.env) (u := result.eval ρ₂.env) hσ₁wf₂ hfresh_range
-      have hagree_st₁ : Env.agreeOn st₁.decls ρ₂.env ρ₁.env := by
-        simpa [VerifM.Env.agreeOn] using VerifM.Env.agreeOn_symm hagree_body
+          (ρ := ρ₂) (u := result.eval ρ₂) hσ₁wf₂ hfresh_range
+      have hagree_st₁ : Env.agreeOn st₁.decls ρ₂ ρ₁ := by
+        simpa [Env.agreeOn] using Env.agreeOn_symm hagree_body
       have hag_eval := FiniteSubst.eval_agreeOn hσ₁wf hagree_st₁
       have hag_eval' : Env.agreeOn (Δ_base.declVars σ₂.dom)
-          ((σ₁.subst.eval ρ₂.env).updateConst .value postName (result.eval ρ₂.env))
-          ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env)) := by
+          ((σ₁.subst.eval ρ₂).updateConst .value postName (result.eval ρ₂))
+          ((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂)) := by
         apply Env.agreeOn_mono
           (FiniteSubst.rename_source_subset_rev σ₁ Δ_base ⟨postName, .value⟩ resVar.name)
         exact Env.agreeOn_update (Env.agreeOn_remove hag_eval)
-      have hpost_transport : Assertion.post W (fun () _ => Φ (result.eval ρ₂.env)) postBody
-          (VerifM.Env.withEnv ρ₁ ((σ₁.subst.eval ρ₁.env).updateConst .value postName (result.eval ρ₂.env))) ⊢
-          Assertion.post W (fun () _ => Φ (result.eval ρ₂.env)) postBody
-            (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
-              (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
+      have hpost_transport : Assertion.post W (fun () _ => Φ (result.eval ρ₂)) postBody
+          (((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂))) ⊢
+          Assertion.post W (fun () _ => Φ (result.eval ρ₂)) postBody
+            ((σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))) := by
         exact Assertion.post_env_agree W hwf_postBody'
           (by
-            simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv]
+            simpa [Env.agreeOn, ]
               using (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval')))
           (fun _ _ _ _ _ _ => .rfl)
       have howns_agree : st₃.sl W ρ₂
             ⊢
-          st₃.sl W (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) := by
+          st₃.sl W (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) := by
         simpa using
           (SpatialContext.interp_env_agree W (VerifM.eval.wf hrest).ownsWf
             (Env.agreeOn_update_fresh_const hfresh_decls)).1
       have hpre_final :
-          st₂.sl W ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
-            Assertion.pre W (fun () _ => Φ (result.eval ρ₂.env) -∗ S) postBody
-              (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
-                (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
+          st₂.sl W ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
+            Assertion.pre W (fun () _ => Φ (result.eval ρ₂) -∗ S) postBody
+              ((σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))) := by
         have hinput :
-            st₂.sl W ρ₂ ∗ (Φ (result.eval ρ₂.env) -∗ S) ⊢
-              st₃.sl W (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)) ∗
-                (Φ (result.eval ρ₂.env) -∗ S) := by
+            st₂.sl W ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
+              st₃.sl W (ρ₂.updateConst .value resVar.name (result.eval ρ₂)) ∗
+                (Φ (result.eval ρ₂) -∗ S) := by
           iintro ⟨Howns, Hwand⟩
           iframe Hwand
           iapply howns_agree
           simp [st₃, TransState.sl]
         exact hinput.trans hpre
       have hpost_final :
-          OuterQ (postName, postBody) (VerifM.Env.withEnv ρ₁ (σ₁.subst.eval ρ₁.env)) ⊢
-            Assertion.post W (fun () _ => Φ (result.eval ρ₂.env)) postBody
-              (VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
-                (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env)) := by
-        exact (forall_elim (result.eval ρ₂.env)).trans hpost_transport
+          OuterQ (postName, postBody) ((σ₁.subst.eval ρ₁)) ⊢
+            Assertion.post W (fun () _ => Φ (result.eval ρ₂)) postBody
+              ((σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))) := by
+        exact (forall_elim (result.eval ρ₂)).trans hpost_transport
       iintro ⟨Howns, HQ, Hwand⟩
       iapply (Assertion.pre_post_combine W
-        (ρ := VerifM.Env.withEnv (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env))
-          (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂.env)).env))
+        (ρ := (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))))
         (m := postBody)
-        (Φ := fun () _ => Φ (result.eval ρ₂.env) -∗ S)
-        (Ψ := fun () _ => Φ (result.eval ρ₂.env))
+        (Φ := fun () _ => Φ (result.eval ρ₂) -∗ S)
+        (Ψ := fun () _ => Φ (result.eval ρ₂))
         (R := S)
         (fun () _ => by
           iintro ⟨Hwand, HΦ⟩
@@ -368,17 +364,17 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base
         iexact HQ
       )
   have hpre :
-      PredTrans.apply W Φ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) =
-      Assertion.pre W OuterQ pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := rfl
+      PredTrans.apply W Φ pt ((σ.subst.eval ρ)) =
+      Assertion.pre W OuterQ pt ((σ.subst.eval ρ)) := rfl
   rw [hpre]
   exact BIBase.Entails.trans
     (by
       have hpost' : st.sl W ρ ∗ emp ⊢
-          Assertion.post W Φpost pt (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) := by
-        simpa [VerifM.Env.withEnv] using hpost
+          Assertion.post W Φpost pt ((σ.subst.eval ρ)) := by
+        simpa [] using hpost
       exact sep_comm.1.trans (sep_mono_right (sep_emp.2.trans hpost')))
     (Assertion.pre_post_combine W
-      (ρ := VerifM.Env.withEnv ρ (σ.subst.eval ρ.env))
+      (ρ := (σ.subst.eval ρ))
       (m := pt)
       (Φ := OuterQ)
       (Ψ := Φpost)

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -181,26 +181,26 @@ def assemble (pairs : List (Typed.ValDecl (Spec.Body Typed.Expr) × List Verifie
 delta mirrors the declared signature, the state is spec-level (no owned
 locations, no variables), and the accumulated function map is well-formed
 with deterministic, split-compatible interpretations. -/
-private structure Inv (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env) : Prop where
+private structure Inv (acc : RelationSpec) (st : TransState) (ρ : Env) : Prop where
   delta : acc.delta = st.decls
   owns : st.owns = []
   vars : st.decls.vars = []
   wf : st.decls.wf
   Γwf : FunCtx.wfIn acc.functionMap st.decls
-  split : FunCtx.splitCompatible acc.functionMap ρ.env
-  det : Relation.BinaryRelDet acc.functionMap ρ.env ρ.env
+  split : FunCtx.splitCompatible acc.functionMap ρ
+  det : Relation.BinaryRelDet acc.functionMap ρ ρ
 
 omit [MicaGS HasLC.hasLC Sig] in
 /-- Declaring one relation-marked declaration preserves the assembly
 invariants; the signature only grows and the environment is only extended
 with fresh interpretations. -/
 private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec.Body Typed.Expr))
-    (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
-    {Q : RelationSpec → TransState → VerifM.Env → Prop}
+    (acc : RelationSpec) (st : TransState) (ρ : Env)
+    {Q : RelationSpec → TransState → Env → Prop}
     (hinv : Inv acc st ρ)
     (heval : VerifM.eval (declareAndAssume acc d) st ρ Q) :
     ∃ acc' st' ρ', Inv acc' st' ρ' ∧
-      st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      st.decls.Subset st'.decls ∧ Env.agreeOn st.decls ρ ρ' ∧
       Q acc' st' ρ' := by
   obtain ⟨hacc, howns, hvars, hwf, hΓwf, hsplit, hdet⟩ := hinv
   simp only [declareAndAssume] at heval
@@ -208,7 +208,7 @@ private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec.Body Typed.Exp
   | none =>
     simp only [hrel] at heval
     exact ⟨acc, st, ρ, ⟨hacc, howns, hvars, hwf, hΓwf, hsplit, hdet⟩,
-      Signature.Subset.refl _, VerifM.Env.agreeOn_refl, VerifM.eval_ret heval⟩
+      Signature.Subset.refl _, Env.agreeOn_refl, VerifM.eval_ret heval⟩
   | some rel_name =>
     simp only [hrel] at heval
     cases hext : extend acc d with
@@ -244,22 +244,22 @@ private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec.Body Typed.Exp
       have hΔwf_acc : acc.delta.wf := hacc ▸ hwf
       -- The chosen interpretations: the ground-truth relation and its split.
       set R : Relation.ValRel :=
-        Relation.semrel acc.functionMap acc.delta ρ.env
+        Relation.semrel acc.functionMap acc.delta ρ
           info.f rel_name info.arg info.res info.body
       set F := Skolemize.semFunc R
       set D : Srt.value.denote → Prop :=
-        Skolemize.semdef acc.functionMap acc.delta ρ.env
+        Skolemize.semdef acc.functionMap acc.delta ρ
           info.f rel_name info.arg info.res info.body info.bv
       have hgraph : ∀ a b, R a b ↔ D a ∧ F a = b := fun a b =>
         Skolemize.bundle_semrel_compatible hinfoEq hsplit hΓwf_acc hΔwf_acc hf hdet a b
-      have henv : Skolemize.relSplitEnv ρ.env rel_name R D F
-          = (Skolemize.defInterpEnv acc.functionMap acc.delta ρ.env
+      have henv : Skolemize.relSplitEnv ρ rel_name R D F
+          = (Skolemize.defInterpEnv acc.functionMap acc.delta ρ
               info.f rel_name info.arg info.res info.body info.bv).updateBinaryRel
             .value .value (SpecFn.relName rel_name) R := by
         simp only [Skolemize.relSplitEnv, Skolemize.defInterpEnv, Skolemize.splitEnv]
         apply Env.ext <;> rfl
       have haxeval : ∀ ax ∈ info.axs,
-          ax.formula.eval (Skolemize.relSplitEnv ρ.env rel_name R D F) := by
+          ax.formula.eval (Skolemize.relSplitEnv ρ rel_name R D F) := by
         rw [henv]
         exact Skolemize.bundle_eval_updateBinaryRel
           hinfoEq hsplit hΓwf_acc hΔwf_acc hf hdet R
@@ -273,9 +273,9 @@ private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec.Body Typed.Exp
       have hdelta4 : info.spec.delta = st4.decls := by rw [hspec_delta, hst4_decls]
       have hΓwf4' : FunCtx.wfIn info.spec.functionMap st4.decls := by
         rw [hspec_fm]; exact hΓwf4
-      have hsplit4' : FunCtx.splitCompatible info.spec.functionMap ρ4.env := by
+      have hsplit4' : FunCtx.splitCompatible info.spec.functionMap ρ4 := by
         rw [hspec_fm]; exact hsplit4
-      have hdet4' : Relation.BinaryRelDet info.spec.functionMap ρ4.env ρ4.env := by
+      have hdet4' : Relation.BinaryRelDet info.spec.functionMap ρ4 ρ4 := by
         rw [hspec_fm]; exact hdet4
       exact ⟨info.spec, st4, ρ4,
         ⟨hdelta4, howns4, hvars4, hwf4, hΓwf4', hsplit4', hdet4'⟩,
@@ -283,18 +283,18 @@ private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec.Body Typed.Exp
 
 omit [MicaGS HasLC.hasLC Sig] in
 private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr)) :
-    ∀ (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
-      {Q : RelationSpec → TransState → VerifM.Env → Prop},
+    ∀ (acc : RelationSpec) (st : TransState) (ρ : Env)
+      {Q : RelationSpec → TransState → Env → Prop},
       Inv acc st ρ →
       VerifM.eval (assembleFrom acc prog) st ρ Q →
       ∃ result stRel ρRel, Inv result stRel ρRel ∧
-        st.decls.Subset stRel.decls ∧ VerifM.Env.agreeOn st.decls ρ ρRel ∧
+        st.decls.Subset stRel.decls ∧ Env.agreeOn st.decls ρ ρRel ∧
         Q result stRel ρRel := by
   induction prog with
   | nil =>
     intro acc st ρ Q hinv heval
     simp only [assembleFrom] at heval
-    exact ⟨acc, st, ρ, hinv, Signature.Subset.refl _, VerifM.Env.agreeOn_refl,
+    exact ⟨acc, st, ρ, hinv, Signature.Subset.refl _, Env.agreeOn_refl,
       VerifM.eval_ret heval⟩
   | cons d ds ih =>
     intro acc st ρ Q hinv heval
@@ -303,18 +303,18 @@ private theorem assembleFrom_correct (prog : Typed.Program (Spec.Body Typed.Expr
       declareAndAssume_correct d acc st ρ hinv (VerifM.eval_bind heval)
     obtain ⟨result, stRel, ρRel, hinvRel, hsubRel, hagRel, hQ⟩ := ih acc' st' ρ' hinv' hcont
     exact ⟨result, stRel, ρRel, hinvRel, hsub'.trans hsubRel,
-      VerifM.Env.agreeOn_trans hag' (VerifM.Env.agreeOn_mono hsub' hagRel), hQ⟩
+      Env.agreeOn_trans hag' (Env.agreeOn_mono hsub' hagRel), hQ⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
 /-- Compiling and declaring one lifted bounded quantifier preserves the
 assembly invariants. -/
 private theorem declareLifting_correct (s : Verifier.BoundedQuantifier.Lifting)
-    (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
-    {Q : RelationSpec → TransState → VerifM.Env → Prop}
+    (acc : RelationSpec) (st : TransState) (ρ : Env)
+    {Q : RelationSpec → TransState → Env → Prop}
     (hinv : Inv acc st ρ)
     (heval : VerifM.eval (declareLifting acc s) st ρ Q) :
     ∃ acc' st' ρ', Inv acc' st' ρ' ∧
-      st.decls.Subset st'.decls ∧ VerifM.Env.agreeOn st.decls ρ ρ' ∧
+      st.decls.Subset st'.decls ∧ Env.agreeOn st.decls ρ ρ' ∧
       Q acc' st' ρ' := by
   obtain ⟨hacc, howns, hvars, hwf, hΓwf, hsplit, hdet⟩ := hinv
   simp only [declareLifting] at heval
@@ -346,18 +346,18 @@ private theorem declareLifting_correct (s : Verifier.BoundedQuantifier.Lifting)
 
 omit [MicaGS HasLC.hasLC Sig] in
 private theorem assembleLiftings_correct (ss : List Verifier.BoundedQuantifier.Lifting) :
-    ∀ (acc : RelationSpec) (st : TransState) (ρ : VerifM.Env)
-      {Q : RelationSpec → TransState → VerifM.Env → Prop},
+    ∀ (acc : RelationSpec) (st : TransState) (ρ : Env)
+      {Q : RelationSpec → TransState → Env → Prop},
       Inv acc st ρ →
       VerifM.eval (assembleLiftings acc ss) st ρ Q →
       ∃ result stRel ρRel, Inv result stRel ρRel ∧
-        st.decls.Subset stRel.decls ∧ VerifM.Env.agreeOn st.decls ρ ρRel ∧
+        st.decls.Subset stRel.decls ∧ Env.agreeOn st.decls ρ ρRel ∧
         Q result stRel ρRel := by
   induction ss with
   | nil =>
     intro acc st ρ Q hinv heval
     simp only [assembleLiftings] at heval
-    exact ⟨acc, st, ρ, hinv, Signature.Subset.refl _, VerifM.Env.agreeOn_refl,
+    exact ⟨acc, st, ρ, hinv, Signature.Subset.refl _, Env.agreeOn_refl,
       VerifM.eval_ret heval⟩
   | cons s ss ih =>
     intro acc st ρ Q hinv heval
@@ -367,13 +367,13 @@ private theorem assembleLiftings_correct (ss : List Verifier.BoundedQuantifier.L
     obtain ⟨result, stRel, ρRel, hinvRel, hsubRel, hagRel, hQ⟩ :=
       ih acc1 st1 ρ1 hinv1 hcont1
     exact ⟨result, stRel, ρRel, hinvRel, hsub1.trans hsubRel,
-      VerifM.Env.agreeOn_trans hag1 (VerifM.Env.agreeOn_mono hsub1 hagRel), hQ⟩
+      Env.agreeOn_trans hag1 (Env.agreeOn_mono hsub1 hagRel), hQ⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
 theorem assemble_correct
     (pairs : List (Typed.ValDecl (Spec.Body Typed.Expr) × List Verifier.BoundedQuantifier.Lifting))
-    {st : TransState} {ρ : VerifM.Env}
-    {Q : RelationSpec → TransState → VerifM.Env → Prop}
+    {st : TransState} {ρ : Env}
+    {Q : RelationSpec → TransState → Env → Prop}
     (hvars0 : st.decls.vars = [])
     (howns0 : st.owns = [])
     (hwf0 : st.decls.wf)
@@ -382,7 +382,7 @@ theorem assemble_correct
       stRel.decls.vars = [] ∧
       stRel.owns = [] ∧
       st.decls.Subset stRel.decls ∧
-      VerifM.Env.agreeOn st.decls ρ ρRel ∧
+      Env.agreeOn st.decls ρ ρRel ∧
       Q { spec0 with delta := stRel.decls } stRel ρRel := by
   unfold RelationSpec.assemble at heval
   have hctx := VerifM.eval_bind heval
@@ -390,10 +390,10 @@ theorem assemble_correct
   have hrest := hassembleFrom hownsWf
   have hempty_Γwf : FunCtx.wfIn empty.functionMap st.decls :=
     ⟨fun _ _ h => (List.not_mem_nil h).elim, fun _ _ h => (List.not_mem_nil h).elim⟩
-  have hempty_split : FunCtx.splitCompatible empty.functionMap ρ.env :=
+  have hempty_split : FunCtx.splitCompatible empty.functionMap ρ :=
     fun _ _ h => (List.not_mem_nil h).elim
   have hempty_det : Relation.BinaryRelDet
-      empty.functionMap ρ.env ρ.env :=
+      empty.functionMap ρ ρ :=
     fun _ _ h => (List.not_mem_nil h).elim
   obtain ⟨acc, st1, ρ1, hinv1, hsub1, hag1, hcont⟩ :=
     assembleFrom_correct (pairs.map Prod.fst) { empty with delta := st.decls } st ρ
@@ -402,7 +402,7 @@ theorem assemble_correct
   obtain ⟨result, stRel, ρRel, hinvRel, hsubRel, hagRel, hQ⟩ :=
     assembleLiftings_correct (pairs.flatMap Prod.snd) acc st1 ρ1 hinv1 hcont
   refine ⟨result, stRel, ρRel, hinvRel.vars, hinvRel.owns, hsub1.trans hsubRel,
-    VerifM.Env.agreeOn_trans hag1 (VerifM.Env.agreeOn_mono hsub1 hagRel), ?_⟩
+    Env.agreeOn_trans hag1 (Env.agreeOn_mono hsub1 hagRel), ?_⟩
   have hresD := hinvRel.delta
   obtain ⟨_, _, _, _⟩ := result
   simp only at hresD; subst hresD
@@ -472,8 +472,8 @@ def Program.verify (reg : Verifier.Registry) (prog : Untyped.Program (Spec.Body 
 omit [MicaGS HasLC.hasLC Sig] in
 theorem Program.prepare_correct (prims : Typed.Prims)
     (prog : Untyped.Program (Spec.Body Untyped.Expr))
-    (st : TransState) (ρ : VerifM.Env)
-    {Q : (TinyML.TypeEnv × Typed.Program (Spec.Body Typed.Expr)) → TransState → VerifM.Env → Prop}
+    (st : TransState) (ρ : Env)
+    {Q : (TinyML.TypeEnv × Typed.Program (Spec.Body Typed.Expr)) → TransState → Env → Prop}
     (heval : VerifM.eval (Program.prepare prims prog) st ρ Q) :
     ∃ Θ typed, Typed.Program.runtime typed = Untyped.Program.runtime prog ∧ Q (Θ, typed) st ρ := by
   unfold Program.prepare at heval
@@ -491,11 +491,11 @@ theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.R
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
-    (st : TransState) (ρ : VerifM.Env)
-    (hag : W.agrees st.decls ρ.env)
+    (st : TransState) (ρ : Env)
+    (hag : W.agrees st.decls ρ)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
-    {Q : Unit → TransState → VerifM.Env → Prop}
+    {Q : Unit → TransState → Env → Prop}
     (heval : VerifM.eval (ValDecl.checkExpr reg W.Θ W.Δ_spec S d) st ρ Q) :
     (□ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ Φ) →
     □ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun _ => Φ) := by
@@ -540,11 +540,11 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
     (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Γfn : FunCtx)
     (S : SpecMap) (d : Typed.ValDecl (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
-    (st : TransState) (ρ : VerifM.Env)
-    (hag : W.agrees st.decls ρ.env)
+    (st : TransState) (ρ : Env)
+    (hag : W.agrees st.decls ρ)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
-    {Q : Spec → TransState → VerifM.Env → Prop}
+    {Q : Spec → TransState → Env → Prop}
     (heval : VerifM.eval (ValDecl.check reg W.Θ W.Δ_spec Γfn S d) st ρ Q) :
     ∃ spec, spec.wfIn W.Δ_spec ∧
             (□ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor W v)) ∧
@@ -597,8 +597,8 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
     (W : TinyML.World) (hW : W.pctx = reg.primCtx) (Γfn : FunCtx)
     (S : SpecMap) (prog : Typed.Program (Spec.Body Typed.Expr)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
-    (st : TransState) (ρ : VerifM.Env)
-    (hag : W.agrees st.decls ρ.env)
+    (st : TransState) (ρ : Env)
+    (hag : W.agrees st.decls ρ)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec) :
     VerifM.eval (Program.check reg W.Θ W.Δ_spec Γfn S prog) st ρ (fun _ _ _ => True) →
@@ -760,12 +760,12 @@ theorem Program.verify_correct (reg : Verifier.Registry)
                             let relations ← RelationSpec.assemble pairs
                             Program.check reg Θ relations.delta relations.functionMap ∅
                               (pairs.map Prod.fst))
-                      TransState.init VerifM.Env.init ctx_mid
+                      TransState.init Env.init ctx_mid
                       (ScopedM.eval_declareConst hverif)
                       TransState.init_holdsFor TransState.init_wf
     have hbind := VerifM.eval_bind hverifM
     obtain ⟨Θ, typed, hrt, hrest⟩ :=
-      Program.prepare_correct reg.sigs p TransState.init VerifM.Env.init hbind
+      Program.prepare_correct reg.sigs p TransState.init Env.init hbind
     -- Peel the bounded-quantifier pass: a rewrite failure is fatal, and a success
     -- leaves the program's runtime erasure unchanged.
     dsimp only at hrest
@@ -792,20 +792,20 @@ theorem Program.verify_correct (reg : Verifier.Registry)
       intro i hi
       exact (Verifier.Registry.extendWithSym_subset_sigOf_of_mem hi).trans
         (hdep_setup.trans hsub_setup_rel)
-    have hρreg : Verifier.Registry.symAgree reg ρRel.env := by
+    have hρreg : Verifier.Registry.symAgree reg ρRel := by
       intro i hi
       exact hstable_setup ρRel hag_setup_rel i hi
     -- The meta-level world: the registry's operational context, the type
     -- environment the elaborator produced, and the specification model the
     -- relational declarations left in the state.
     let W : TinyML.World :=
-      { pctx := reg.primCtx, Θ, Δ_spec := stRel.decls, ρ_spec := ρRel.env }
+      { pctx := reg.primCtx, Θ, Δ_spec := stRel.decls, ρ_spec := ρRel }
     have hcorrect := Program.check_correct reg hSound W rfl spec0.functionMap
                        ∅ (pairs.map Prod.fst) Runtime.Subst.id
                        (SpecMap.empty_wfIn _)
                        ⟨hcheck_eval.1.namesDisjoint, hvars⟩
                        stRel ρRel
-                       ⟨Signature.Subset.refl _, VerifM.Env.agreeOn_refl⟩
+                       ⟨Signature.Subset.refl _, Env.agreeOn_refl⟩
                        hΔreg
                        hρreg
                        hcheck_eval

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -66,14 +66,14 @@ omit [MicaGS HasLC.hasLC Sig] in
 
 /-- Build an environment binding each argument name to its value, left-to-right.
     Later arguments shadow earlier ones with the same name. -/
-def argsEnv (ρ : VerifM.Env) : List (String × TinyML.Typ) → List Runtime.Val → VerifM.Env
+def argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val → Env
   | [], _ | _, [] => ρ
   | (name, _) :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
 
 def isPrecondFor (W : TinyML.World)
     (f : Runtime.Val) (s : Spec) : iProp :=
-  iprop(□ ∀ (ρ : VerifM.Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
-      ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ.env⌝ -∗
+  iprop(□ ∀ (ρ : Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
+      ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ -∗
       TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
         PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
           (argsEnv ρ s.args vs) -∗
@@ -140,8 +140,8 @@ instance : Iris.BI.Persistent (isPrecondFor W f s) := by
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
 theorem isPrecondFor_intro (W : TinyML.World) (s : Spec)
     (f : Runtime.Val) :
-    iprop(□ ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-      (⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ.env⌝ ∗
+    iprop(□ ∀ (ρ : Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+      (⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ ∗
         TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
         PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
           (argsEnv ρ s.args vs)) -∗
@@ -162,16 +162,16 @@ theorem isPrecondFor_fix {W : TinyML.World} {s : Spec}
     {R : iProp}
     (hargs : args.length = s.args.length)
     (h : R ⊢ □ (s.isPrecondFor W (.fix f args e) -∗
-        ∀ (ρ : VerifM.Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ.env⌝ -∗
+        ∀ (ρ : Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+          ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ -∗
           TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
           PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
               (argsEnv ρ s.args vs) -∗
           wp W.pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
     R ⊢ s.isPrecondFor W (.fix f args e) := by
   refine (SpatialContext.wp_fix' (pctx := W.pctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
-      iprop(∃ ρ : VerifM.Env,
-        ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ.env⌝ ∗
+      iprop(∃ ρ : Env,
+        ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ ∗
           TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
           PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
             (argsEnv ρ s.args vs))) ?_ (h.trans ?_)).trans ?_
@@ -234,11 +234,11 @@ section EnvironmentAgreement
 omit [MicaGS HasLC.hasLC Sig] in
 /-- `argsEnv` preserves `agreeOn`: if two envs agree on `Δ`,
     then after applying the same updates, they agree on `argVars args ++ Δ`. -/
-theorem argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : VerifM.Env}
-    (h : VerifM.Env.agreeOn Δ ρ₁ ρ₂) :
+theorem argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : Env}
+    (h : Env.agreeOn Δ ρ₁ ρ₂) :
     ∀ (args : List (String × TinyML.Typ)) (vals : List Runtime.Val),
     args.length ≤ vals.length →
-    VerifM.Env.agreeOn (Δ.declVars (argVars args))
+    Env.agreeOn (Δ.declVars (argVars args))
       (argsEnv ρ₁ args vals) (argsEnv ρ₂ args vals) := by
   intro args
   induction args generalizing Δ ρ₁ ρ₂ with
@@ -251,7 +251,7 @@ theorem argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : VerifM.Env}
     | cons v vs =>
       simp only [argsEnv, argVars, List.map]
       simpa [Signature.declVars] using
-        ih (VerifM.Env.agreeOn_declVar h) vs (by simp [List.length] at hlen ⊢; omega)
+        ih (Env.agreeOn_declVar h) vs (by simp [List.length] at hlen ⊢; omega)
 
 end EnvironmentAgreement
 
@@ -263,8 +263,8 @@ omit [MicaGS HasLC.hasLC Sig] in
     substitution is well-formed, types match, and the env agrees with `argsEnv`. -/
 theorem declareArgs_correct (W : TinyML.World) :
     ∀ (args : List (String × TinyML.Typ)) (sargs : List (TinyML.Typ × Term .value))
-      (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
-      (Ψ : FiniteSubst → TransState → VerifM.Env → Prop),
+      (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : Env)
+      (Ψ : FiniteSubst → TransState → Env → Prop),
     σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.declareArgs W.Θ σ args sargs) st ρ Ψ →
@@ -274,10 +274,10 @@ theorem declareArgs_correct (W : TinyML.World) :
       @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
       ((Δ_base.declVars σ.dom).declVars (Spec.argVars args)).Subset
         (Δ_base.declVars σ'.dom) ∧
-      VerifM.Env.agreeOn ((Δ_base.declVars σ.dom).declVars (Spec.argVars args))
-        (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env))
-        (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) args
-          (sargs.map fun p => p.2.eval ρ.env)) := by
+      Env.agreeOn ((Δ_base.declVars σ.dom).declVars (Spec.argVars args))
+        ((σ'.subst.eval ρ'))
+        (Spec.argsEnv ((σ.subst.eval ρ)) args
+          (sargs.map fun p => p.2.eval ρ)) := by
   intro args
   induction args with
   | nil =>
@@ -286,7 +286,7 @@ theorem declareArgs_correct (W : TinyML.World) :
     | nil =>
       simp [Spec.declareArgs] at heval
       exact ⟨σ, st, ρ, VerifM.eval_ret heval, hσwf, rfl, .nil, Signature.Subset.refl _,
-        by simp [Spec.argVars, Spec.argsEnv]; exact VerifM.Env.agreeOn_refl⟩
+        by simp [Spec.argVars, Spec.argsEnv]; exact Env.agreeOn_refl⟩
     | cons _ _ =>
       simp [Spec.declareArgs] at heval
       exact (VerifM.eval_fatal heval).elim
@@ -306,7 +306,7 @@ theorem declareArgs_correct (W : TinyML.World) :
           (VerifM.eval_bind (VerifM.eval_ret (VerifM.eval_bind heval)))
         set argVar := st.freshConst (some name) .value
         set σ' := σ.rename ⟨name, .value⟩ argVar.name
-        set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ.env)
+        set ρ₁ := ρ.updateConst .value argVar.name (sarg.eval ρ)
         have hstwf : st.decls.wf := hσwf.useWf
         have hfresh_decls : argVar.name ∉ st.decls.allNames :=
           st.freshConst_fresh (some name) .value
@@ -319,22 +319,22 @@ theorem declareArgs_correct (W : TinyML.World) :
               hσwf hfresh_range hfresh_decls)
         have hsarg_wf : sarg.wfIn st.decls := hsargs _ (List.mem_cons_self ..)
         have hassume := VerifM.eval_assumePure
-          (VerifM.eval_bind (hdecl (sarg.eval ρ.env)))
+          (VerifM.eval_bind (hdecl (sarg.eval ρ)))
           (by
             simpa [argVar] using
               (Formula.eq_wfIn_addConst_of_fresh
                 (Δ := st.decls) (c := argVar) hstwf hsarg_wf hfresh_decls))
           (by
-            simpa [argVar, VerifM.Env.updateConst_env] using
+            simpa [argVar] using
               (Formula.eq_eval_updateConst_of_fresh
-                (Δ := st.decls) (ρ := ρ.env) (c := argVar) hsarg_wf hfresh_decls))
+                (Δ := st.decls) (ρ := ρ) (c := argVar) hsarg_wf hfresh_decls))
         have hstwf_add : (st.decls.addConst argVar).wf := Signature.wf_addConst hstwf hfresh_decls
         have hsargs_rest : ∀ p ∈ sargs_rest, (p : TinyML.Typ × Term .value).2.wfIn
             (st.decls.addConst argVar) := fun p hp =>
           Term.wfIn_mono _ (hsargs p (List.mem_cons_of_mem _ hp))
             (Signature.Subset.subset_addConst _ _) hstwf_add
-        have hsargs_eval : sargs_rest.map (fun p => p.2.eval ρ₁.env) =
-            sargs_rest.map (fun p => p.2.eval ρ.env) :=
+        have hsargs_eval : sargs_rest.map (fun p => p.2.eval ρ₁) =
+            sargs_rest.map (fun p => p.2.eval ρ) :=
           List.map_congr_left fun p hp => Term.eval_env_agree
             (hsargs p (List.mem_cons_of_mem _ hp))
             (Env.agreeOn_symm (Env.agreeOn_update_fresh_const hfresh_decls))
@@ -351,40 +351,39 @@ theorem declareArgs_correct (W : TinyML.World) :
           have hag_rename := FiniteSubst.rename_agreeOn
             (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
             (v := ⟨name, .value⟩) (name' := argVar.name)
-            (ρ := ρ.env) (u := sarg.eval ρ.env) hσwf hfresh_range
+            (ρ := ρ) (u := sarg.eval ρ) hσwf hfresh_range
           have hag_env := Spec.argsEnv_agreeOn
-            (ρ₁ := VerifM.Env.withEnv ρ (σ'.subst.eval ρ₁.env))
-            (ρ₂ := VerifM.Env.withEnv ρ ((σ.subst.eval ρ.env).updateConst .value name (sarg.eval ρ.env)))
-            (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', VerifM.Env.withEnv_env] using hag_rename)
-            rest (sargs_rest.map fun p => p.2.eval ρ.env) (by simp [List.length_map]; omega)
+            (ρ₁ := (σ'.subst.eval ρ₁))
+            (ρ₂ := ((σ.subst.eval ρ).updateConst .value name (sarg.eval ρ)))
+            (by simpa [Env.agreeOn, σ', ] using hag_rename)
+            rest (sargs_rest.map fun p => p.2.eval ρ) (by simp [List.length_map]; omega)
           rw [hsargs_eval] at hagree
-          change VerifM.Env.agreeOn
+          change Env.agreeOn
             (((Δ_base.declVars σ.dom).declVar ⟨name, .value⟩).declVars (Spec.argVars rest))
-            (VerifM.Env.withEnv ρ'' (σ''.subst.eval ρ''.env))
-            (Spec.argsEnv ((VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)).updateConst
-              .value name (sarg.eval ρ.env)) rest
-              (sargs_rest.map fun p => p.2.eval ρ.env))
-          simpa [σ', FiniteSubst.rename_source_eq, Spec.argsEnv, VerifM.Env.withEnv,
-            VerifM.Env.agreeOn] using
-            (VerifM.Env.agreeOn_trans hagree hag_env)
+            ((σ''.subst.eval ρ''))
+            (Spec.argsEnv (((σ.subst.eval ρ)).updateConst
+              .value name (sarg.eval ρ)) rest
+              (sargs_rest.map fun p => p.2.eval ρ))
+          simpa [σ', FiniteSubst.rename_source_eq, Spec.argsEnv,             Env.agreeOn] using
+            (Env.agreeOn_trans hagree hag_env)
       · simp [hsub_ty] at heval
         exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
 theorem call_correct (W : TinyML.World) (s : Spec) (Δ_base : Signature)
     (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
-    (st : TransState) (ρ : VerifM.Env)
-    (Ψ : (TinyML.Typ × Term .value) → TransState → VerifM.Env → Prop)
+    (st : TransState) (ρ : Env)
+    (Ψ : (TinyML.Typ × Term .value) → TransState → Env → Prop)
     (Φ : Runtime.Val → iProp) (R : iProp) :
     s.pred.wfIn ((Δ_base.declVars σ.dom).declVars (Spec.argVars s.args)) →
     σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.call W.Θ σ s sargs) st ρ Ψ →
-    (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ'.env = v →
+    (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
       st'.sl W ρ' ∗ R ∗ TinyML.ValHasType W v s.retTy ⊢ Φ v) →
     @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
     (st.sl W ρ ∗ R ⊢ PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
-      (Spec.argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) s.args
-        (sargs.map fun p => p.2.eval ρ.env))) := by
+      (Spec.argsEnv ((σ.subst.eval ρ)) s.args
+        (sargs.map fun p => p.2.eval ρ))) := by
   intro hwf hσwf hsargs heval hΨ
   simp only [Spec.call] at heval
   have hb_grow := VerifM.eval.decls_grow ρ (VerifM.eval_bind heval)
@@ -400,7 +399,7 @@ theorem call_correct (W : TinyML.World) (s : Spec) (Δ_base : Signature)
       apply wand_intro
       iintro ⟨⟨Howns, HR⟩, Hty⟩
       iintuitionistic Hty
-      ihave Hpure := (TinyML.typeConstraints_hold (ty := s.retTy) (t := t) (ρ := ρ''.env) (W := W) (v := v) hteval) $$ Hty
+      ihave Hpure := (TinyML.typeConstraints_hold (ty := s.retTy) (t := t) (ρ := ρ'') (W := W) (v := v) hteval) $$ Hty
       ipure Hpure
       obtain ⟨st₃, hst₃_decls, hst₃_owns, _, hret⟩ :=
         VerifM.eval_assumeAll (VerifM.eval_bind hΨ'')
@@ -421,26 +420,26 @@ section ImplementCorrectness
 
 /-- Correctness payload for `declareImplArgs`. -/
 def DeclareImplArgs.Result (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
-    (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
-    (Ψ : (FiniteSubst × List FOL.Const) → TransState → VerifM.Env → Prop) : Prop :=
+    (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : Env)
+    (Ψ : (FiniteSubst × List FOL.Const) → TransState → Env → Prop) : Prop :=
   ∃ σ' implVars st' ρ', Ψ (σ', implVars) st' ρ' ∧
     σ'.wfIn Δ_base st'.decls ∧
     st.decls.Subset st'.decls ∧
-    VerifM.Env.agreeOn st.decls ρ ρ' ∧
+    Env.agreeOn st.decls ρ ρ' ∧
     st'.owns = st.owns ∧
     ((Δ_base.declVars σ.dom).declVars (argVars args)).Subset
       (Δ_base.declVars σ'.dom) ∧
-    VerifM.Env.agreeOn ((Δ_base.declVars σ.dom).declVars (argVars args))
-      (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env))
-      (argsEnv (VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)) args vs) ∧
+    Env.agreeOn ((Δ_base.declVars σ.dom).declVars (argVars args))
+      ((σ'.subst.eval ρ'))
+      (argsEnv ((σ.subst.eval ρ)) args vs) ∧
     (∀ v ∈ implVars, v ∈ st'.decls.consts) ∧
     (∀ v ∈ implVars, v.sort = .value) ∧
-    Terms.Eval ρ'.env (implVars.map (fun av => .const (.uninterpreted av.name .value))) vs
+    Terms.Eval ρ' (implVars.map (fun av => .const (.uninterpreted av.name .value))) vs
 
 theorem declareImplArgs_correct (W : TinyML.World) :
     ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
-      (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : VerifM.Env)
-      (Ψ : (FiniteSubst × List FOL.Const) → TransState → VerifM.Env → Prop),
+      (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : Env)
+      (Ψ : (FiniteSubst × List FOL.Const) → TransState → Env → Prop),
     σ.wfIn Δ_base st.decls →
     VerifM.eval (Spec.declareImplArgs σ args) st ρ Ψ →
     TinyML.ValsHaveTypes W vs (args.map Prod.snd) ⊢
@@ -457,8 +456,8 @@ theorem declareImplArgs_correct (W : TinyML.World) :
       have := VerifM.eval_ret heval
       ipureintro
       exact ⟨σ, [], st, ρ, this, hσwf,
-        Signature.Subset.refl _, VerifM.Env.agreeOn_refl, rfl, Signature.Subset.refl _,
-        by simp [Spec.argVars, Spec.argsEnv]; exact VerifM.Env.agreeOn_refl,
+        Signature.Subset.refl _, Env.agreeOn_refl, rfl, Signature.Subset.refl _,
+        by simp [Spec.argVars, Spec.argsEnv]; exact Env.agreeOn_refl,
         nofun,
         nofun,
         .nil⟩
@@ -493,11 +492,11 @@ theorem declareImplArgs_correct (W : TinyML.World) :
       have hvar_wf : (Term.const (.uninterpreted argVar.name .value)).wfIn (st.decls.addConst argVar) := by
         simpa using
           (Term.const_wfIn_addConst_of_fresh (Δ := st.decls) (c := argVar) hstwf hfresh_decls)
-      have hvar_eval : (Term.const (.uninterpreted argVar.name .value)).eval ρ₁.env = v := by
+      have hvar_eval : (Term.const (.uninterpreted argVar.name .value)).eval ρ₁ = v := by
         simp [ρ₁]
       ihave %htyped_formulas := TinyML.typeConstraints_hold (ty := ty)
           (t := .const (.uninterpreted argVar.name .value))
-          (ρ := ρ₁.env) (W := W) (v := v) hvar_eval $$ Hv
+          (ρ := ρ₁) (W := W) (v := v) hvar_eval $$ Hv
       obtain ⟨st₂, hst₂_decls, hst₂_owns, _, hdecl₂⟩ :=
         VerifM.eval_assumeAll (VerifM.eval_bind hdecl)
           (fun φ hφ => TinyML.typeConstraints_wfIn hvar_wf φ hφ)
@@ -515,30 +514,29 @@ theorem declareImplArgs_correct (W : TinyML.World) :
       have hag_rename := FiniteSubst.rename_agreeOn
         (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
         (v := ⟨name, .value⟩) (name' := argVar.name)
-        (ρ := ρ.env) (u := v) hσwf hfresh_range
+        (ρ := ρ) (u := v) hσwf hfresh_range
       have hag_env := Spec.argsEnv_agreeOn
-        (ρ₁ := VerifM.Env.withEnv ρ₁ (σ'.subst.eval ρ₁.env))
-        (ρ₂ := VerifM.Env.withEnv ρ ((σ.subst.eval ρ.env).updateConst .value name v))
-        (by simpa [VerifM.Env.agreeOn, VerifM.Env.withEnv, σ', VerifM.Env.withEnv_env] using hag_rename)
+        (ρ₁ := (σ'.subst.eval ρ₁))
+        (ρ₂ := ((σ.subst.eval ρ).updateConst .value name v))
+        (by simpa [Env.agreeOn, σ', ] using hag_rename)
         rest vs' (by simp [List.length_map] at hlen_rest; omega)
       ipureintro
       refine ⟨σ'', argVar :: argVars', st', ρ', hΨ, hσ''wf,
         Signature.Subset.trans hst_st₂ hdsub',
-        VerifM.Env.agreeOn_trans
-          (VerifM.Env.agreeOn_update_fresh (ρ := ρ) (c := argVar) (u := v) hfresh_decls)
-          (VerifM.Env.agreeOn_mono hst_st₂ hragree'),
+        Env.agreeOn_trans
+          (Env.agreeOn_update_fresh_const (ρ := ρ) (c := argVar) (u := v) hfresh_decls)
+          (Env.agreeOn_mono hst_st₂ hragree'),
         howns.trans hst₂_owns, ?_, ?_, ?_, ?_, ?_⟩
       · change (((Δ_base.declVars σ.dom).declVar ⟨name, .value⟩).declVars
             (Spec.argVars rest)).Subset (Δ_base.declVars σ''.dom)
         simpa [σ', FiniteSubst.rename_source_eq] using hdom_sub
-      · change VerifM.Env.agreeOn
+      · change Env.agreeOn
           (((Δ_base.declVars σ.dom).declVar ⟨name, .value⟩).declVars (Spec.argVars rest))
-          (VerifM.Env.withEnv ρ' (σ''.subst.eval ρ'.env))
-          (Spec.argsEnv ((VerifM.Env.withEnv ρ (σ.subst.eval ρ.env)).updateConst .value name v)
+          ((σ''.subst.eval ρ'))
+          (Spec.argsEnv (((σ.subst.eval ρ)).updateConst .value name v)
             rest vs')
-        simpa [σ', FiniteSubst.rename_source_eq, Spec.argsEnv, VerifM.Env.withEnv,
-          VerifM.Env.agreeOn] using
-          (VerifM.Env.agreeOn_trans hagree hag_env)
+        simpa [σ', FiniteSubst.rename_source_eq, Spec.argsEnv,           Env.agreeOn] using
+          (Env.agreeOn_trans hagree hag_env)
       · intro w hw
         cases List.mem_cons.mp hw with
         | inl h => subst h; exact hdsub'.consts argVar (hst₂_decls ▸ List.mem_cons_self ..)
@@ -549,31 +547,31 @@ theorem declareImplArgs_correct (W : TinyML.World) :
         | inr h => exact hsorts w h
       · refine List.Forall₂.cons ?_ hlookups
         have h1 := hragree'.2.1 argVar (hst₂_decls ▸ List.mem_cons_self ..)
-        have h1' : Term.eval ρ'.env (Term.const (.uninterpreted argVar.name .value)) =
-            Term.eval ρ₁.env (Term.const (.uninterpreted argVar.name .value)) := by
+        have h1' : Term.eval ρ' (Term.const (.uninterpreted argVar.name .value)) =
+            Term.eval ρ₁ (Term.const (.uninterpreted argVar.name .value)) := by
           simpa [Term.eval, Const.denote, Env.lookupConst] using h1.symm
         exact h1'.trans hvar_eval
 
 theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
-    (st : TransState) (ρ : VerifM.Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
+    (st : TransState) (ρ : Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
     s.wfIn W.Δ_spec →
     W.wf →
-    W.agrees st.decls ρ.env →
+    W.agrees st.decls ρ →
     VerifM.eval (Spec.implement W.Δ_spec s body) st ρ (fun _ _ _ => True) →
-    (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : VerifM.Env) (Q : iProp),
+    (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : Env) (Q : iProp),
       st.decls.Subset st'.decls →
-      VerifM.Env.agreeOn st.decls ρ ρ' →
+      Env.agreeOn st.decls ρ ρ' →
       (∀ v ∈ argVars, v ∈ st'.decls.consts) →
       (∀ v ∈ argVars, v.sort = .value) →
-      List.Forall₂ (fun av val => ρ'.env.consts .value av.name = val) argVars vs →
+      List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs →
       VerifM.eval (body argVars) st' ρ'
         (fun result st'' ρ'' =>
           ∀ (S : iProp), result.wfIn st''.decls →
-            st''.sl W ρ'' ∗ Q ∗ ((TinyML.ValHasType W (result.eval ρ''.env) s.retTy -∗ Φ (result.eval ρ''.env)) -∗ S) ⊢ S) →
+            st''.sl W ρ'' ∗ Q ∗ ((TinyML.ValHasType W (result.eval ρ'') s.retTy -∗ Φ (result.eval ρ'')) -∗ S) ⊢ S) →
       st'.sl W ρ' ∗ Q ⊢ R) →
     st.sl W ρ ∗ TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
       PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
-        (Spec.argsEnv ⟨W.ρ_spec⟩ s.args vs) ⊢ R := by
+        (Spec.argsEnv W.ρ_spec s.args vs) ⊢ R := by
   intro hswf hwf hag heval hbody
   simp only [Spec.implement] at heval
   have hb := VerifM.eval_bind heval
@@ -588,13 +586,13 @@ theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const �
   obtain ⟨σ', argVars, st', ρ', hΨ, hσ'wf, hdsub, hragree, howns, hdom_sub, hagree,
     hmem_decls, hsorts, hlookups⟩ := Hdecl
   have hag_base :
-      VerifM.Env.agreeOn (W.Δ_spec.declVars (Spec.argVars s.args))
-        (Spec.argsEnv ⟨W.ρ_spec⟩ s.args vs)
-            (Spec.argsEnv (VerifM.Env.withEnv ρ ((FiniteSubst.base W.Δ_spec).subst.eval ρ.env)) s.args vs) :=
+      Env.agreeOn (W.Δ_spec.declVars (Spec.argVars s.args))
+        (Spec.argsEnv W.ρ_spec s.args vs)
+            (Spec.argsEnv (((FiniteSubst.base W.Δ_spec).subst.eval ρ)) s.args vs) :=
     Spec.argsEnv_agreeOn (Δ := W.Δ_spec)
-      (ρ₁ := ⟨W.ρ_spec⟩)
-      (ρ₂ := VerifM.Env.withEnv ρ ((FiniteSubst.base W.Δ_spec).subst.eval ρ.env))
-      (by simpa [FiniteSubst.base, VerifM.Env.withEnv] using hag.agree)
+      (ρ₁ := W.ρ_spec)
+      (ρ₂ := ((FiniteSubst.base W.Δ_spec).subst.eval ρ))
+      (by simpa [FiniteSubst.base, ] using hag.agree)
       s.args vs
       (by
         simp [List.length_map] at hlen_vals
@@ -602,7 +600,7 @@ theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const �
   have hst'_wf : st'.decls.wf := (VerifM.eval.wf hΨ).namesDisjoint
   iapply (show st'.sl W ρ' ∗
         PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
-          (VerifM.Env.withEnv ρ' (σ'.subst.eval ρ'.env)) ⊢ R from
+          ((σ'.subst.eval ρ')) ⊢ R from
     PredTrans.implement_correct W s.pred W.Δ_spec σ' (body argVars) st' ρ'
       (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) R
       (PredTrans.wfIn_mono hswf hdom_sub hσ'wf.srcWf)
@@ -610,9 +608,9 @@ theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const �
       (fun st'' ρ'' Q hdsub' hragree' hbody_eval => by
         apply hbody argVars st'' ρ'' Q
           (hdsub.trans hdsub')
-          (VerifM.Env.agreeOn_trans hragree (VerifM.Env.agreeOn_mono hdsub hragree'))
+          (Env.agreeOn_trans hragree (Env.agreeOn_mono hdsub hragree'))
           (fun v hv => hdsub'.consts v (hmem_decls v hv)) hsorts
-        · refine Terms.Eval.lookup_const (Terms.Eval.env_agree (ρ := ρ'.env) ?_ hragree' hlookups)
+        · refine Terms.Eval.lookup_const (Terms.Eval.env_agree (ρ := ρ') ?_ hragree' hlookups)
           intro t ht
           obtain ⟨av, hav, rfl⟩ := List.mem_map.mp ht
           obtain ⟨_, _⟩ := av
@@ -626,8 +624,8 @@ theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const �
       simpa [TransState.sl] using
         (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf hragree).1)
     iexact Howns
-  · iapply (PredTrans.apply_env_agree W hswf (VerifM.Env.agreeOn_trans hag_base (by
-        simpa [FiniteSubst.base, Signature.declVars] using VerifM.Env.agreeOn_symm hagree)))
+  · iapply (PredTrans.apply_env_agree W hswf (Env.agreeOn_trans hag_base (by
+        simpa [FiniteSubst.base, Signature.declVars] using Env.agreeOn_symm hagree)))
     iexact Happ
 
 end ImplementCorrectness

--- a/Mica/Verifier/State.lean
+++ b/Mica/Verifier/State.lean
@@ -26,56 +26,6 @@ end CtxItem
 
 namespace VerifM
 
-structure Env where
-  env : _root_.Env
-
-def Env.empty : Env :=
-  { env := _root_.Env.empty }
-
-@[simp] theorem Env.empty_env : Env.empty.env = _root_.Env.empty := rfl
-
-def Env.updateConst (ρ : Env) (t : Srt) (x : String) (u : t.denote) : Env :=
-  { ρ with env := _root_.Env.updateConst ρ.env t x u }
-
-@[simp] theorem Env.updateConst_env (ρ : Env) (t : Srt) (x : String) (u : t.denote) :
-    (ρ.updateConst t x u).env = ρ.env.updateConst t x u := rfl
-
-def Env.updateUnary (ρ : Env) (τ₁ τ₂ : Srt) (x : String) (f : τ₁.denote → τ₂.denote) : Env :=
-  { ρ with env := _root_.Env.updateUnary ρ.env τ₁ τ₂ x f }
-
-@[simp] theorem Env.updateUnary_env (ρ : Env) (τ₁ τ₂ : Srt) (x : String) (f : τ₁.denote → τ₂.denote) :
-    (ρ.updateUnary τ₁ τ₂ x f).env = ρ.env.updateUnary τ₁ τ₂ x f := rfl
-
-def Env.updateBinary (ρ : Env) (τ₁ τ₂ τ₃ : Srt) (x : String)
-    (f : τ₁.denote → τ₂.denote → τ₃.denote) : Env :=
-  { ρ with env := _root_.Env.updateBinary ρ.env τ₁ τ₂ τ₃ x f }
-
-@[simp] theorem Env.updateBinary_env (ρ : Env) (τ₁ τ₂ τ₃ : Srt) (x : String)
-    (f : τ₁.denote → τ₂.denote → τ₃.denote) :
-    (ρ.updateBinary τ₁ τ₂ τ₃ x f).env = ρ.env.updateBinary τ₁ τ₂ τ₃ x f := rfl
-
-def Env.updateTernary (ρ : Env) (τ₁ τ₂ τ₃ τ₄ : Srt) (x : String)
-    (f : τ₁.denote → τ₂.denote → τ₃.denote → τ₄.denote) : Env :=
-  { ρ with env := _root_.Env.updateTernary ρ.env τ₁ τ₂ τ₃ τ₄ x f }
-
-@[simp] theorem Env.updateTernary_env (ρ : Env) (τ₁ τ₂ τ₃ τ₄ : Srt) (x : String)
-    (f : τ₁.denote → τ₂.denote → τ₃.denote → τ₄.denote) :
-    (ρ.updateTernary τ₁ τ₂ τ₃ τ₄ x f).env = ρ.env.updateTernary τ₁ τ₂ τ₃ τ₄ x f := rfl
-
-def Env.updateUnaryRel (ρ : Env) (τ : Srt) (x : String) (f : τ.denote → Prop) : Env :=
-  { ρ with env := _root_.Env.updateUnaryRel ρ.env τ x f }
-
-@[simp] theorem Env.updateUnaryRel_env (ρ : Env) (τ : Srt) (x : String) (f : τ.denote → Prop) :
-    (ρ.updateUnaryRel τ x f).env = ρ.env.updateUnaryRel τ x f := rfl
-
-def Env.updateBinaryRel (ρ : Env) (τ₁ τ₂ : Srt) (x : String)
-    (f : τ₁.denote → τ₂.denote → Prop) : Env :=
-  { ρ with env := _root_.Env.updateBinaryRel ρ.env τ₁ τ₂ x f }
-
-@[simp] theorem Env.updateBinaryRel_env (ρ : Env) (τ₁ τ₂ : Srt) (x : String)
-    (f : τ₁.denote → τ₂.denote → Prop) :
-    (ρ.updateBinaryRel τ₁ τ₂ x f).env = ρ.env.updateBinaryRel τ₁ τ₂ x f := rfl
-
 /-- Builtin declarations the verifier requires in a signature; extend with a
 field per builtin. -/
 structure Builtins.wf (Δ : Signature) : Prop where
@@ -88,80 +38,7 @@ theorem Builtins.wf.mono {Δ Δ' : Signature} (hsub : Δ.Subset Δ')
 /-- Facts about the environment required by the verifier's builtin constants;
 extend with a field per builtin. -/
 structure Builtins.holdsFor (ρ : Env) : Prop where
-  guard : ρ.env.supportsGuarding
-
-def Env.withEnv (ρ : Env) (env' : _root_.Env) : Env :=
-  { ρ with env := env' }
-
-@[simp] theorem Env.withEnv_env (ρ : Env) (env' : _root_.Env) :
-    (ρ.withEnv env').env = env' := rfl
-
-def Env.agreeOn (Δ : Signature) (ρ ρ' : Env) : Prop :=
-  _root_.Env.agreeOn Δ ρ.env ρ'.env
-
-theorem Env.agreeOn_refl : Env.agreeOn Δ ρ ρ :=
-  _root_.Env.agreeOn_refl
-
-theorem Env.agreeOn_mono {Δ₁ Δ₂ : Signature} (hsub : Δ₁.Subset Δ₂)
-    (h : Env.agreeOn Δ₂ ρ ρ') : Env.agreeOn Δ₁ ρ ρ' :=
-  _root_.Env.agreeOn_mono hsub h
-
-theorem Env.agreeOn_symm {Δ : Signature} (h : Env.agreeOn Δ ρ ρ') :
-    Env.agreeOn Δ ρ' ρ :=
-  _root_.Env.agreeOn_symm h
-
-theorem Env.agreeOn_trans {Δ : Signature}
-    (h₁₂ : Env.agreeOn Δ ρ₁ ρ₂) (h₂₃ : Env.agreeOn Δ ρ₂ ρ₃) :
-    Env.agreeOn Δ ρ₁ ρ₃ :=
-  _root_.Env.agreeOn_trans h₁₂ h₂₃
-
-theorem Env.agreeOn_declVar {ρ ρ' : Env} {Δ : Signature} {τ : Srt} {x : String} {v : τ.denote} :
-    Env.agreeOn Δ ρ ρ' →
-    Env.agreeOn (Δ.declVar ⟨x, τ⟩) (ρ.updateConst τ x v) (ρ'.updateConst τ x v) := by
-  intro hagree
-  simpa [Env.agreeOn, Env.updateConst] using
-    (_root_.Env.agreeOn_declVar (ρ := ρ.env) (ρ' := ρ'.env) (Δ := Δ) (τ := τ) (x := x) (v := v) hagree)
-
-theorem Env.agreeOn_update_fresh {ρ : Env} {c : FOL.Const} {u : c.sort.denote}
-    {Δ : Signature} (hfresh : c.name ∉ Δ.allNames) :
-    Env.agreeOn Δ ρ (ρ.updateConst c.sort c.name u) := by
-  simpa [Env.agreeOn, Env.updateConst] using
-    (Env.agreeOn_update_fresh_const (ρ := ρ.env) (c := c) (u := u) (Δ := Δ) hfresh)
-
-theorem Env.agreeOn_update_fresh_unary {ρ : Env} {u : FOL.Unary}
-    {f : u.arg.denote → u.ret.denote}
-    {Δ : Signature} (hfresh : u.name ∉ Δ.allNames) :
-    Env.agreeOn Δ ρ (ρ.updateUnary u.arg u.ret u.name f) := by
-  simpa [Env.agreeOn, Env.updateUnary] using
-    (_root_.Env.agreeOn_update_fresh_unary (ρ := ρ.env) (u := u) (f := f) (Δ := Δ) hfresh)
-
-theorem Env.agreeOn_update_fresh_binary {ρ : Env} {b : FOL.Binary}
-    {f : b.arg1.denote → b.arg2.denote → b.ret.denote}
-    {Δ : Signature} (hfresh : b.name ∉ Δ.allNames) :
-    Env.agreeOn Δ ρ (ρ.updateBinary b.arg1 b.arg2 b.ret b.name f) := by
-  simpa [Env.agreeOn, Env.updateBinary] using
-    (_root_.Env.agreeOn_update_fresh_binary (ρ := ρ.env) (b := b) (f := f) (Δ := Δ) hfresh)
-
-theorem Env.agreeOn_update_fresh_ternary {ρ : Env} {t : FOL.Ternary}
-    {f : t.arg1.denote → t.arg2.denote → t.arg3.denote → t.ret.denote}
-    {Δ : Signature} (hfresh : t.name ∉ Δ.allNames) :
-    Env.agreeOn Δ ρ (ρ.updateTernary t.arg1 t.arg2 t.arg3 t.ret t.name f) := by
-  simpa [Env.agreeOn, Env.updateTernary] using
-    (_root_.Env.agreeOn_update_fresh_ternary (ρ := ρ.env) (t := t) (f := f) (Δ := Δ) hfresh)
-
-theorem Env.agreeOn_update_fresh_unaryRel {ρ : Env} {u : FOL.UnaryRel}
-    {f : u.arg.denote → Prop}
-    {Δ : Signature} (hfresh : u.name ∉ Δ.allNames) :
-    Env.agreeOn Δ ρ (ρ.updateUnaryRel u.arg u.name f) := by
-  simpa [Env.agreeOn, Env.updateUnaryRel] using
-    (_root_.Env.agreeOn_update_fresh_unaryRel (ρ := ρ.env) (u := u) (f := f) (Δ := Δ) hfresh)
-
-theorem Env.agreeOn_update_fresh_binaryRel {ρ : Env} {b : FOL.BinaryRel}
-    {f : b.arg1.denote → b.arg2.denote → Prop}
-    {Δ : Signature} (hfresh : b.name ∉ Δ.allNames) :
-    Env.agreeOn Δ ρ (ρ.updateBinaryRel b.arg1 b.arg2 b.name f) := by
-  simpa [Env.agreeOn, Env.updateBinaryRel] using
-    (_root_.Env.agreeOn_update_fresh_binaryRel (ρ := ρ.env) (b := b) (f := f) (Δ := Δ) hfresh)
+  guard : ρ.supportsGuarding
 
 /-- Builtin facts transfer along environments that agree on a signature
 declaring the builtins. -/
@@ -174,13 +51,13 @@ end VerifM
 
 /-- Semantic interpretation of a verifier context item. -/
 def CtxItem.interp [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
-    (ρ : VerifM.Env) : CtxItem → iProp
-  | .pure φ => ⌜φ.eval ρ.env⌝
-  | .spatial a => a.interp W ρ.env
+    (ρ : Env) : CtxItem → iProp
+  | .pure φ => ⌜φ.eval ρ⌝
+  | .spatial a => a.interp W ρ
 
-def CtxItem.purePart (i : CtxItem) (ρ : VerifM.Env) : Prop :=
+def CtxItem.purePart (i : CtxItem) (ρ : Env) : Prop :=
   match i with
-  | .pure φ => φ.eval ρ.env
+  | .pure φ => φ.eval ρ
   | .spatial _ => True
 
 /-- Pure formulas implied by an item's interpretation. -/
@@ -197,8 +74,8 @@ theorem CtxItem.facts_wfIn {i : CtxItem} {Δ : Signature} (h : i.wfIn Δ) :
 
 /-- An item's interpretation implies its pure facts. -/
 theorem CtxItem.interp_facts [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
-    (ρ : VerifM.Env) (i : CtxItem) :
-    i.interp W ρ ⊢ ⌜∀ φ ∈ i.facts, φ.eval ρ.env⌝ ∗ i.interp W ρ := by
+    (ρ : Env) (i : CtxItem) :
+    i.interp W ρ ⊢ ⌜∀ φ ∈ i.facts, φ.eval ρ⌝ ∗ i.interp W ρ := by
   cases i with
   | pure φ =>
     istart
@@ -211,12 +88,12 @@ theorem CtxItem.interp_facts [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
     exact SpatialAtom.interp_facts W a
 
 def TransState.sl [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
-    (st : TransState) (ρ : VerifM.Env) : iProp :=
-  SpatialContext.interp W ρ.env st.owns
+    (st : TransState) (ρ : Env) : iProp :=
+  SpatialContext.interp W ρ st.owns
 
 @[simp] theorem TransState.sl_eq [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
-    (st : TransState) (ρ : VerifM.Env) :
-    st.sl W ρ = SpatialContext.interp W ρ.env st.owns := rfl
+    (st : TransState) (ρ : Env) :
+    st.sl W ρ = SpatialContext.interp W ρ st.owns := rfl
 
 /-- Drop the non-persistent spatial part of the verifier state. -/
 def TransState.persist (st : TransState) : TransState :=
@@ -229,7 +106,7 @@ def TransState.persist (st : TransState) : TransState :=
     st.persist.asserts = st.asserts := rfl
 
 theorem TransState.sl_entails_persist [MicaGS HasLC.hasLC Sig] (W : TinyML.World)
-    (st : TransState) (ρ : VerifM.Env) :
+    (st : TransState) (ρ : Env) :
     st.sl W ρ ⊢ □ st.persist.sl W ρ := by
   istart
   iintro _
@@ -287,11 +164,11 @@ def TransState.init : TransState := ⟨Signature.empty.addConst guardConst, [], 
 
 /-- The environment satisfies the verifier state: every assertion holds and the
 builtin facts are in force. -/
-structure TransState.holdsFor (st : TransState) (ρ : VerifM.Env) : Prop where
-  asserts : ∀ φ ∈ st.asserts, φ.eval ρ.env
+structure TransState.holdsFor (st : TransState) (ρ : Env) : Prop where
+  asserts : ∀ φ ∈ st.asserts, φ.eval ρ
   builtins : VerifM.Builtins.holdsFor ρ
 
-theorem TransState.holdsFor_mono {st st' : TransState} {ρ : VerifM.Env}
+theorem TransState.holdsFor_mono {st st' : TransState} {ρ : Env}
     (hsub : st.asserts ⊆ st'.asserts) (h : st'.holdsFor ρ) : st.holdsFor ρ :=
   ⟨fun φ hφ => h.asserts φ (hsub hφ), h.builtins⟩
 
@@ -309,13 +186,13 @@ theorem TransState.init_wf : TransState.init.wf where
   builtins := ⟨List.Mem.head _⟩
 
 /-- The canonical initial environment: the guard constant pinned to true. -/
-def VerifM.Env.init : VerifM.Env :=
-  VerifM.Env.empty.updateConst guardConst.sort guardConst.name true
+def Env.init : Env :=
+  Env.empty.updateConst guardConst.sort guardConst.name true
 
-theorem TransState.init_holdsFor : TransState.init.holdsFor VerifM.Env.init where
+theorem TransState.init_holdsFor : TransState.init.holdsFor Env.init where
   asserts := fun φ hφ => by simp [TransState.init] at hφ
-  builtins := ⟨by simpa [VerifM.Env.init] using
-    Env.supportsGuarding_updateConst VerifM.Env.empty.env⟩
+  builtins := ⟨by simpa [Env.init] using
+    Env.supportsGuarding_updateConst Env.empty⟩
 
 def TransState.freshConst (hint : Option String) (t : Srt) (st : TransState) : FOL.Const :=
   let base := hint.getD "_v"


### PR DESCRIPTION
This PR flattens the wrapper that was introduced in the verifier around the environment:
```
structure Env where
  env : _root_.Env
```