### PR TITLE
Move a spec's argument and result types out of `Spec`

### DIFF
--- a/Mica/SourceTinyML/Assertions.lean
+++ b/Mica/SourceTinyML/Assertions.lean
@@ -94,10 +94,10 @@ instance : DecidableEq PredTrans := by
 -- Specifications
 -- ---------------------------------------------------------------------------
 
-/-- A complete specification for a (possibly multi-argument) function, pairing the
-    predicate transformer with the argument and return types from the function annotation. -/
+/-- A complete specification for a (possibly multi-argument) function: the
+    argument names and the predicate transformer describing its behavior. The
+    argument and result *types* live in the enclosing n-ary arrow, not here. -/
 structure Spec where
-  args    : List (String × TinyML.Typ)
-  retTy   : TinyML.Typ
-  pred    : PredTrans
+  args : List String
+  pred : PredTrans
   deriving DecidableEq

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -579,8 +579,9 @@ private def specArgTypes : List Typed.Binder → List String → Except TypeErro
 
 /-- Elaborate a spec body against its function's typed signature, layering the
 spec's arguments on top of the program's global bindings `Γbase`. The argument
-and return types recovered here are exactly the ones the resulting `Spec`
-carries. -/
+and return types recovered here type the spec's leaf expressions; the `Spec`
+itself keeps only the argument names, since the types belong to the function's
+arrow. -/
 def elabSpecBody (env : SpecEnv σ) (Θ : TypeEnv) (Γbase : TyCtx) (body : Typed.Expr)
     (rb : Spec.Body Untyped.Expr) : TypeM σ Spec := do
   let (names, pre) := rb
@@ -594,7 +595,7 @@ def elabSpecBody (env : SpecEnv σ) (Θ : TypeEnv) (Γbase : TyCtx) (body : Type
       let post' ← elabPost env Θ (Γ.extend vname retTy) (ns ++ [vname]) post
       pure (vname, post'))
     Γ₀ names pre
-  pure { args := argTys, retTy := retTy, pred := pred }
+  pure { args := names, pred := pred }
 
 /-- Elaborate a declaration's optional spec against the typed function `body`. -/
 def elabSpec (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TyCtx) (body : Typed.Expr) :

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -67,11 +67,11 @@ theorem valsHaveTypes_off_shape [MicaGS HasLC.hasLC Sig] {W : TinyML.World}
 /-- Respect for an arity-one symbol survives the argument-binding fold; each
     step rebinds a `value` constant, which never touches the unary table. -/
 private theorem respects_argsEnv_one {s : FOL.Symbol .one} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : Env},
+    ∀ (args : List String) (vs : List Runtime.Val) {ρ : Env},
       ρ.respects (some s) → (Spec.argsEnv ρ args vs).respects (some s)
   | [], _, _, h => h
   | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
+  | _ :: rest, _ :: vs, ρ, h => by
       simp only [Spec.argsEnv]
       refine respects_argsEnv_one rest vs ?_
       simpa only [Env.respects, Env.updateConst_unary] using h
@@ -79,11 +79,11 @@ private theorem respects_argsEnv_one {s : FOL.Symbol .one} :
 /-- Respect for an arity-two symbol survives the argument-binding fold; each
     step rebinds a `value` constant, which never touches the binary table. -/
 private theorem respects_argsEnv_two {s : FOL.Symbol .two} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : Env},
+    ∀ (args : List String) (vs : List Runtime.Val) {ρ : Env},
       ρ.respects (some s) → (Spec.argsEnv ρ args vs).respects (some s)
   | [], _, _, h => h
   | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
+  | _ :: rest, _ :: vs, ρ, h => by
       simp only [Spec.argsEnv]
       refine respects_argsEnv_two rest vs ?_
       simpa only [Env.respects, Env.updateConst_binary] using h
@@ -91,11 +91,11 @@ private theorem respects_argsEnv_two {s : FOL.Symbol .two} :
 /-- Respect for an arity-three symbol survives the argument-binding fold; each
     step rebinds a `value` constant, which never touches the ternary table. -/
 private theorem respects_argsEnv_three {s : FOL.Symbol .three} :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val) {ρ : Env},
+    ∀ (args : List String) (vs : List Runtime.Val) {ρ : Env},
       ρ.respects (some s) → (Spec.argsEnv ρ args vs).respects (some s)
   | [], _, _, h => h
   | _ :: _, [], _, h => h
-  | (_, _) :: rest, _ :: vs, ρ, h => by
+  | _ :: rest, _ :: vs, ρ, h => by
       simp only [Spec.argsEnv]
       refine respects_argsEnv_three rest vs ?_
       simpa only [Env.respects, Env.updateConst_ternary] using h
@@ -453,9 +453,10 @@ def Zero.toIntrinsic (b : Zero) : Intrinsic where
   path   := b.path
   reduce := Reduce.pure fun () v => v = b.res.inject b.f
   wp     := fun () Q => Q (b.res.inject b.f)
+  argTys := []
+  retTy  := b.res.typ
   spec   :=
     { args  := []
-      retTy := b.res.typ
       pred  := .ret ("ret",
         .assert (.eq .value (.var .value "ret") b.opTerm) (.ret ())) }
   typing := schemeTyping []
@@ -467,9 +468,6 @@ def Zero.toIntrinsic (b : Zero) : Intrinsic where
 
 @[simp] theorem Zero.toReduce_eq (b : Zero) (v : Runtime.Val) (μ μ' : TinyML.Heap) :
     b.toIntrinsic.toReduce [] μ v μ' = (v = b.res.inject b.f ∧ μ' = μ) := rfl
-
-@[simp] theorem Zero.instantiate_retTy (b : Zero) (σ : TinyML.TyVar → TinyML.Typ) :
-    (b.toIntrinsic.spec.instantiate σ).retTy = b.res.typ.subst σ := rfl
 
 /-- Proof obligations for a pure zero-arity intrinsic. The `nameFresh` premise
     keeps the generated constant symbol distinct from the spec's `"ret"`
@@ -489,6 +487,7 @@ structure Zero.Lawful (b : Zero) where
 /-- The `IntrinsicSound` instance for a pure zero-arity intrinsic. -/
 @[reducible] def Zero.Lawful.sound {b : Zero} (l : b.Lawful) :
     IntrinsicSound [b.toIntrinsic] b.toIntrinsic where
+  argLen := rfl
   specWf := fun _ hsub hwf => specWf_of_base l.specBaseWf hsub hwf
   wp_sound := by
     intro _ ctx hctx vs Φ
@@ -509,7 +508,6 @@ structure Zero.Lawful (b : Zero) where
       iexact HΦ
   bridge := by
     intro _ σ W vs ρ Φ hρ
-    simp only [Zero.instantiate_retTy, Spec.instantiate_pred]
     show TinyML.ValsHaveTypes W vs [] ∗ _ ⊢ _
     match vs with
     | _ :: _ => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -592,9 +590,10 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
   reduce := Reduce.pure fun a v =>
     ∃ x, a = b.arg.inject x ∧ b.dom x ∧ v = b.res.inject (b.f x)
   wp     := fun a Q => iprop(∃ x, ⌜a = b.arg.inject x ∧ b.dom x⌝ ∗ Q (b.res.inject (b.f x)))
+  argTys := [b.arg.typ]
+  retTy  := b.res.typ
   spec   :=
-    { args  := [("a", b.arg.typ)]
-      retTy := b.res.typ
+    { args  := ["a"]
       pred  := withPre (b.pre.map (· "a")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a"))) (.ret ())) }
@@ -616,11 +615,11 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a"))) (.ret ()))) := rfl
 
-@[simp] theorem Unary.instantiate_args (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
-    (b.toIntrinsic.spec.instantiate σ).args = [("a", b.arg.typ.subst σ)] := rfl
+@[simp] theorem Unary.argTys_map_subst (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
+    b.toIntrinsic.argTys.map (·.subst σ) = [b.arg.typ.subst σ] := rfl
 
-@[simp] theorem Unary.instantiate_retTy (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
-    (b.toIntrinsic.spec.instantiate σ).retTy = b.res.typ.subst σ := rfl
+@[simp] theorem Unary.retTy_subst (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
+    b.toIntrinsic.retTy.subst σ = b.res.typ.subst σ := rfl
 
 /-- Proof obligations for a pure unary intrinsic. `domSound` extracts the
     carrier-level domain from the evaluated precondition; when `pre = none` the
@@ -646,6 +645,7 @@ structure Unary.Lawful (b : Unary) where
 /-- The `IntrinsicSound` instance for a pure unary intrinsic. -/
 @[reducible] def Unary.Lawful.sound {b : Unary} (l : b.Lawful) :
     IntrinsicSound [b.toIntrinsic] b.toIntrinsic where
+  argLen := rfl
   specWf := fun _ hsub hwf => specWf_of_base l.specBaseWf hsub hwf
   wp_sound := by
     intro _ ctx hctx vs Φ
@@ -678,8 +678,7 @@ structure Unary.Lawful (b : Unary) where
       iexact HΦ
   bridge := by
     intro _ σ W vs ρ Φ hρ
-    simp only [Unary.instantiate_args, Unary.instantiate_retTy,
-      Spec.instantiate_pred, Unary.spec_pred, List.map_cons, List.map_nil]
+    simp only [Unary.argTys_map_subst, Unary.retTy_subst, Unary.spec_pred]
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | _ :: _ :: _ =>
@@ -798,9 +797,10 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
   wp     := fun (a, c) Q =>
     iprop(∃ x y, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ b.dom x y⌝ ∗
       Q (b.res.inject (b.f x y)))
+  argTys := [b.arg₁.typ, b.arg₂.typ]
+  retTy  := b.res.typ
   spec   :=
-    { args  := [("a", b.arg₁.typ), ("b", b.arg₂.typ)]
-      retTy := b.res.typ
+    { args  := ["a", "b"]
       pred  := withPre (b.pre.map (· "a" "b")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())) }
@@ -824,12 +824,12 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ()))) := rfl
 
-@[simp] theorem Binary.instantiate_args (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
-    (b.toIntrinsic.spec.instantiate σ).args
-      = [("a", b.arg₁.typ.subst σ), ("b", b.arg₂.typ.subst σ)] := rfl
+@[simp] theorem Binary.argTys_map_subst (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
+    b.toIntrinsic.argTys.map (·.subst σ)
+      = [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ] := rfl
 
-@[simp] theorem Binary.instantiate_retTy (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
-    (b.toIntrinsic.spec.instantiate σ).retTy = b.res.typ.subst σ := rfl
+@[simp] theorem Binary.retTy_subst (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
+    b.toIntrinsic.retTy.subst σ = b.res.typ.subst σ := rfl
 
 /-- Proof obligations for a pure binary intrinsic: lawful embeddings, the three
     well-formedness facts (spec/def-axiom/type-axiom — one-liners at literal
@@ -858,6 +858,7 @@ structure Binary.Lawful (b : Binary) where
 /-- The whole `IntrinsicSound` instance for a pure binary intrinsic. -/
 @[reducible] def Binary.Lawful.sound {b : Binary} (l : b.Lawful) :
     IntrinsicSound [b.toIntrinsic] b.toIntrinsic where
+  argLen := rfl
   specWf := fun _ hsub hwf => specWf_of_base l.specBaseWf hsub hwf
   wp_sound := by
     intro _ ctx hctx vs Φ
@@ -895,8 +896,7 @@ structure Binary.Lawful (b : Binary) where
       iexact HΦ
   bridge := by
     intro _ σ W vs ρ Φ hρ
-    simp only [Binary.instantiate_args, Binary.instantiate_retTy,
-      Spec.instantiate_pred, Binary.spec_pred, List.map_cons, List.map_nil]
+    simp only [Binary.argTys_map_subst, Binary.retTy_subst, Binary.spec_pred]
     show TinyML.ValsHaveTypes W vs [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ] ∗ _ ⊢ _
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -1035,9 +1035,10 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
   wp     := fun (a, c, d) Q =>
     iprop(∃ x y z, ⌜a = b.arg₁.inject x ∧ c = b.arg₂.inject y ∧ d = b.arg₃.inject z ∧
       b.dom x y z⌝ ∗ Q (b.res.inject (b.f x y z)))
+  argTys := [b.arg₁.typ, b.arg₂.typ, b.arg₃.typ]
+  retTy  := b.res.typ
   spec   :=
-    { args  := [("a", b.arg₁.typ), ("b", b.arg₂.typ), ("c", b.arg₃.typ)]
-      retTy := b.res.typ
+    { args  := ["a", "b", "c"]
       pred  := withPre (b.pre.map (· "a" "b" "c")) <| .ret ("ret",
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())) }
@@ -1061,12 +1062,12 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
         .assert (.eq .value (.var .value "ret")
           (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ()))) := rfl
 
-@[simp] theorem Ternary.instantiate_args (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
-    (b.toIntrinsic.spec.instantiate σ).args
-      = [("a", b.arg₁.typ.subst σ), ("b", b.arg₂.typ.subst σ), ("c", b.arg₃.typ.subst σ)] := rfl
+@[simp] theorem Ternary.argTys_map_subst (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
+    b.toIntrinsic.argTys.map (·.subst σ)
+      = [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ, b.arg₃.typ.subst σ] := rfl
 
-@[simp] theorem Ternary.instantiate_retTy (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
-    (b.toIntrinsic.spec.instantiate σ).retTy = b.res.typ.subst σ := rfl
+@[simp] theorem Ternary.retTy_subst (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
+    b.toIntrinsic.retTy.subst σ = b.res.typ.subst σ := rfl
 
 /-- Proof obligations for a pure ternary intrinsic. -/
 structure Ternary.Lawful (b : Ternary) where
@@ -1095,6 +1096,7 @@ structure Ternary.Lawful (b : Ternary) where
 /-- The whole `IntrinsicSound` instance for a pure ternary intrinsic. -/
 @[reducible] def Ternary.Lawful.sound {b : Ternary} (l : b.Lawful) :
     IntrinsicSound [b.toIntrinsic] b.toIntrinsic where
+  argLen := rfl
   specWf := fun _ hsub hwf => specWf_of_base l.specBaseWf hsub hwf
   wp_sound := by
     intro _ ctx hctx vs Φ
@@ -1136,8 +1138,7 @@ structure Ternary.Lawful (b : Ternary) where
       iexact HΦ
   bridge := by
     intro _ σ W vs ρ Φ hρ
-    simp only [Ternary.instantiate_args, Ternary.instantiate_retTy,
-      Spec.instantiate_pred, Ternary.spec_pred, List.map_cons, List.map_nil]
+    simp only [Ternary.argTys_map_subst, Ternary.retTy_subst, Ternary.spec_pred]
     show TinyML.ValsHaveTypes W vs
       [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ, b.arg₃.typ.subst σ] ∗ _ ⊢ _
     match vs with

--- a/Mica/Verifier/BoundedQuantifier.lean
+++ b/Mica/Verifier/BoundedQuantifier.lean
@@ -180,9 +180,10 @@ def intrinsic (name : String) (path : String) : Verifier.Intrinsic where
   path := some ("Range", [path])
   reduce := fun _ _ _ _ => False
   wp := fun _ _ => iprop(False)
+  argTys := [.int, .int, .arrow [.int] .bool]
+  retTy := .bool
   spec :=
-    { args := [("lo", .int), ("hi", .int), ("body", .arrow [.int] .bool)]
-      retTy := .bool
+    { args := ["lo", "hi", "body"]
       pred := .assert .false_ (.ret ("ret", .ret ())) }
   typing := Verifier.monoTyping .three
   folSym := none
@@ -203,13 +204,14 @@ def existsIntrinsic : Verifier.Intrinsic := intrinsic existsName "exists"
 are both false, and it contributes no solver symbols or axioms. -/
 @[reducible] def intrinsicSound (name path : String) :
     Verifier.IntrinsicSound [] (intrinsic name path) where
+  argLen := rfl
   specWf := by
     intro Δ _ _
     simp [intrinsic, Verifier.Intrinsic.specArgs, PredTrans.wfIn, Assertion.wfIn]
     trivial
   bridge := by
     intro _ σ Θ vs ρ Φ _
-    simp only [intrinsic, Spec.instantiate, PredTrans.apply, Assertion.pre]
+    simp only [intrinsic, PredTrans.apply, Assertion.pre]
     iintro H
     icases H with ⟨_, %hfalse, _⟩
     exact hfalse.elim

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -272,22 +272,23 @@ mutual
           VerifM.assume (.pure sc.isFalse)
           compile reg Θ Δ_spec S B Γ els
     | .app (.var f fty) args aty => do
-        let spec ← VerifM.expectSome s!"no spec for function {f}" (S.lookup f)
+        let e ← VerifM.expectSome s!"no spec for function {f}" (S.lookup f)
         let sterms ← compileExprs reg Θ Δ_spec S B Γ args
         let sargs := (args.map Expr.ty).zip sterms
-        VerifM.expectEq "app type annotation mismatch" spec.retTy aty
+        VerifM.expectEq "app type annotation mismatch" e.retTy aty
         VerifM.expectEq "app type annotation mismatch"
-          fty (.arrow (spec.args.map Prod.snd) spec.retTy)
-        let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) spec sargs
+          fty (.arrow e.argTys e.retTy)
+        let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) e.argTys e.retTy e.spec sargs
         pure result
     | .app (.prim n inst _) args aty => do
         let i ← VerifM.expectSome s!"unknown primitive `{n}`"
           (reg.lookup? n)
-        let spec := i.spec.instantiate fun v => (inst.lookup v).getD (.tvar v)
-        VerifM.expectEq "primitive return type mismatch" spec.retTy aty
+        let σi : TinyML.TyVar → TinyML.Typ := fun v => (inst.lookup v).getD (.tvar v)
+        VerifM.expectEq "primitive return type mismatch" (i.retTy.subst σi) aty
         let sterms ← compileExprs reg Θ Δ_spec S B Γ args
         let sargs := (args.map Expr.ty).zip sterms
-        let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) spec sargs
+        let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec)
+          (i.argTys.map (·.subst σi)) (i.retTy.subst σi) i.spec sargs
         pure result
     | .prim n _ _ => VerifM.fatal s!"primitive `{n}` must be applied"
     | .tuple es => do
@@ -2926,19 +2927,20 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       obtain ⟨_, hΨ_args⟩ := VerifM.eval_bind_expectEq hΨ_args
       have hΔspec_args : W.Δ_spec.Subset st_args.decls := hag.subset.trans hdecls_args
       have hst_args_wf : st_args.decls.wf := (VerifM.eval.wf hΨ_args).namesDisjoint
-      have hwf_pred : spec.pred.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars (Spec.argVars spec.args)) := by
-        simpa [FiniteSubst.base, Signature.declVars] using hSwf f spec hlookup
+      have hlen_e : spec.spec.args.length = spec.argTys.length := (hSwf f spec hlookup).1
+      have hwf_pred : spec.spec.pred.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars (Spec.argVars spec.spec.args)) := by
+        simpa [FiniteSubst.base, Signature.declVars] using (hSwf f spec hlookup).2
       have hbase_wf : (FiniteSubst.base W.Δ_spec).wfIn W.Δ_spec st_args.decls :=
         FiniteSubst.base_wfIn hΔspec_args hwf.wf hst_args_wf hwf.vars
       have htypedArgs_wf : ∀ p ∈ typedArgs, p.2.wfIn st_args.decls := by
         intro p hp
         have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
         exact hsargs_wf _ hp''
-      have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base W.Δ_spec) spec typedArgs) st_args ρ_args
+      have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base W.Δ_spec) spec.argTys spec.retTy spec.spec typedArgs) st_args ρ_args
           (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind hΨ_args
-      have hcall := Spec.call_correct W spec W.Δ_spec (FiniteSubst.base W.Δ_spec) typedArgs st_args ρ_args
+      have hcall := Spec.call_correct W spec.argTys spec.retTy spec.spec W.Δ_spec (FiniteSubst.base W.Δ_spec) typedArgs st_args ρ_args
         (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
-        hwf_pred
+        hlen_e hwf_pred
         hbase_wf htypedArgs_wf hcall_eval
         (fun v st' ρ' t hΨ hwf heval => by
           have h := hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval
@@ -2954,7 +2956,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
             · iexact HR')
       obtain ⟨hsub_ty, happly⟩ := hcall
       refine SpatialContext.wp_val ?_
-      unfold Spec.isPrecondFor
+      unfold SpecEntry.isPrecondFor Spec.isPrecondFor
       istart
       iintro ⟨Howns, Hvals, #HS, #Hspec, HR⟩
       iintuitionistic Hvals
@@ -2962,7 +2964,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       ipure Hlen
       have hlen_typed : (args.map Expr.ty).length = sargs.length := by
         rw [← Hlen]; exact hlen_sargs.symm
-      have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
+      have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) spec.argTys := by
         simpa [typedArgs, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
       have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
         have hsnd :
@@ -2976,13 +2978,10 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
                   simpa [typedArgs, List.map_map] using
                     congrArg (List.map (fun t => t.eval ρ_args)) hsnd
           _ = vs := Terms.Eval.map_eval heval_sargs
-      have hlen_vs : vs.length = (spec.args.map Prod.snd).length := by
-        have := hsub_ty'.length_eq
-        rw [Hlen]; exact this
       have happly' :
           st_args.sl W ρ_args ∗ R ⊢
-            PredTrans.apply W (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.pred
-              (Spec.argsEnv ρ_args spec.args vs) := by
+            PredTrans.apply W (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.spec.pred
+              (Spec.argsEnv ρ_args spec.spec.args vs) := by
         rw [heval_sargs_map] at happly
         exact happly
       have hagree_ρ_args : Env.agreeOn W.Δ_spec W.ρ_spec ρ_args :=
@@ -3014,16 +3013,19 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
     obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
     let σi : TinyML.TyVar → TinyML.Typ := fun v => (inst.lookup v).getD (.tvar v)
-    let spec := i.spec.instantiate σi
+    let argTys := i.argTys.map (·.subst σi)
+    let retTy := i.retTy.subst σi
     let typedArgs := (args.map Expr.ty).zip sargs
     have hlen_sargs : sargs.length = vs.length := by
       simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
     have hΔspec_args : W.Δ_spec.Subset st_args.decls := hag.subset.trans hdecls_args
     have hst_args_wf : st_args.decls.wf := (VerifM.eval.wf hΨ_args).namesDisjoint
+    have hlen_i : i.spec.args.length = argTys.length := by
+      simp only [argTys, List.length_map]; exact hbridge.argLen
     have hwf_pred :
-        spec.pred.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars
-          (Spec.argVars spec.args)) := by
-      simpa [spec, FiniteSubst.base, Signature.declVars, Verifier.Intrinsic.specArgs] using
+        i.spec.pred.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars
+          (Spec.argVars i.spec.args)) := by
+      simpa [FiniteSubst.base, Signature.declVars, Verifier.Intrinsic.specArgs] using
         hbridge.specWf W.Δ_spec (hΔreg i hi_mem) hwf.wf
     have hbase_wf : (FiniteSubst.base W.Δ_spec).wfIn W.Δ_spec st_args.decls :=
       FiniteSubst.base_wfIn hΔspec_args hwf.wf hst_args_wf hwf.vars
@@ -3031,13 +3033,13 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       intro p hp
       have hp'' : p.2 ∈ sargs := (List.of_mem_zip hp).2
       exact hsargs_wf _ hp''
-    have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base W.Δ_spec) spec typedArgs) st_args ρ_args
+    have hcall_eval : VerifM.eval (Spec.call W.Θ (FiniteSubst.base W.Δ_spec) argTys retTy i.spec typedArgs) st_args ρ_args
         (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) := VerifM.eval_bind hΨ_args
-    have hcall := Spec.call_correct W spec W.Δ_spec (FiniteSubst.base W.Δ_spec) typedArgs st_args ρ_args
+    have hcall := Spec.call_correct W argTys retTy i.spec W.Δ_spec (FiniteSubst.base W.Δ_spec) typedArgs st_args ρ_args
       (fun p st' ρ' => VerifM.eval (pure p.2) st' ρ' Ψ) Φ R
-      hwf_pred hbase_wf htypedArgs_wf hcall_eval
+      hlen_i hwf_pred hbase_wf htypedArgs_wf hcall_eval
       (fun v st' ρ' t hΨ hwf heval => by
-        have hret_eq' : spec.retTy = aty := hret_eq
+        have hret_eq' : retTy = aty := hret_eq
         have h := hpost v ρ' st' t (VerifM.eval_ret hΨ) hwf heval
         rw [← hret_eq'] at h
         iintro H
@@ -3064,7 +3066,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     ipure Hlen
     have hlen_typed : (args.map Expr.ty).length = sargs.length := by
       rw [← Hlen]; exact hlen_sargs.symm
-    have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) (spec.args.map Prod.snd) := by
+    have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) argTys := by
       have hfst : typedArgs.map Prod.fst = args.map Expr.ty := by
         simpa [typedArgs] using
           (List.map_fst_zip (l₁ := args.map Expr.ty) (l₂ := sargs)
@@ -3084,8 +3086,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
         _ = vs := Terms.Eval.map_eval heval_sargs
     have happly' :
         st_args.sl W ρ_args ∗ R ⊢
-          PredTrans.apply W (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.pred
-            (Spec.argsEnv ρ_args spec.args vs) := by
+          PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) i.spec.pred
+            (Spec.argsEnv ρ_args i.spec.args vs) := by
       rw [heval_sargs_map] at happly
       exact happly
     have hagree_ρ_args : Env.agreeOn W.Δ_spec W.ρ_spec ρ_args :=
@@ -3093,9 +3095,9 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     have hρ_args_reg : ρ_args.respects i.folSym :=
       Env.respects_of_agreeOn_extendWithSym (hρreg i hi_mem) (hΔreg i hi_mem) hagree_ρ_args
     iapply (show
-        TinyML.ValsHaveTypes W vs (spec.args.map Prod.snd) ∗
-          PredTrans.apply W (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.pred
-            (Spec.argsEnv ρ_args spec.args vs) ⊢ i.toWp vs Φ from
+        TinyML.ValsHaveTypes W vs argTys ∗
+          PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) i.spec.pred
+            (Spec.argsEnv ρ_args i.spec.args vs) ⊢ i.toWp vs Φ from
         hbridge.bridge σi W vs ρ_args Φ hρ_args_reg)
     isplitl [Hvals]
     · iapply (TinyML.ValsHaveTypes.sub hsub_ty')

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -21,39 +21,39 @@ open Typed
 
 /-- Compile the body of a specification under its argument context and
     check that the inferred return type is a subtype of the declared one. -/
-def checkBody (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (s : Spec)
+def checkBody (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (e : SpecEntry)
     (argNames : List String) (body : Expr)
     (argVars : List FOL.Const) : VerifM (Term .value) := do
   let B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
-  let Γ := (argNames.zip (s.args.map Prod.snd)).foldl
+  let Γ := (argNames.zip e.argTys).foldl
     (fun ctx (name, ty) => ctx.extend name ty) TinyML.TyCtx.empty
   let se ← compile reg Θ Δ_spec S B Γ body
-  if TinyML.Typ.sub Θ body.ty s.retTy then pure ()
+  if TinyML.Typ.sub Θ body.ty e.retTy then pure ()
   else VerifM.fatal s!"checkSpec: return type mismatch"
   pure se
 
-def checkSpec (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (e : Expr) (s : Spec) : VerifM Unit := do
-  let (fb, argNames, body) ← match e with
+def checkSpec (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (expr : Expr) (e : SpecEntry) : VerifM Unit := do
+  let (fb, argNames, body) ← match expr with
     | .fix fb argBinders _ body => do
-      match extractArgNames argBinders s.args with
+      match extractArgNames argBinders e.spec.args with
       | .ok names => pure (fb, names, body)
       | .error msg => VerifM.fatal msg
     | _ => VerifM.fatal "checkSpec: expected function"
-  let S' := SpecMap.eraseAll argNames (S.insertBinder fb s)
+  let S' := SpecMap.eraseAll argNames (S.insertBinder fb e)
   VerifM.persist
-  Spec.implement Δ_spec s (checkBody reg Θ Δ_spec S' s argNames body)
+  Spec.implement Δ_spec e.argTys e.spec (checkBody reg Θ Δ_spec S' e argNames body)
 
 /-- Soundness of `checkBody`: given argument variables supplied by
     `Spec.implement_correct` and a successful `checkBody` evaluation, the
     compiled body's `wp` holds. -/
 theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (S : SpecMap) (s : Spec)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (S : SpecMap) (e : SpecEntry)
     (γ : Runtime.Subst)
-    (hswf : s.wfIn W.Δ_spec) (hSwf : S.wfIn W.Δ_spec)
+    (hswf : e.wfIn W.Δ_spec) (hSwf : S.wfIn W.Δ_spec)
     (hwf : W.wf)
     (fb : Binder) (argBinders : List Binder) (body : Expr)
     (argNames : List String)
-    (hext : extractArgNames argBinders s.args = Except.ok argNames)
+    (hext : extractArgNames argBinders e.spec.args = Except.ok argNames)
     (bs : List Runtime.Binder) (hbs_def : bs = argBinders.map (·.runtime))
     (fval : Runtime.Val)
     (vs : List Runtime.Val)
@@ -66,22 +66,22 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     (hargVars_sort : ∀ v ∈ argVars, v.sort = .value)
     (hargVars_lookup : List.Forall₂ (fun av val => ρ'.consts .value av.name = val) argVars vs)
     (hbody_eval : VerifM.eval
-        (checkBody reg W.Θ W.Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb s)) s argNames body argVars)
+        (checkBody reg W.Θ W.Δ_spec (SpecMap.eraseAll argNames (S.insertBinder fb e)) e argNames body argVars)
         st' ρ'
         (fun result st'' ρ'' => ∀ S, result.wfIn st''.decls →
           st''.sl W ρ'' ∗ Q ∗
-            ((TinyML.ValHasType W (result.eval ρ'') s.retTy -∗ P (result.eval ρ'')) -∗ S) ⊢ S)) :
-    st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗ Q ⊢
-      (S.satisfiedBy W γ ∗ s.isPrecondFor W fval) -∗
+            ((TinyML.ValHasType W (result.eval ρ'') e.retTy -∗ P (result.eval ρ'')) -∗ S) ⊢ S)) :
+    st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs e.argTys ∗ Q ⊢
+      (S.satisfiedBy W γ ∗ e.isPrecondFor W fval) -∗
         wp W.pctx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P := by
   simp only [checkBody] at hbody_eval
   obtain ⟨hargNames_len, _, hbs_eq⟩ := extractArgNames_spec hext
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_def ▸ hbs_eq
   set γ_body := γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs
-  set S' : SpecMap := SpecMap.eraseAll argNames (S.insertBinder fb s)
+  set S' : SpecMap := SpecMap.eraseAll argNames (S.insertBinder fb e)
   have hS'wf : S'.wfIn W.Δ_spec :=
     SpecMap.wfIn_eraseAll (SpecMap.wfIn_insertBinder hSwf hswf)
-  set Γ := (argNames.zip (s.args.map Prod.snd)).foldl
+  set Γ := (argNames.zip (e.argTys)).foldl
     (fun ctx (x : String × TinyML.Typ) => ctx.extend x.1 x.2) TinyML.TyCtx.empty
   set B : Bindings := Bindings.empty ++ (argNames.zip argVars).reverse
   have hbwf : Bindings.wfIn B st'.decls := by
@@ -94,7 +94,7 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
   iintro ⟨Howns, #Hvals, HQ⟩
   ihave %hlen_vals := TinyML.ValsHaveTypes.length_eq $$ Hvals
   have hlen_nv : argNames.length = vs.length := by
-    simp [List.length_map] at hlen_vals
+    have := hswf.1
     omega
   have hlen_avs : argNames.length = argVars.length := by
     have := hargVars_lookup.length_eq
@@ -113,17 +113,17 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     · exact hargVars_sort
     · exact hargVars_lookup
   have hts :
-      TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ⊢
+      TinyML.ValsHaveTypes W vs (e.argTys) ⊢
         Bindings.typedSubst W B Γ γ_body := by
     iintro #HvalsArg
     iapply (Bindings.typedSubst_of_agreeOnLinked (W := W) hagree)
     imodintro
     iintro %x %x' %t %hmem %hΓ
-    set args' := argNames.zip (s.args.map Prod.snd)
+    set args' := argNames.zip (e.argTys)
     have hfst : args'.map Prod.fst = argNames := by
-      simp [args']; exact List.map_fst_zip (by simp; omega)
-    have hsnd : args'.map Prod.snd = s.args.map Prod.snd := by
-      simp [args']; exact List.map_snd_zip (by simp; omega)
+      simp [args']; exact List.map_fst_zip (by omega)
+    have hsnd : args'.map Prod.snd = e.argTys := by
+      simp [args']; exact List.map_snd_zip (by omega)
     iapply (valHasType_lookup_zip_reverse args' argVars vs ρ' TinyML.TyCtx.empty x x' t
       (by rw [hfst]; exact hlen_avs)
       (by rw [hfst]; exact hlen_nv)
@@ -132,14 +132,14 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     rw [hsnd]
     iassumption
   have hS'_sat :
-      S.satisfiedBy W γ ∗ s.isPrecondFor W fval ⊢
+      S.satisfiedBy W γ ∗ e.isPrecondFor W fval ⊢
         S'.satisfiedBy W γ_body := by
     have hinsert :
-        S.satisfiedBy W γ ∗ s.isPrecondFor W fval ⊢
-          (S.insertBinder fb s).satisfiedBy W (γ.updateBinder fb.runtime fval) :=
+        S.satisfiedBy W γ ∗ e.isPrecondFor W fval ⊢
+          (S.insertBinder fb e).satisfiedBy W (γ.updateBinder fb.runtime fval) :=
       SpecMap.satisfiedBy_insertBinder_updateBinder
     have herase :
-        (S.insertBinder fb s).satisfiedBy W (γ.updateBinder fb.runtime fval) ⊢
+        (S.insertBinder fb e).satisfiedBy W (γ.updateBinder fb.runtime fval) ⊢
           S'.satisfiedBy W ((γ.updateBinder fb.runtime fval).updateAllBinder (argNames.map Runtime.Binder.named) vs) :=
       SpecMap.satisfiedBy_eraseAll_updateAllBinder hlen_nv
     exact hinsert.trans <| by simpa [S', γ_body, hbs_runtime] using herase
@@ -151,7 +151,7 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       hag hΔreg hρreg ?_
     intro v ρ'' st'' se hΨ hse_wf heval_se
     obtain ⟨_, _, hΨ⟩ := hΨ
-    by_cases hsub : TinyML.Typ.sub W.Θ body.ty s.retTy
+    by_cases hsub : TinyML.Typ.sub W.Θ body.ty e.retTy
     case neg =>
       simp [hsub] at hΨ
       exact (VerifM.eval_fatal hΨ).elim
@@ -161,7 +161,7 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     rw [← heval_se]
     refine (show st''.sl W ρ'' ∗ TinyML.ValHasType W (se.eval ρ'') body.ty ∗ Q ⊢
         st''.sl W ρ'' ∗ Q ∗
-          ((TinyML.ValHasType W (se.eval ρ'') s.retTy -∗ P (se.eval ρ'')) -∗
+          ((TinyML.ValHasType W (se.eval ρ'') e.retTy -∗ P (se.eval ρ'')) -∗
             P (se.eval ρ'')) from ?_).trans (hΨ' _ hse_wf)
     iintro ⟨Howns, Hty, HQ⟩
     iframe Howns HQ
@@ -179,26 +179,26 @@ theorem checkBody_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
     iexact Hvals
 
 theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
-    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (S : SpecMap) (e : Expr) (s : Spec)
+    (W : TinyML.World) (hW : W.pctx = reg.primCtx) (S : SpecMap) (expr : Expr) (e : SpecEntry)
     (γ : Runtime.Subst)
-    (hswf : s.wfIn W.Δ_spec) (hSwf : S.wfIn W.Δ_spec)
+    (hswf : e.wfIn W.Δ_spec) (hSwf : S.wfIn W.Δ_spec)
     (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec) :
-    VerifM.eval (checkSpec reg W.Θ W.Δ_spec S e s) st ρ (fun _ _ _ => True) →
-    st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (e.runtime.subst γ) (fun v => s.isPrecondFor W v) := by
+    VerifM.eval (checkSpec reg W.Θ W.Δ_spec S expr e) st ρ (fun _ _ _ => True) →
+    st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (expr.runtime.subst γ) (fun v => e.isPrecondFor W v) := by
   intro heval
   -- All non-`fix` shapes (and bad `extractArgNames`) discharge the same way.
   have elim_bind_fatal : ∀ {α β} {msg} {k : α → VerifM β} {st ρ Ψ},
       VerifM.eval (VerifM.fatal msg >>= k) st ρ Ψ → False :=
     fun h => VerifM.eval_fatal (VerifM.eval_bind h)
-  cases e
+  cases expr
   case fix fb argBinders retTy body =>
     simp only [checkSpec] at heval
     -- Case split on extractArgNames result
-    cases hext : extractArgNames argBinders s.args with
+    cases hext : extractArgNames argBinders e.spec.args with
     | error msg =>
       simp [hext] at heval
       exact (elim_bind_fatal heval).elim
@@ -210,7 +210,7 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       dsimp only at himpl
       set bs := argBinders.map (·.runtime)
       set γ' := (γ.remove' fb.runtime).removeAll' bs with hγ'_def
-      set S' : SpecMap := SpecMap.eraseAll argNames (S.insertBinder fb s)
+      set S' : SpecMap := SpecMap.eraseAll argNames (S.insertBinder fb e)
       have hgoal : (Expr.fix fb argBinders retTy body).runtime.subst γ =
           Runtime.Expr.fix fb.runtime (argBinders.map (·.runtime))
             (body.runtime.subst γ') := by
@@ -219,10 +219,11 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       rw [hgoal]
       set fval := Runtime.Val.fix fb.runtime (argBinders.map (·.runtime))
         (body.runtime.subst γ') with hfval_def
-      obtain ⟨_, hargs_len, hbs_eq⟩ := extractArgNames_spec hext
+      obtain ⟨hnames_len, hargs_len, hbs_eq⟩ := extractArgNames_spec hext
       have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_eq
       apply SpatialContext.wp_func
-      apply Spec.isPrecondFor_fix (by simpa using hargs_len)
+      unfold SpecEntry.isPrecondFor
+      apply Spec.isPrecondFor_fix (by simpa using hargs_len) hswf.1.symm
       istart
       iintro H
       icases H with ⟨Hsl, #Hspec⟩
@@ -232,29 +233,30 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       -- fuse it with γ via `subst_fix_comp` so it matches `body_correct`.
       ihave %hlen_typed := TinyML.ValsHaveTypes.length_eq $$ Htyped
       have hlen_vs : bs.length = vs.length := by
-        simp [hbs_runtime, List.length_map] at hlen_typed ⊢
+        simp only [hbs_runtime, List.length_map]
+        have := hswf.1
         omega
       have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
       simp only [] at hsub; rw [hsub]
-      have hbody' : TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
-          PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
-          (Spec.argsEnv ρ_call s.args vs) ⊢
-          SpecMap.satisfiedBy W S γ ∗ s.isPrecondFor W fval -∗
+      have hbody' : TinyML.ValsHaveTypes W vs e.argTys ∗
+          PredTrans.apply W (fun r => TinyML.ValHasType W r e.retTy -∗ P r) e.spec.pred
+          (Spec.argsEnv ρ_call e.spec.args vs) ⊢
+          SpecMap.satisfiedBy W S γ ∗ e.isPrecondFor W fval -∗
             wp W.pctx (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
         iintro H
         icases H with ⟨Htyped', Hpred'⟩
         iintuitionistic Htyped'
         have hag_persist : W.agrees (TransState.persist st).decls ρ := by
           simpa using hag
-        ihave Hwand := Spec.implement_correct W s _ (TransState.persist st) ρ vs P
-          (TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
-            (S.satisfiedBy W γ ∗ s.isPrecondFor W fval) -∗
+        ihave Hwand := Spec.implement_correct W e.argTys e.retTy e.spec _ (TransState.persist st) ρ vs P
+          (TinyML.ValsHaveTypes W vs e.argTys -∗
+            (S.satisfiedBy W γ ∗ e.isPrecondFor W fval) -∗
               wp W.pctx (body.runtime.subst (γ.updateBinder fb.runtime fval |>.updateAllBinder bs vs)) P)
-          hswf hwf hag_persist himpl
+          hswf.1 hswf.2 hwf hag_persist himpl
           (fun argVars st' ρ' Q hst_sub hρ_agree hargVars_mem hargVars_sort hargVars_lookup hbody_eval => by
             have hag' : W.agrees st'.decls ρ' := hag_persist.step hst_sub hρ_agree
             iintro ⟨Hsl, HQ⟩ Htyped''
-            iapply (checkBody_correct reg hSound W hW S s γ hswf hSwf hwf fb argBinders body argNames
+            iapply (checkBody_correct reg hSound W hW S e γ hswf hSwf hwf fb argBinders body argNames
               hext bs rfl fval vs P hag' hΔreg hρreg hargVars_mem hargVars_sort hargVars_lookup hbody_eval)
             isplitl [Hsl]
             · iexact Hsl
@@ -266,14 +268,13 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
             iempintro
           · isplitl [Htyped']
             · iexact Htyped'
-            · have hlen_vals_call : s.args.length ≤ vs.length := by
-                have hlen := hlen_typed
-                simp [List.length_map] at hlen
+            · have hlen_vals_call : e.spec.args.length ≤ vs.length := by
+                have := hswf.1
                 omega
-              iapply (PredTrans.apply_env_agree W (ρ := Spec.argsEnv ρ_call s.args vs)
-                (ρ' := Spec.argsEnv W.ρ_spec s.args vs) hswf
+              iapply (PredTrans.apply_env_agree W (ρ := Spec.argsEnv ρ_call e.spec.args vs)
+                (ρ' := Spec.argsEnv W.ρ_spec e.spec.args vs) hswf.2
                 (Spec.argsEnv_agreeOn (Δ := W.Δ_spec) (ρ₁ := ρ_call) (ρ₂ := W.ρ_spec)
-                  (Env.agreeOn_symm hagree_call) s.args vs hlen_vals_call))
+                  (Env.agreeOn_symm hagree_call) e.spec.args vs hlen_vals_call))
               iexact Hpred'
         iapply Hwand
         iexact Htyped'

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -278,11 +278,15 @@ structure Intrinsic where
   path     : Option (String × List String)
   reduce   : Arity.tup arity Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop
   wp       : Arity.tup arity Runtime.Val → (Runtime.Val → iProp) → iProp
-  /-- The intrinsic's specification, the single source of its argument names/
-      types, return type, and predicate transformer. Argument and return types
-      may contain type variables (a *scheme*); a polymorphic intrinsic is a
-      family of functions with the same implementation, instantiated per use
-      site via `Spec.instantiate`. -/
+  /-- The intrinsic's argument types, in order. May contain type variables (a
+      *scheme*); substituted per use site by the elaborator's instantiation. -/
+  argTys   : List TinyML.Typ
+  /-- The intrinsic's result type; likewise a scheme. -/
+  retTy    : TinyML.Typ
+  /-- The intrinsic's specification: argument names and predicate transformer.
+      A polymorphic intrinsic is a family of functions with the same
+      implementation; only the argument/return types vary per use site, while
+      the names and predicate are shared. -/
   spec     : Spec
   /-- The typing function: given the inferred argument types of a use site,
       compute the type-variable instantiation (or reject with a message). It is
@@ -318,7 +322,7 @@ theorem agreeOn_extend_fresh (i : Intrinsic) {Δ : Signature} (ρ : Env)
     (hfresh : match i.folSym with | none => True | some sym => sym.name ∉ Δ.allNames) :
     Env.agreeOn Δ ρ (ρ.extendWithSym i.folSym) := by
   cases i with
-  | mk arity name path reduce wp spec typing folSym axioms =>
+  | mk arity name path reduce wp argTys retTy spec typing folSym axioms =>
     cases arity with
     | zero =>
       cases folSym with
@@ -351,13 +355,13 @@ theorem agreeOn_extend_fresh (i : Intrinsic) {Δ : Signature} (ρ : Env)
             (t := ⟨s.name, .value, .value, .value, .value⟩)
             (f := fun a b c => s.interp (a, b, c)) (Δ := Δ) hfresh)
 
-/-- The intrinsic's argument types, in left-to-right order. Read off the spec. -/
+/-- The intrinsic's argument types, in left-to-right order. -/
 def argTysList (i : Intrinsic) : List TinyML.Typ :=
-  i.spec.args.map Prod.snd
+  i.argTys
 
-/-- The intrinsic's result type. Read off the spec. -/
+/-- The intrinsic's result type. -/
 def resultTy (i : Intrinsic) : TinyML.Typ :=
-  i.spec.retTy
+  i.retTy
 
 /-- The intrinsic's full arrow (scheme) type. -/
 def arrowType (i : Intrinsic) : TinyML.Typ :=
@@ -387,12 +391,12 @@ theorem toReduce_two_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .two Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .two)) (axioms : List Axiom)
     (a b v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    (Intrinsic.mk .two name path reduce wp spec typing folSym axioms).toReduce [a, b] μ v μ'
+    (Intrinsic.mk .two name path reduce wp argTys retTy spec typing folSym axioms).toReduce [a, b] μ v μ'
       = reduce (a, b) μ v μ' := rfl
 
 /-- Unfolding lemma for `toReduce` at arity-three, three args. -/
@@ -400,12 +404,12 @@ theorem toReduce_three_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .three Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .three Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .three)) (axioms : List Axiom)
     (a b c v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    (Intrinsic.mk .three name path reduce wp spec typing folSym axioms).toReduce [a, b, c] μ v μ'
+    (Intrinsic.mk .three name path reduce wp argTys retTy spec typing folSym axioms).toReduce [a, b, c] μ v μ'
       = reduce (a, b, c) μ v μ' := rfl
 
 /-- Unfolding lemma for `toReduce` at arity-one, one arg. -/
@@ -413,12 +417,12 @@ theorem toReduce_one_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .one Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .one)) (axioms : List Axiom)
     (a v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    (Intrinsic.mk .one name path reduce wp spec typing folSym axioms).toReduce [a] μ v μ'
+    (Intrinsic.mk .one name path reduce wp argTys retTy spec typing folSym axioms).toReduce [a] μ v μ'
       = reduce a μ v μ' := rfl
 
 /-- Unfolding lemma for `toReduce` at arity-zero, no args. -/
@@ -426,12 +430,12 @@ theorem toReduce_zero_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .zero Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .zero)) (axioms : List Axiom)
     (v : Runtime.Val) (μ μ' : TinyML.Heap) :
-    (Intrinsic.mk .zero name path reduce wp spec typing folSym axioms).toReduce [] μ v μ'
+    (Intrinsic.mk .zero name path reduce wp argTys retTy spec typing folSym axioms).toReduce [] μ v μ'
       = reduce () μ v μ' := rfl
 
 /-- Adapter from the list-shaped argument call to the arity-shaped `wp`
@@ -453,12 +457,12 @@ theorem toWp_two_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .two Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .two)) (axioms : List Axiom)
     (a b : Runtime.Val) (Q : Runtime.Val → iProp) :
-    (Intrinsic.mk .two name path reduce wp spec typing folSym axioms).toWp [a, b] Q
+    (Intrinsic.mk .two name path reduce wp argTys retTy spec typing folSym axioms).toWp [a, b] Q
       = wp (a, b) Q := rfl
 
 /-- Unfolding lemma for `toWp` at arity-three, three args. -/
@@ -466,12 +470,12 @@ theorem toWp_three_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .three Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .three Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .three)) (axioms : List Axiom)
     (a b c : Runtime.Val) (Q : Runtime.Val → iProp) :
-    (Intrinsic.mk .three name path reduce wp spec typing folSym axioms).toWp [a, b, c] Q
+    (Intrinsic.mk .three name path reduce wp argTys retTy spec typing folSym axioms).toWp [a, b, c] Q
       = wp (a, b, c) Q := rfl
 
 /-- Unfolding lemma for `toWp` at arity-one, one arg. -/
@@ -479,12 +483,12 @@ theorem toWp_one_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .one Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .one)) (axioms : List Axiom)
     (a : Runtime.Val) (Q : Runtime.Val → iProp) :
-    (Intrinsic.mk .one name path reduce wp spec typing folSym axioms).toWp [a] Q
+    (Intrinsic.mk .one name path reduce wp argTys retTy spec typing folSym axioms).toWp [a] Q
       = wp a Q := rfl
 
 /-- Unfolding lemma for `toWp` at arity-zero, no args. -/
@@ -492,12 +496,12 @@ theorem toWp_zero_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .zero Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .zero)) (axioms : List Axiom)
     (Q : Runtime.Val → iProp) :
-    (Intrinsic.mk .zero name path reduce wp spec typing folSym axioms).toWp [] Q
+    (Intrinsic.mk .zero name path reduce wp argTys retTy spec typing folSym axioms).toWp [] Q
       = wp () Q := rfl
 
 /-- Fold a registry fragment's FOL symbols into a starting signature. The
@@ -522,7 +526,7 @@ below. The aggregate over the registry is the def `Registry.Sound`. -/
 
 /-- Argument list for the spec view: the spec's own argument names paired with
     their types. -/
-def specArgs (i : Intrinsic) : List (String × TinyML.Typ) :=
+def specArgs (i : Intrinsic) : List String :=
   i.spec.args
 
 end Intrinsic
@@ -543,12 +547,15 @@ end Intrinsic
     by the caller from the registry-derived signature/environment.
 
     `bridge` is a family indexed by the type-variable substitution `σ`: it is
-    stated at the *instantiated* spec `i.spec.instantiate σ`, for every `σ`.
+    stated at the argument/result types substituted by `σ`, for every `σ`, with
+    the spec's names and predicate transformer shared across instantiations.
 
     `axiomWf`/`proof` are stated against the dependency `fragment`: each axiom is
     well-formed in the signature supplied by the fragment, and is satisfied by
     every environment that respects every FOL symbol in the fragment. -/
 class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Prop where
+  /-- The spec's argument-name count matches the intrinsic's arity. -/
+  argLen : i.spec.args.length = i.argTys.length
   specWf :
     ∀ (Δ : Signature), (Signature.empty.extendWithSym i.folSym).Subset Δ → Δ.wf →
       PredTrans.wfIn (Δ.declVars (Spec.argVars i.specArgs)) i.spec.pred
@@ -556,10 +563,10 @@ class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Pr
     ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ) (W : TinyML.World)
       (vs : List Runtime.Val) (ρ : Env) (Φ : Runtime.Val → iProp),
     ρ.respects i.folSym →
-    TinyML.ValsHaveTypes W vs ((i.spec.instantiate σ).args.map Prod.snd) ∗
-      PredTrans.apply W (fun r => TinyML.ValHasType W r (i.spec.instantiate σ).retTy -∗ Φ r)
-        (i.spec.instantiate σ).pred
-        (Spec.argsEnv ρ (i.spec.instantiate σ).args vs) ⊢ i.toWp vs Φ
+    TinyML.ValsHaveTypes W vs (i.argTys.map (·.subst σ)) ∗
+      PredTrans.apply W (fun r => TinyML.ValHasType W r (i.retTy.subst σ) -∗ Φ r)
+        i.spec.pred
+        (Spec.argsEnv ρ i.spec.args vs) ⊢ i.toWp vs Φ
   wp_sound :
     ∀ [MicaGS HasLC.hasLC Sig] (ctx : TinyML.PrimCtx),
       (∀ vs μ v μ', ctx i.name vs μ v μ' ↔ i.toReduce vs μ v μ') →
@@ -819,6 +826,7 @@ end Registry
 theorem IntrinsicSound.mono {deps deps' : Registry} {i : Intrinsic}
     (h : IntrinsicSound deps i) (hsub : deps ⊆ deps') :
     IntrinsicSound deps' i where
+  argLen := h.argLen
   specWf := h.specWf
   bridge := h.bridge
   wp_sound := h.wp_sound
@@ -884,7 +892,7 @@ theorem eval_declFOLSym (i : Intrinsic) {st : TransState} {ρ : Env}
       ρ'.respects i.folSym ∧
       Q () { st with decls := st.decls.extendWithSym i.folSym } ρ' := by
   cases i with
-  | mk arity name path reduce wp spec typing folSym axioms =>
+  | mk arity name path reduce wp argTys retTy spec typing folSym axioms =>
     cases arity with
     | zero =>
       cases folSym with

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -19,6 +19,29 @@ open Typed
 open Verifier.RelationalEncoding (FunCtx encodeWith)
 open Verifier.RelationalEncoding.Skolemize (encoderOps DefVal)
 
+/-- Bundle a declaration's spec with the argument and result types of the
+    function literal it annotates. Validates that the spec's argument-name count
+    matches the function's arity. -/
+def SpecEntry.ofFunction (s : Spec) (e : Expr) : Except String SpecEntry :=
+  match e with
+  | .fix _ argBinders retTy _ =>
+    if s.args.length = argBinders.length then
+      .ok { argTys := argBinders.map (·.ty), retTy, spec := s }
+    else .error s!"spec argument count does not match function arity"
+  | _ => .error "SpecEntry.ofFunction: expected function"
+
+omit [MicaGS HasLC.hasLC Sig] in
+/-- A bundled entry's spec-argument count matches its argument-type count. -/
+theorem SpecEntry.ofFunction_argLen {s : Spec} {expr : Expr} {e : SpecEntry}
+    (h : SpecEntry.ofFunction s expr = .ok e) : e.spec.args.length = e.argTys.length := by
+  simp only [SpecEntry.ofFunction] at h
+  split at h
+  · split at h
+    · rename_i hlen
+      injection h with h; subst h; simpa using hlen
+    · simp at h
+  · simp at h
+
 /-! ## Program-level verification
 
 Iterates over a list of declarations, verifying each one against its spec
@@ -439,14 +462,17 @@ end RelationSpec
 /-- Check an individual declaration. Each declaration's `checkSpec` runs inside a `seq` bracket so its
     declarations and assertions don't pollute subsequent verifications. -/
 def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature)
-    (S : SpecMap) (d : Typed.ValDecl Spec) : VerifM Spec := do
+    (S : SpecMap) (d : Typed.ValDecl Spec) : VerifM SpecEntry := do
   let spec ← match d.declMeta.spec with
     | some s => .ret s
     | none => .fatal "declaration has no spec"
-  let () ← match Spec.checkWf spec Δ_spec with
+  let e ← match SpecEntry.ofFunction spec d.body with
+    | .ok s => .ret s
+    | .error msg => .fatal msg
+  let () ← match Spec.checkWf e.spec Δ_spec with
     | .ok () => .ret ()
     | .error msg => .fatal msg
-  VerifM.seq (checkSpec reg Θ Δ_spec S d.body spec) (pure spec)
+  VerifM.seq (checkSpec reg Θ Δ_spec S d.body e) (pure e)
 
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
 def ValDecl.checkExpr (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (d : Typed.ValDecl Spec) : VerifM Unit :=
@@ -563,7 +589,7 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
     (hag : W.agrees st.decls ρ)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
-    {Q : Spec → TransState → Env → Prop}
+    {Q : SpecEntry → TransState → Env → Prop}
     (heval : VerifM.eval (ValDecl.check reg W.Θ W.Δ_spec S d) st ρ Q) :
     ∃ spec, spec.wfIn W.Δ_spec ∧
             (□ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor W v)) ∧
@@ -573,30 +599,38 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
   | none =>
     simp only [hspec] at heval
     exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
-  | some spec =>
+  | some s =>
     simp only [hspec] at heval
-    have h3 := VerifM.eval_ret (VerifM.eval_bind heval)
-    cases hcheckWf : Spec.checkWf spec W.Δ_spec with
+    have h2 := VerifM.eval_ret (VerifM.eval_bind heval)
+    cases hentry : SpecEntry.ofFunction s d.body with
     | error msg =>
-      simp only [hcheckWf] at h3
-      exact (VerifM.eval_fatal (VerifM.eval_bind h3)).elim
-    | ok u =>
-      simp only [hcheckWf] at h3
-      have h4 := VerifM.eval_ret (VerifM.eval_bind h3)
-      have hswf : spec.wfIn W.Δ_spec := Spec.checkWf_ok (by cases u; exact hcheckWf)
-      have ⟨hcheckSpec, hpure⟩ := VerifM.eval_seq h4
-      exact ⟨spec, hswf,
-        by
-          have hcheck :=
-            checkSpec_correct reg hSound W hW S d.body spec γ
-              hswf hSwf hwf st ρ hag hΔreg hρreg hcheckSpec
-          refine BIBase.Entails.trans ?_ hcheck
-          istart
-          iintro ⟨#Hsl, #Hspec⟩
-          isplitl [Hsl]
-          · iexact Hsl
-          · iexact Hspec,
-             VerifM.eval_ret hpure⟩
+      simp only [hentry] at h2
+      exact (VerifM.eval_fatal (VerifM.eval_bind h2)).elim
+    | ok spec =>
+      simp only [hentry] at h2
+      have h3 := VerifM.eval_ret (VerifM.eval_bind h2)
+      cases hcheckWf : Spec.checkWf spec.spec W.Δ_spec with
+      | error msg =>
+        simp only [hcheckWf] at h3
+        exact (VerifM.eval_fatal (VerifM.eval_bind h3)).elim
+      | ok u =>
+        simp only [hcheckWf] at h3
+        have h4 := VerifM.eval_ret (VerifM.eval_bind h3)
+        have hswf : spec.wfIn W.Δ_spec :=
+          ⟨SpecEntry.ofFunction_argLen hentry, Spec.checkWf_ok (by cases u; exact hcheckWf)⟩
+        have ⟨hcheckSpec, hpure⟩ := VerifM.eval_seq h4
+        exact ⟨spec, hswf,
+          by
+            have hcheck :=
+              checkSpec_correct reg hSound W hW S d.body spec γ
+                hswf hSwf hwf st ρ hag hΔreg hρreg hcheckSpec
+            refine BIBase.Entails.trans ?_ hcheck
+            istart
+            iintro ⟨#Hsl, #Hspec⟩
+            isplitl [Hsl]
+            · iexact Hsl
+            · iexact Hspec,
+               VerifM.eval_ret hpure⟩
 
 theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)

--- a/Mica/Verifier/SpecMaps.lean
+++ b/Mica/Verifier/SpecMaps.lean
@@ -17,7 +17,33 @@ variable [MicaGS HasLC.hasLC Sig]
 -- SpecMap
 -- ---------------------------------------------------------------------------
 
-abbrev SpecMap := Finmap (fun _ : TinyML.Var => Spec)
+/-- A function specification bundled with the argument and result types. -/
+structure SpecEntry where
+  argTys : List TinyML.Typ
+  retTy  : TinyML.Typ
+  spec   : Spec
+  deriving DecidableEq
+
+/-- The precondition assertion for a specified function value, reading the
+    argument and result types off the entry. Reducible so it unifies definitionally
+    with the underlying `Spec.isPrecondFor`. -/
+@[reducible] def SpecEntry.isPrecondFor (W : TinyML.World) (e : SpecEntry) (f : Runtime.Val) : iProp :=
+  e.spec.isPrecondFor W e.argTys e.retTy f
+
+instance : Iris.BI.Persistent (SpecEntry.isPrecondFor W e f) := by
+  unfold SpecEntry.isPrecondFor; infer_instance
+
+/-- Well-formedness of an entry: the spec's argument count matches the arrow
+    arity, and its predicate transformer is well-formed. -/
+def SpecEntry.wfIn (e : SpecEntry) (Δ : Signature) : Prop :=
+  e.spec.args.length = e.argTys.length ∧ e.spec.wfIn Δ
+
+omit [MicaGS HasLC.hasLC Sig] in
+theorem SpecEntry.wfIn_mono {e : SpecEntry} {Δ Δ' : Signature}
+    (h : e.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : e.wfIn Δ' :=
+  ⟨h.1, Spec.wfIn_mono h.2 hsub hwf⟩
+
+abbrev SpecMap := Finmap (fun _ : TinyML.Var => SpecEntry)
 
 def SpecMap.satisfiedBy (W : TinyML.World)
     (S : SpecMap) (γ : Runtime.Subst) : iProp :=
@@ -27,7 +53,7 @@ def SpecMap.satisfiedBy (W : TinyML.World)
 instance : Iris.BI.Persistent (SpecMap.satisfiedBy W S γ) := by
   unfold SpecMap.satisfiedBy; infer_instance
 
-theorem SpecMap.project {x : TinyML.Var} {s : Spec} {Q : iProp} (P : iProp)
+theorem SpecMap.project {x : TinyML.Var} {s : SpecEntry} {Q : iProp} (P : iProp)
     (W : TinyML.World) (S : SpecMap) (γ : Runtime.Subst) :
   (P ⊢ S.satisfiedBy W γ) →
   S.lookup x = some s →
@@ -60,7 +86,7 @@ omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.wfIn_mono {S : SpecMap} {Δ Δ' : Signature}
     (h : S.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) :
     S.wfIn Δ' :=
-  fun f spec hlookup => Spec.wfIn_mono (h f spec hlookup) hsub hwf
+  fun f spec hlookup => SpecEntry.wfIn_mono (h f spec hlookup) hsub hwf
 
 omit [MicaGS HasLC.hasLC Sig] in
 theorem SpecMap.wfIn_erase {S : SpecMap} {x : TinyML.Var} {Δ : Signature}
@@ -102,18 +128,18 @@ theorem SpecMap.wfIn_eraseAll {keys : List String} {S : SpecMap} {Δ : Signature
   | nil => exact h
   | cons k ks ih => exact ih (SpecMap.wfIn_erase h)
 
-def SpecMap.insertBinder (S : SpecMap) (b : Typed.Binder) (spec : Spec) : SpecMap :=
+def SpecMap.insertBinder (S : SpecMap) (b : Typed.Binder) (spec : SpecEntry) : SpecMap :=
   match b.name with
   | some x => S.insert x spec
   | none => S
 
 omit [MicaGS HasLC.hasLC Sig] in
-@[simp] theorem SpecMap.insertBinder_none {S : SpecMap} {b : Typed.Binder} {spec : Spec}
+@[simp] theorem SpecMap.insertBinder_none {S : SpecMap} {b : Typed.Binder} {spec : SpecEntry}
     (h : b.name = none) : S.insertBinder b spec = S := by
   simp [SpecMap.insertBinder, h]
 
 omit [MicaGS HasLC.hasLC Sig] in
-@[simp] theorem SpecMap.insertBinder_some {S : SpecMap} {b : Typed.Binder} {spec : Spec}
+@[simp] theorem SpecMap.insertBinder_some {S : SpecMap} {b : Typed.Binder} {spec : SpecEntry}
     {x : TinyML.Var} (h : b.name = some x) : S.insertBinder b spec = S.insert x spec := by
   simp [SpecMap.insertBinder, h]
 
@@ -152,12 +178,12 @@ theorem SpecMap.satisfiedBy_preserved {W : TinyML.World}
 
 /-- Generic insert: fresh precondition for `x ↦ fval` plus preservation elsewhere. -/
 theorem SpecMap.satisfiedBy_insert_of_preserved {W : TinyML.World} {S : SpecMap}
-    {γ γ' : Runtime.Subst} {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec}
+    {γ γ' : Runtime.Subst} {x : TinyML.Var} {fval : Runtime.Val} {spec : SpecEntry}
     (hγ' : γ' x = some fval)
     (hγ : ∀ y f, y ≠ x → γ y = some f → γ' y = some f) :
     S.satisfiedBy W γ ∗ spec.isPrecondFor W fval ⊢
       SpecMap.satisfiedBy W (Finmap.insert x spec S) γ' := by
-  simp only [SpecMap.satisfiedBy, Spec.isPrecondFor]
+  simp only [SpecMap.satisfiedBy, SpecEntry.isPrecondFor, Spec.isPrecondFor]
   iintro ⟨#HS, #Hf⟩
   imodintro
   iintro %y %s' %hlookup
@@ -176,13 +202,13 @@ theorem SpecMap.satisfiedBy_insert_of_preserved {W : TinyML.World} {S : SpecMap}
     ipureintro; exact hγ y f hyx hγf
 
 theorem SpecMap.satisfiedBy_insert {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
-    {x : TinyML.Var} {fval : Runtime.Val} {spec : Spec} (hγ : γ x = some fval) :
+    {x : TinyML.Var} {fval : Runtime.Val} {spec : SpecEntry} (hγ : γ x = some fval) :
     S.satisfiedBy W γ ∗ spec.isPrecondFor W fval ⊢
       SpecMap.satisfiedBy W (Finmap.insert x spec S) γ :=
   SpecMap.satisfiedBy_insert_of_preserved hγ (fun _ _ _ hf => hf)
 
 theorem SpecMap.satisfiedBy_insert_update {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
-    {x : TinyML.Var} {v : Runtime.Val} {spec : Spec} :
+    {x : TinyML.Var} {v : Runtime.Val} {spec : SpecEntry} :
     S.satisfiedBy W γ ∗ spec.isPrecondFor W v ⊢
       SpecMap.satisfiedBy W (Finmap.insert x spec S) (γ.update x v) :=
   SpecMap.satisfiedBy_insert_of_preserved
@@ -190,7 +216,7 @@ theorem SpecMap.satisfiedBy_insert_update {W : TinyML.World} {S : SpecMap} {γ :
     (fun y f hyx hf => by simp [Runtime.Subst.update, beq_false_of_ne hyx, hf])
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : Signature}
+theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : SpecEntry} {Δ : Signature}
     (hS : S.wfIn Δ) (hs : spec.wfIn Δ) : SpecMap.wfIn (Finmap.insert x spec S) Δ := by
   intro y s' hlookup
   by_cases hyx : y = x
@@ -198,7 +224,7 @@ theorem SpecMap.wfIn_insert {S : SpecMap} {x : TinyML.Var} {spec : Spec} {Δ : S
   · rw [Finmap.lookup_insert_of_ne _ hyx] at hlookup; exact hS y s' hlookup
 
 theorem SpecMap.satisfiedBy_insertBinder {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
-    {b : Typed.Binder} {fval : Runtime.Val} {spec : Spec}
+    {b : Typed.Binder} {fval : Runtime.Val} {spec : SpecEntry}
     (hγ : ∀ x ty, b = Typed.Binder.named x ty → γ x = some fval) :
     S.satisfiedBy W γ ∗ spec.isPrecondFor W fval ⊢
       SpecMap.satisfiedBy W (S.insertBinder b spec) γ := by
@@ -208,7 +234,7 @@ theorem SpecMap.satisfiedBy_insertBinder {W : TinyML.World} {S : SpecMap} {γ : 
     rw [SpecMap.insertBinder_some rfl]; exact SpecMap.satisfiedBy_insert (hγ x ty rfl)
 
 theorem SpecMap.satisfiedBy_insertBinder_updateBinder {W : TinyML.World} {S : SpecMap} {γ : Runtime.Subst}
-    {b : Typed.Binder} {v : Runtime.Val} {spec : Spec} :
+    {b : Typed.Binder} {v : Runtime.Val} {spec : SpecEntry} :
     S.satisfiedBy W γ ∗ spec.isPrecondFor W v ⊢
       SpecMap.satisfiedBy W (S.insertBinder b spec) (Runtime.Subst.updateBinder b.runtime v γ) := by
   rcases hb : b.name with _ | _
@@ -218,7 +244,7 @@ theorem SpecMap.satisfiedBy_insertBinder_updateBinder {W : TinyML.World} {S : Sp
     exact SpecMap.satisfiedBy_insert_update
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem SpecMap.wfIn_insertBinder {S : SpecMap} {b : Typed.Binder} {spec : Spec} {Δ : Signature}
+theorem SpecMap.wfIn_insertBinder {S : SpecMap} {b : Typed.Binder} {spec : SpecEntry} {Δ : Signature}
     (hS : S.wfIn Δ) (hs : spec.wfIn Δ) : SpecMap.wfIn (S.insertBinder b spec) Δ := by
   rcases hb : b.name with _ | _
   · rwa [SpecMap.insertBinder_none hb]

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -29,45 +29,22 @@ namespace Spec
 /-! ## Definitions -/
 
 /-- The list of SMT variables corresponding to a spec's arguments. -/
-def argVars (args : List (String × TinyML.Typ)) : List Var :=
-  args.map fun (name, _) => ⟨name, .value⟩
-
-/-- Instantiate a spec scheme: substitute `σ` into the argument and return
-    types. The predicate transformer is untouched — a polymorphic intrinsic is a
-    family of functions with the same implementation, so only the types vary
-    with the instantiation. -/
-def instantiate (s : Spec) (σ : TinyML.TyVar → TinyML.Typ) : Spec :=
-  { args  := s.args.map fun (name, ty) => (name, ty.subst σ)
-    retTy := s.retTy.subst σ
-    pred  := s.pred }
-
-omit [MicaGS HasLC.hasLC Sig] in
-@[simp] theorem instantiate_pred (s : Spec) (σ : TinyML.TyVar → TinyML.Typ) :
-    (s.instantiate σ).pred = s.pred := rfl
-
-omit [MicaGS HasLC.hasLC Sig] in
-@[simp] theorem instantiate_retTy (s : Spec) (σ : TinyML.TyVar → TinyML.Typ) :
-    (s.instantiate σ).retTy = s.retTy.subst σ := rfl
-
-omit [MicaGS HasLC.hasLC Sig] in
-/-- Instantiation preserves argument names, hence the argument variables. -/
-@[simp] theorem instantiate_argVars (s : Spec) (σ : TinyML.TyVar → TinyML.Typ) :
-    argVars (s.instantiate σ).args = argVars s.args := by
-  simp only [instantiate, argVars, List.map_map]
-  rfl
+def argVars (args : List String) : List Var :=
+  args.map fun name => ⟨name, .value⟩
 
 /-- Build an environment binding each argument name to its value, left-to-right.
     Later arguments shadow earlier ones with the same name. -/
-def argsEnv (ρ : Env) : List (String × TinyML.Typ) → List Runtime.Val → Env
+def argsEnv (ρ : Env) : List String → List Runtime.Val → Env
   | [], _ | _, [] => ρ
-  | (name, _) :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
+  | name :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
 
 def isPrecondFor (W : TinyML.World)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ)
     (f : Runtime.Val) (s : Spec) : iProp :=
   iprop(□ ∀ (ρ : Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ -∗
-      TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
-        PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
+      TinyML.ValsHaveTypes W vs argTys -∗
+        PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
           (argsEnv ρ s.args vs) -∗
         wp W.pctx (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
@@ -80,64 +57,72 @@ def checkWf (spec : Spec) (Δ : Signature) : Except String Unit :=
   PredTrans.checkWf (Δ.declVars (argVars spec.args)) spec.pred
 
 /-- Declare argument variables, check types, and assume equalities for a spec call.
-    Returns the updated substitution. -/
+    The argument names come from the spec and the argument types from the enclosing
+    arrow. Returns the updated substitution. -/
 def declareArgs (Θ : TinyML.TypeEnv) (σ : FiniteSubst) :
-    List (String × TinyML.Typ) → List (TinyML.Typ × Term .value) → VerifM FiniteSubst
-  | [], [] => pure σ
-  | (name, ty) :: rest, (targ, sarg) :: sargs => do
+    List String → List TinyML.Typ → List (TinyML.Typ × Term .value) → VerifM FiniteSubst
+  | [], [], [] => pure σ
+  | name :: names, ty :: tys, (targ, sarg) :: sargs => do
     if TinyML.Typ.sub Θ targ ty then pure ()
     else VerifM.fatal s!"type mismatch in call to spec"
     let argVar ← VerifM.decl (some name) .value
     let σ' := σ.rename ⟨name, .value⟩ argVar.name
     VerifM.assume (.pure (.eq .value (.const (.uninterpreted argVar.name .value)) sarg))
-    declareArgs Θ σ' rest sargs
-  | _, _ => VerifM.fatal "wrong number of arguments"
+    declareArgs Θ σ' names tys sargs
+  | _, _, _ => VerifM.fatal "wrong number of arguments"
 
 /-- Full call protocol for a spec: declare argument variables, assume they equal the
-    compiled argument terms, check argument types, then invoke `PredTrans.call`. -/
-def call (Θ : TinyML.TypeEnv) (σ : FiniteSubst) (s : Spec) (sargs : List (TinyML.Typ × Term .value)) :
+    compiled argument terms, check argument types, then invoke `PredTrans.call`. The
+    argument and result types come from the enclosing arrow. -/
+def call (Θ : TinyML.TypeEnv) (σ : FiniteSubst)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ)
+    (s : Spec) (sargs : List (TinyML.Typ × Term .value)) :
     VerifM (TinyML.Typ × Term .value) := do
-  let σ' ← declareArgs Θ σ s.args sargs
+  let σ' ← declareArgs Θ σ s.args argTys sargs
   let result ← PredTrans.call σ' s.pred
-  VerifM.assumeAll (TinyML.typeConstraints s.retTy result)
-  pure (s.retTy, result)
+  VerifM.assumeAll (TinyML.typeConstraints retTy result)
+  pure (retTy, result)
 
-/-- Declare implementation argument variables: for each `(name, ty)` in `args`,
+/-- Declare implementation argument variables: for each name/type pair,
     declare a fresh variable, assume its type constraints, and rename in `σ`.
     Returns the final substitution and the list of declared argument variables. -/
 def declareImplArgs (σ : FiniteSubst) :
-    List (String × TinyML.Typ) → VerifM (FiniteSubst × List FOL.Const)
-  | [] => pure (σ, [])
-  | (name, ty) :: rest => do
+    List String → List TinyML.Typ → VerifM (FiniteSubst × List FOL.Const)
+  | [], [] => pure (σ, [])
+  | name :: names, ty :: tys => do
     let argVar ← VerifM.decl (some name) .value
     VerifM.assumeAll (TinyML.typeConstraints ty (.const (.uninterpreted argVar.name .value)))
     let σ' := σ.rename ⟨name, .value⟩ argVar.name
-    let (σ'', vars) ← declareImplArgs σ' rest
+    let (σ'', vars) ← declareImplArgs σ' names tys
     pure (σ'', argVar :: vars)
+  | _, _ => VerifM.fatal "wrong number of arguments"
 
 /-- Full implementation protocol for a spec: declare argument variables,
-    assume type constraints, then invoke `PredTrans.implement`. Dual to `call`. -/
-def implement (Δ_base : Signature) (s : Spec) (body : List FOL.Const → VerifM (Term .value)) : VerifM Unit := do
-  let (σ, argVars) ← declareImplArgs (FiniteSubst.base Δ_base) s.args
+    assume type constraints, then invoke `PredTrans.implement`. Dual to `call`.
+    The argument types come from the enclosing arrow. -/
+def implement (Δ_base : Signature) (argTys : List TinyML.Typ) (s : Spec)
+    (body : List FOL.Const → VerifM (Term .value)) : VerifM Unit := do
+  let (σ, argVars) ← declareImplArgs (FiniteSubst.base Δ_base) s.args argTys
   PredTrans.implement σ s.pred (body argVars)
 
 /-! ## Precondition Proofs -/
 section Precondition
 
-instance : Iris.BI.Persistent (isPrecondFor W f s) := by
+instance : Iris.BI.Persistent (isPrecondFor W argTys retTy f s) := by
   unfold isPrecondFor
   infer_instance
 
 /-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
-theorem isPrecondFor_intro (W : TinyML.World) (s : Spec)
+theorem isPrecondFor_intro (W : TinyML.World)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec)
     (f : Runtime.Val) :
     iprop(□ ∀ (ρ : Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
       (⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ ∗
-        TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
-        PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
+        TinyML.ValsHaveTypes W vs argTys ∗
+        PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ P r) s.pred
           (argsEnv ρ s.args vs)) -∗
-        wp W.pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor W f := by
+        wp W.pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor W argTys retTy f := by
   unfold isPrecondFor
   iintro #H
   imodintro
@@ -149,23 +134,25 @@ theorem isPrecondFor_intro (W : TinyML.World) (s : Spec)
 /-- Löb-style rule for spec preconditions on `fix`: to prove
     `s.isPrecondFor W (.fix f args e)`, assume it as the recursive hypothesis and
     prove the `wp` of the body (after the usual fix-substitution). -/
-theorem isPrecondFor_fix {W : TinyML.World} {s : Spec}
+theorem isPrecondFor_fix {W : TinyML.World}
+    {argTys : List TinyML.Typ} {retTy : TinyML.Typ} {s : Spec}
     {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {R : iProp}
     (hargs : args.length = s.args.length)
-    (h : R ⊢ □ (s.isPrecondFor W (.fix f args e) -∗
+    (hargTys : argTys.length = s.args.length)
+    (h : R ⊢ □ (s.isPrecondFor W argTys retTy (.fix f args e) -∗
         ∀ (ρ : Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ -∗
-          TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) -∗
-          PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
+          TinyML.ValsHaveTypes W vs argTys -∗
+          PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ P r) s.pred
               (argsEnv ρ s.args vs) -∗
           wp W.pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
-    R ⊢ s.isPrecondFor W (.fix f args e) := by
+    R ⊢ s.isPrecondFor W argTys retTy (.fix f args e) := by
   refine (SpatialContext.wp_fix' (pctx := W.pctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
       iprop(∃ ρ : Env,
         ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ ∗
-          TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
-          PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ P r) s.pred
+          TinyML.ValsHaveTypes W vs argTys ∗
+          PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ P r) s.pred
             (argsEnv ρ s.args vs))) ?_ (h.trans ?_)).trans ?_
   · intro vs P
     istart
@@ -228,16 +215,15 @@ omit [MicaGS HasLC.hasLC Sig] in
     then after applying the same updates, they agree on `argVars args ++ Δ`. -/
 theorem argsEnv_agreeOn {Δ : Signature} {ρ₁ ρ₂ : Env}
     (h : Env.agreeOn Δ ρ₁ ρ₂) :
-    ∀ (args : List (String × TinyML.Typ)) (vals : List Runtime.Val),
+    ∀ (args : List String) (vals : List Runtime.Val),
     args.length ≤ vals.length →
     Env.agreeOn (Δ.declVars (argVars args))
       (argsEnv ρ₁ args vals) (argsEnv ρ₂ args vals) := by
   intro args
   induction args generalizing Δ ρ₁ ρ₂ with
   | nil => intro vals _; simp only [argVars, List.map, argsEnv, Signature.declVars]; exact h
-  | cons arg rest ih =>
+  | cons name rest ih =>
     intro vals hlen
-    obtain ⟨name, ty⟩ := arg
     cases vals with
     | nil => simp at hlen
     | cons v vs =>
@@ -254,26 +240,31 @@ omit [MicaGS HasLC.hasLC Sig] in
 /-- Correctness of `declareArgs`: after processing all arguments, the resulting
     substitution is well-formed, types match, and the env agrees with `argsEnv`. -/
 theorem declareArgs_correct (W : TinyML.World) :
-    ∀ (args : List (String × TinyML.Typ)) (sargs : List (TinyML.Typ × Term .value))
+    ∀ (argNames : List String) (argTys : List TinyML.Typ)
+      (sargs : List (TinyML.Typ × Term .value))
       (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : Env)
       (Ψ : FiniteSubst → TransState → Env → Prop),
+    argNames.length = argTys.length →
     σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
-    VerifM.eval (Spec.declareArgs W.Θ σ args sargs) st ρ Ψ →
+    VerifM.eval (Spec.declareArgs W.Θ σ argNames argTys sargs) st ρ Ψ →
     ∃ σ' st' ρ', Ψ σ' st' ρ' ∧
       σ'.wfIn Δ_base st'.decls ∧
       st'.owns = st.owns ∧
-      @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) (args.map Prod.snd) ∧
-      ((Δ_base.declVars σ.dom).declVars (Spec.argVars args)).Subset
+      @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) argTys ∧
+      ((Δ_base.declVars σ.dom).declVars (Spec.argVars argNames)).Subset
         (Δ_base.declVars σ'.dom) ∧
-      Env.agreeOn ((Δ_base.declVars σ.dom).declVars (Spec.argVars args))
+      Env.agreeOn ((Δ_base.declVars σ.dom).declVars (Spec.argVars argNames))
         ((σ'.subst.eval ρ'))
-        (Spec.argsEnv ((σ.subst.eval ρ)) args
+        (Spec.argsEnv ((σ.subst.eval ρ)) argNames
           (sargs.map fun p => p.2.eval ρ)) := by
-  intro args
-  induction args with
+  intro argNames
+  induction argNames with
   | nil =>
-    intro sargs Δ_base σ st ρ Ψ hσwf _ heval
+    intro argTys sargs Δ_base σ st ρ Ψ hlen hσwf _ heval
+    cases argTys with
+    | cons _ _ => simp at hlen
+    | nil =>
     cases sargs with
     | nil =>
       simp [Spec.declareArgs] at heval
@@ -282,9 +273,12 @@ theorem declareArgs_correct (W : TinyML.World) :
     | cons _ _ =>
       simp [Spec.declareArgs] at heval
       exact (VerifM.eval_fatal heval).elim
-  | cons arg rest ih =>
-    intro sargs Δ_base σ st ρ Ψ hσwf hsargs heval
-    obtain ⟨name, ty⟩ := arg
+  | cons name rest ih =>
+    intro argTys sargs Δ_base σ st ρ Ψ hlen hσwf hsargs heval
+    cases argTys with
+    | nil => simp at hlen
+    | cons ty tys =>
+    have hlen_rest : rest.length = tys.length := by simpa using hlen
     cases sargs with
     | nil =>
       simp [Spec.declareArgs] at heval
@@ -331,7 +325,7 @@ theorem declareArgs_correct (W : TinyML.World) :
             (hsargs p (List.mem_cons_of_mem _ hp))
             (Env.agreeOn_symm (Env.agreeOn_update_fresh_const hfresh_decls))
         obtain ⟨σ'', st'', ρ'', hΨ, hσ''wf, howns, hsublist, hdom_sub, hagree⟩ :=
-          ih sargs_rest Δ_base σ' _ ρ₁ Ψ hσ'wf hsargs_rest hassume
+          ih tys sargs_rest Δ_base σ' _ ρ₁ Ψ hlen_rest hσ'wf hsargs_rest hassume
         refine ⟨σ'', st'', ρ'', hΨ, hσ''wf, howns,
           .cons (TinyML.Typ.sub_sound hsub_ty) hsublist, ?_, ?_⟩
         · change (((Δ_base.declVars σ.dom).declVar ⟨name, .value⟩).declVars
@@ -361,43 +355,45 @@ theorem declareArgs_correct (W : TinyML.World) :
       · simp [hsub_ty] at heval
         exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
-theorem call_correct (W : TinyML.World) (s : Spec) (Δ_base : Signature)
+theorem call_correct (W : TinyML.World)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec) (Δ_base : Signature)
     (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
     (st : TransState) (ρ : Env)
     (Ψ : (TinyML.Typ × Term .value) → TransState → Env → Prop)
     (Φ : Runtime.Val → iProp) (R : iProp) :
+    s.args.length = argTys.length →
     s.pred.wfIn ((Δ_base.declVars σ.dom).declVars (Spec.argVars s.args)) →
     σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
-    VerifM.eval (Spec.call W.Θ σ s sargs) st ρ Ψ →
-    (∀ v st' ρ' t, Ψ (s.retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
-      st'.sl W ρ' ∗ R ∗ TinyML.ValHasType W v s.retTy ⊢ Φ v) →
-    @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) (s.args.map Prod.snd) ∧
-    (st.sl W ρ ∗ R ⊢ PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
+    VerifM.eval (Spec.call W.Θ σ argTys retTy s sargs) st ρ Ψ →
+    (∀ v st' ρ' t, Ψ (retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
+      st'.sl W ρ' ∗ R ∗ TinyML.ValHasType W v retTy ⊢ Φ v) →
+    @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) argTys ∧
+    (st.sl W ρ ∗ R ⊢ PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
       (Spec.argsEnv ((σ.subst.eval ρ)) s.args
         (sargs.map fun p => p.2.eval ρ))) := by
-  intro hwf hσwf hsargs heval hΨ
+  intro hlen hwf hσwf hsargs heval hΨ
   simp only [Spec.call] at heval
   have hb_grow := VerifM.eval.decls_grow ρ (VerifM.eval_bind heval)
   obtain ⟨σ', st', ρ', ⟨hdsub, hragree, hΨ'⟩, hσ'wf, howns, hsublist, hdom_sub, hagree⟩ :=
-    declareArgs_correct W s.args sargs Δ_base σ st ρ _ hσwf hsargs hb_grow
+    declareArgs_correct W s.args argTys sargs Δ_base σ st ρ _ hlen hσwf hsargs hb_grow
   refine ⟨hsublist, ?_⟩
   have hwf'' : s.pred.wfIn (Δ_base.declVars σ'.dom) :=
     PredTrans.wfIn_mono hwf hdom_sub hσ'wf.srcWf
   have hcall := PredTrans.call_correct W s.pred Δ_base σ' st' ρ'
-    _ (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) R
+    _ (fun r => TinyML.ValHasType W r retTy -∗ Φ r) R
     hwf'' hσ'wf (VerifM.eval_bind hΨ')
     (fun v st'' ρ'' t hΨ'' htwf hteval => by
       apply wand_intro
       iintro ⟨⟨Howns, HR⟩, Hty⟩
       iintuitionistic Hty
-      ihave Hpure := (TinyML.typeConstraints_hold (ty := s.retTy) (t := t) (ρ := ρ'') (W := W) (v := v) hteval) $$ Hty
+      ihave Hpure := (TinyML.typeConstraints_hold (ty := retTy) (t := t) (ρ := ρ'') (W := W) (v := v) hteval) $$ Hty
       ipure Hpure
       obtain ⟨st₃, hst₃_decls, hst₃_owns, _, hret⟩ :=
         VerifM.eval_assumeAll (VerifM.eval_bind hΨ'')
           (fun φ hφ => TinyML.typeConstraints_wfIn htwf φ hφ)
           (fun φ hφ => Hpure φ hφ)
-      ihave Harg : (st₃.sl W ρ'' ∗ R ∗ TinyML.ValHasType W v s.retTy) $$ [HR Howns Hty]
+      ihave Harg : (st₃.sl W ρ'' ∗ R ∗ TinyML.ValHasType W v retTy) $$ [HR Howns Hty]
       · iframe HR Hty
         simp [TransState.sl, hst₃_owns]; iassumption
       iapply (hΨ v st₃ ρ'' t (VerifM.eval_ret hret) (hst₃_decls ▸ htwf) hteval) $$ Harg)
@@ -411,7 +407,7 @@ end CallCorrectness
 section ImplementCorrectness
 
 /-- Correctness payload for `declareImplArgs`. -/
-def DeclareImplArgs.Result (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
+def DeclareImplArgs.Result (argNames : List String) (vs : List Runtime.Val)
     (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : Env)
     (Ψ : (FiniteSubst × List FOL.Const) → TransState → Env → Prop) : Prop :=
   ∃ σ' implVars st' ρ', Ψ (σ', implVars) st' ρ' ∧
@@ -419,27 +415,31 @@ def DeclareImplArgs.Result (args : List (String × TinyML.Typ)) (vs : List Runti
     st.decls.Subset st'.decls ∧
     Env.agreeOn st.decls ρ ρ' ∧
     st'.owns = st.owns ∧
-    ((Δ_base.declVars σ.dom).declVars (argVars args)).Subset
+    ((Δ_base.declVars σ.dom).declVars (argVars argNames)).Subset
       (Δ_base.declVars σ'.dom) ∧
-    Env.agreeOn ((Δ_base.declVars σ.dom).declVars (argVars args))
+    Env.agreeOn ((Δ_base.declVars σ.dom).declVars (argVars argNames))
       ((σ'.subst.eval ρ'))
-      (argsEnv ((σ.subst.eval ρ)) args vs) ∧
+      (argsEnv ((σ.subst.eval ρ)) argNames vs) ∧
     (∀ v ∈ implVars, v ∈ st'.decls.consts) ∧
     (∀ v ∈ implVars, v.sort = .value) ∧
     Terms.Eval ρ' (implVars.map (fun av => .const (.uninterpreted av.name .value))) vs
 
 theorem declareImplArgs_correct (W : TinyML.World) :
-    ∀ (args : List (String × TinyML.Typ)) (vs : List Runtime.Val)
+    ∀ (argNames : List String) (argTys : List TinyML.Typ) (vs : List Runtime.Val)
       (Δ_base : Signature) (σ : FiniteSubst) (st : TransState) (ρ : Env)
       (Ψ : (FiniteSubst × List FOL.Const) → TransState → Env → Prop),
+    argNames.length = argTys.length →
     σ.wfIn Δ_base st.decls →
-    VerifM.eval (Spec.declareImplArgs σ args) st ρ Ψ →
-    TinyML.ValsHaveTypes W vs (args.map Prod.snd) ⊢
-      ⌜Spec.DeclareImplArgs.Result args vs Δ_base σ st ρ Ψ⌝ := by
-  intro args
-  induction args with
+    VerifM.eval (Spec.declareImplArgs σ argNames argTys) st ρ Ψ →
+    TinyML.ValsHaveTypes W vs argTys ⊢
+      ⌜Spec.DeclareImplArgs.Result argNames vs Δ_base σ st ρ Ψ⌝ := by
+  intro argNames
+  induction argNames with
   | nil =>
-    intro vs Δ_base σ st ρ Ψ hσwf heval
+    intro argTys vs Δ_base σ st ρ Ψ hlen_names hσwf heval
+    cases argTys with
+    | cons _ _ => simp at hlen_names
+    | nil =>
     iintro Hvs
     ihave %hlen := TinyML.ValsHaveTypes.length_eq $$ Hvs
     cases vs with
@@ -455,14 +455,17 @@ theorem declareImplArgs_correct (W : TinyML.World) :
         .nil⟩
     | cons _ _ =>
       simp at hlen
-  | cons arg rest ih =>
-    intro vs Δ_base σ st ρ Ψ hσwf heval
-    obtain ⟨name, ty⟩ := arg
+  | cons name rest ih =>
+    intro argTys vs Δ_base σ st ρ Ψ hlen_names hσwf heval
+    cases argTys with
+    | nil => simp at hlen_names
+    | cons ty tys =>
+    have hlen_rest_names : rest.length = tys.length := by simpa using hlen_names
     cases vs with
     | nil =>
-      exact (TinyML.ValsHaveTypes.nil_cons W ty (rest.map Prod.snd)).1.trans false_elim
+      exact (TinyML.ValsHaveTypes.nil_cons W ty tys).1.trans false_elim
     | cons v vs' =>
-      refine (TinyML.ValsHaveTypes.cons W v vs' ty (rest.map Prod.snd)).1.trans ?_
+      refine (TinyML.ValsHaveTypes.cons W v vs' ty tys).1.trans ?_
       iintro Hvs
       icases Hvs with ⟨Hv, Hvs_rest⟩
       simp only [Spec.declareImplArgs] at heval
@@ -495,8 +498,9 @@ theorem declareImplArgs_correct (W : TinyML.World) :
           (fun φ hφ => htyped_formulas φ hφ)
       have hst_st₂ : st.decls.Subset st₂.decls :=
         hst₂_decls ▸ Signature.Subset.subset_addConst _ _
-      ihave %hih := ih vs' Δ_base σ' st₂ ρ₁
+      ihave %hih := ih tys vs' Δ_base σ' st₂ ρ₁
         (fun p st' ρ' => Ψ (p.1, argVar :: p.2) st' ρ')
+        hlen_rest_names
         (hst₂_decls ▸ hσ'wf)
         ((VerifM.eval_bind hdecl₂).mono (fun _ _ _ hp => VerifM.eval_ret hp))
         $$ Hvs_rest
@@ -510,8 +514,8 @@ theorem declareImplArgs_correct (W : TinyML.World) :
       have hag_env := Spec.argsEnv_agreeOn
         (ρ₁ := (σ'.subst.eval ρ₁))
         (ρ₂ := ((σ.subst.eval ρ).updateConst .value name v))
-        (by simpa [Env.agreeOn, σ', ] using hag_rename)
-        rest vs' (by simp [List.length_map] at hlen_rest; omega)
+        (by simpa [Env.agreeOn, σ'] using hag_rename)
+        rest vs' (by omega)
       ipureintro
       refine ⟨σ'', argVar :: argVars', st', ρ', hΨ, hσ''wf,
         Signature.Subset.trans hst_st₂ hdsub',
@@ -544,12 +548,15 @@ theorem declareImplArgs_correct (W : TinyML.World) :
           simpa [Term.eval, Const.denote, Env.lookupConst] using h1.symm
         exact h1'.trans hvar_eval
 
-theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const → VerifM (Term .value))
+theorem implement_correct (W : TinyML.World)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec)
+    (body : List FOL.Const → VerifM (Term .value))
     (st : TransState) (ρ : Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
+    s.args.length = argTys.length →
     s.wfIn W.Δ_spec →
     W.wf →
     W.agrees st.decls ρ →
-    VerifM.eval (Spec.implement W.Δ_spec s body) st ρ (fun _ _ _ => True) →
+    VerifM.eval (Spec.implement W.Δ_spec argTys s body) st ρ (fun _ _ _ => True) →
     (∀ (argVars : List FOL.Const) (st' : TransState) (ρ' : Env) (Q : iProp),
       st.decls.Subset st'.decls →
       Env.agreeOn st.decls ρ ρ' →
@@ -559,19 +566,20 @@ theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const �
       VerifM.eval (body argVars) st' ρ'
         (fun result st'' ρ'' =>
           ∀ (S : iProp), result.wfIn st''.decls →
-            st''.sl W ρ'' ∗ Q ∗ ((TinyML.ValHasType W (result.eval ρ'') s.retTy -∗ Φ (result.eval ρ'')) -∗ S) ⊢ S) →
+            st''.sl W ρ'' ∗ Q ∗ ((TinyML.ValHasType W (result.eval ρ'') retTy -∗ Φ (result.eval ρ'')) -∗ S) ⊢ S) →
       st'.sl W ρ' ∗ Q ⊢ R) →
-    st.sl W ρ ∗ TinyML.ValsHaveTypes W vs (s.args.map Prod.snd) ∗
-      PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
+    st.sl W ρ ∗ TinyML.ValsHaveTypes W vs argTys ∗
+      PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
         (Spec.argsEnv W.ρ_spec s.args vs) ⊢ R := by
-  intro hswf hwf hag heval hbody
+  intro hlen hswf hwf hag heval hbody
   simp only [Spec.implement] at heval
   have hb := VerifM.eval_bind heval
   iintro H
   icases H with ⟨Howns, Hvals, Happ⟩
   iintuitionistic Hvals
   ihave %hlen_vals := TinyML.ValsHaveTypes.length_eq $$ Hvals
-  ihave Hdecl := declareImplArgs_correct W s.args vs W.Δ_spec (FiniteSubst.base W.Δ_spec) st ρ _
+  ihave Hdecl := declareImplArgs_correct W s.args argTys vs W.Δ_spec (FiniteSubst.base W.Δ_spec) st ρ _
+      hlen
       (FiniteSubst.base_wfIn hag.subset hwf.wf (VerifM.eval.wf heval).namesDisjoint hwf.vars)
       hb $$ Hvals
   ipure Hdecl
@@ -586,15 +594,13 @@ theorem implement_correct (W : TinyML.World) (s : Spec) (body : List FOL.Const �
       (ρ₂ := ((FiniteSubst.base W.Δ_spec).subst.eval ρ))
       (by simpa [FiniteSubst.base, ] using hag.agree)
       s.args vs
-      (by
-        simp [List.length_map] at hlen_vals
-        omega)
+      (by omega)
   have hst'_wf : st'.decls.wf := (VerifM.eval.wf hΨ).namesDisjoint
   iapply (show st'.sl W ρ' ∗
-        PredTrans.apply W (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) s.pred
+        PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
           ((σ'.subst.eval ρ')) ⊢ R from
     PredTrans.implement_correct W s.pred W.Δ_spec σ' (body argVars) st' ρ'
-      (fun r => TinyML.ValHasType W r s.retTy -∗ Φ r) R
+      (fun r => TinyML.ValHasType W r retTy -∗ Φ r) R
       (PredTrans.wfIn_mono hswf hdom_sub hσ'wf.srcWf)
       hσ'wf hΨ
       (fun st'' ρ'' Q hdsub' hragree' hbody_eval => by

--- a/Mica/Verifier/Utils.lean
+++ b/Mica/Verifier/Utils.lean
@@ -10,9 +10,9 @@ import Mica.Verifier.Bindings
 import Mica.Verifier.State
 import Mathlib.Data.Finmap
 
-/-- Extract argument names from binders, pairing with spec arg info.
-    Requires exact length match. -/
-def extractArgNames : List Typed.Binder → List (String × TinyML.Typ) →
+/-- Extract argument names from binders, checking against the spec's argument
+    names. Requires exact length match. -/
+def extractArgNames : List Typed.Binder → List String →
     Except String (List String)
   | [], [] => .ok []
   | ⟨some x, _⟩ :: rest, _ :: specRest => do
@@ -21,7 +21,7 @@ def extractArgNames : List Typed.Binder → List (String × TinyML.Typ) →
   | _, _ => .error "argument mismatch"
 
 theorem extractArgNames_spec {argBinders : List Typed.Binder}
-    {specArgs : List (String × TinyML.Typ)} {names : List String}
+    {specArgs : List String} {names : List String}
     (h : extractArgNames argBinders specArgs = .ok names) :
     names.length = specArgs.length ∧
     argBinders.length = specArgs.length ∧


### PR DESCRIPTION
`Spec` no longer carries the argument and result types of the function it describes — it keeps only the argument names and the predicate transformer, and the types are supplied by the caller. At the verifier level a new `SpecEntry` bundles a spec with the `argTys`/`retTy` read off the annotated function literal, and `SpecMap` maps variables to entries; well-formedness of an entry additionally requires the spec's argument count to match the arity. This prepares for storing specifications inside `Typ.arrow`, where the types are already present and duplicating them in `Spec` would be redundant.