### PR TITLE
Parameterize the assertion syntax by the type language it mentions

### DIFF
--- a/Mica/SourceTinyML.lean
+++ b/Mica/SourceTinyML.lean
@@ -1,5 +1,6 @@
 -- SUMMARY: Bundle for `SourceTinyML/`, containing the source language: types, the untyped and typed IRs, elaboration, specifications, and their interpretation.
 
+import Mica.SourceTinyML.Assertions
 import Mica.SourceTinyML.Types
 import Mica.SourceTinyML.Untyped
 import Mica.SourceTinyML.Typed

--- a/Mica/SourceTinyML/Assertions.lean
+++ b/Mica/SourceTinyML/Assertions.lean
@@ -84,10 +84,17 @@ instance [DecidableEq α] : DecidableEq (Assertion α) := Assertion.decideEq
 -- Predicate transformers
 -- ---------------------------------------------------------------------------
 
-def PredTrans := Assertion (Pred (Assertion Unit))
+/-- The postcondition of a predicate transformer: the name bound to the result
+    value, together with the assertion that must hold of it. -/
+structure Post where
+  name : String
+  body : Assertion Unit
+  deriving DecidableEq
+
+def PredTrans := Assertion Post
 
 instance : DecidableEq PredTrans := by
-  unfold PredTrans Pred
+  unfold PredTrans
   infer_instance
 
 -- ---------------------------------------------------------------------------

--- a/Mica/SourceTinyML/Assertions.lean
+++ b/Mica/SourceTinyML/Assertions.lean
@@ -1,47 +1,74 @@
--- SUMMARY: Assertion data for specifications: atoms, the assertion language, predicate transformers, and specs.
-import Mica.SourceTinyML.Types
+-- SUMMARY: Data of atoms, assertions, and completed specifications, parametric in the type language they mention.
 import Mica.FOL.Formulas
 
 /-!
 # Assertion data
 
-The data of the assertion language a specification elaborates into: `Atom`,
-`Assertion`, `PredTrans`, and `Spec`. Everything here needs only `TinyML.Typ`
-and the FOL term/formula language, so it sits *below* typing, which is what lets
-elaboration produce a `Spec` in a single walk.
+The syntax of verifier atoms, assertions, and completed specifications,
+separated from their semantics and from the verifier operations on them
+(`Mica/Verifier/Atoms.lean`, `Mica/Verifier/Assertions.lean`,
+`Mica/Verifier/Specifications.lean`).
 
-Operations, semantic interpretations, and proofs stay in the verifier:
-`Verifier/Atoms.lean`, `Verifier/Assertions.lean`,
-`Verifier/PredicateTransformers.lean`, and `Verifier/Specifications.lean`.
+Everything here is parametric in the type language `T` that atoms mention;
+the verifier instantiates `T := TinyML.Typ`. The parameter exists because a
+TinyML function type carries the specification of the function it describes,
+so `TinyML.Typ` is defined by nesting the types below and cannot be defined
+before them.
+
+For the same reason `Post` is a named structure rather than a pair: a nested
+inductive may not occur inside its own type parameter, so the payload of the
+outer assertion has to be a type constructor other than `Assertion` itself.
 -/
-
--- ---------------------------------------------------------------------------
--- Atoms
--- ---------------------------------------------------------------------------
 
 /-- A sort predicate: asserts that a value-sorted term has a specific sort,
     and extracts the underlying typed value. -/
-inductive Atom : Srt → Type where
-  | isint  : Term .value → Atom .int
-  | isbool : Term .value → Atom .bool
-  | isinj  (tag : Nat) (arity : Nat) : Term .value → Atom .value
-  | own    : Term .value → TinyML.Typ → Atom .value
-  | arr : Term .value → TinyML.Typ → Atom .value
-  | rel    (name : String) : Term .value → Atom .value
+inductive Atom (T : Type) : Srt → Type where
+  | isint  : Term .value → Atom T .int
+  | isbool : Term .value → Atom T .bool
+  | isinj  (tag : Nat) (arity : Nat) : Term .value → Atom T .value
+  | own    : Term .value → T → Atom T .value
+  | arr : Term .value → T → Atom T .value
+  | rel    (name : String) : Term .value → Atom T .value
   deriving DecidableEq
 
+/-- An assertion: a sequence of assumptions, bindings, and case splits ending
+    in a value of type `α`. -/
+inductive Assertion (T : Type) : Type → Type where
+  | ret    : α → Assertion T α
+  | assert : Formula → Assertion T α → Assertion T α
+  | let_   : (v : Var) → Term v.sort → Assertion T α → Assertion T α
+  | pred   : (v : Var) → Atom T v.sort → Assertion T α → Assertion T α
+  | ite    : Formula → Assertion T α → Assertion T α → Assertion T α
+
+/-- The postcondition of a predicate transformer: the name bound to the result
+    value, together with the assertion that must hold of it. -/
+structure Post (T : Type) where
+  name : String
+  body : Assertion T Unit
+
+/-- A predicate transformer: an assertion establishing the precondition and
+    ending in the postcondition the result must satisfy.
+
+    `Spec.pred` spells this type out rather than naming it: `Typ` nests `Spec`,
+    and the nested-inductive elaborator does not unfold definitions. -/
+def PredTrans (T : Type) := Assertion T (Post T)
+
+/-- A complete specification for a (possibly multi-argument) function: the
+    argument names and the predicate transformer describing its behavior. The
+    argument and result *types* live in the enclosing n-ary arrow, not here. -/
+structure Spec (T : Type) where
+  args : List String
+  pred : Assertion T (Post T)
+
+/-- Specifications print as a placeholder. -/
+instance : Repr (Spec T) := ⟨fun _ _ => "<spec>"⟩
+
 -- ---------------------------------------------------------------------------
--- Assertions
+-- Decidable equality
 -- ---------------------------------------------------------------------------
 
-inductive Assertion : Type → Type where
-  | ret    : α → Assertion α
-  | assert : Formula → Assertion α → Assertion α
-  | let_   : (v : Var) → Term v.sort → Assertion α → Assertion α
-  | pred   : (v : Var) → Atom v.sort → Assertion α → Assertion α
-  | ite    : Formula → Assertion α → Assertion α → Assertion α
-
-private def Assertion.decideEq [DecidableEq α] : (a b : Assertion α) → Decidable (a = b)
+private def Assertion.decideEq [DecidableEq T] [DecidableEq α] :
+    (a b : Assertion T α) → Decidable (a = b)
   | .ret a, .ret b => match decEq a b with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -78,33 +105,11 @@ private def Assertion.decideEq [DecidableEq α] : (a b : Assertion α) → Decid
   | .ite .., .ret _ | .ite .., .assert .. | .ite .., .let_ .. | .ite .., .pred .. =>
     isFalse (by intro h; cases h)
 
-instance [DecidableEq α] : DecidableEq (Assertion α) := Assertion.decideEq
+instance [DecidableEq T] [DecidableEq α] : DecidableEq (Assertion T α) := Assertion.decideEq
 
--- ---------------------------------------------------------------------------
--- Predicate transformers
--- ---------------------------------------------------------------------------
+deriving instance DecidableEq for Post
 
-/-- The postcondition of a predicate transformer: the name bound to the result
-    value, together with the assertion that must hold of it. -/
-structure Post where
-  name : String
-  body : Assertion Unit
-  deriving DecidableEq
+instance [DecidableEq T] : DecidableEq (PredTrans T) := by
+  unfold PredTrans; infer_instance
 
-def PredTrans := Assertion Post
-
-instance : DecidableEq PredTrans := by
-  unfold PredTrans
-  infer_instance
-
--- ---------------------------------------------------------------------------
--- Specifications
--- ---------------------------------------------------------------------------
-
-/-- A complete specification for a (possibly multi-argument) function: the
-    argument names and the predicate transformer describing its behavior. The
-    argument and result *types* live in the enclosing n-ary arrow, not here. -/
-structure Spec where
-  args : List String
-  pred : PredTrans
-  deriving DecidableEq
+deriving instance DecidableEq for Spec

--- a/Mica/SourceTinyML/OUTLINE.md
+++ b/Mica/SourceTinyML/OUTLINE.md
@@ -3,7 +3,6 @@
 - `Assertions.lean` — Data of atoms, assertions, and completed specifications, parametric in the type language they mention.
 - `LogicalRelation.lean` — Iris logical relations for TinyML values and types, together with soundness proofs for type constraints.
 - `Printer.lean` — Pretty-printing for the untyped TinyML IR and declarations.
-- `Semantics.lean` — Semantics of atoms, assertions, and specifications, parametric in the value relation interpreting types.
 - `Spec.lean` — Abstract syntax for specifications embedded in TinyML programs.
 - `TypeConstraints.lean` — First-order constraint formulas asserting that a term has a given TinyML type.
 - `Typed.lean` — Typed TinyML IR, with erasure to the runtime IR.

--- a/Mica/SourceTinyML/OUTLINE.md
+++ b/Mica/SourceTinyML/OUTLINE.md
@@ -1,8 +1,9 @@
 **Mica/SourceTinyML**
 
-- `Assertions.lean` — Assertion data for specifications: atoms, the assertion language, predicate transformers, and specs.
+- `Assertions.lean` — Data of atoms, assertions, and completed specifications, parametric in the type language they mention.
 - `LogicalRelation.lean` — Iris logical relations for TinyML values and types, together with soundness proofs for type constraints.
 - `Printer.lean` — Pretty-printing for the untyped TinyML IR and declarations.
+- `Semantics.lean` — Semantics of atoms, assertions, and specifications, parametric in the value relation interpreting types.
 - `Spec.lean` — Abstract syntax for specifications embedded in TinyML programs.
 - `TypeConstraints.lean` — First-order constraint formulas asserting that a term has a given TinyML type.
 - `Typed.lean` — Typed TinyML IR, with erasure to the runtime IR.

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -593,7 +593,7 @@ def elabSpecBody (env : SpecEnv σ) (Θ : TypeEnv) (Γbase : TyCtx) (body : Type
   let pred ← elabAssert env Θ
     (fun Γ ns (vname, post) => do
       let post' ← elabPost env Θ (Γ.extend vname retTy) (ns ++ [vname]) post
-      pure (vname, post'))
+      pure ⟨vname, post'⟩)
     Γ₀ names pre
   pure { args := names, pred := pred }
 

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -502,7 +502,7 @@ directly rather than an intermediate typed spec body. This reuses the global
 context from `Program.elaborate`, so a spec may refer to earlier definitions. -/
 
 /-- Assert all formulas in order before continuing with the assertion body. -/
-private def assertAll (φs : List Formula) (k : Assertion α) : Assertion α :=
+private def assertAll (φs : List Formula) (k : Assertion Typ α) : Assertion Typ α :=
   φs.foldr .assert k
 
 /-- The formula stating that a leaf's value term is the boolean `true`. -/
@@ -519,7 +519,7 @@ private def specVar (names : List String) (x : String) : TypeM σ (Term .value) 
 /-- Elaborate a spec predicate into the atom binding its payload, checking the
 scrutinee against both the type context and the spec-level scope. -/
 private def elabPred (Γ : TyCtx) (names : List String) (ty : Typ) :
-    Spec.Pred → TypeM σ (Atom .value)
+    Spec.Pred → TypeM σ (Atom Typ .value)
   | .isinj tag arity scrut => do pure (.isinj tag arity (← specVar names scrut))
   | .own loc =>
     match Γ loc with
@@ -541,7 +541,7 @@ is typechecked and then translated, and its definedness condition is asserted
 before the value it guards is bound or tested. The `inner` callback elaborates
 the return payload in the current type context and spec-level scope. -/
 def elabAssert (env : SpecEnv σ) (Θ : TypeEnv) (inner : TyCtx → List String → α → TypeM σ β) :
-    TyCtx → List String → Spec.Assert Untyped.Expr α → TypeM σ (Assertion β)
+    TyCtx → List String → Spec.Assert Untyped.Expr α → TypeM σ (Assertion Typ β)
   | Γ, ns, .ret a => do pure (.ret (← inner Γ ns a))
   | Γ, ns, .assert cond rest => do
     let cond' ← check env Θ Γ cond .bool
@@ -565,7 +565,7 @@ def elabAssert (env : SpecEnv σ) (Θ : TypeEnv) (inner : TyCtx → List String 
       (← elabAssert env Θ inner Γ ns thn) (← elabAssert env Θ inner Γ ns els)))
 
 private def elabPost (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TyCtx) (ns : List String)
-    (post : Spec.Post Untyped.Expr) : TypeM σ (Assertion Unit) :=
+    (post : Spec.Post Untyped.Expr) : TypeM σ (Assertion Typ Unit) :=
   elabAssert env Θ (fun _ _ () => pure ()) Γ ns post
 
 /-- Match the spec's bound names against the typed function binders to recover
@@ -583,7 +583,7 @@ and return types recovered here type the spec's leaf expressions; the `Spec`
 itself keeps only the argument names, since the types belong to the function's
 arrow. -/
 def elabSpecBody (env : SpecEnv σ) (Θ : TypeEnv) (Γbase : TyCtx) (body : Typed.Expr)
-    (rb : Spec.Body Untyped.Expr) : TypeM σ Spec := do
+    (rb : Spec.Body Untyped.Expr) : TypeM σ (Spec Typ) := do
   let (names, pre) := rb
   let (argBinders, retTy) ← match body with
     | .fix _ args retTy _ => pure (args, retTy)
@@ -599,7 +599,7 @@ def elabSpecBody (env : SpecEnv σ) (Θ : TypeEnv) (Γbase : TyCtx) (body : Type
 
 /-- Elaborate a declaration's optional spec against the typed function `body`. -/
 def elabSpec (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TyCtx) (body : Typed.Expr) :
-    Option (Spec.Body Untyped.Expr) → TypeM σ (Option Spec)
+    Option (Spec.Body Untyped.Expr) → TypeM σ (Option (Spec Typ))
   | none => pure none
   | some rb => do
     let s ← elabSpecBody env Θ Γ body rb
@@ -607,7 +607,7 @@ def elabSpec (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TyCtx) (body : Typed.Expr) 
 
 def ValDecl.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (d : Untyped.ValDecl (Spec.Body Untyped.Expr)) :
-    TypeM σ (Typed.ValDecl Spec) := do
+    TypeM σ (Typed.ValDecl (Spec Typ)) := do
   let (bodyTy, body') ←
     match d.name with
     | .named _ (some ty) => do
@@ -622,7 +622,7 @@ def ValDecl.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
          declMeta := { spec := spec', relation := d.declMeta.relation } }
 
 def Program.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
-    Untyped.Program (Spec.Body Untyped.Expr) → TypeM σ (TypeEnv × Typed.Program Spec)
+    Untyped.Program (Spec.Body Untyped.Expr) → TypeM σ (TypeEnv × Typed.Program (Spec Typ))
   | [] => pure (Θ, [])
   | d :: ds => do
       match d with
@@ -1132,7 +1132,7 @@ end
 
 theorem ValDecl.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (d : Untyped.ValDecl (Spec.Body Untyped.Expr)) :
-    ∀ {s : σ} {d' : Typed.ValDecl Spec} {s' : σ},
+    ∀ {s : σ} {d' : Typed.ValDecl (Spec Typ)} {s' : σ},
       Typed.ValDecl.elaborate env Θ Γ d s = .ok (d', s') →
       d'.runtime = d.runtime := by
   intro s d' s' helab
@@ -1160,7 +1160,7 @@ theorem ValDecl.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML
 
 theorem Program.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (prog : Untyped.Program (Spec.Body Untyped.Expr)) :
-    ∀ {s : σ} {Θ' : TypeEnv} {prog' : Typed.Program Spec} {s' : σ},
+    ∀ {s : σ} {Θ' : TypeEnv} {prog' : Typed.Program (Spec Typ)} {s' : σ},
       Typed.Program.elaborate env Θ Γ prog s = .ok ((Θ', prog'), s') →
       prog'.runtime = prog.runtime := by
   induction prog generalizing Θ Γ with

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -30,14 +30,14 @@ theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runti
 /-- Wrap an optional precondition around a spec predicate: `some φ` prepends an
     `.assert φ`; `none` leaves the predicate untouched, keeping the emitted spec
     of precondition-free intrinsics unchanged. -/
-def withPre : Option Formula → PredTrans → PredTrans
+def withPre : Option Formula → PredTrans TinyML.Typ → PredTrans TinyML.Typ
   | none,   post => post
   | some φ, post => .assert φ post
 
 /-- Eliminate `withPre`: applying the wrapped predicate yields the precondition
     as a pure fact (vacuous for `none`) alongside the unwrapped application. -/
 theorem withPre_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runtime.Val → iProp)
-    (pre : Option Formula) (post : PredTrans) (ρ : Env) :
+    (pre : Option Formula) (post : PredTrans TinyML.Typ) (ρ : Env) :
     PredTrans.apply W Φ (withPre pre post) ρ ⊢
       iprop(⌜∀ φ, pre = some φ → φ.eval ρ⌝ ∗ PredTrans.apply W Φ post ρ) := by
   cases pre with

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -14,12 +14,12 @@ namespace Intrinsics
 
 /-! ## Shared helpers -/
 
-/-- Apply a `.ret (s, .assert φ ...)` spec at a value, discharging the asserted
+/-- Apply a `.ret ⟨s, .assert φ ...⟩` spec at a value, discharging the asserted
     `φ` as a pure side condition. -/
 theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runtime.Val → iProp)
     (s : String) (ρ : Env) (φ : Formula) (v : Runtime.Val)
     (hφ : φ.eval (ρ.updateConst .value s v)) :
-    PredTrans.apply W Φ (.ret (s, .assert φ (.ret ()))) ρ ⊢ Φ v := by
+    PredTrans.apply W Φ (.ret ⟨s, .assert φ (.ret ())⟩) ρ ⊢ Φ v := by
   simp only [PredTrans.apply, Assertion.pre, Assertion.post]
   refine (forall_elim v).trans ?_
   iintro Hw
@@ -457,8 +457,8 @@ def Zero.toIntrinsic (b : Zero) : Intrinsic where
   retTy  := b.res.typ
   spec   :=
     { args  := []
-      pred  := .ret ("ret",
-        .assert (.eq .value (.var .value "ret") b.opTerm) (.ret ())) }
+      pred  := .ret ⟨"ret",
+        .assert (.eq .value (.var .value "ret") b.opTerm) (.ret ())⟩ }
   typing := schemeTyping []
   folSym := some b.sym
   axioms := ⟨b.defAxiom, .low⟩ :: (b.typeAxiom.map (⟨·, .low⟩)).toList
@@ -594,9 +594,9 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
   retTy  := b.res.typ
   spec   :=
     { args  := ["a"]
-      pred  := withPre (b.pre.map (· "a")) <| .ret ("ret",
+      pred  := withPre (b.pre.map (· "a")) <| .ret ⟨"ret",
         .assert (.eq .value (.var .value "ret")
-          (b.opTerm (.var .value "a"))) (.ret ())) }
+          (b.opTerm (.var .value "a"))) (.ret ())⟩ }
   typing := schemeTyping [b.arg.typ]
   folSym := some b.sym
   axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
@@ -611,9 +611,9 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
 
 @[simp] theorem Unary.spec_pred (b : Unary) :
     b.toIntrinsic.spec.pred = withPre (b.pre.map (· "a"))
-      (.ret ("ret",
+      (.ret ⟨"ret",
         .assert (.eq .value (.var .value "ret")
-          (b.opTerm (.var .value "a"))) (.ret ()))) := rfl
+          (b.opTerm (.var .value "a"))) (.ret ())⟩) := rfl
 
 @[simp] theorem Unary.argTys_map_subst (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
     b.toIntrinsic.argTys.map (·.subst σ) = [b.arg.typ.subst σ] := rfl
@@ -801,9 +801,9 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
   retTy  := b.res.typ
   spec   :=
     { args  := ["a", "b"]
-      pred  := withPre (b.pre.map (· "a" "b")) <| .ret ("ret",
+      pred  := withPre (b.pre.map (· "a" "b")) <| .ret ⟨"ret",
         .assert (.eq .value (.var .value "ret")
-          (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())) }
+          (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())⟩ }
   typing := schemeTyping [b.arg₁.typ, b.arg₂.typ]
   folSym := some b.sym
   axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
@@ -820,9 +820,9 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
 
 @[simp] theorem Binary.spec_pred (b : Binary) :
     b.toIntrinsic.spec.pred = withPre (b.pre.map (· "a" "b"))
-      (.ret ("ret",
+      (.ret ⟨"ret",
         .assert (.eq .value (.var .value "ret")
-          (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ()))) := rfl
+          (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())⟩) := rfl
 
 @[simp] theorem Binary.argTys_map_subst (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
     b.toIntrinsic.argTys.map (·.subst σ)
@@ -1039,9 +1039,9 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
   retTy  := b.res.typ
   spec   :=
     { args  := ["a", "b", "c"]
-      pred  := withPre (b.pre.map (· "a" "b" "c")) <| .ret ("ret",
+      pred  := withPre (b.pre.map (· "a" "b" "c")) <| .ret ⟨"ret",
         .assert (.eq .value (.var .value "ret")
-          (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())) }
+          (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())⟩ }
   typing := schemeTyping [b.arg₁.typ, b.arg₂.typ, b.arg₃.typ]
   folSym := some b.sym
   axioms := ⟨b.defAxiom, .high⟩ :: (b.typeAxiom.map (⟨·, .high⟩)).toList
@@ -1058,9 +1058,9 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
 
 @[simp] theorem Ternary.spec_pred (b : Ternary) :
     b.toIntrinsic.spec.pred = withPre (b.pre.map (· "a" "b" "c"))
-      (.ret ("ret",
+      (.ret ⟨"ret",
         .assert (.eq .value (.var .value "ret")
-          (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ()))) := rfl
+          (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())⟩) := rfl
 
 @[simp] theorem Ternary.argTys_map_subst (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
     b.toIntrinsic.argTys.map (·.subst σ)

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -25,7 +25,7 @@ Semantic interpretations and VerifM-level operations `Assertion.assume` and
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Assertion.pre (W : TinyML.World) (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
+def Assertion.pre (W : TinyML.World) (Φ : α → Env → iProp) (m : Assertion TinyML.Typ α) (ρ : Env) : iProp :=
   (match m with
   | .ret a        => Φ a ρ
   | .assert φ k   => ⌜φ.eval ρ⌝ ∗ Assertion.pre W Φ k ρ
@@ -35,7 +35,7 @@ def Assertion.pre (W : TinyML.World) (Φ : α → Env → iProp) (m : Assertion 
       iprop((⌜φ.eval ρ⌝ -∗ Assertion.pre W Φ kt ρ) ∧
             (⌜¬ φ.eval ρ⌝ -∗ Assertion.pre W Φ ke ρ)))
 
-def Assertion.post (W : TinyML.World) {α} (Φ : α → Env → iProp) (m : Assertion α) (ρ : Env) : iProp :=
+def Assertion.post (W : TinyML.World) {α} (Φ : α → Env → iProp) (m : Assertion TinyML.Typ α) (ρ : Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
   | .assert φ k   => ⌜φ.eval ρ⌝ -∗ Assertion.post W Φ k ρ
@@ -55,7 +55,7 @@ def Assertion.post (W : TinyML.World) {α} (Φ : α → Env → iProp) (m : Asse
     and term it mentions only refers to variables/symbols from `Δ` (extended by its own
     let-bindings). The `retWf` predicate specifies an additional well-formedness
     condition on the return value; by default it is trivially true. -/
-def Assertion.wfIn (retWf : α → Signature → Prop) (Δ : Signature) : Assertion α → Prop
+def Assertion.wfIn (retWf : α → Signature → Prop) (Δ : Signature) : Assertion TinyML.Typ α → Prop
   | .ret a       => retWf a Δ
   | .assert φ k  => φ.wfIn Δ ∧ k.wfIn retWf Δ
   | .let_ v t k  => t.wfIn Δ ∧ k.wfIn retWf (Δ.declVar v)
@@ -64,7 +64,7 @@ def Assertion.wfIn (retWf : α → Signature → Prop) (Δ : Signature) : Assert
 
 
 def Assertion.checkWf (retCheck : α → Signature → Except String Unit)
-    (Δ : Signature) : Assertion α → Except String Unit
+    (Δ : Signature) : Assertion TinyML.Typ α → Except String Unit
   | .ret a       => retCheck a Δ
   | .assert φ k  => do φ.checkWf Δ; k.checkWf retCheck Δ
   | .let_ v t k  => do t.checkWf Δ; k.checkWf retCheck (Δ.declVar v)
@@ -72,7 +72,7 @@ def Assertion.checkWf (retCheck : α → Signature → Except String Unit)
   | .ite φ kt ke => do φ.checkWf Δ; kt.checkWf retCheck Δ; ke.checkWf retCheck Δ
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Assertion.checkWf_ok {m : Assertion α} {retCheck : α → Signature → Except String Unit}
+theorem Assertion.checkWf_ok {m : Assertion TinyML.Typ α} {retCheck : α → Signature → Except String Unit}
     {retWf : α → Signature → Prop} {Δ : Signature}
     (hret : ∀ a Δ', retCheck a Δ' = .ok () → retWf a Δ')
     (h : m.checkWf retCheck Δ = .ok ()) : m.wfIn retWf Δ := by
@@ -93,7 +93,7 @@ theorem Assertion.checkWf_ok {m : Assertion α} {retCheck : α → Signature →
     exact ⟨Formula.checkWf_ok h1, iht h2, ihe h3⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Prop)
+theorem Assertion.wfIn_mono (m : Assertion TinyML.Typ α) (retWf : α → Signature → Prop)
     (hret : ∀ a Δ Δ', Δ.Subset Δ' → Δ'.wf → retWf a Δ → retWf a Δ')
     {Δ Δ' : Signature}
     (h : m.wfIn retWf Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : m.wfIn retWf Δ' := by
@@ -113,7 +113,7 @@ theorem Assertion.wfIn_mono (m : Assertion α) (retWf : α → Signature → Pro
 -- Environment agreement
 -- ---------------------------------------------------------------------------
 
-theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : α → Signature → Prop}
+theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion TinyML.Typ α} {retWf : α → Signature → Prop}
     {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
@@ -173,7 +173,7 @@ theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion α} {retWf : �
       iapply hnφ
       iapply Hnφ
 
-theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : α → Signature → Prop}
+theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion TinyML.Typ α} {retWf : α → Signature → Prop}
     {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
@@ -227,7 +227,7 @@ theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion α} {retWf : 
 
 /-- Combining caller-side `pre` with verifier-side `post`. -/
 theorem Assertion.pre_post_combine (W : TinyML.World) {α : Type}
-    {m : Assertion α}
+    {m : Assertion TinyML.Typ α}
     {Φ : α → Env → iProp} {Ψ : α → Env → iProp}
     {ρ : Env}
     {R : iProp}
@@ -290,7 +290,7 @@ theorem Assertion.pre_post_combine (W : TinyML.World) {α : Type}
 
 /-- Introduce preconditions: assume formulas, declare and bind let-variables.
     Threads a `FiniteSubst` that maps assertion-level names to fresh SMT-level names. -/
-def Assertion.assume (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst × α)
+def Assertion.assume (σ : FiniteSubst) : Assertion TinyML.Typ α → VerifM (FiniteSubst × α)
   | .ret a => pure (σ, a)
   | .assert φ k => do
     VerifM.assume (.pure (φ.subst σ.subst σ.range.allNames))
@@ -316,7 +316,7 @@ def Assertion.assume (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst �
 
 /-- Assert postconditions: assert formulas, declare and bind let-variables.
     Threads a `FiniteSubst` that maps assertion-level names to fresh SMT-level names. -/
-def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst × α)
+def Assertion.prove (σ : FiniteSubst) : Assertion TinyML.Typ α → VerifM (FiniteSubst × α)
   | .ret a => pure (σ, a)
   | .assert φ k => do
     VerifM.assert (φ.subst σ.subst σ.range.allNames)
@@ -348,7 +348,7 @@ def Assertion.prove (σ : FiniteSubst) : Assertion α → VerifM (FiniteSubst ×
 -- Correctness theorems
 -- ---------------------------------------------------------------------------
 
-theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
+theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion TinyML.Typ α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : Env)
     (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)
@@ -576,7 +576,7 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion α) (Δ_base 
         iapply (ihe Δ_base σ { st with asserts := _ :: st.asserts } ρ Ψ hσwf hkewf hassume hpost)
         simp [TransState.sl]
 
-theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion α) (Δ_base : Signature) (σ : FiniteSubst)
+theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion TinyML.Typ α) (Δ_base : Signature) (σ : FiniteSubst)
     (retWf : α → Signature → Prop)
     (st : TransState) (ρ : Env)
     (Ψ : (FiniteSubst × α) → TransState → Env → Prop) (Φ : α → Env → iProp) (R : iProp)

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -24,7 +24,7 @@ itself lives in `SourceTinyML/Assertions.lean`.
 -- Substitution
 -- ---------------------------------------------------------------------------
 
-def Atom.subst (σ : Subst) : Atom τ → Atom τ
+def Atom.subst (σ : Subst) : Atom TinyML.Typ τ → Atom TinyML.Typ τ
   | .isint t  => .isint (t.subst σ)
   | .isbool t => .isbool (t.subst σ)
   | .isinj tag arity t => .isinj tag arity (t.subst σ)
@@ -34,7 +34,7 @@ def Atom.subst (σ : Subst) : Atom τ → Atom τ
 
 
 /-- Convert an instantiated atom into the corresponding verifier context item. -/
-def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
+def Atom.toItem (a : Atom TinyML.Typ τ) (t : Term τ) : CtxItem :=
   match a with
   | .isint v => .pure (.eq .value v (.unop .ofInt t))
   | .isbool v => .pure (.eq .value v (.unop .ofBool t))
@@ -47,7 +47,7 @@ def Atom.toItem (a : Atom τ) (t : Term τ) : CtxItem :=
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def Atom.eval (W : TinyML.World) {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote → iProp :=
+def Atom.eval (W : TinyML.World) {τ : Srt} (p : Atom TinyML.Typ τ) (ρ : Env) : τ.denote → iProp :=
   match p with
   | isint t  => λ v => ⌜.int v = t.eval ρ⌝
   | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
@@ -62,7 +62,7 @@ def Atom.eval (W : TinyML.World) {τ : Srt} (p : Atom τ) (ρ : Env) : τ.denote
 
 
 /-- Try to match a formula against an atom, returning the extracted term if it matches. -/
-def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
+def Formula.matchAtom (φ : Formula) (a : Atom TinyML.Typ τ) : Option (Term τ) :=
   match a with
   | .isint v =>
     match φ with
@@ -82,7 +82,7 @@ def Formula.matchAtom (φ : Formula) (a : Atom τ) : Option (Term τ) :=
   | .rel _ _ => none
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : Signature}
+theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom TinyML.Typ τ} {t : Term τ} {Δ : Signature}
     (h : φ.matchAtom a = some t) (hφ : φ.wfIn Δ) : t.wfIn Δ := by
   cases a with
   | isint v =>
@@ -100,7 +100,7 @@ theorem Formula.matchAtom_wfIn {φ : Formula} {a : Atom τ} {t : Term τ} {Δ : 
 
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
+theorem Formula.matchAtom_correct {φ : Formula} {a : Atom TinyML.Typ τ} {t : Term τ}
     (h : φ.matchAtom a = some t) : a.toItem t = .pure φ := by
   cases a with
   | isint v =>
@@ -123,10 +123,10 @@ theorem Formula.matchAtom_correct {φ : Formula} {a : Atom τ} {t : Term τ}
 -- ---------------------------------------------------------------------------
 
 /-- Resolve an atom against a list of formulas. -/
-def Atom.resolve (a : Atom τ) (C : List Formula) : Option (Term τ) :=
+def Atom.resolve (a : Atom TinyML.Typ τ) (C : List Formula) : Option (Term τ) :=
   C.findSome? (·.matchAtom a)
 
-theorem Atom.resolve_correct (W : TinyML.World) {a : Atom τ} {C : List Formula} {t : Term τ}
+theorem Atom.resolve_correct (W : TinyML.World) {a : Atom TinyML.Typ τ} {C : List Formula} {t : Term τ}
     (h : a.resolve C = some t) (ρ : Env) (hC : ∀ φ ∈ C, φ.eval ρ) :
     ⊢ (a.toItem t).interp W ρ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
@@ -134,7 +134,7 @@ theorem Atom.resolve_correct (W : TinyML.World) {a : Atom τ} {C : List Formula}
   simpa [CtxItem.interp, hC _ hφ_mem] using (pure_intro (PROP := iProp) trivial)
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Atom.resolve_wfIn {a : Atom τ} {C : List Formula} {t : Term τ} {Δ : Signature}
+theorem Atom.resolve_wfIn {a : Atom TinyML.Typ τ} {C : List Formula} {t : Term τ} {Δ : Signature}
     (h : a.resolve C = some t) (hwf : ∀ φ ∈ C, φ.wfIn Δ) :
     t.wfIn Δ := by
   obtain ⟨φ, hφ_mem, hφ_match⟩ := List.exists_of_findSome?_eq_some h
@@ -145,7 +145,7 @@ theorem Atom.resolve_wfIn {a : Atom τ} {C : List Formula} {t : Term τ} {Δ : S
 -- Printer
 -- ---------------------------------------------------------------------------
 
-def Atom.toStringHum : {τ : Srt} → Atom τ → String
+def Atom.toStringHum : {τ : Srt} → Atom TinyML.Typ τ → String
   | _, .isint  t => s!"isint {t.toStringHum}"
   | _, .isbool t => s!"isbool {t.toStringHum}"
   | _, .isinj tag arity t => s!"isinj {tag}/{arity} {t.toStringHum}"
@@ -158,7 +158,7 @@ def Atom.toStringHum : {τ : Srt} → Atom τ → String
 -- ---------------------------------------------------------------------------
 
 /-- An atom is well-formed in a signature. -/
-def Atom.wfIn (Δ : Signature) : Atom τ → Prop
+def Atom.wfIn (Δ : Signature) : Atom TinyML.Typ τ → Prop
   | .isint t  => t.wfIn Δ
   | .isbool t => t.wfIn Δ
   | .isinj _ _ t => t.wfIn Δ
@@ -166,7 +166,7 @@ def Atom.wfIn (Δ : Signature) : Atom τ → Prop
   | .arr t _ => t.wfIn Δ
   | .rel name t => (SpecFn.isDefined name t).wfIn Δ ∧ (SpecFn.call name t).wfIn Δ
 
-def Atom.checkWf (p : Atom τ) (Δ : Signature) : Except String Unit :=
+def Atom.checkWf (p : Atom TinyML.Typ τ) (Δ : Signature) : Except String Unit :=
   match p with
   | .isint t  => t.checkWf Δ
   | .isbool t => t.checkWf Δ
@@ -178,7 +178,7 @@ def Atom.checkWf (p : Atom τ) (Δ : Signature) : Except String Unit :=
       (SpecFn.call name t).checkWf Δ
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Atom.checkWf_ok {p : Atom τ} {Δ : Signature} (h : p.checkWf Δ = .ok ()) : p.wfIn Δ := by
+theorem Atom.checkWf_ok {p : Atom TinyML.Typ τ} {Δ : Signature} (h : p.checkWf Δ = .ok ()) : p.wfIn Δ := by
   cases p with
   | isint t  => exact Term.checkWf_ok h
   | isbool t => exact Term.checkWf_ok h
@@ -190,7 +190,7 @@ theorem Atom.checkWf_ok {p : Atom τ} {Δ : Signature} (h : p.checkWf Δ = .ok (
     exact ⟨Formula.checkWf_ok hd, Term.checkWf_ok hv⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
+theorem Atom.wfIn_mono {p : Atom TinyML.Typ τ} {Δ Δ' : Signature}
     (h : p.wfIn Δ) (hmono : Δ.Subset Δ') (hwf : Δ'.wf) : p.wfIn Δ' := by
   cases p with
   | isint t  => exact Term.wfIn_mono t h hmono hwf
@@ -201,7 +201,7 @@ theorem Atom.wfIn_mono {p : Atom τ} {Δ Δ' : Signature}
   | rel name t =>
     exact ⟨Formula.wfIn_mono _ h.1 hmono hwf, Term.wfIn_mono _ h.2 hmono hwf⟩
 
-theorem Atom.eval_env_agree (W : TinyML.World) {p : Atom τ} {ρ ρ' : Env} {Δ : Signature}
+theorem Atom.eval_env_agree (W : TinyML.World) {p : Atom TinyML.Typ τ} {ρ ρ' : Env} {Δ : Signature}
     (hwf : p.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') : p.eval W ρ = p.eval W ρ' := by
   cases p with
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
@@ -216,7 +216,7 @@ theorem Atom.eval_env_agree (W : TinyML.World) {p : Atom τ} {ρ ρ' : Env} {Δ 
         Term.eval_env_agree hwf.2 hagree]
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
+theorem Atom.toItem_wfIn {p : Atom TinyML.Typ τ} {t : Term τ} {Δ : Signature}
     (hp : p.wfIn Δ) (ht : t.wfIn Δ) :
     (p.toItem t).wfIn Δ := by
   cases p with
@@ -239,7 +239,7 @@ theorem Atom.toItem_wfIn {p : Atom τ} {t : Term τ} {Δ : Signature}
     simp only [Atom.toItem, CtxItem.wfIn, Formula.wfIn]
     exact ⟨hp.1, hp.2, ht⟩
 
-theorem Atom.toItem_eval (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : Env} :
+theorem Atom.toItem_eval (W : TinyML.World) {p : Atom TinyML.Typ τ} {t : Term τ} {ρ : Env} :
     CtxItem.interp W ρ (p.toItem t) ⊣⊢ p.eval W ρ (t.eval ρ) := by
   cases p with
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
@@ -254,7 +254,7 @@ theorem Atom.toItem_eval (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : En
   | rel name arg =>
     simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval]
 
-theorem Atom.eval_purePart (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : Env} :
+theorem Atom.eval_purePart (W : TinyML.World) {p : Atom TinyML.Typ τ} {t : Term τ} {ρ : Env} :
     p.eval W ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
   cases p with
   | isint v =>
@@ -278,7 +278,7 @@ theorem Atom.eval_purePart (W : TinyML.World) {p : Atom τ} {t : Term τ} {ρ : 
 -- ---------------------------------------------------------------------------
 
 -- @agent: change eval_subst to a bi-entailment in the future.
-theorem Atom.eval_subst (W : TinyML.World) {p : Atom τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signature}
+theorem Atom.eval_subst (W : TinyML.World) {p : Atom TinyML.Typ τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hwfΔ' : Δ'.wf) :
     (p.subst σ).eval W ρ = p.eval W ((σ.eval ρ)) := by
   cases p with
@@ -310,7 +310,7 @@ theorem Atom.eval_subst (W : TinyML.World) {p : Atom τ} {σ : Subst} {ρ : Env}
     simp [Subst.eval]
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Signature}
+theorem Atom.subst_wfIn {p : Atom TinyML.Typ τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn dom Δ') (hdom : Δ.vars ⊆ dom)
     (hsymbols : Δ.SymbolSubset Δ')
     (hwf : Δ'.wf) :
@@ -335,7 +335,7 @@ theorem Atom.subst_wfIn {p : Atom τ} {σ : Subst} {dom : VarCtx} {Δ Δ' : Sign
 
 /-- Candidate resolutions for an atom, each guarded by a provability condition.
     Each pair `(φ, t)` means: if `φ` is provable, then `t` resolves the atom. -/
-def Atom.candidates : Atom τ → List (Formula × Term τ)
+def Atom.candidates : Atom TinyML.Typ τ → List (Formula × Term τ)
   | .isint  v => [(.unpred .isInt v, .unop .toInt v)]
   | .isbool v => [(.unpred .isBool v, .unop .toBool v)]
   | .isinj tag arity v =>
@@ -349,7 +349,7 @@ def Atom.candidates : Atom τ → List (Formula × Term τ)
   | .arr _ _ => []
   | .rel _ _ => []
 
-theorem Atom.candidates_correct (W : TinyML.World) {a : Atom τ} {φ : Formula} {t : Term τ} {ρ : Env}
+theorem Atom.candidates_correct (W : TinyML.World) {a : Atom TinyML.Typ τ} {φ : Formula} {t : Term τ} {ρ : Env}
     (hmem : (φ, t) ∈ a.candidates) (h : φ.eval ρ) : ⊢ (a.toItem t).interp W ρ := by
   cases a with
   | isint v =>
@@ -375,7 +375,7 @@ theorem Atom.candidates_correct (W : TinyML.World) {a : Atom τ} {φ : Formula} 
   | rel name arg => simp [candidates] at hmem
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem Atom.candidates_wfIn {a : Atom τ} {φ : Formula} {t : Term τ} {Δ : Signature}
+theorem Atom.candidates_wfIn {a : Atom TinyML.Typ τ} {φ : Formula} {t : Term τ} {Δ : Signature}
     (hmem : (φ, t) ∈ a.candidates) (h : a.wfIn Δ) : φ.wfIn Δ ∧ t.wfIn Δ := by
   cases a with
   | isint v =>
@@ -408,7 +408,7 @@ def VerifM.tryCandidates : List (Formula × Term τ) → VerifM (Option (Term τ
     else VerifM.tryCandidates rest
 
 private theorem VerifM.eval_tryCandidates (W : TinyML.World)
-    {candidates : List (Formula × Term τ)} {a : Atom τ}
+    {candidates : List (Formula × Term τ)} {a : Atom TinyML.Typ τ}
     {st : TransState} {ρ : Env} {Q : Option (Term τ) → TransState → Env → Prop}
     (h : VerifM.eval (VerifM.tryCandidates candidates) st ρ Q)
     (hcands : ∀ p ∈ candidates, p ∈ a.candidates)
@@ -694,7 +694,7 @@ private theorem sep_intro_valid_left {P Q : iProp} (h : ⊢ P) : Q ⊢ P ∗ Q :
 /-- Look up an atom in the assertion context.
     Tier 1: syntactic search through the context.
     Tier 2: try candidate resolutions via the SMT solver. -/
-def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
+def VerifM.resolve : {τ : Srt} → Atom TinyML.Typ τ → VerifM (Option (Term τ))
   | _, .own l ty => do
       VerifM.findMatch .ref l ty
   | _, .arr a ty => do
@@ -710,7 +710,7 @@ def VerifM.resolve : {τ : Srt} → Atom τ → VerifM (Option (Term τ))
       | none => VerifM.tryCandidates a.candidates
 
 /-- Helper: resolution of a pure atom via formula matching or SMT candidates. -/
-private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom τ} {st : TransState} {ρ : Env}
+private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom TinyML.Typ τ} {st : TransState} {ρ : Env}
     {Q : Option (Term τ) → TransState → Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (do
@@ -751,7 +751,7 @@ private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom τ} {st
         exact (sep_intro_valid_left hpred).trans
           (hsome t st ρ hqsome (Signature.Subset.refl _) Env.agreeOn_refl htwf)
 
-theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom τ} {st : TransState} {ρ : Env}
+theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom TinyML.Typ τ} {st : TransState} {ρ : Env}
     {Q : Option (Term τ) → TransState → Env → Prop}
     {R Φ : iProp}
     (h : VerifM.eval (VerifM.resolve pred) st ρ Q)

--- a/Mica/Verifier/BoundedQuantifier.lean
+++ b/Mica/Verifier/BoundedQuantifier.lean
@@ -184,7 +184,7 @@ def intrinsic (name : String) (path : String) : Verifier.Intrinsic where
   retTy := .bool
   spec :=
     { args := ["lo", "hi", "body"]
-      pred := .assert .false_ (.ret ("ret", .ret ())) }
+      pred := .assert .false_ (.ret ⟨"ret", .ret ()⟩) }
   typing := Verifier.monoTyping .three
   folSym := none
   axioms := []

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -2928,7 +2928,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       have hΔspec_args : W.Δ_spec.Subset st_args.decls := hag.subset.trans hdecls_args
       have hst_args_wf : st_args.decls.wf := (VerifM.eval.wf hΨ_args).namesDisjoint
       have hlen_e : spec.spec.args.length = spec.argTys.length := (hSwf f spec hlookup).1
-      have hwf_pred : spec.spec.pred.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars (Spec.argVars spec.spec.args)) := by
+      have hwf_pred : PredTrans.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars (Spec.argVars spec.spec.args)) spec.spec.pred := by
         simpa [FiniteSubst.base, Signature.declVars] using (hSwf f spec hlookup).2
       have hbase_wf : (FiniteSubst.base W.Δ_spec).wfIn W.Δ_spec st_args.decls :=
         FiniteSubst.base_wfIn hΔspec_args hwf.wf hst_args_wf hwf.vars
@@ -3023,8 +3023,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     have hlen_i : i.spec.args.length = argTys.length := by
       simp only [argTys, List.length_map]; exact hbridge.argLen
     have hwf_pred :
-        i.spec.pred.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars
-          (Spec.argVars i.spec.args)) := by
+        PredTrans.wfIn ((W.Δ_spec.declVars (FiniteSubst.base W.Δ_spec).dom).declVars
+          (Spec.argVars i.spec.args)) i.spec.pred := by
       simpa [FiniteSubst.base, Signature.declVars, Verifier.Intrinsic.specArgs] using
         hbridge.specWf W.Δ_spec (hΔreg i hi_mem) hwf.wf
     have hbase_wf : (FiniteSubst.base W.Δ_spec).wfIn W.Δ_spec st_args.decls :=

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -287,7 +287,7 @@ structure Intrinsic where
       A polymorphic intrinsic is a family of functions with the same
       implementation; only the argument/return types vary per use site, while
       the names and predicate are shared. -/
-  spec     : Spec
+  spec     : Spec TinyML.Typ
   /-- The typing function: given the inferred argument types of a use site,
       compute the type-variable instantiation (or reject with a message). It is
       untrusted — the elaborator re-checks arguments against the instantiated
@@ -391,7 +391,7 @@ theorem toReduce_two_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .two Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .two)) (axioms : List Axiom)
@@ -404,7 +404,7 @@ theorem toReduce_three_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .three Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .three Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .three)) (axioms : List Axiom)
@@ -417,7 +417,7 @@ theorem toReduce_one_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .one Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .one)) (axioms : List Axiom)
@@ -430,7 +430,7 @@ theorem toReduce_zero_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .zero Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .zero)) (axioms : List Axiom)
@@ -457,7 +457,7 @@ theorem toWp_two_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .two Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .two)) (axioms : List Axiom)
@@ -470,7 +470,7 @@ theorem toWp_three_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .three Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .three Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .three)) (axioms : List Axiom)
@@ -483,7 +483,7 @@ theorem toWp_one_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .one Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .one)) (axioms : List Axiom)
@@ -496,7 +496,7 @@ theorem toWp_zero_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .zero Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .zero)) (axioms : List Axiom)
@@ -516,7 +516,7 @@ def foldSig (Δ : Signature) : List Intrinsic → Signature
 def sigOf (fragment : List Intrinsic) : Signature :=
   foldSig Signature.empty fragment
 
-/-! ### Spec→wp bridge
+/-! ### Spec TinyML.Typ→wp bridge
 
 `compile` routes a `.prim n args` call through `Spec.call` against the
 intrinsic's spec. The resulting `PredTrans.apply` obligation must be bridged

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -28,13 +28,13 @@ which is defined in `SourceTinyML/Assertions.lean`.
     and each inner postcondition assertion is also well-formed (in the extended context). -/
 def PredTrans.wfIn (Δ : Signature) (pt : PredTrans) : Prop :=
   Assertion.wfIn
-    (fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2)
+    (fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.name, .value⟩) post.body)
     Δ pt
 
 
 def PredTrans.checkWf (Δ : Signature) (pt : PredTrans) : Except String Unit :=
   Assertion.checkWf
-    (fun post Δ' => Assertion.checkWf (fun _ _ => .ok ()) (Δ'.declVar ⟨post.1, .value⟩) post.2)
+    (fun post Δ' => Assertion.checkWf (fun _ _ => .ok ()) (Δ'.declVar ⟨post.name, .value⟩) post.body)
     Δ pt
 
 omit [MicaGS HasLC.hasLC Sig] in
@@ -51,7 +51,7 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : Env) : iProp :=
   Assertion.pre W (fun post ρ' =>
     BIBase.forall fun v : Runtime.Val =>
-      Assertion.post W (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
+      Assertion.post W (fun () _ => Φ v) post.body (ρ'.updateConst .value post.name v)
   ) m ρ
 
 -- ---------------------------------------------------------------------------
@@ -62,7 +62,7 @@ def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTra
     assertion) and assume the postcondition (assume the inner assertion). Returns a term
     representing the result value. -/
 def PredTrans.call (σ : FiniteSubst) (pt : PredTrans) : VerifM (Term .value) := do
-  let (σ₁, (postName, postBody)) ← Assertion.prove σ pt
+  let (σ₁, ⟨postName, postBody⟩) ← Assertion.prove σ pt
   let resVar ← VerifM.decl (some postName) .value
   let σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
   let (_, ()) ← Assertion.assume σ₂ postBody
@@ -72,7 +72,7 @@ def PredTrans.call (σ : FiniteSubst) (pt : PredTrans) : VerifM (Term .value) :=
     assertion), run `body` to produce a result term, then assert the postcondition (prove the
     inner assertion). Dual to `PredTrans.call`. -/
 def PredTrans.implement (σ : FiniteSubst) (pt : PredTrans) (body : VerifM (Term .value)) : VerifM Unit := do
-  let (σ₁, (postName, postBody)) ← Assertion.assume σ pt
+  let (σ₁, ⟨postName, postBody⟩) ← Assertion.assume σ pt
   let result ← body
   let resVar ← VerifM.decl (some postName) .value
   let σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
@@ -90,8 +90,8 @@ theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
   unfold PredTrans.wfIn at h ⊢
   exact Assertion.wfIn_mono pt _
     (fun post ds ds' hsub' hwf' hpost =>
-      Assertion.wfIn_mono post.2 _ (fun _ _ _ _ _ h => h) hpost
-        (Signature.Subset.declVar hsub' ⟨post.1, .value⟩)
+      Assertion.wfIn_mono post.body _ (fun _ _ _ _ _ h => h) hpost
+        (Signature.Subset.declVar hsub' ⟨post.name, .value⟩)
         (Signature.wf_declVar hwf'))
     h hsub hwf
 
@@ -125,16 +125,16 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Si
   intro hwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind heval
-  let retWf : (String × Assertion Unit) → Signature → Prop :=
-    fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let Φpost : (String × Assertion Unit) → Env → iProp :=
+  let retWf : Post → Signature → Prop :=
+    fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.name, .value⟩) post.body
+  let Φpost : Post → Env → iProp :=
     fun post ρ' =>
       BIBase.forall fun v : Runtime.Val =>
-        Assertion.post W (fun () _ => Φ v) post.2 (ρ'.updateConst .value post.1 v)
-  let Ψcall : (FiniteSubst × (String × Assertion Unit)) → TransState → Env → Prop :=
+        Assertion.post W (fun () _ => Φ v) post.body (ρ'.updateConst .value post.name v)
+  let Ψcall : (FiniteSubst × Post) → TransState → Env → Prop :=
     fun r st' ρ' =>
       match r with
-      | (σ₁, postName, postBody) => (do
+      | (σ₁, ⟨postName, postBody⟩) => (do
           let resVar ← VerifM.decl (some postName) Srt.value
           let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
           Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
@@ -221,13 +221,13 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind heval
   have hb_grow := VerifM.eval.decls_grow ρ hb
-  let retWf : (String × Assertion Unit) → Signature → Prop :=
-    fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.1, .value⟩) post.2
-  let OuterQ : (String × Assertion Unit) → Env → iProp :=
+  let retWf : Post → Signature → Prop :=
+    fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.name, .value⟩) post.body
+  let OuterQ : Post → Env → iProp :=
     fun ⟨postName, postBody⟩ ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post W (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
-  let Φpost : (String × Assertion Unit) → Env → iProp :=
+  let Φpost : Post → Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
   have hpost := Assertion.assume_correct W pt Δ_base σ retWf
     st ρ _ Φpost emp
@@ -247,7 +247,7 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base
       apply BIBase.Entails.trans sep_comm.1
       apply BIBase.Entails.trans emp_sep.1
       have hcont_body := VerifM.eval_bind hcont
-      change st₁.sl W ρ₁ ⊢ OuterQ (postName, postBody) ((σ₁.subst.eval ρ₁)) -∗ R
+      change st₁.sl W ρ₁ ⊢ OuterQ ⟨postName, postBody⟩ ((σ₁.subst.eval ρ₁)) -∗ R
       refine wand_intro ?_
       refine hbody st₁ ρ₁ _ hdsub_st hagree_st ?_
       refine (VerifM.eval.decls_grow ρ₁ hcont_body).mono ?_
@@ -331,7 +331,7 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base
           simp [st₃, TransState.sl]
         exact hinput.trans hpre
       have hpost_final :
-          OuterQ (postName, postBody) ((σ₁.subst.eval ρ₁)) ⊢
+          OuterQ ⟨postName, postBody⟩ ((σ₁.subst.eval ρ₁)) ⊢
             Assertion.post W (fun () _ => Φ (result.eval ρ₂)) postBody
               ((σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))) := by
         exact (forall_elim (result.eval ρ₂)).trans hpost_transport

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -26,19 +26,19 @@ which is defined in `SourceTinyML/Assertions.lean`.
 
 /-- A predicate transformer is well-formed when its outer assertion is well-formed
     and each inner postcondition assertion is also well-formed (in the extended context). -/
-def PredTrans.wfIn (Δ : Signature) (pt : PredTrans) : Prop :=
+def PredTrans.wfIn (Δ : Signature) (pt : PredTrans TinyML.Typ) : Prop :=
   Assertion.wfIn
     (fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.name, .value⟩) post.body)
     Δ pt
 
 
-def PredTrans.checkWf (Δ : Signature) (pt : PredTrans) : Except String Unit :=
+def PredTrans.checkWf (Δ : Signature) (pt : PredTrans TinyML.Typ) : Except String Unit :=
   Assertion.checkWf
     (fun post Δ' => Assertion.checkWf (fun _ _ => .ok ()) (Δ'.declVar ⟨post.name, .value⟩) post.body)
     Δ pt
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
+theorem PredTrans.checkWf_ok {pt : PredTrans TinyML.Typ} {Δ : Signature}
     (h : pt.checkWf Δ = .ok ()) : pt.wfIn Δ :=
   Assertion.checkWf_ok
     (fun _ _ hok => Assertion.checkWf_ok (fun _ _ _ => trivial) hok)
@@ -48,7 +48,7 @@ theorem PredTrans.checkWf_ok {pt : PredTrans} {Δ : Signature}
 -- Semantics
 -- ---------------------------------------------------------------------------
 
-def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTrans) (ρ : Env) : iProp :=
+def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTrans TinyML.Typ) (ρ : Env) : iProp :=
   Assertion.pre W (fun post ρ' =>
     BIBase.forall fun v : Runtime.Val =>
       Assertion.post W (fun () _ => Φ v) post.body (ρ'.updateConst .value post.name v)
@@ -61,7 +61,7 @@ def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTra
 /-- The caller side of a predicate transformer: assert the precondition (prove the outer
     assertion) and assume the postcondition (assume the inner assertion). Returns a term
     representing the result value. -/
-def PredTrans.call (σ : FiniteSubst) (pt : PredTrans) : VerifM (Term .value) := do
+def PredTrans.call (σ : FiniteSubst) (pt : PredTrans TinyML.Typ) : VerifM (Term .value) := do
   let (σ₁, ⟨postName, postBody⟩) ← Assertion.prove σ pt
   let resVar ← VerifM.decl (some postName) .value
   let σ₂ := σ₁.rename ⟨postName, .value⟩ resVar.name
@@ -71,7 +71,7 @@ def PredTrans.call (σ : FiniteSubst) (pt : PredTrans) : VerifM (Term .value) :=
 /-- The implementor side of a predicate transformer: assume the precondition (assume the outer
     assertion), run `body` to produce a result term, then assert the postcondition (prove the
     inner assertion). Dual to `PredTrans.call`. -/
-def PredTrans.implement (σ : FiniteSubst) (pt : PredTrans) (body : VerifM (Term .value)) : VerifM Unit := do
+def PredTrans.implement (σ : FiniteSubst) (pt : PredTrans TinyML.Typ) (body : VerifM (Term .value)) : VerifM Unit := do
   let (σ₁, ⟨postName, postBody⟩) ← Assertion.assume σ pt
   let result ← body
   let resVar ← VerifM.decl (some postName) .value
@@ -85,7 +85,7 @@ def PredTrans.implement (σ : FiniteSubst) (pt : PredTrans) (body : VerifM (Term
 -- ---------------------------------------------------------------------------
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
+theorem PredTrans.wfIn_mono {pt : PredTrans TinyML.Typ} {Δ Δ' : Signature}
     (h : pt.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) : pt.wfIn Δ' := by
   unfold PredTrans.wfIn at h ⊢
   exact Assertion.wfIn_mono pt _
@@ -95,7 +95,7 @@ theorem PredTrans.wfIn_mono {pt : PredTrans} {Δ Δ' : Signature}
         (Signature.wf_declVar hwf'))
     h hsub hwf
 
-theorem PredTrans.apply_env_agree (W : TinyML.World) {pt : PredTrans} {Φ : Runtime.Val → iProp}
+theorem PredTrans.apply_env_agree (W : TinyML.World) {pt : PredTrans TinyML.Typ} {Φ : Runtime.Val → iProp}
     {ρ ρ' : Env} {Δ : Signature}
     (hwf : pt.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
     PredTrans.apply W Φ pt ρ ⊢ PredTrans.apply W Φ pt ρ' := by
@@ -113,7 +113,7 @@ theorem PredTrans.apply_env_agree (W : TinyML.World) {pt : PredTrans} {Φ : Runt
 -- Correctness
 -- ---------------------------------------------------------------------------
 
-theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
+theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans TinyML.Typ) (Δ_base : Signature) (σ : FiniteSubst)
     (st : TransState) (ρ : Env)
     (Ψ : Term .value → TransState → Env → Prop) (Φ : Runtime.Val → iProp) R :
     pt.wfIn (Δ_base.declVars σ.dom) →
@@ -125,13 +125,13 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Si
   intro hwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind heval
-  let retWf : Post → Signature → Prop :=
+  let retWf : Post TinyML.Typ → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.name, .value⟩) post.body
-  let Φpost : Post → Env → iProp :=
+  let Φpost : Post TinyML.Typ → Env → iProp :=
     fun post ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post W (fun () _ => Φ v) post.body (ρ'.updateConst .value post.name v)
-  let Ψcall : (FiniteSubst × Post) → TransState → Env → Prop :=
+  let Ψcall : (FiniteSubst × Post TinyML.Typ) → TransState → Env → Prop :=
     fun r st' ρ' =>
       match r with
       | (σ₁, ⟨postName, postBody⟩) => (do
@@ -201,7 +201,7 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Si
   simpa [PredTrans.apply, Φpost] using hpre
 
 
-theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base : Signature) (σ : FiniteSubst)
+theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans TinyML.Typ) (Δ_base : Signature) (σ : FiniteSubst)
     (body : VerifM (Term .value))
     (st : TransState) (ρ : Env) (Φ : Runtime.Val → iProp) (R : iProp) :
     pt.wfIn (Δ_base.declVars σ.dom) →
@@ -221,13 +221,13 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans) (Δ_base
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind heval
   have hb_grow := VerifM.eval.decls_grow ρ hb
-  let retWf : Post → Signature → Prop :=
+  let retWf : Post TinyML.Typ → Signature → Prop :=
     fun post Δ' => Assertion.wfIn (fun _ _ => True) (Δ'.declVar ⟨post.name, .value⟩) post.body
-  let OuterQ : Post → Env → iProp :=
+  let OuterQ : Post TinyML.Typ → Env → iProp :=
     fun ⟨postName, postBody⟩ ρ' =>
       BIBase.forall fun v : Runtime.Val =>
         Assertion.post W (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
-  let Φpost : Post → Env → iProp :=
+  let Φpost : Post TinyML.Typ → Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
   have hpost := Assertion.assume_correct W pt Δ_base σ retWf
     st ρ _ Φpost emp

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -22,7 +22,7 @@ open Verifier.RelationalEncoding.Skolemize (encoderOps DefVal)
 /-- Bundle a declaration's spec with the argument and result types of the
     function literal it annotates. Validates that the spec's argument-name count
     matches the function's arity. -/
-def SpecEntry.ofFunction (s : Spec) (e : Expr) : Except String SpecEntry :=
+def SpecEntry.ofFunction (s : Spec TinyML.Typ) (e : Expr) : Except String SpecEntry :=
   match e with
   | .fix _ argBinders retTy _ =>
     if s.args.length = argBinders.length then
@@ -32,7 +32,7 @@ def SpecEntry.ofFunction (s : Spec) (e : Expr) : Except String SpecEntry :=
 
 omit [MicaGS HasLC.hasLC Sig] in
 /-- A bundled entry's spec-argument count matches its argument-type count. -/
-theorem SpecEntry.ofFunction_argLen {s : Spec} {expr : Expr} {e : SpecEntry}
+theorem SpecEntry.ofFunction_argLen {s : Spec TinyML.Typ} {expr : Expr} {e : SpecEntry}
     (h : SpecEntry.ofFunction s expr = .ok e) : e.spec.args.length = e.argTys.length := by
   simp only [SpecEntry.ofFunction] at h
   split at h
@@ -95,7 +95,7 @@ its specifications already translated, and the final elaboration state (which
 carries the lifted bounded quantifiers). -/
 def Program.prepare (env : Typed.SpecEnv σ) (s : σ)
     (prog : Untyped.Program (Spec.Body Untyped.Expr)) :
-    VerifM (TinyML.TypeEnv × Typed.Program Spec × σ) :=
+    VerifM (TinyML.TypeEnv × Typed.Program (Spec TinyML.Typ) × σ) :=
   match Typed.Program.elaborate env TinyML.TypeEnv.empty TinyML.TyCtx.empty prog s with
   | .ok ((Θ, typed), s') => .ret (Θ, typed, s')
   | .error err => .fatal (toString err)
@@ -124,7 +124,7 @@ private structure RelationDecl where
   body : Typed.Expr
   bv : Skolemize.DefVal
 
-private def validateDecl (d : Typed.ValDecl Spec) :
+private def validateDecl (d : Typed.ValDecl (Spec TinyML.Typ)) :
     Except String (TinyML.Var × TinyML.Var × Typed.Expr) := do
   if d.declMeta.spec.isSome then
     .error s!"declaration cannot have both [@@spec] and [@@fn]"
@@ -139,7 +139,7 @@ private def validateDecl (d : Typed.ValDecl Spec) :
   | .fix _ _ _ _ => .error s!"[@@fn] requires a unary function"
   | _ => .error s!"[@@fn] requires a function body"
 
-private def extend (acc : RelationSpec) (d : Typed.ValDecl Spec) :
+private def extend (acc : RelationSpec) (d : Typed.ValDecl (Spec TinyML.Typ)) :
     Except String RelationDecl := do
   match d.declMeta.relation with
   | none => .error "internal error: expected relation declaration"
@@ -171,7 +171,7 @@ private def extend (acc : RelationSpec) (d : Typed.ValDecl Spec) :
                                   (SpecFn.func rel)).addUnaryRel (SpecFn.defined rel) }
         .ok { spec, res, axs, f, rel, arg, body, bv }
 
-private def declareAndAssume (acc : RelationSpec) (d : Typed.ValDecl Spec) :
+private def declareAndAssume (acc : RelationSpec) (d : Typed.ValDecl (Spec TinyML.Typ)) :
     VerifM RelationSpec := do
   match d.declMeta.relation with
   | none => pure acc
@@ -200,7 +200,7 @@ private def declareLifting (acc : RelationSpec) (s : Verifier.BoundedQuantifier.
                  functionMap := acc.functionMap ++ [(s.name, s.name)],
                  delta := s.extendSignature acc.delta }
 
-private def assembleFrom : RelationSpec → Typed.Program Spec → VerifM RelationSpec
+private def assembleFrom : RelationSpec → Typed.Program (Spec TinyML.Typ) → VerifM RelationSpec
   | acc, [] => pure acc
   | acc, d :: ds => do
       let acc' ← declareAndAssume acc d
@@ -220,7 +220,7 @@ Quantifier symbols are declared after all program declarations: assembly never
 consults specs, and the only cross-references between lifted bodies — inner
 occurrences captured by outer ones — respect the lift order, which elaboration
 preserves. -/
-def assemble (prog : Typed.Program Spec)
+def assemble (prog : Typed.Program (Spec TinyML.Typ))
     (liftings : List Verifier.BoundedQuantifier.Lifting) : VerifM RelationSpec := do
   let Δ ← VerifM.ctx (fun st => (st.decls, st.owns))
   let acc ← assembleFrom { RelationSpec.empty with delta := Δ } prog
@@ -243,7 +243,7 @@ omit [MicaGS HasLC.hasLC Sig] in
 /-- Declaring one relation-marked declaration preserves the assembly
 invariants; the signature only grows and the environment is only extended
 with fresh interpretations. -/
-private theorem declareAndAssume_correct (d : Typed.ValDecl Spec)
+private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec TinyML.Typ))
     (acc : RelationSpec) (st : TransState) (ρ : Env)
     {Q : RelationSpec → TransState → Env → Prop}
     (hinv : Inv acc st ρ)
@@ -331,7 +331,7 @@ private theorem declareAndAssume_correct (d : Typed.ValDecl Spec)
         hsub4, hagree4, VerifM.eval_ret hcont⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
-private theorem assembleFrom_correct (prog : Typed.Program Spec) :
+private theorem assembleFrom_correct (prog : Typed.Program (Spec TinyML.Typ)) :
     ∀ (acc : RelationSpec) (st : TransState) (ρ : Env)
       {Q : RelationSpec → TransState → Env → Prop},
       Inv acc st ρ →
@@ -419,7 +419,7 @@ private theorem assembleLiftings_correct (ss : List Verifier.BoundedQuantifier.L
       Env.agreeOn_trans hag1 (Env.agreeOn_mono hsub1 hagRel), hQ⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem assemble_correct (prog : Typed.Program Spec)
+theorem assemble_correct (prog : Typed.Program (Spec TinyML.Typ))
     (liftings : List Verifier.BoundedQuantifier.Lifting)
     {st : TransState} {ρ : Env}
     {Q : RelationSpec → TransState → Env → Prop}
@@ -462,7 +462,7 @@ end RelationSpec
 /-- Check an individual declaration. Each declaration's `checkSpec` runs inside a `seq` bracket so its
     declarations and assertions don't pollute subsequent verifications. -/
 def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature)
-    (S : SpecMap) (d : Typed.ValDecl Spec) : VerifM SpecEntry := do
+    (S : SpecMap) (d : Typed.ValDecl (Spec TinyML.Typ)) : VerifM SpecEntry := do
   let spec ← match d.declMeta.spec with
     | some s => .ret s
     | none => .fatal "declaration has no spec"
@@ -475,12 +475,12 @@ def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Sig
   VerifM.seq (checkSpec reg Θ Δ_spec S d.body e) (pure e)
 
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
-def ValDecl.checkExpr (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (d : Typed.ValDecl Spec) : VerifM Unit :=
+def ValDecl.checkExpr (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (d : Typed.ValDecl (Spec TinyML.Typ)) : VerifM Unit :=
   VerifM.seq (do let _ ← compile reg Θ Δ_spec S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
 
 /-- Verify all declarations in a program, accumulating specs as we go. -/
 def Program.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) :
-    SpecMap → Typed.Program Spec → VerifM Unit
+    SpecMap → Typed.Program (Spec TinyML.Typ) → VerifM Unit
   | _, [] => pure ()
   | S, d :: ds => do
     match d.name.name, d.declMeta.spec with
@@ -516,7 +516,7 @@ omit [MicaGS HasLC.hasLC Sig] in
 theorem Program.prepare_correct (env : Typed.SpecEnv σ) (s : σ)
     (prog : Untyped.Program (Spec.Body Untyped.Expr))
     (st : TransState) (ρ : Env)
-    {Q : (TinyML.TypeEnv × Typed.Program Spec × σ) → TransState → Env → Prop}
+    {Q : (TinyML.TypeEnv × Typed.Program (Spec TinyML.Typ) × σ) → TransState → Env → Prop}
     (heval : VerifM.eval (Program.prepare env s prog) st ρ Q) :
     ∃ Θ typed s', Typed.Program.runtime typed = Untyped.Program.runtime prog ∧
       Q (Θ, typed, s') st ρ := by
@@ -534,7 +534,7 @@ theorem Program.prepare_correct (env : Typed.SpecEnv σ) (s : σ)
 
 theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
-    (S : SpecMap) (d : Typed.ValDecl Spec) (γ : Runtime.Subst)
+    (S : SpecMap) (d : Typed.ValDecl (Spec TinyML.Typ)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
@@ -583,7 +583,7 @@ theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.R
 
 theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
-    (S : SpecMap) (d : Typed.ValDecl Spec) (γ : Runtime.Subst)
+    (S : SpecMap) (d : Typed.ValDecl (Spec TinyML.Typ)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
@@ -634,7 +634,7 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
 
 theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
-    (S : SpecMap) (prog : Typed.Program Spec) (γ : Runtime.Subst)
+    (S : SpecMap) (prog : Typed.Program (Spec TinyML.Typ)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)

--- a/Mica/Verifier/SpecMaps.lean
+++ b/Mica/Verifier/SpecMaps.lean
@@ -21,7 +21,7 @@ variable [MicaGS HasLC.hasLC Sig]
 structure SpecEntry where
   argTys : List TinyML.Typ
   retTy  : TinyML.Typ
-  spec   : Spec
+  spec   : Spec TinyML.Typ
   deriving DecidableEq
 
 /-- The precondition assertion for a specified function value, reading the

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -40,7 +40,7 @@ def argsEnv (ρ : Env) : List String → List Runtime.Val → Env
 
 def isPrecondFor (W : TinyML.World)
     (argTys : List TinyML.Typ) (retTy : TinyML.Typ)
-    (f : Runtime.Val) (s : Spec) : iProp :=
+    (f : Runtime.Val) (s : Spec TinyML.Typ) : iProp :=
   iprop(□ ∀ (ρ : Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ -∗
       TinyML.ValsHaveTypes W vs argTys -∗
@@ -50,10 +50,10 @@ def isPrecondFor (W : TinyML.World)
 
 /-- A spec is well-formed when its predicate transformer is well-formed in the
     context extended with all argument variables. -/
-def wfIn (spec : Spec) (Δ : Signature) : Prop :=
+def wfIn (spec : Spec TinyML.Typ) (Δ : Signature) : Prop :=
   PredTrans.wfIn (Δ.declVars (argVars spec.args)) spec.pred
 
-def checkWf (spec : Spec) (Δ : Signature) : Except String Unit :=
+def checkWf (spec : Spec TinyML.Typ) (Δ : Signature) : Except String Unit :=
   PredTrans.checkWf (Δ.declVars (argVars spec.args)) spec.pred
 
 /-- Declare argument variables, check types, and assume equalities for a spec call.
@@ -76,7 +76,7 @@ def declareArgs (Θ : TinyML.TypeEnv) (σ : FiniteSubst) :
     argument and result types come from the enclosing arrow. -/
 def call (Θ : TinyML.TypeEnv) (σ : FiniteSubst)
     (argTys : List TinyML.Typ) (retTy : TinyML.Typ)
-    (s : Spec) (sargs : List (TinyML.Typ × Term .value)) :
+    (s : Spec TinyML.Typ) (sargs : List (TinyML.Typ × Term .value)) :
     VerifM (TinyML.Typ × Term .value) := do
   let σ' ← declareArgs Θ σ s.args argTys sargs
   let result ← PredTrans.call σ' s.pred
@@ -100,7 +100,7 @@ def declareImplArgs (σ : FiniteSubst) :
 /-- Full implementation protocol for a spec: declare argument variables,
     assume type constraints, then invoke `PredTrans.implement`. Dual to `call`.
     The argument types come from the enclosing arrow. -/
-def implement (Δ_base : Signature) (argTys : List TinyML.Typ) (s : Spec)
+def implement (Δ_base : Signature) (argTys : List TinyML.Typ) (s : Spec TinyML.Typ)
     (body : List FOL.Const → VerifM (Term .value)) : VerifM Unit := do
   let (σ, argVars) ← declareImplArgs (FiniteSubst.base Δ_base) s.args argTys
   PredTrans.implement σ s.pred (body argVars)
@@ -115,7 +115,7 @@ instance : Iris.BI.Persistent (isPrecondFor W argTys retTy f s) := by
 /-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
 theorem isPrecondFor_intro (W : TinyML.World)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec TinyML.Typ)
     (f : Runtime.Val) :
     iprop(□ ∀ (ρ : Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
       (⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ ∗
@@ -135,7 +135,7 @@ theorem isPrecondFor_intro (W : TinyML.World)
     `s.isPrecondFor W (.fix f args e)`, assume it as the recursive hypothesis and
     prove the `wp` of the body (after the usual fix-substitution). -/
 theorem isPrecondFor_fix {W : TinyML.World}
-    {argTys : List TinyML.Typ} {retTy : TinyML.Typ} {s : Spec}
+    {argTys : List TinyML.Typ} {retTy : TinyML.Typ} {s : Spec TinyML.Typ}
     {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {R : iProp}
     (hargs : args.length = s.args.length)
@@ -194,12 +194,12 @@ end Precondition
 section WellFormedness
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem checkWf_ok {spec : Spec} {Δ : Signature}
+theorem checkWf_ok {spec : Spec TinyML.Typ} {Δ : Signature}
     (h : spec.checkWf Δ = .ok ()) : spec.wfIn Δ :=
   PredTrans.checkWf_ok h
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem wfIn_mono {spec : Spec} {Δ Δ' : Signature}
+theorem wfIn_mono {spec : Spec TinyML.Typ} {Δ Δ' : Signature}
     (h : spec.wfIn Δ) (hsub : Δ.Subset Δ') (hwf : Δ'.wf) :
     spec.wfIn Δ' :=
   PredTrans.wfIn_mono h (Signature.Subset.declVars hsub (argVars spec.args))
@@ -356,13 +356,13 @@ theorem declareArgs_correct (W : TinyML.World) :
         exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
 
 theorem call_correct (W : TinyML.World)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec) (Δ_base : Signature)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec TinyML.Typ) (Δ_base : Signature)
     (σ : FiniteSubst) (sargs : List (TinyML.Typ × Term .value))
     (st : TransState) (ρ : Env)
     (Ψ : (TinyML.Typ × Term .value) → TransState → Env → Prop)
     (Φ : Runtime.Val → iProp) (R : iProp) :
     s.args.length = argTys.length →
-    s.pred.wfIn ((Δ_base.declVars σ.dom).declVars (Spec.argVars s.args)) →
+    PredTrans.wfIn ((Δ_base.declVars σ.dom).declVars (Spec.argVars s.args)) s.pred →
     σ.wfIn Δ_base st.decls →
     (∀ p ∈ sargs, (p : TinyML.Typ × Term .value).2.wfIn st.decls) →
     VerifM.eval (Spec.call W.Θ σ argTys retTy s sargs) st ρ Ψ →
@@ -378,7 +378,7 @@ theorem call_correct (W : TinyML.World)
   obtain ⟨σ', st', ρ', ⟨hdsub, hragree, hΨ'⟩, hσ'wf, howns, hsublist, hdom_sub, hagree⟩ :=
     declareArgs_correct W s.args argTys sargs Δ_base σ st ρ _ hlen hσwf hsargs hb_grow
   refine ⟨hsublist, ?_⟩
-  have hwf'' : s.pred.wfIn (Δ_base.declVars σ'.dom) :=
+  have hwf'' : PredTrans.wfIn (Δ_base.declVars σ'.dom) s.pred :=
     PredTrans.wfIn_mono hwf hdom_sub hσ'wf.srcWf
   have hcall := PredTrans.call_correct W s.pred Δ_base σ' st' ρ'
     _ (fun r => TinyML.ValHasType W r retTy -∗ Φ r) R
@@ -549,7 +549,7 @@ theorem declareImplArgs_correct (W : TinyML.World) :
         exact h1'.trans hvar_eval
 
 theorem implement_correct (W : TinyML.World)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec)
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec TinyML.Typ)
     (body : List FOL.Const → VerifM (Term .value))
     (st : TransState) (ρ : Env) (vs : List Runtime.Val) (Φ : Runtime.Val → iProp) (R : iProp) :
     s.args.length = argTys.length →


### PR DESCRIPTION
The assertion syntax — atoms, assertions, postconditions, predicate transformers, and specs — becomes parametric in the type language it mentions, and the verifier instantiates it at `TinyML.Typ`. Along the way, the postcondition of a predicate transformer gets a name, `Post`, rather than being an anonymous pair. Together this makes the syntax independent of the type language, which is what later lets a function type carry the specification of the function it describes.

Stacked on #138.