### PR TITLE
Interpret specified function types by their specification

### DIFF
--- a/Mica/SeparationLogic/Wp.lean
+++ b/Mica/SeparationLogic/Wp.lean
@@ -802,29 +802,32 @@ theorem wp.prim_pure {ctx : TinyML.PrimCtx} {n : String} {vs : List Runtime.Val}
 
 /-! ## Recursion -/
 
+/-- Fixpoint unfolding with a continuation-indexed invariant, where the caller's
+    resources are guarded: the beta step is what strips the guard, so the body is
+    proved from the unguarded invariant. The argument count is a pure premise,
+    since the step needs it before the guard can be stripped. -/
 theorem wp.fix' {ctx : TinyML.PrimCtx} {f : Runtime.Binder} {args : List Runtime.Binder}
-    {e : Runtime.Expr} {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp}
-    (hlen : ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-      Φ P vs ⊢ (⌜args.length = vs.length⌝ : iProp)) :
+    {e : Runtime.Expr} {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp} :
     □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-        Φ P vs -∗ wp ctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
+        ⌜args.length = vs.length⌝ -∗ ▷ Φ P vs -∗
+          wp ctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
       ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-        Φ P vs -∗ wp ctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)
-    ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp), Φ P vs -∗ wp ctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) := by
+        ⌜args.length = vs.length⌝ -∗ Φ P vs -∗
+          wp ctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)
+    ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
+        ⌜args.length = vs.length⌝ -∗ ▷ Φ P vs -∗
+          wp ctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) := by
   istart
   iintro #H
   iapply loeb_wand_intuitionistically
   imodintro
   iintro #HG
   imodintro
-  iintro %vs %P HΦ
-  ihave %hl : (⌜args.length = vs.length⌝ : iProp) $$ [HΦ]
-  · iapply hlen vs P
-    iexact HΦ
+  iintro %vs %P %hl HΦ
   iapply wp.pure_step' (fun _ => .beta hl) (fun _ _ _ h => h.beta_inv)
   inext
   ispecialize H $$ HG
-  iapply H $$ %vs %P HΦ
+  iapply H $$ %vs %P %hl HΦ
 
 /-- Definitional unfolding of `wp` into the Iris weakest precondition; stated
     here so it remains usable once `wp` is marked irreducible (adequacy needs

--- a/Mica/SourceTinyML/LogicalRelation.lean
+++ b/Mica/SourceTinyML/LogicalRelation.lean
@@ -8,6 +8,7 @@ import Mica.FOL.Formulas
 import Mica.Base.Fresh
 import Mica.SeparationLogic.Wp
 import Mica.SourceTinyML.World
+import Mica.SourceTinyML.Semantics
 import Iris.BI.Lib.Fixpoint
 
 open Iris Iris.BI Iris.OFE
@@ -36,9 +37,6 @@ abbrev RecIdx := LeibnizO (Runtime.Val × TypeName × List Typ)
 @[reducible] def RecCont.ofPred (Φ : RecIdx → iProp) : RecCont :=
   fun v T args => Φ ⟨(v, T, args)⟩
 
-/-- The outer approximation ranges over closed value relations. -/
-abbrev ValShape := Runtime.Val → Typ → iProp
-
 /-- Interpret one primitive type as an Iris assertion over a runtime value. -/
 def PrimitiveType.valRelBody : PrimitiveType → Runtime.Val → iProp
   | .unit, v => iprop(⌜v = .unit⌝)
@@ -60,44 +58,53 @@ References use the outer approximation `R`; named types use the inner
 continuation `k`. Tuples and sums are structural and mutually recursive with
 the list/sum helpers below. Vectors are a big separating conjunction over the
 elements.
+
+An unspecified function type is uninhabited. A specified one is interpreted by
+its specification, taken at the outer approximation `R`: the specification
+mentions types, which `isPrecondFor` interprets through the relation being
+defined. `R` rather than `k`, because `R` occurs both negatively (arguments) and
+positively (result), so the body is neither monotone nor antitone in the inner
+continuation. The guard that makes this well-defined sits inside
+`isPrecondFor`, on its resource premises.
 -/
 mutual
-  def ValRelBody (R : ValShape) (v : Runtime.Val) (t : Typ) (k : RecCont) : iProp :=
+  def ValRelBody (W : World) (R : ValueRelation) (v : Runtime.Val) (t : Typ) (k : RecCont) : iProp :=
     match t with
     | .prim p     => p.valRelBody v
     | .value      => iprop(True)
     | .empty      => iprop(False)
-    | .arrow ..  => iprop(False)
+    | .arrow _ _ none     => iprop(False)
+    | .arrow args ret (some s) => s.isPrecondFor W R args ret v
     | .tvar _     => iprop(False)
     | .ref t      => iprop(∃ l, ⌜v = .loc l⌝ ∗ locinv l (fun w => R w t))
     | .array t    => iprop(∃ len l, ⌜v = .array len l⌝ ∗ arrayinv len l (fun w => R w t))
     | .ownedArray _ => iprop(∃ len l, ⌜v = .array len l⌝)
     | .vec t      =>
-        iprop(∃ vs, ⌜v = .vec vs⌝ ∗ [∗list] w ∈ vs, ValRelBody R w t k)
+        iprop(∃ vs, ⌜v = .vec vs⌝ ∗ [∗list] w ∈ vs, ValRelBody W R w t k)
     | .owned _    => iprop(∃ l, ⌜v = .loc l⌝)
     | .named T args => k v T args
-    | .tuple ts   => iprop(∃ vs, ⌜v = .tuple vs⌝ ∗ ValsRelBody R vs ts k)
+    | .tuple ts   => iprop(∃ vs, ⌜v = .tuple vs⌝ ∗ ValsRelBody W R vs ts k)
     | .sum ts     =>
         iprop(∃ tag payload, ⌜v = .inj tag ts.length payload⌝ ∗
-          ValSumRelBody R tag payload ts k)
+          ValSumRelBody W R tag payload ts k)
 
-  def ValsRelBody : ValShape → List Runtime.Val → List Typ → RecCont → iProp
+  def ValsRelBody (W : World) : ValueRelation → List Runtime.Val → List Typ → RecCont → iProp
     | _, [], [], _ => iprop(emp)
-    | R, v :: vs, t :: ts, k => iprop(ValRelBody R v t k ∗ ValsRelBody R vs ts k)
+    | R, v :: vs, t :: ts, k => iprop(ValRelBody W R v t k ∗ ValsRelBody W R vs ts k)
     | _, _, _, _ => iprop(False)
 
-  def ValSumRelBody : ValShape → Nat → Runtime.Val → List Typ → RecCont → iProp
+  def ValSumRelBody (W : World) : ValueRelation → Nat → Runtime.Val → List Typ → RecCont → iProp
     | _, _, _, [], _ => iprop(False)
-    | R, 0, payload, t :: _, k => ValRelBody R payload t k
-    | R, n + 1, payload, _ :: ts, k => ValSumRelBody R n payload ts k
+    | R, 0, payload, t :: _, k => ValRelBody W R payload t k
+    | R, n + 1, payload, _ :: ts, k => ValSumRelBody W R n payload ts k
 end
 
 /-! Monotonicity in the inner continuation. -/
 
 mutual
-  private theorem ValRelBody.mono_int (R : ValShape) (t : Typ) (v : Runtime.Val) {k k' : RecCont} :
+  private theorem ValRelBody.mono_int (W : World) (R : ValueRelation) (t : Typ) (v : Runtime.Val) {k k' : RecCont} :
       ⊢ □ (∀ v T args, k v T args -∗ k' v T args) -∗
-        (ValRelBody R v t k -∗ ValRelBody R v t k' : iProp) := by
+        (ValRelBody W R v t k -∗ ValRelBody W R v t k' : iProp) := by
     unfold ValRelBody
     match t with
     | .named T args =>
@@ -110,7 +117,7 @@ mutual
         isplitr
         · ipureintro
           exact heq
-        · iapply (ValsRelBody.mono_int R ts vs)
+        · iapply (ValsRelBody.mono_int W R ts vs)
           · iexact Hk
           · iexact Hvs
     | .vec t =>
@@ -122,7 +129,7 @@ mutual
         · iapply BigSepL.bigSepL_impl $$ Hvs
           imodintro
           iintro %i %w %hget
-          iapply (ValRelBody.mono_int R t w)
+          iapply (ValRelBody.mono_int W R t w)
           iexact Hk
     | .sum ts =>
         iintro #Hk ⟨%tag, %payload, %heq, Hsum⟩
@@ -130,20 +137,21 @@ mutual
         isplitr
         · ipureintro
           exact heq
-        · iapply (ValSumRelBody.mono_int R ts tag payload)
+        · iapply (ValSumRelBody.mono_int W R ts tag payload)
           · iexact Hk
           · iexact Hsum
     | .prim _ =>
         iintro _ H
         iexact H
-    | .value | .empty | .arrow .. | .tvar _ | .ref _ | .array _ | .ownedArray _ | .owned _ =>
+    | .value | .empty | .arrow _ _ none | .arrow _ _ (some _) | .tvar _ | .ref _ | .array _
+    | .ownedArray _ | .owned _ =>
         iintro _ H
         iexact H
 
-  private theorem ValsRelBody.mono_int (R : ValShape) (ts : List Typ) (vs : List Runtime.Val)
+  private theorem ValsRelBody.mono_int (W : World) (R : ValueRelation) (ts : List Typ) (vs : List Runtime.Val)
       {k k' : RecCont} :
       ⊢ □ (∀ v T args, k v T args -∗ k' v T args) -∗
-        (ValsRelBody R vs ts k -∗ ValsRelBody R vs ts k' : iProp) := by
+        (ValsRelBody W R vs ts k -∗ ValsRelBody W R vs ts k' : iProp) := by
     unfold ValsRelBody
     match vs, ts with
     | [], [] =>
@@ -152,20 +160,20 @@ mutual
     | v :: vs, t :: ts =>
         iintro #Hk ⟨Hv, Hvs⟩
         isplitl [Hv]
-        · iapply (ValRelBody.mono_int R t v)
+        · iapply (ValRelBody.mono_int W R t v)
           · iexact Hk
           · iexact Hv
-        · iapply (ValsRelBody.mono_int R ts vs)
+        · iapply (ValsRelBody.mono_int W R ts vs)
           · iexact Hk
           · iexact Hvs
     | [], _ :: _ | _ :: _, [] =>
         iintro _ H
         iexact H
 
-  private theorem ValSumRelBody.mono_int (R : ValShape) (ts : List Typ) (tag : Nat)
+  private theorem ValSumRelBody.mono_int (W : World) (R : ValueRelation) (ts : List Typ) (tag : Nat)
       (payload : Runtime.Val) {k k' : RecCont} :
       ⊢ □ (∀ v T args, k v T args -∗ k' v T args) -∗
-        (ValSumRelBody R tag payload ts k -∗ ValSumRelBody R tag payload ts k' : iProp) := by
+        (ValSumRelBody W R tag payload ts k -∗ ValSumRelBody W R tag payload ts k' : iProp) := by
     unfold ValSumRelBody
     match tag, ts with
     | _, [] =>
@@ -173,12 +181,12 @@ mutual
         iexact H
     | 0, t :: _ =>
         iintro #Hk Hv
-        iapply (ValRelBody.mono_int R t payload)
+        iapply (ValRelBody.mono_int W R t payload)
         · iexact Hk
         · iexact Hv
     | n + 1, _ :: ts =>
         iintro #Hk Hv
-        iapply (ValSumRelBody.mono_int R ts n payload)
+        iapply (ValSumRelBody.mono_int W R ts n payload)
         · iexact Hk
         · iexact Hv
 end
@@ -186,9 +194,9 @@ end
 /-! Mixed OFE continuity in the outer approximation and inner continuation. -/
 
 mutual
-  private theorem ValRelBody.dist {n : Nat} {R S : ValShape} {k k' : RecCont}
+  private theorem ValRelBody.dist {n : Nat} {W : World} {R S : ValueRelation} {k k' : RecCont}
       (hR : DistLater n R S) (hk : k ≡{n}≡ k') (t : Typ) (v : Runtime.Val) :
-      ValRelBody R v t k ≡{n}≡ ValRelBody S v t k' := by
+      ValRelBody W R v t k ≡{n}≡ ValRelBody W S v t k' := by
     unfold ValRelBody
     match t with
     | .ref t =>
@@ -222,14 +230,16 @@ mutual
         refine exists_ne fun payload => ?_
         refine sep_ne.ne (.of_eq rfl) ?_
         exact ValSumRelBody.dist hR hk ts tag payload
+    | .arrow args ret (some s) =>
+        exact Spec.isPrecondFor_contractive hR args ret v s
     | .prim _ =>
         exact Dist.rfl
-    | .value | .empty | .arrow .. | .tvar _ | .owned _ =>
+    | .value | .empty | .arrow _ _ none | .tvar _ | .owned _ =>
         exact Dist.rfl
 
-  private theorem ValsRelBody.dist {n : Nat} {R S : ValShape} {k k' : RecCont}
+  private theorem ValsRelBody.dist {n : Nat} {W : World} {R S : ValueRelation} {k k' : RecCont}
       (hR : DistLater n R S) (hk : k ≡{n}≡ k') (ts : List Typ) (vs : List Runtime.Val) :
-      ValsRelBody R vs ts k ≡{n}≡ ValsRelBody S vs ts k' := by
+      ValsRelBody W R vs ts k ≡{n}≡ ValsRelBody W S vs ts k' := by
     unfold ValsRelBody
     match vs, ts with
     | [], [] =>
@@ -241,10 +251,10 @@ mutual
     | [], _ :: _ | _ :: _, [] =>
         exact Dist.rfl
 
-  private theorem ValSumRelBody.dist {n : Nat} {R S : ValShape} {k k' : RecCont}
+  private theorem ValSumRelBody.dist {n : Nat} {W : World} {R S : ValueRelation} {k k' : RecCont}
       (hR : DistLater n R S) (hk : k ≡{n}≡ k') (ts : List Typ) (tag : Nat)
       (payload : Runtime.Val) :
-      ValSumRelBody R tag payload ts k ≡{n}≡ ValSumRelBody S tag payload ts k' := by
+      ValSumRelBody W R tag payload ts k ≡{n}≡ ValSumRelBody W S tag payload ts k' := by
     unfold ValSumRelBody
     match tag, ts with
     | _, [] =>
@@ -255,18 +265,18 @@ mutual
         exact ValSumRelBody.dist hR hk ts n payload
 end
 
-private instance ValRelBody.contractive (k : RecCont) (v : Runtime.Val) (t : Typ) :
-    Contractive (fun R : ValShape => ValRelBody R v t k) where
+private instance ValRelBody.contractive (W : World) (k : RecCont) (v : Runtime.Val) (t : Typ) :
+    Contractive (fun R : ValueRelation => ValRelBody W R v t k) where
   distLater_dist hR := ValRelBody.dist hR Dist.rfl t v
 
 /-- One unfolding of the inner recursive type interpretation. -/
-private def ValRelIndF (W : World) (R : ValShape) (Φ : RecIdx → iProp) (x : RecIdx) : iProp :=
+private def ValRelIndF (W : World) (R : ValueRelation) (Φ : RecIdx → iProp) (x : RecIdx) : iProp :=
   match x with
   | ⟨(v, T, args)⟩ =>
       iprop(∃ ty, ⌜TypeName.unfold W.Θ T args = some ty⌝ ∗
-        ValRelBody R v ty (RecCont.ofPred Φ))
+        ValRelBody W R v ty (RecCont.ofPred Φ))
 
-private instance (W : World) (R : ValShape) (Φ : RecIdx → iProp) :
+private instance (W : World) (R : ValueRelation) (Φ : RecIdx → iProp) :
     NonExpansive (ValRelIndF W R Φ) where
   ne {_ x y} h := by
     obtain ⟨x⟩ := x
@@ -275,16 +285,16 @@ private instance (W : World) (R : ValShape) (Φ : RecIdx → iProp) :
     exact Dist.of_eq rfl
 
 private theorem ValRelIndF.contractive (W : World) (Φ : RecIdx → iProp) (x : RecIdx) :
-    Contractive (fun R : ValShape => ValRelIndF W R Φ x) where
+    Contractive (fun R : ValueRelation => ValRelIndF W R Φ x) where
   distLater_dist {n R S} hR := by
     obtain ⟨v, T, args⟩ := x
     simp only [ValRelIndF]
     refine exists_ne fun ty => ?_
     refine sep_ne.ne (.of_eq rfl) ?_
     exact Contractive.distLater_dist
-      (f := fun R : ValShape => ValRelBody R v ty (RecCont.ofPred Φ)) hR
+      (f := fun R : ValueRelation => ValRelBody W R v ty (RecCont.ofPred Φ)) hR
 
-private instance (W : World) (R : ValShape) : BIMonoPred (ValRelIndF W R) where
+private instance (W : World) (R : ValueRelation) : BIMonoPred (ValRelIndF W R) where
   mono_pred := by
     intro Φ Ψ _ _
     iintro #HΦΨ %x HF
@@ -295,7 +305,7 @@ private instance (W : World) (R : ValShape) : BIMonoPred (ValRelIndF W R) where
     isplitr
     · ipureintro
       exact hunfold
-    · iapply (ValRelBody.mono_int R ty v
+    · iapply (ValRelBody.mono_int W R ty v
         (k := RecCont.ofPred Φ) (k' := RecCont.ofPred Ψ))
       · imodintro
         iintro %v' %T' %args'
@@ -308,20 +318,20 @@ private instance (W : World) (R : ValShape) : BIMonoPred (ValRelIndF W R) where
     exact Dist.of_eq rfl
 
 /-- The inner least fixpoint for named types, with the outer approximation fixed. -/
-private def ValRelInd (W : World) (R : ValShape) : RecCont :=
+private def ValRelInd (W : World) (R : ValueRelation) : RecCont :=
   fun v T args => Iris.bi_least_fixpoint (ValRelIndF W R) ⟨(v, T, args)⟩
 
-private theorem ValRelInd.unfold {W : World} {R : ValShape}
+private theorem ValRelInd.unfold {W : World} {R : ValueRelation}
     {v : Runtime.Val} {T : TypeName} {args : List Typ} :
     ValRelInd W R v T args ⊣⊢
       iprop(∃ ty, ⌜TypeName.unfold W.Θ T args = some ty⌝ ∗
-        ValRelBody R v ty (ValRelInd W R)) := by
+        ValRelBody W R v ty (ValRelInd W R)) := by
   have h := Iris.least_fixpoint_unfold (ValRelIndF W R) (x := ⟨(v, T, args)⟩)
   simp only [ValRelIndF] at h
   exact equiv_iff.mp h
 
 private instance ValRelInd.contractive (W : World) :
-    Contractive (fun R : ValShape => ValRelInd W R) where
+    Contractive (fun R : ValueRelation => ValRelInd W R) where
   distLater_dist {n R S} hR v T args := by
     unfold ValRelInd Iris.bi_least_fixpoint
     refine forall_ne fun Φ => ?_
@@ -332,48 +342,63 @@ private instance ValRelInd.contractive (W : World) :
     exact (ValRelIndF.contractive W (fun x => Φ x) x).distLater_dist hR
 
 /-- The outer functional. It closes the named-type continuation using `ValRelInd`. -/
-private def ValRelF (W : World) (R : ValShape) : ValShape :=
-  fun v t => ValRelBody R v t (ValRelInd W R)
+private def ValRelF (W : World) (R : ValueRelation) : ValueRelation :=
+  fun v t => ValRelBody W R v t (ValRelInd W R)
 
 private instance ValRelF.contractive (W : World) : Contractive (ValRelF W) where
   distLater_dist {n R S} hR v t := by
     unfold ValRelF
     have hk : ValRelInd W R ≡{n}≡ ValRelInd W S :=
-      Contractive.distLater_dist (f := fun R : ValShape => ValRelInd W R) hR
+      Contractive.distLater_dist (f := fun R : ValueRelation => ValRelInd W R) hR
     exact ValRelBody.dist hR hk t v
 
 /-- The mixed recursive value relation. -/
-def ValHasType (W : World) : ValShape :=
+def ValHasType (W : World) : ValueRelation :=
   fixpoint (ValRelF W)
 
-/-- Final tuple/list relation induced by the mixed recursive value relation. -/
-def ValsHaveTypes (W : World) (vs : List Runtime.Val) (ts : List Typ) : iProp :=
-  ValsRelBody (ValHasType W) vs ts (ValRelInd W (ValHasType W))
+/-- Final tuple/list relation induced by the mixed recursive value relation.
+    Reducible so that it unifies with `ValsRel` at an instantiated `V`. -/
+@[reducible] def ValsHaveTypes (W : World) (vs : List Runtime.Val) (ts : List Typ) : iProp :=
+  ValsRel (ValHasType W) vs ts
 
 /-- Final sum-payload relation induced by the mixed recursive value relation. -/
 def ValSumRel (W : World) (tag : Nat) (payload : Runtime.Val)
     (ts : List Typ) : iProp :=
-  ValSumRelBody (ValHasType W) tag payload ts (ValRelInd W (ValHasType W))
+  ValSumRelBody W (ValHasType W) tag payload ts (ValRelInd W (ValHasType W))
 
 theorem ValHasType.unfold (W : World) (v : Runtime.Val) (t : Typ) :
-    ValHasType W v t ≡ ValRelBody (ValHasType W) v t (ValRelInd W (ValHasType W)) := by
-  let F : ValShape -c> ValShape := {
+    ValHasType W v t ≡ ValRelBody W (ValHasType W) v t (ValRelInd W (ValHasType W)) := by
+  let F : ValueRelation -c> ValueRelation := {
     f := ValRelF W
     contractive := inferInstance
   }
   exact (fixpoint_unfold F) v t
 
+/-- At the fixpoint, the pointwise lifting agrees with the structural list
+    layer of the value relation. -/
+theorem ValsHaveTypes.unfold (W : World) :
+    ∀ (vs : List Runtime.Val) (ts : List Typ),
+      ValsHaveTypes W vs ts ⊣⊢ ValsRelBody W (ValHasType W) vs ts (ValRelInd W (ValHasType W))
+  | [], [] => .rfl
+  | [], _ :: _ | _ :: _, [] => .rfl
+  | v :: vs, t :: ts => by
+      show iprop(ValHasType W v t ∗ ValsRel (ValHasType W) vs ts) ⊣⊢
+        iprop(ValRelBody W (ValHasType W) v t (ValRelInd W (ValHasType W)) ∗
+          ValsRelBody W (ValHasType W) vs ts (ValRelInd W (ValHasType W)))
+      exact sep_congr (equiv_iff.mp (ValHasType.unfold W v t)) (ValsHaveTypes.unfold W vs ts)
+
 
 /-! Persistence of the mixed value relation. -/
 
 mutual
-  theorem ValRelBody.persistent (R : ValShape) (t : Typ) (v : Runtime.Val) {k : RecCont}
-      (hk : ∀ v T args, Persistent (k v T args)) : Persistent (ValRelBody R v t k) := by
+  theorem ValRelBody.persistent (W : World) (R : ValueRelation) (t : Typ) (v : Runtime.Val) {k : RecCont}
+      (hk : ∀ v T args, Persistent (k v T args)) : Persistent (ValRelBody W R v t k) := by
     unfold ValRelBody
     match t with
     | .prim _ =>
         exact PrimitiveType.valRelBody_persistent _ v
-    | .value | .empty | .arrow .. | .tvar _ | .owned _ | .ownedArray _ =>
+    | .value | .empty | .arrow _ _ none | .arrow _ _ (some _) | .tvar _ | .owned _
+    | .ownedArray _ =>
         infer_instance
     | .ref _ =>
         have := locinv_persistent
@@ -384,78 +409,78 @@ mutual
     | .named T args =>
         exact hk v T args
     | .tuple ts =>
-        have : ∀ vs, Persistent (ValsRelBody R vs ts k) :=
-          fun vs => ValsRelBody.persistent R ts vs hk
+        have : ∀ vs, Persistent (ValsRelBody W R vs ts k) :=
+          fun vs => ValsRelBody.persistent W R ts vs hk
         infer_instance
     | .vec t =>
-        have hw : ∀ (w : Runtime.Val), Persistent (ValRelBody R w t k) :=
-          fun w => ValRelBody.persistent R t w hk
+        have hw : ∀ (w : Runtime.Val), Persistent (ValRelBody W R w t k) :=
+          fun w => ValRelBody.persistent W R t w hk
         have : ∀ vs : List Runtime.Val,
-            Persistent (iprop([∗list] w ∈ vs, ValRelBody R w t k)) :=
+            Persistent (iprop([∗list] w ∈ vs, ValRelBody W R w t k)) :=
           fun _ => BigSepL.bigSepL_persistent (fun _ w _ => hw w)
         infer_instance
     | .sum ts =>
-        have : ∀ n payload, Persistent (ValSumRelBody R n payload ts k) :=
-          fun n payload => ValSumRelBody.persistent R ts n payload hk
+        have : ∀ n payload, Persistent (ValSumRelBody W R n payload ts k) :=
+          fun n payload => ValSumRelBody.persistent W R ts n payload hk
         infer_instance
 
-  theorem ValsRelBody.persistent (R : ValShape) (ts : List Typ) (vs : List Runtime.Val)
+  theorem ValsRelBody.persistent (W : World) (R : ValueRelation) (ts : List Typ) (vs : List Runtime.Val)
       {k : RecCont} (hk : ∀ v T args, Persistent (k v T args)) :
-      Persistent (ValsRelBody R vs ts k) := by
+      Persistent (ValsRelBody W R vs ts k) := by
     unfold ValsRelBody
     match vs, ts with
     | [], [] =>
         infer_instance
     | v :: vs, t :: ts =>
-        have := ValRelBody.persistent R t v hk
-        have := ValsRelBody.persistent R ts vs hk
+        have := ValRelBody.persistent W R t v hk
+        have := ValsRelBody.persistent W R ts vs hk
         infer_instance
     | [], _ :: _ | _ :: _, [] =>
         infer_instance
 
-  theorem ValSumRelBody.persistent (R : ValShape) (ts : List Typ) (n : Nat)
+  theorem ValSumRelBody.persistent (W : World) (R : ValueRelation) (ts : List Typ) (n : Nat)
       (payload : Runtime.Val) {k : RecCont} (hk : ∀ v T args, Persistent (k v T args)) :
-      Persistent (ValSumRelBody R n payload ts k) := by
+      Persistent (ValSumRelBody W R n payload ts k) := by
     unfold ValSumRelBody
     match n, ts with
     | _, [] =>
         infer_instance
     | 0, t :: _ =>
-        exact ValRelBody.persistent R t payload hk
+        exact ValRelBody.persistent W R t payload hk
     | n + 1, _ :: ts =>
-        exact ValSumRelBody.persistent R ts n payload hk
+        exact ValSumRelBody.persistent W R ts n payload hk
 end
 
-private instance ValRelIndF.persistent (W : World) (R : ValShape) (Φ : RecIdx → iProp)
+private instance ValRelIndF.persistent (W : World) (R : ValueRelation) (Φ : RecIdx → iProp)
     [∀ x, Persistent (Φ x)] (x : RecIdx) : Persistent (ValRelIndF W R Φ x) := by
   obtain ⟨v, T, args⟩ := x
   simp only [ValRelIndF]
-  have : ∀ ty, Persistent (ValRelBody R v ty (RecCont.ofPred Φ)) :=
-    fun ty => ValRelBody.persistent R ty v (fun _ _ _ => inferInstance)
+  have : ∀ ty, Persistent (ValRelBody W R v ty (RecCont.ofPred Φ)) :=
+    fun ty => ValRelBody.persistent W R ty v (fun _ _ _ => inferInstance)
   infer_instance
 
-private instance ValRelIndF.absorbing (W : World) (R : ValShape) (Φ : RecIdx → iProp)
+private instance ValRelIndF.absorbing (W : World) (R : ValueRelation) (Φ : RecIdx → iProp)
     [∀ x, Absorbing (Φ x)] (x : RecIdx) : Absorbing (ValRelIndF W R Φ x) := by
   obtain ⟨v, T, args⟩ := x
   simp only [ValRelIndF]
   infer_instance
 
-instance (W : World) (R : ValShape) (v : Runtime.Val) (T : TypeName)
+instance (W : World) (R : ValueRelation) (v : Runtime.Val) (T : TypeName)
     (args : List Typ) : Persistent (ValRelInd W R v T args) :=
   @Iris.least_fixpoint_persistent_absorbing iProp RecIdx _ _ (ValRelIndF W R) _
     (fun _ _ _ => inferInstance) (fun _ _ _ => inferInstance) ⟨(v, T, args)⟩
 
 instance (W : World) (v : Runtime.Val) (t : Typ) : Persistent (ValHasType W v t) :=
   (persistent_congr (equiv_iff.mp (ValHasType.unfold W v t))).mpr
-    (ValRelBody.persistent (ValHasType W) t v (fun _ _ _ => inferInstance))
+    (ValRelBody.persistent W (ValHasType W) t v (fun _ _ _ => inferInstance))
 
 instance (W : World) (vs : List Runtime.Val) (ts : List Typ) :
     Persistent (ValsHaveTypes W vs ts) :=
-  ValsRelBody.persistent (ValHasType W) ts vs (fun _ _ _ => inferInstance)
+  ValsRel.persistent (ValHasType W) (fun _ _ => inferInstance) vs ts
 
 instance (W : World) (tag : Nat) (payload : Runtime.Val) (ts : List Typ) :
     Persistent (ValSumRel W tag payload ts) :=
-  ValSumRelBody.persistent (ValHasType W) ts tag payload (fun _ _ _ => inferInstance)
+  ValSumRelBody.persistent W (ValHasType W) ts tag payload (fun _ _ _ => inferInstance)
 
 
 /-! Per-type unfoldings -/
@@ -498,10 +523,20 @@ theorem ValHasType.empty (W : World) (v : Runtime.Val) :
     ValHasType W v .empty ⊣⊢ iprop(False) := by
   exact equiv_iff.mp (ValHasType.unfold W v .empty)
 
-theorem ValHasType.arrow (W : World) (v : Runtime.Val) (args : List Typ) (ret : Typ)
-    (spec : Option (Spec Typ)) :
-    ValHasType W v (.arrow args ret spec) ⊣⊢ iprop(False) := by
-  exact equiv_iff.mp (ValHasType.unfold W v (.arrow args ret spec))
+/-- An unspecified function type is uninhabited: nothing is known about a
+    function that carries no specification. -/
+theorem ValHasType.arrow_none (W : World) (v : Runtime.Val) (args : List Typ) (ret : Typ) :
+    ValHasType W v (.arrow args ret none) ⊣⊢ iprop(False) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.arrow args ret none))
+
+/-- A specified function type holds of exactly the values that satisfy its
+    specification, with the specification's types interpreted by the value
+    relation itself. -/
+theorem ValHasType.arrow_some (W : World) (v : Runtime.Val) (args : List Typ) (ret : Typ)
+    (s : Spec Typ) :
+    ValHasType W v (.arrow args ret (some s)) ⊣⊢
+      s.isPrecondFor W (ValHasType W) args ret v := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.arrow args ret (some s)))
 
 theorem ValHasType.tvar (W : World) (v : Runtime.Val) (x : TyVar) :
     ValHasType W v (.tvar x) ⊣⊢ iprop(False) := by
@@ -540,7 +575,8 @@ theorem ValHasType.vec (W : World) (v : Runtime.Val) (t : Typ) :
 theorem ValHasType.tuple (W : World) (v : Runtime.Val) (ts : List Typ) :
     ValHasType W v (.tuple ts) ⊣⊢
       iprop(∃ vs, ⌜v = .tuple vs⌝ ∗ ValsHaveTypes W vs ts) := by
-  exact equiv_iff.mp (ValHasType.unfold W v (.tuple ts))
+  refine (equiv_iff.mp (ValHasType.unfold W v (.tuple ts))).trans ?_
+  exact exists_congr fun vs => sep_congr .rfl (ValsHaveTypes.unfold W vs ts).symm
 
 theorem ValHasType.sum (W : World) (v : Runtime.Val) (ts : List Typ) :
     ValHasType W v (.sum ts) ⊣⊢
@@ -579,26 +615,23 @@ theorem ValHasType.named_of_unfold {W : World} {v : Runtime.Val}
 
 theorem ValsHaveTypes.nil (W : World) :
     ValsHaveTypes W [] [] ⊣⊢ iprop(emp) := by
-  unfold ValsHaveTypes ValsRelBody
+  unfold ValsHaveTypes ValsRel
   exact .rfl
 
 theorem ValsHaveTypes.cons (W : World) (v : Runtime.Val) (vs : List Runtime.Val)
     (t : Typ) (ts : List Typ) :
     ValsHaveTypes W (v :: vs) (t :: ts) ⊣⊢ ValHasType W v t ∗ ValsHaveTypes W vs ts := by
-  unfold ValsHaveTypes
-  change iprop(ValRelBody (ValHasType W) v t (ValRelInd W (ValHasType W)) ∗
-      ValsRelBody (ValHasType W) vs ts (ValRelInd W (ValHasType W))) ⊣⊢
-    iprop(ValHasType W v t ∗ ValsRelBody (ValHasType W) vs ts (ValRelInd W (ValHasType W)))
-  exact sep_congr (equiv_iff.mp (ValHasType.unfold W v t).symm) .rfl
+  simp only [ValsHaveTypes, ValsRel]
+  exact .rfl
 
 theorem ValsHaveTypes.nil_cons (W : World) (t : Typ) (ts : List Typ) :
     ValsHaveTypes W [] (t :: ts) ⊣⊢ iprop(False) := by
-  unfold ValsHaveTypes ValsRelBody
+  unfold ValsHaveTypes ValsRel
   exact .rfl
 
 theorem ValsHaveTypes.cons_nil (W : World) (v : Runtime.Val) (vs : List Runtime.Val) :
     ValsHaveTypes W (v :: vs) [] ⊣⊢ iprop(False) := by
-  unfold ValsHaveTypes ValsRelBody
+  unfold ValsHaveTypes ValsRel
   exact .rfl
 
 /-! ### The vector type -/
@@ -653,8 +686,8 @@ theorem ValSumRel.succ (W : World) (tag : Nat) (payload : Runtime.Val)
     (t : Typ) (ts : List Typ) :
     ValSumRel W (tag + 1) payload (t :: ts) ⊣⊢ ValSumRel W tag payload ts := by
   unfold ValSumRel
-  change ValSumRelBody (ValHasType W) tag payload ts (ValRelInd W (ValHasType W)) ⊣⊢
-    ValSumRelBody (ValHasType W) tag payload ts (ValRelInd W (ValHasType W))
+  change ValSumRelBody W (ValHasType W) tag payload ts (ValRelInd W (ValHasType W)) ⊣⊢
+    ValSumRelBody W (ValHasType W) tag payload ts (ValRelInd W (ValHasType W))
   exact .rfl
 
 /-! Indexing and subtyping compatibility. -/
@@ -779,7 +812,7 @@ mutual
         · iapply (ValSumRel.sub hlist payload tag)
           iexact Hsum
     | .arrow .. =>
-        exact (ValHasType.arrow W v _ _ _).1.trans false_elim
+        exact (ValHasType.arrow_none W v _ _).1.trans false_elim
     | .tuple hlist =>
         refine (ValHasType.tuple W v _).1.trans ?_
         refine .trans ?_ (ValHasType.tuple W v _).2
@@ -855,18 +888,8 @@ end
 
 /-- Length agreement for `ValsHaveTypes`, as an entailment. -/
 theorem ValsHaveTypes.length_eq {W : World} {vs : List Runtime.Val} {ts : List Typ} :
-    ValsHaveTypes W vs ts ⊢ iprop(⌜vs.length = ts.length⌝) := by
-  match vs, ts with
-  | [], [] =>
-      exact (ValsHaveTypes.nil W).1.trans (pure_intro rfl)
-  | v :: vs, t :: ts =>
-      exact ((ValsHaveTypes.cons W v vs t ts).1.trans sep_elim_right).trans
-        ((ValsHaveTypes.length_eq (W := W) (vs := vs) (ts := ts)).trans
-          (pure_mono (fun h => by simp [h])))
-  | [], t :: ts =>
-      exact (ValsHaveTypes.nil_cons W t ts).1.trans false_elim
-  | v :: vs, [] =>
-      exact (ValsHaveTypes.cons_nil W v vs).1.trans false_elim
+    ValsHaveTypes W vs ts ⊢ iprop(⌜vs.length = ts.length⌝) :=
+  ValsRel.length_eq
 
 /-- If `ts[n]? = some t`, then a related list of values contains a value at
 index `n` related at type `t`. -/
@@ -1244,7 +1267,10 @@ mutual
         exact htail φ hφ
     | sum _ | ref _ | value | named _ _ =>
       iintro _; ipureintro; simp [typeConstraints]
-    | arrow args ret spec => exact (TinyML.ValHasType.arrow W v args ret spec).1.trans false_elim
+    | arrow args ret spec =>
+      cases spec with
+      | none => exact (TinyML.ValHasType.arrow_none W v args ret).1.trans false_elim
+      | some _ => iintro _; ipureintro; simp [typeConstraints]
     | empty => exact (TinyML.ValHasType.empty W v).1.trans false_elim
     | tvar x => exact (TinyML.ValHasType.tvar W v x).1.trans false_elim
 

--- a/Mica/SourceTinyML/OUTLINE.md
+++ b/Mica/SourceTinyML/OUTLINE.md
@@ -3,7 +3,7 @@
 - `Assertions.lean` — Data of atoms, assertions, and completed specifications, parametric in the type language they mention.
 - `LogicalRelation.lean` — Iris logical relations for TinyML values and types, together with soundness proofs for type constraints.
 - `Printer.lean` — Pretty-printing for the untyped TinyML IR and declarations.
-- `Semantics.lean` — Semantics of atoms, assertions, and specifications, interpreting types by the logical relation.
+- `Semantics.lean` — Semantics of atoms, assertions, and specifications, parametric in the value relation interpreting types.
 - `Spec.lean` — Abstract syntax for specifications embedded in TinyML programs.
 - `TypeConstraints.lean` — First-order constraint formulas asserting that a term has a given TinyML type.
 - `Typed.lean` — Typed TinyML IR, with erasure to the runtime IR.

--- a/Mica/SourceTinyML/Semantics.lean
+++ b/Mica/SourceTinyML/Semantics.lean
@@ -1,6 +1,7 @@
--- SUMMARY: Semantics of atoms, assertions, and specifications, interpreting types by the logical relation.
+-- SUMMARY: Semantics of atoms, assertions, and specifications, parametric in the value relation interpreting types.
 import Mica.SourceTinyML.Assertions
-import Mica.SourceTinyML.LogicalRelation
+import Mica.SourceTinyML.World
+import Mica.SeparationLogic.Wp
 import Mica.FOL.SpecFn
 
 open Iris Iris.BI Iris.OFE
@@ -12,65 +13,183 @@ variable [MicaGS HasLC.hasLC Sig]
 
 The Iris meaning of the assertion syntax in `Mica/SourceTinyML/Assertions.lean`,
 up to `Spec.isPrecondFor`, the predicate saying that a runtime value satisfies a
-specification. Types are interpreted by the logical relation of the world the
-semantics is taken in.
+specification.
+
+Everything here is parametric in a `ValueRelation`, the interpretation of types
+as predicates on runtime values. That parameter is what puts this file *below*
+the logical relation rather than above it: a specified function type is
+interpreted by `isPrecondFor` at the relation's own approximation, so the
+specification semantics may not itself depend on the logical relation.
 
 The verifier operations on the same syntax — `toItem`, `resolve`,
 `assume`/`prove`, `call`/`implement` — and all well-formedness conditions and
-correctness proofs live in `Mica/Verifier/`.
+correctness proofs live in `Mica/Verifier/`, above the logical relation, where
+they instantiate `V := TinyML.ValHasType W`.
 -/
+
+namespace TinyML
+
+/-- An interpretation of closed types as predicates on runtime values. Both
+    the outer approximation of the recursive relation and the specification
+    semantics range over these. -/
+abbrev ValueRelation := Runtime.Val → Typ → iProp
+
+/-- Pointwise lifting of a value relation to a list of values and types.
+    Lists of different lengths are unrelated. -/
+def ValsRel (V : ValueRelation) : List Runtime.Val → List Typ → iProp
+  | [], []           => iprop(emp)
+  | v :: vs, t :: ts => iprop(V v t ∗ ValsRel V vs ts)
+  | _, _             => iprop(False)
+
+omit [MicaGS HasLC.hasLC Sig] in
+theorem ValsRel.persistent (V : ValueRelation) (hV : ∀ v t, Persistent (V v t)) :
+    ∀ (vs : List Runtime.Val) (ts : List Typ), Persistent (ValsRel V vs ts)
+  | [], [] => by unfold ValsRel; infer_instance
+  | [], _ :: _ => by unfold ValsRel; infer_instance
+  | _ :: _, [] => by unfold ValsRel; infer_instance
+  | v :: vs, t :: ts => by
+      have := hV v t
+      have := ValsRel.persistent V hV vs ts
+      unfold ValsRel; infer_instance
+
+omit [MicaGS HasLC.hasLC Sig] in
+/-- Related lists have equal lengths, for any value relation. -/
+theorem ValsRel.length_eq {V : ValueRelation} :
+    ∀ {vs : List Runtime.Val} {ts : List Typ},
+      ValsRel V vs ts ⊢ iprop(⌜vs.length = ts.length⌝)
+  | [], [] => by unfold ValsRel; exact pure_intro rfl
+  | [], _ :: _ | _ :: _, [] => by unfold ValsRel; exact false_elim
+  | v :: vs, t :: ts => by
+      unfold ValsRel
+      exact (sep_elim_right.trans (ValsRel.length_eq (vs := vs) (ts := ts))).trans
+        (pure_mono (by simp))
+
+omit [MicaGS HasLC.hasLC Sig] in
+/-- The lifting is non-expansive in the value relation. -/
+theorem ValsRel.ne {n : Nat} {V V' : ValueRelation} (hV : V ≡{n}≡ V') :
+    ∀ (vs : List Runtime.Val) (ts : List Typ), ValsRel V vs ts ≡{n}≡ ValsRel V' vs ts
+  | [], [] => Dist.rfl
+  | [], _ :: _ | _ :: _, [] => Dist.rfl
+  | v :: vs, t :: ts => by
+      unfold ValsRel
+      exact sep_ne.ne (hV v t) (ValsRel.ne hV vs ts)
+
+end TinyML
 
 -- ---------------------------------------------------------------------------
 -- Atoms
 -- ---------------------------------------------------------------------------
 
-def Atom.eval (W : TinyML.World) {τ : Srt} (p : Atom TinyML.Typ τ) (ρ : Env) : τ.denote → iProp :=
+/-- The Iris meaning of an atom: what it takes for the term it constrains to
+    evaluate to the given sorted value. The spatial atoms `own`/`arr` are the
+    only ones mentioning the value relation. -/
+def Atom.eval (V : TinyML.ValueRelation) {τ : Srt} (p : Atom TinyML.Typ τ) (ρ : Env) : τ.denote → iProp :=
   match p with
   | isint t  => λ v => ⌜.int v = t.eval ρ⌝
   | isbool t => λ v => ⌜.bool v = t.eval ρ⌝
   | isinj tag arity t => λ v => ⌜.inj tag arity v = t.eval ρ⌝
   | own l ty => λ v => ∃ loc : Runtime.Location,
-      ⌜l.eval ρ = .loc loc⌝ ∗ loc ↦ [v] ∗ TinyML.ValHasType W v ty
+      ⌜l.eval ρ = .loc loc⌝ ∗ loc ↦ [v] ∗ V v ty
   | arr a ty => λ v => ∃ loc : Runtime.Location, ∃ vs : List Runtime.Val,
       ⌜a.eval ρ = .array vs.length loc⌝ ∗ ⌜v = .vec vs⌝ ∗ loc ↦ vs ∗
-        TinyML.ValHasType W (.vec vs) (.vec ty)
+        V (.vec vs) (.vec ty)
   | rel name arg => λ v =>
     ⌜(SpecFn.isDefined name arg).eval ρ ∧ (SpecFn.call name arg).eval ρ = v⌝
+
+/-- Atom semantics is non-expansive in the value relation. Only the spatial
+    atoms mention it, and they do so under a separating conjunction. -/
+theorem Atom.eval_ne {n : Nat} {V V' : TinyML.ValueRelation} (hV : V ≡{n}≡ V')
+    (p : Atom TinyML.Typ τ) (ρ : Env) (v : τ.denote) :
+    p.eval V ρ v ≡{n}≡ p.eval V' ρ v := by
+  cases p with
+  | isint _ => exact OFE.Dist.rfl
+  | isbool _ => exact OFE.Dist.rfl
+  | isinj _ _ _ => exact OFE.Dist.rfl
+  | rel _ _ => exact OFE.Dist.rfl
+  | own l ty =>
+    simp only [Atom.eval]
+    exact exists_ne fun _ => sep_ne.ne .rfl (sep_ne.ne .rfl (hV v ty))
+  | arr a ty =>
+    simp only [Atom.eval]
+    exact exists_ne fun _ => exists_ne fun vs =>
+      sep_ne.ne .rfl (sep_ne.ne .rfl (sep_ne.ne .rfl (hV (.vec vs) (.vec ty))))
 
 -- ---------------------------------------------------------------------------
 -- Assertions
 -- ---------------------------------------------------------------------------
 
-def Assertion.pre (W : TinyML.World) (Φ : α → Env → iProp) (m : Assertion TinyML.Typ α) (ρ : Env) : iProp :=
+def Assertion.pre (V : TinyML.ValueRelation) (Φ : α → Env → iProp) (m : Assertion TinyML.Typ α) (ρ : Env) : iProp :=
   (match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ⌝ ∗ Assertion.pre W Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ; Assertion.pre W Φ k (ρ.updateConst x.sort x.name v)
-  | .pred x p k   => ∃ (v : x.sort.denote), p.eval W ρ v ∗ Assertion.pre W Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ⌝ ∗ Assertion.pre V Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ; Assertion.pre V Φ k (ρ.updateConst x.sort x.name v)
+  | .pred x p k   => ∃ (v : x.sort.denote), p.eval V ρ v ∗ Assertion.pre V Φ k (ρ.updateConst x.sort x.name v)
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ⌝ -∗ Assertion.pre W Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ⌝ -∗ Assertion.pre W Φ ke ρ)))
+      iprop((⌜φ.eval ρ⌝ -∗ Assertion.pre V Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ⌝ -∗ Assertion.pre V Φ ke ρ)))
 
-def Assertion.post (W : TinyML.World) {α} (Φ : α → Env → iProp) (m : Assertion TinyML.Typ α) (ρ : Env) : iProp :=
+def Assertion.post (V : TinyML.ValueRelation) {α} (Φ : α → Env → iProp) (m : Assertion TinyML.Typ α) (ρ : Env) : iProp :=
   match m with
   | .ret a        => Φ a ρ
-  | .assert φ k   => ⌜φ.eval ρ⌝ -∗ Assertion.post W Φ k ρ
-  | .let_ x t k   => let v := t.eval ρ; Assertion.post W Φ k (ρ.updateConst x.sort x.name v)
+  | .assert φ k   => ⌜φ.eval ρ⌝ -∗ Assertion.post V Φ k ρ
+  | .let_ x t k   => let v := t.eval ρ; Assertion.post V Φ k (ρ.updateConst x.sort x.name v)
   | .pred x p k   => iprop(∀ (v : x.sort.denote),
-      p.eval W ρ v -∗ Assertion.post W Φ k (ρ.updateConst x.sort x.name v))
+      p.eval V ρ v -∗ Assertion.post V Φ k (ρ.updateConst x.sort x.name v))
   | .ite φ kt ke  =>
-      iprop((⌜φ.eval ρ⌝ -∗ Assertion.post W Φ kt ρ) ∧
-            (⌜¬ φ.eval ρ⌝ -∗ Assertion.post W Φ ke ρ))
+      iprop((⌜φ.eval ρ⌝ -∗ Assertion.post V Φ kt ρ) ∧
+            (⌜¬ φ.eval ρ⌝ -∗ Assertion.post V Φ ke ρ))
+
+/-- Both assertion semantics are non-expansive in the value relation and in the
+    return continuation. The two are proved together because a predicate
+    transformer nests a `post` inside the continuation of a `pre`. -/
+theorem Assertion.pre_ne {n : Nat} {V V' : TinyML.ValueRelation}
+    {Φ Φ' : α → Env → iProp}
+    (hV : V ≡{n}≡ V') (hΦ : ∀ a ρ, Φ a ρ ≡{n}≡ Φ' a ρ) :
+    ∀ (m : Assertion TinyML.Typ α) (ρ : Env),
+      Assertion.pre V Φ m ρ ≡{n}≡ Assertion.pre V' Φ' m ρ := by
+  intro m
+  induction m with
+  | ret a => exact fun ρ => hΦ a ρ
+  | assert φ k ih => exact fun ρ => sep_ne.ne .rfl (ih ρ)
+  | let_ x t k ih => exact fun ρ => ih _
+  | pred x p k ih =>
+    exact fun ρ => exists_ne fun v => sep_ne.ne (Atom.eval_ne hV p ρ v) (ih _)
+  | ite φ kt ke iht ihe =>
+    exact fun ρ => and_ne.ne (wand_ne.ne .rfl (iht ρ)) (wand_ne.ne .rfl (ihe ρ))
+
+theorem Assertion.post_ne {n : Nat} {V V' : TinyML.ValueRelation}
+    {Φ Φ' : α → Env → iProp}
+    (hV : V ≡{n}≡ V') (hΦ : ∀ a ρ, Φ a ρ ≡{n}≡ Φ' a ρ) :
+    ∀ (m : Assertion TinyML.Typ α) (ρ : Env),
+      Assertion.post V Φ m ρ ≡{n}≡ Assertion.post V' Φ' m ρ := by
+  intro m
+  induction m with
+  | ret a => exact fun ρ => hΦ a ρ
+  | assert φ k ih => exact fun ρ => wand_ne.ne .rfl (ih ρ)
+  | let_ x t k ih => exact fun ρ => ih _
+  | pred x p k ih =>
+    exact fun ρ => forall_ne fun v => wand_ne.ne (Atom.eval_ne hV p ρ v) (ih _)
+  | ite φ kt ke iht ihe =>
+    exact fun ρ => and_ne.ne (wand_ne.ne .rfl (iht ρ)) (wand_ne.ne .rfl (ihe ρ))
 
 -- ---------------------------------------------------------------------------
 -- Predicate transformers
 -- ---------------------------------------------------------------------------
 
-def PredTrans.apply (W : TinyML.World) (Φ : Runtime.Val → iProp) (m : PredTrans TinyML.Typ) (ρ : Env) : iProp :=
-  Assertion.pre W (fun post ρ' =>
+def PredTrans.apply (V : TinyML.ValueRelation) (Φ : Runtime.Val → iProp) (m : PredTrans TinyML.Typ) (ρ : Env) : iProp :=
+  Assertion.pre V (fun post ρ' =>
     BIBase.forall fun v : Runtime.Val =>
-      Assertion.post W (fun () _ => Φ v) post.body (ρ'.updateConst .value post.name v)
+      Assertion.post V (fun () _ => Φ v) post.body (ρ'.updateConst .value post.name v)
   ) m ρ
+
+/-- Applying a predicate transformer is non-expansive in the value relation and
+    in the postcondition. -/
+theorem PredTrans.apply_ne {n : Nat} {V V' : TinyML.ValueRelation}
+    {Φ Φ' : Runtime.Val → iProp} (hV : V ≡{n}≡ V') (hΦ : ∀ v, Φ v ≡{n}≡ Φ' v)
+    (m : PredTrans TinyML.Typ) (ρ : Env) :
+    PredTrans.apply V Φ m ρ ≡{n}≡ PredTrans.apply V' Φ' m ρ :=
+  Assertion.pre_ne hV
+    (fun _ _ => forall_ne fun v => Assertion.post_ne hV (fun _ _ => hΦ v) _ _) m ρ
 
 -- ---------------------------------------------------------------------------
 -- Specifications
@@ -84,18 +203,62 @@ def argsEnv (ρ : Env) : List String → List Runtime.Val → Env
   | [], _ | _, [] => ρ
   | name :: rest, v :: vs => argsEnv (ρ.updateConst .value name v) rest vs
 
-def isPrecondFor (W : TinyML.World)
+/-- `f` satisfies the specification `s` at argument types `argTys` and result
+    type `retTy`: applying it to arguments related at `argTys` and a proof of
+    the precondition yields the postcondition, with the result related at
+    `retTy`. Types are interpreted using `V` in world `W`.
+
+    Both resource premises are guarded. That is what makes the predicate
+    contractive in `V` — every occurrence of the value relation sits under the
+    `later` — while leaving the conclusion unguarded, so a caller holding this
+    predicate can use it directly. The guard is discharged by the function's own
+    beta step: `isPrecondFor_fix` gets the premises back, unguarded, in the body.
+    The argument count is a separate pure premise because the beta step needs it
+    *before* the guard can be stripped. -/
+def isPrecondFor (W : TinyML.World) (V : TinyML.ValueRelation)
     (argTys : List TinyML.Typ) (retTy : TinyML.Typ)
     (f : Runtime.Val) (s : Spec TinyML.Typ) : iProp :=
   iprop(□ ∀ (ρ : Env) (Φ : Runtime.Val → iProp) (vs : List Runtime.Val),
       ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ -∗
-      TinyML.ValsHaveTypes W vs argTys -∗
-        PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
+      ⌜vs.length = argTys.length⌝ -∗
+      ▷ TinyML.ValsRel V vs argTys -∗
+        ▷ PredTrans.apply V (fun r => V r retTy -∗ Φ r) s.pred
           (argsEnv ρ s.args vs) -∗
         wp W.pctx (Runtime.Expr.app (.val f) (vs.map fun v => .val v)) Φ)
 
-instance : Iris.BI.Persistent (isPrecondFor W argTys retTy f s) := by
+instance : Iris.BI.Persistent (isPrecondFor W V argTys retTy f s) := by
   unfold isPrecondFor
   infer_instance
+
+/-- The specification predicate is non-expansive in the value relation. The
+    argument relation occurs negatively and the result relation positively, so
+    this is the strongest uniform statement available. -/
+theorem isPrecondFor_ne {n : Nat} {W : TinyML.World} {V V' : TinyML.ValueRelation}
+    (hV : V ≡{n}≡ V') (argTys : List TinyML.Typ) (retTy : TinyML.Typ)
+    (f : Runtime.Val) (s : Spec TinyML.Typ) :
+    s.isPrecondFor W V argTys retTy f ≡{n}≡ s.isPrecondFor W V' argTys retTy f := by
+  unfold isPrecondFor
+  refine intuitionistically_ne.ne (forall_ne fun ρ => forall_ne fun Φ => forall_ne fun vs => ?_)
+  refine wand_ne.ne .rfl (wand_ne.ne .rfl
+    (wand_ne.ne (later_ne.ne (TinyML.ValsRel.ne hV vs argTys)) (wand_ne.ne ?_ .rfl)))
+  exact later_ne.ne (PredTrans.apply_ne hV (fun r => wand_ne.ne (hV r retTy) .rfl) s.pred _)
+
+/-- Guarding both resource premises makes the specification predicate
+    contractive in the value relation: every occurrence of `V` sits under a
+    `later`. This is what lets the value relation interpret a specified function
+    type by its own approximation. -/
+theorem isPrecondFor_contractive {n : Nat} {W : TinyML.World}
+    {V V' : TinyML.ValueRelation} (hV : Iris.OFE.DistLater n V V')
+    (argTys : List TinyML.Typ) (retTy : TinyML.Typ)
+    (f : Runtime.Val) (s : Spec TinyML.Typ) :
+    s.isPrecondFor W V argTys retTy f ≡{n}≡ s.isPrecondFor W V' argTys retTy f := by
+  unfold isPrecondFor
+  refine intuitionistically_ne.ne (forall_ne fun ρ => forall_ne fun Φ => forall_ne fun vs => ?_)
+  refine wand_ne.ne .rfl (wand_ne.ne .rfl (wand_ne.ne ?_ (wand_ne.ne ?_ .rfl)))
+  · exact Iris.OFE.Contractive.distLater_dist (f := fun P : iProp => iprop(▷ P))
+      fun m hm => TinyML.ValsRel.ne (hV m hm) vs argTys
+  · exact Iris.OFE.Contractive.distLater_dist (f := fun P : iProp => iprop(▷ P))
+      fun m hm => PredTrans.apply_ne (hV m hm)
+        (fun r => wand_ne.ne ((hV m hm) r retTy) .rfl) s.pred _
 
 end Spec

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -19,7 +19,7 @@ namespace Intrinsics
 theorem assert_ret_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runtime.Val → iProp)
     (s : String) (ρ : Env) (φ : Formula) (v : Runtime.Val)
     (hφ : φ.eval (ρ.updateConst .value s v)) :
-    PredTrans.apply W Φ (.ret ⟨s, .assert φ (.ret ())⟩) ρ ⊢ Φ v := by
+    PredTrans.apply (TinyML.ValHasType W) Φ (.ret ⟨s, .assert φ (.ret ())⟩) ρ ⊢ Φ v := by
   simp only [PredTrans.apply, Assertion.pre, Assertion.post]
   refine (forall_elim v).trans ?_
   iintro Hw
@@ -38,8 +38,8 @@ def withPre : Option Formula → PredTrans TinyML.Typ → PredTrans TinyML.Typ
     as a pure fact (vacuous for `none`) alongside the unwrapped application. -/
 theorem withPre_apply [MicaGS HasLC.hasLC Sig] (W : TinyML.World) (Φ : Runtime.Val → iProp)
     (pre : Option Formula) (post : PredTrans TinyML.Typ) (ρ : Env) :
-    PredTrans.apply W Φ (withPre pre post) ρ ⊢
-      iprop(⌜∀ φ, pre = some φ → φ.eval ρ⌝ ∗ PredTrans.apply W Φ post ρ) := by
+    PredTrans.apply (TinyML.ValHasType W) Φ (withPre pre post) ρ ⊢
+      iprop(⌜∀ φ, pre = some φ → φ.eval ρ⌝ ∗ PredTrans.apply (TinyML.ValHasType W) Φ post ρ) := by
   cases pre with
   | none =>
     simp only [withPre]

--- a/Mica/Verifier/Assertions.lean
+++ b/Mica/Verifier/Assertions.lean
@@ -88,11 +88,11 @@ theorem Assertion.wfIn_mono (m : Assertion TinyML.Typ α) (retWf : α → Signat
 -- Environment agreement
 -- ---------------------------------------------------------------------------
 
-theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion TinyML.Typ α} {retWf : α → Signature → Prop}
+theorem Assertion.pre_env_agree (V : TinyML.ValueRelation) {m : Assertion TinyML.Typ α} {retWf : α → Signature → Prop}
     {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
-    Assertion.pre W Φ m ρ ⊢ Assertion.pre W Φ m ρ' := by
+    Assertion.pre V Φ m ρ ⊢ Assertion.pre V Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
   | assert φ k ih =>
@@ -117,8 +117,8 @@ theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion TinyML.Typ α}
     iintro ⟨%w, Hsep⟩
     iexists w
     iapply (sep_mono
-      (show p.eval W ρ w ⊢ p.eval W ρ' w by
-        simp [(Atom.eval_env_agree W hpwf hagree)])
+      (show p.eval V ρ w ⊢ p.eval V ρ' w by
+        simp [(Atom.eval_env_agree hpwf hagree)])
       (ih hkwf (Env.agreeOn_declVar hagree)))
     iexact Hsep
   | ite φ kt ke iht ihe =>
@@ -148,11 +148,11 @@ theorem Assertion.pre_env_agree (W : TinyML.World) {m : Assertion TinyML.Typ α}
       iapply hnφ
       iapply Hnφ
 
-theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion TinyML.Typ α} {retWf : α → Signature → Prop}
+theorem Assertion.post_env_agree (V : TinyML.ValueRelation) {m : Assertion TinyML.Typ α} {retWf : α → Signature → Prop}
     {Φ : α → Env → iProp} {ρ ρ' : Env} {Δ : Signature}
     (hwf : m.wfIn retWf Δ) (hagree : Env.agreeOn Δ ρ ρ')
     (hΦ : ∀ a Δ ρ₁ ρ₂, retWf a Δ → Env.agreeOn Δ ρ₁ ρ₂ → Φ a ρ₁ ⊢ Φ a ρ₂) :
-    Assertion.post W Φ m ρ ⊢ Assertion.post W Φ m ρ' := by
+    Assertion.post V Φ m ρ ⊢ Assertion.post V Φ m ρ' := by
   induction m generalizing Δ ρ ρ' with
   | ret a => exact hΦ a Δ ρ ρ' hwf hagree
   | assert φ k ih =>
@@ -177,7 +177,7 @@ theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion TinyML.Typ α
     iintro %w Hw
     iapply (ih hkwf (Env.agreeOn_declVar hagree))
     iapply H
-    iapply (show p.eval W ρ' w ⊢ p.eval W ρ w by simp [(Atom.eval_env_agree W hpwf hagree)])
+    iapply (show p.eval V ρ' w ⊢ p.eval V ρ w by simp [(Atom.eval_env_agree hpwf hagree)])
     iexact Hw
   | ite φ kt ke iht ihe =>
     obtain ⟨hφwf, hktwf, hkewf⟩ := hwf
@@ -201,13 +201,13 @@ theorem Assertion.post_env_agree (W : TinyML.World) {m : Assertion TinyML.Typ α
       exact hnφ'
 
 /-- Combining caller-side `pre` with verifier-side `post`. -/
-theorem Assertion.pre_post_combine (W : TinyML.World) {α : Type}
+theorem Assertion.pre_post_combine (V : TinyML.ValueRelation) {α : Type}
     {m : Assertion TinyML.Typ α}
     {Φ : α → Env → iProp} {Ψ : α → Env → iProp}
     {ρ : Env}
     {R : iProp}
     (hR : ∀ (a : α) (ρ0 : Env), Φ a ρ0 ∗ Ψ a ρ0 ⊢ R)
-    : (Assertion.pre W Φ m ρ ∗ Assertion.post W Ψ m ρ) ⊢ R := by
+    : (Assertion.pre V Φ m ρ ∗ Assertion.post V Ψ m ρ) ⊢ R := by
   induction m generalizing ρ R with
   | ret a =>
     simpa [Assertion.pre, Assertion.post] using hR a ρ
@@ -334,7 +334,7 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion TinyML.Typ α
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
       retWf a (Δ_base.declVars σ'.dom) →
       st'.sl W ρ' ∗ R ⊢ Φ a ((σ'.subst.eval ρ'))) →
-    st.sl W ρ ∗ R ⊢ Assertion.post W Φ m ((σ.subst.eval ρ)) := by
+    st.sl W ρ ∗ R ⊢ Assertion.post (TinyML.ValHasType W) Φ m ((σ.subst.eval ρ)) := by
   intro hσwf hwf heval hpost
   induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
@@ -378,7 +378,7 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion TinyML.Typ α
       have hinterp_bi : st.sl W ρ ⊣⊢ st.sl W (ρ.updateConst v.sort v'.name u) :=
         SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf
           (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-      exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.post_env_agree W hkwf'
+      exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.post_env_agree (TinyML.ValHasType W) hkwf'
         (by
           simpa [σ', Env.agreeOn, Env.updateConst] using
             (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -410,23 +410,23 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion TinyML.Typ α
         Atom.toItem_wfIn
           (Atom.wfIn_mono hp_subst_wf (Signature.Subset.subset_addConst _ _)
             (Signature.wf_addConst hσwf.useWf hv'_fresh_decls)) hvar_wf
-      have hpu' : p.eval W ((σ.subst.eval ρ)) u ⊢
-          (p.subst σ.subst).eval W (ρ.updateConst v.sort v'.name u)
+      have hpu' : p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ)) u ⊢
+          (p.subst σ.subst).eval (TinyML.ValHasType W) (ρ.updateConst v.sort v'.name u)
             ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
               (ρ.updateConst v.sort v'.name u)) := by
         have hconst : ((.const (.uninterpreted v'.name v.sort) : Term v.sort).eval
             (ρ.updateConst v.sort v'.name u)) = u := by
           simp [Term.eval, Const.denote, Env.updateConst]
         rw [hconst]
-        rw [Atom.eval_subst W hpwf hσwf.subst hσwf.rangeWf]
+        rw [Atom.eval_subst hpwf hσwf.subst hσwf.rangeWf]
         have hagree := FiniteSubst.eval_update_fresh (σ := σ) (ρ := ρ)
           (τ := v.sort) (name' := v'.name) (u := u) hσwf hv'_fresh_range
         have heval_agree :
-            p.eval W ((σ.subst.eval ρ)) =
-              p.eval W (σ.subst.eval (ρ.updateConst v.sort v'.name u)) :=
-          Atom.eval_env_agree W (p := p)
+            p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ)) =
+              p.eval (TinyML.ValHasType W) ((σ.subst.eval (ρ.updateConst v.sort v'.name u))) :=
+          Atom.eval_env_agree (p := p)
             (ρ := (σ.subst.eval ρ))
-            (ρ' := σ.subst.eval (ρ.updateConst v.sort v'.name u))
+            (ρ' := (σ.subst.eval (ρ.updateConst v.sort v'.name u)))
             (Δ := Δ_base.declVars σ.dom) hpwf (by
               simpa [Env.agreeOn, ] using hagree)
         rw [heval_agree]
@@ -441,10 +441,10 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion TinyML.Typ α
         simpa [σ', FiniteSubst.rename_source_eq] using hkwf
       cases hitem : item with
       | pure φ =>
-        have hφ_entail : p.eval W ((σ.subst.eval ρ)) u ⊢
+        have hφ_entail : p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ)) u ⊢
             ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ := by
           simpa [item, hitem] using
-            (hpu'.trans (Atom.eval_purePart W (p := p.subst σ.subst)
+            (hpu'.trans (Atom.eval_purePart (p := p.subst σ.subst)
               (t := .const (.uninterpreted v'.name v.sort))
               (ρ := (ρ.updateConst v.sort v'.name u))))
         ihave Hφ : ⌜φ.eval (ρ.updateConst v.sort v'.name u)⌝ $$ [Hpu]
@@ -472,7 +472,7 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion TinyML.Typ α
             (by
               iintro HR
               iexact HR)
-        iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree W hkwf'
+        iapply (hframe.trans <| hih.trans <| Assertion.post_env_agree (TinyML.ValHasType W) hkwf'
           (by
             simpa [σ', Env.agreeOn, Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -487,14 +487,14 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion TinyML.Typ α
         have hitem_wf' : (.spatial a : CtxItem).wfIn (st.decls.addConst v') := by
           simpa [item, hitem] using hitem_wf
         have hitem_interp :
-            p.eval W ((σ.subst.eval ρ)) u ⊢
+            p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ)) u ⊢
               CtxItem.interp W (ρ.updateConst v.sort v'.name u) item := by
           simpa [item] using
             (hpu'.trans (Atom.toItem_eval W (p := p.subst σ.subst)
               (t := .const (.uninterpreted v'.name v.sort))
               (ρ := (ρ.updateConst v.sort v'.name u))).2)
         have hspatial_interp :
-            p.eval W ((σ.subst.eval ρ)) u ⊢
+            p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ)) u ⊢
               SpatialAtom.interp W (ρ.updateConst v.sort v'.name u) a := by
           simpa [item, hitem, CtxItem.interp] using hitem_interp
         ihave Ha : SpatialAtom.interp W (ρ.updateConst v.sort v'.name u) a $$ [Hpu]
@@ -512,7 +512,7 @@ theorem Assertion.assume_correct (W : TinyML.World) (m : Assertion TinyML.Typ α
               st.sl W (ρ.updateConst v.sort v'.name u) :=
           (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf
             (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)).1
-        iapply (hih.trans <| Assertion.post_env_agree W hkwf'
+        iapply (hih.trans <| Assertion.post_env_agree (TinyML.ValHasType W) hkwf'
           (by
             simpa [σ', Env.agreeOn, Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -562,7 +562,7 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion TinyML.Typ α)
     (∀ σ' a st' ρ', Ψ (σ', a) st' ρ' → σ'.wfIn Δ_base st'.decls →
       retWf a (Δ_base.declVars σ'.dom) →
       st'.sl W ρ' ∗ R ⊢ Φ a ((σ'.subst.eval ρ'))) →
-    st.sl W ρ ∗ R ⊢ Assertion.pre W Φ m ((σ.subst.eval ρ)) := by
+    st.sl W ρ ∗ R ⊢ Assertion.pre (TinyML.ValHasType W) Φ m ((σ.subst.eval ρ)) := by
   intro hσwf hwf heval hpost
   induction m generalizing Δ_base σ st ρ Ψ with
   | ret a =>
@@ -574,7 +574,7 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion TinyML.Typ α)
         (FiniteSubst.subst_wfIn_formula hσwf hφwf)
       have hφ_holds := (FiniteSubst.eval_subst_formula hσwf hφwf).mp hassert.1
       show st.sl W ρ ∗ R ⊢
-        (⌜φ.eval (σ.subst.eval ρ)⌝ ∗ Assertion.pre W Φ k ((σ.subst.eval ρ)) : iProp)
+        (⌜φ.eval (σ.subst.eval ρ)⌝ ∗ Assertion.pre (TinyML.ValHasType W) Φ k ((σ.subst.eval ρ)) : iProp)
       istart
       iintro ⟨Howns, HR⟩
       isplitr [Howns HR]
@@ -610,7 +610,7 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion TinyML.Typ α)
       have hinterp_bi : st.sl W ρ ⊣⊢ st.sl W (ρ.updateConst v.sort v'.name u) :=
         SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf
           (Env.agreeOn_update_fresh_const (c := v') hv'_fresh_decls)
-      exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.pre_env_agree W hkwf'
+      exact (sep_mono_left hinterp_bi.1).trans <| hih.trans <| Assertion.pre_env_agree (TinyML.ValHasType W) hkwf'
         (by
           simpa [σ', Env.agreeOn, Env.updateConst] using
             (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st.decls)
@@ -637,12 +637,12 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion TinyML.Typ α)
           iexists (t.eval ρ')
           isplitr [Howns HR]
           · have hpred_subst :
-                (p.subst σ.subst).eval W ρ' (t.eval ρ') ⊢
-                  p.eval W ((σ.subst.eval ρ')) (t.eval ρ') := by
+                (p.subst σ.subst).eval (TinyML.ValHasType W) ρ' (t.eval ρ') ⊢
+                  p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ')) (t.eval ρ') := by
               simpa [] using
-                (show (p.subst σ.subst).eval W ρ' (t.eval ρ') ⊢
-                    p.eval W ((σ.subst.eval ρ')) (t.eval ρ') by
-                  rw [Atom.eval_subst W hpwf hσwf.subst hσwf.rangeWf]
+                (show (p.subst σ.subst).eval (TinyML.ValHasType W) ρ' (t.eval ρ') ⊢
+                    p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ')) (t.eval ρ') by
+                  rw [Atom.eval_subst hpwf hσwf.subst hσwf.rangeWf]
                   exact BIBase.Entails.rfl)
             have hagree_subst :
                 Env.agreeOn (Δ_base.declVars σ.dom)
@@ -650,9 +650,9 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion TinyML.Typ α)
                   ((σ.subst.eval ρ')) := by
               exact FiniteSubst.eval_agreeOn hσwf hagree
             have hpred_transport :
-                p.eval W ((σ.subst.eval ρ')) (t.eval ρ') ⊢
-                  p.eval W ((σ.subst.eval ρ)) (t.eval ρ') := by
-              rw [Atom.eval_env_agree W hpwf (Env.agreeOn_symm hagree_subst)]
+                p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ')) (t.eval ρ') ⊢
+                  p.eval (TinyML.ValHasType W) ((σ.subst.eval ρ)) (t.eval ρ') := by
+              rw [Atom.eval_env_agree hpwf (Env.agreeOn_symm hagree_subst)]
               exact BIBase.Entails.rfl
             iapply hpred_transport
             iapply hpred_subst
@@ -684,7 +684,7 @@ theorem Assertion.prove_correct (W : TinyML.World) (m : Assertion TinyML.Typ α)
             have hframe : st'.sl W ρ' ∗ R ⊢
                 st'.sl W (ρ'.updateConst v.sort v'.name (t.eval ρ')) ∗ R :=
               sep_mono_left hinterp_bi.1
-            iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree W hkwf'
+            iapply (hframe.trans <| hih.trans <| Assertion.pre_env_agree (TinyML.ValHasType W) hkwf'
               (by
                 have hrename := (FiniteSubst.rename_agreeOn (σ := σ) (Δ_base := Δ_base) (Δ_use := st'.decls)
                     (v := v) (name' := v'.name) (ρ := ρ') (u := t.eval ρ')

--- a/Mica/Verifier/Atoms.lean
+++ b/Mica/Verifier/Atoms.lean
@@ -185,8 +185,9 @@ theorem Atom.wfIn_mono {p : Atom TinyML.Typ τ} {Δ Δ' : Signature}
   | rel name t =>
     exact ⟨Formula.wfIn_mono _ h.1 hmono hwf, Term.wfIn_mono _ h.2 hmono hwf⟩
 
-theorem Atom.eval_env_agree (W : TinyML.World) {p : Atom TinyML.Typ τ} {ρ ρ' : Env} {Δ : Signature}
-    (hwf : p.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') : p.eval W ρ = p.eval W ρ' := by
+theorem Atom.eval_env_agree {V : TinyML.ValueRelation} {p : Atom TinyML.Typ τ}
+    {ρ ρ' : Env} {Δ : Signature}
+    (hwf : p.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') : p.eval V ρ = p.eval V ρ' := by
   cases p with
   | isint t  => simp [Atom.eval, Term.eval_env_agree hwf hagree]
   | isbool t => simp [Atom.eval, Term.eval_env_agree hwf hagree]
@@ -224,7 +225,7 @@ theorem Atom.toItem_wfIn {p : Atom TinyML.Typ τ} {t : Term τ} {Δ : Signature}
     exact ⟨hp.1, hp.2, ht⟩
 
 theorem Atom.toItem_eval (W : TinyML.World) {p : Atom TinyML.Typ τ} {t : Term τ} {ρ : Env} :
-    CtxItem.interp W ρ (p.toItem t) ⊣⊢ p.eval W ρ (t.eval ρ) := by
+    CtxItem.interp W ρ (p.toItem t) ⊣⊢ p.eval (TinyML.ValHasType W) ρ (t.eval ρ) := by
   cases p with
   | isint v  => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
   | isbool v => simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval, Term.eval, eq_comm]
@@ -238,8 +239,9 @@ theorem Atom.toItem_eval (W : TinyML.World) {p : Atom TinyML.Typ τ} {t : Term �
   | rel name arg =>
     simp [Atom.eval, Atom.toItem, CtxItem.interp, Formula.eval]
 
-theorem Atom.eval_purePart (W : TinyML.World) {p : Atom TinyML.Typ τ} {t : Term τ} {ρ : Env} :
-    p.eval W ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
+theorem Atom.eval_purePart {V : TinyML.ValueRelation} {p : Atom TinyML.Typ τ} {t : Term τ}
+    {ρ : Env} :
+    p.eval V ρ (t.eval ρ) ⊢ ⌜(p.toItem t).purePart ρ⌝ := by
   cases p with
   | isint v =>
     simp [Atom.eval, CtxItem.purePart, Atom.toItem, Formula.eval, Term.eval, eq_comm]
@@ -262,9 +264,10 @@ theorem Atom.eval_purePart (W : TinyML.World) {p : Atom TinyML.Typ τ} {t : Term
 -- ---------------------------------------------------------------------------
 
 -- @agent: change eval_subst to a bi-entailment in the future.
-theorem Atom.eval_subst (W : TinyML.World) {p : Atom TinyML.Typ τ} {σ : Subst} {ρ : Env} {Δ Δ' : Signature}
+theorem Atom.eval_subst {V : TinyML.ValueRelation} {p : Atom TinyML.Typ τ} {σ : Subst}
+    {ρ : Env} {Δ Δ' : Signature}
     (hp : p.wfIn Δ) (hσ : σ.wfIn Δ.vars Δ') (hwfΔ' : Δ'.wf) :
-    (p.subst σ).eval W ρ = p.eval W ((σ.eval ρ)) := by
+    (p.subst σ).eval V ρ = p.eval V ((σ.eval ρ)) := by
   cases p with
   | isint t =>
     funext v
@@ -706,7 +709,7 @@ private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom TinyML.
       Env.agreeOn st.decls ρ ρ' → st'.sl W ρ' ∗ R ⊢ Φ)
     (hsome : ∀ v st' ρ', Q (.some v) st' ρ' → st.decls.Subset st'.decls →
       Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
-      Atom.eval W pred ρ' (v.eval ρ') ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
+      Atom.eval (TinyML.ValHasType W) pred ρ' (v.eval ρ') ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
     st.sl W ρ ∗ R ⊢ Φ := by
     have hb1 := VerifM.eval_bind h
     have ⟨hctx_q, hholds, hwfAsserts⟩ := VerifM.eval_ctxPure hb1
@@ -715,7 +718,7 @@ private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom TinyML.
       simp [hres] at hctx_q
       have hq := VerifM.eval_ret hctx_q
       have htwf : t.wfIn st.decls := Atom.resolve_wfIn hres hwfAsserts
-      have hpred : ⊢ Atom.eval W pred ρ (t.eval ρ) :=
+      have hpred : ⊢ Atom.eval (TinyML.ValHasType W) pred ρ (t.eval ρ) :=
         (Atom.resolve_correct W hres ρ hholds.asserts).trans (Atom.toItem_eval W).1
       exact (sep_intro_valid_left hpred).trans
         (hsome t st ρ hq (Signature.Subset.refl _) Env.agreeOn_refl htwf)
@@ -730,7 +733,7 @@ private theorem VerifM.eval_resolve_pure (W : TinyML.World) {pred : Atom TinyML.
       | some t =>
         have htwf : t.wfIn st.decls := hresult_wf t hr
         have hqsome : Q (.some t) st ρ := by simpa [hr] using hq
-        have hpred : ⊢ Atom.eval W pred ρ (t.eval ρ) :=
+        have hpred : ⊢ Atom.eval (TinyML.ValHasType W) pred ρ (t.eval ρ) :=
           (hresult_eval t hr).trans (Atom.toItem_eval W).1
         exact (sep_intro_valid_left hpred).trans
           (hsome t st ρ hqsome (Signature.Subset.refl _) Env.agreeOn_refl htwf)
@@ -744,7 +747,7 @@ theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom TinyML.Typ τ} {st :
       Env.agreeOn st.decls ρ ρ' → st'.sl W ρ' ∗ R ⊢ Φ)
     (hsome : ∀ v st' ρ', Q (.some v) st' ρ' → st.decls.Subset st'.decls →
       Env.agreeOn st.decls ρ ρ' → v.wfIn st'.decls →
-      Atom.eval W pred ρ' (v.eval ρ') ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
+      Atom.eval (TinyML.ValHasType W) pred ρ' (v.eval ρ') ∗ st'.sl W ρ' ∗ R ⊢ Φ) :
     st.sl W ρ ∗ R ⊢ Φ := by
   match pred, hwf, hsome, h with
   | .own l ty, hwf, hsome, h =>
@@ -755,7 +758,7 @@ theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom TinyML.Typ τ} {st :
       have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
       have hsome' := hsome v st' ρ hqsome hsub Env.agreeOn_refl hvwf'
       have heq : SpatialAtom.interp W ρ (SpatialAtom.Kind.ref.atom l v ty) ⊢
-          Atom.eval W (Atom.own l ty) ρ (v.eval ρ) := by
+          Atom.eval (TinyML.ValHasType W) (Atom.own l ty) ρ (v.eval ρ) := by
         simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
@@ -769,7 +772,7 @@ theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom TinyML.Typ τ} {st :
       have hvwf' : v.wfIn st'.decls := by rw [hdecls]; exact hvwf
       have hsome' := hsome v st' ρ hqsome hsub Env.agreeOn_refl hvwf'
       have heq : SpatialAtom.interp W ρ (SpatialAtom.Kind.array.atom a v ty) ⊢
-          Atom.eval W (Atom.arr a ty) ρ (v.eval ρ) := by
+          Atom.eval (TinyML.ValHasType W) (Atom.arr a ty) ρ (v.eval ρ) := by
         simp only [SpatialAtom.Kind.atom, Atom.eval, SpatialAtom.interp]
         exact BIBase.Entails.rfl
       exact (sep_mono heq BIBase.Entails.rfl).trans hsome'
@@ -797,7 +800,7 @@ theorem VerifM.eval_resolve (W : TinyML.World) {pred : Atom TinyML.Typ τ} {st :
       simp at hafter
       have hdef : (SpecFn.isDefined name t).eval ρ := hok_sound rfl
       have hqsome : Q (some (SpecFn.call name t)) st ρ := VerifM.eval_ret hafter
-      have hpred : ⊢ Atom.eval W (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ) :=
+      have hpred : ⊢ Atom.eval (TinyML.ValHasType W) (Atom.rel name t) ρ ((SpecFn.call name t).eval ρ) :=
         pure_intro (PROP := iProp) ⟨hdef, rfl⟩
       exact (sep_intro_valid_left hpred).trans (hsome (SpecFn.call name t) st ρ hqsome
         (Signature.Subset.refl _) Env.agreeOn_refl hwf.2)

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -2980,7 +2980,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
           _ = vs := Terms.Eval.map_eval heval_sargs
       have happly' :
           st_args.sl W ρ_args ∗ R ⊢
-            PredTrans.apply W (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.spec.pred
+            PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r spec.retTy -∗ Φ r) spec.spec.pred
               (Spec.argsEnv ρ_args spec.spec.args vs) := by
         rw [heval_sargs_map] at happly
         exact happly
@@ -2992,9 +2992,14 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       iapply Hspec
       · ipureintro
         exact hagree_ρ_args
-      · iapply (TinyML.ValsHaveTypes.sub hsub_ty')
+      · ipureintro
+        have := TinyML.Typ.SubList.length_eq hsub_ty'
+        omega
+      · iapply later_intro
+        iapply (TinyML.ValsHaveTypes.sub hsub_ty')
         iexact Hvals
-      · iapply happly'
+      · iapply later_intro
+        iapply happly'
         isplitl [Howns]
         · iexact Howns
         · iexact HR
@@ -3086,7 +3091,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
         _ = vs := Terms.Eval.map_eval heval_sargs
     have happly' :
         st_args.sl W ρ_args ∗ R ⊢
-          PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) i.spec.pred
+          PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r retTy -∗ Φ r) i.spec.pred
             (Spec.argsEnv ρ_args i.spec.args vs) := by
       rw [heval_sargs_map] at happly
       exact happly
@@ -3096,7 +3101,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       Env.respects_of_agreeOn_extendWithSym (hρreg i hi_mem) (hΔreg i hi_mem) hagree_ρ_args
     iapply (show
         TinyML.ValsHaveTypes W vs argTys ∗
-          PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) i.spec.pred
+          PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r retTy -∗ Φ r) i.spec.pred
             (Spec.argsEnv ρ_args i.spec.args vs) ⊢ i.toWp vs Φ from
         hbridge.bridge σi W vs ρ_args Φ hρ_args_reg)
     isplitl [Hvals]

--- a/Mica/Verifier/Functions.lean
+++ b/Mica/Verifier/Functions.lean
@@ -239,7 +239,7 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
       have hsub := Runtime.Expr.subst_fix_comp body.runtime fb.runtime bs γ fval vs hlen_vs
       simp only [] at hsub; rw [hsub]
       have hbody' : TinyML.ValsHaveTypes W vs e.argTys ∗
-          PredTrans.apply W (fun r => TinyML.ValHasType W r e.retTy -∗ P r) e.spec.pred
+          PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r e.retTy -∗ P r) e.spec.pred
           (Spec.argsEnv ρ_call e.spec.args vs) ⊢
           SpecMap.satisfiedBy W S γ ∗ e.isPrecondFor W fval -∗
             wp W.pctx (Runtime.Expr.subst ((Runtime.Subst.updateBinder fb.runtime fval γ).updateAllBinder bs vs) body.runtime) P := by
@@ -271,7 +271,7 @@ theorem checkSpec_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.
             · have hlen_vals_call : e.spec.args.length ≤ vs.length := by
                 have := hswf.1
                 omega
-              iapply (PredTrans.apply_env_agree W (ρ := Spec.argsEnv ρ_call e.spec.args vs)
+              iapply (PredTrans.apply_env_agree (TinyML.ValHasType W) (ρ := Spec.argsEnv ρ_call e.spec.args vs)
                 (ρ' := Spec.argsEnv W.ρ_spec e.spec.args vs) hswf.2
                 (Spec.argsEnv_agreeOn (Δ := W.Δ_spec) (ρ₁ := ρ_call) (ρ₂ := W.ρ_spec)
                   (Env.agreeOn_symm hagree_call) e.spec.args vs hlen_vals_call))

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -564,7 +564,7 @@ class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Pr
       (vs : List Runtime.Val) (ρ : Env) (Φ : Runtime.Val → iProp),
     ρ.respects i.folSym →
     TinyML.ValsHaveTypes W vs (i.argTys.map (·.subst σ)) ∗
-      PredTrans.apply W (fun r => TinyML.ValHasType W r (i.retTy.subst σ) -∗ Φ r)
+      PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r (i.retTy.subst σ) -∗ Φ r)
         i.spec.pred
         (Spec.argsEnv ρ i.spec.args vs) ⊢ i.toWp vs Φ
   wp_sound :

--- a/Mica/Verifier/PredicateTransformers.lean
+++ b/Mica/Verifier/PredicateTransformers.lean
@@ -86,17 +86,17 @@ theorem PredTrans.wfIn_mono {pt : PredTrans TinyML.Typ} {Δ Δ' : Signature}
         (Signature.wf_declVar hwf'))
     h hsub hwf
 
-theorem PredTrans.apply_env_agree (W : TinyML.World) {pt : PredTrans TinyML.Typ} {Φ : Runtime.Val → iProp}
+theorem PredTrans.apply_env_agree (V : TinyML.ValueRelation) {pt : PredTrans TinyML.Typ} {Φ : Runtime.Val → iProp}
     {ρ ρ' : Env} {Δ : Signature}
     (hwf : pt.wfIn Δ) (hagree : Env.agreeOn Δ ρ ρ') :
-    PredTrans.apply W Φ pt ρ ⊢ PredTrans.apply W Φ pt ρ' := by
+    PredTrans.apply V Φ pt ρ ⊢ PredTrans.apply V Φ pt ρ' := by
   unfold PredTrans.apply at ⊢
-  apply Assertion.pre_env_agree W hwf hagree
+  apply Assertion.pre_env_agree V hwf hagree
   intro ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree_post
   apply forall_intro
   intro v
   exact (forall_elim v).trans <|
-    Assertion.post_env_agree W hwf_post
+    Assertion.post_env_agree V hwf_post
       (Env.agreeOn_declVar hagree_post)
       (fun _ _ _ _ _ _ => .rfl)
 
@@ -112,7 +112,7 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans TinyML.Typ) (�
     VerifM.eval (PredTrans.call σ pt) st ρ Ψ →
     (∀ v st' ρ' t, Ψ t st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
       (st'.sl W ρ' ∗ R ⊢ Φ v)) →
-    st.sl W ρ ∗ R ⊢ PredTrans.apply W Φ pt ((σ.subst.eval ρ)) := by
+    st.sl W ρ ∗ R ⊢ PredTrans.apply (TinyML.ValHasType W) Φ pt ((σ.subst.eval ρ)) := by
   intro hwf hσwf heval hΨ
   simp only [PredTrans.call] at heval
   have hb := VerifM.eval_bind heval
@@ -121,7 +121,7 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans TinyML.Typ) (�
   let Φpost : Post TinyML.Typ → Env → iProp :=
     fun post ρ' =>
       BIBase.forall fun v : Runtime.Val =>
-        Assertion.post W (fun () _ => Φ v) post.body (ρ'.updateConst .value post.name v)
+        Assertion.post (TinyML.ValHasType W) (fun () _ => Φ v) post.body (ρ'.updateConst .value post.name v)
   let Ψcall : (FiniteSubst × Post TinyML.Typ) → TransState → Env → Prop :=
     fun r st' ρ' =>
       match r with
@@ -129,12 +129,12 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans TinyML.Typ) (�
           let resVar ← VerifM.decl (some postName) Srt.value
           let _ ← Assertion.assume (σ₁.rename ⟨postName, .value⟩ resVar.name) postBody
           Pure.pure (Term.const (.uninterpreted resVar.name .value))).eval st' ρ' Ψ
-  have hpre : st.sl W ρ ∗ R ⊢ Assertion.pre W Φpost pt ((σ.subst.eval ρ)) := by
+  have hpre : st.sl W ρ ∗ R ⊢ Assertion.pre (TinyML.ValHasType W) Φpost pt ((σ.subst.eval ρ)) := by
     exact Assertion.prove_correct W pt Δ_base σ retWf st ρ Ψcall Φpost R
       (fun ⟨postName, postBody⟩ Δ' ρ₁ ρ₂ hwf_post hagree =>
         forall_intro fun v =>
           (forall_elim v).trans <|
-            Assertion.post_env_agree W hwf_post
+            Assertion.post_env_agree (TinyML.ValHasType W) hwf_post
               (Env.agreeOn_declVar hagree)
               (fun _ _ _ _ _ _ => .rfl))
       hσwf hwf hb
@@ -182,7 +182,7 @@ theorem PredTrans.call_correct (W : TinyML.World) (pt : PredTrans TinyML.Typ) (�
             st₁.sl W ρ₁ ⊣⊢ st₁.sl W (ρ₁.updateConst .value resVar.name v) :=
           SpatialContext.interp_env_agree W (VerifM.eval.wf hcont).ownsWf
             (Env.agreeOn_update_fresh_const (c := resVar) hfresh_decls)
-        exact (sep_mono_left hinterp_bi.1).trans <| hassume.trans <| Assertion.post_env_agree W hwf₁'
+        exact (sep_mono_left hinterp_bi.1).trans <| hassume.trans <| Assertion.post_env_agree (TinyML.ValHasType W) hwf₁'
           (by
             simpa [σ₂, Env.agreeOn, Env.updateConst] using
               (FiniteSubst.rename_agreeOn (σ := σ₁) (Δ_base := Δ_base) (Δ_use := st₁.decls)
@@ -207,7 +207,7 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans TinyML.Ty
         result.wfIn st''.decls →
         (st''.sl W ρ'' ∗ Q ∗ (Φ (result.eval ρ'') -∗ S) ⊢ S)) →
       st'.sl W ρ' ∗ Q ⊢ R) →
-    st.sl W ρ ∗ PredTrans.apply W Φ pt ((σ.subst.eval ρ)) ⊢ R := by
+    st.sl W ρ ∗ PredTrans.apply (TinyML.ValHasType W) Φ pt ((σ.subst.eval ρ)) ⊢ R := by
   intro hwf hσwf heval hbody
   simp only [PredTrans.implement] at heval
   have hb := VerifM.eval_bind heval
@@ -217,7 +217,7 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans TinyML.Ty
   let OuterQ : Post TinyML.Typ → Env → iProp :=
     fun ⟨postName, postBody⟩ ρ' =>
       BIBase.forall fun v : Runtime.Val =>
-        Assertion.post W (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
+        Assertion.post (TinyML.ValHasType W) (fun () _ => Φ v) postBody (ρ'.updateConst .value postName v)
   let Φpost : Post TinyML.Typ → Env → iProp :=
     fun a ρ' => OuterQ a ρ' -∗ R
   have hpost := Assertion.assume_correct W pt Δ_base σ retWf
@@ -230,7 +230,7 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans TinyML.Ty
       apply forall_intro
       intro v
       exact (forall_elim v).trans <|
-        Assertion.post_env_agree W hwf_post
+        Assertion.post_env_agree (TinyML.ValHasType W) hwf_post
           (Env.agreeOn_symm (Env.agreeOn_declVar hagree))
           (fun _ _ _ _ _ _ => .rfl))
     hσwf hwf hb_grow
@@ -293,11 +293,11 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans TinyML.Ty
         apply Env.agreeOn_mono
           (FiniteSubst.rename_source_subset_rev σ₁ Δ_base ⟨postName, .value⟩ resVar.name)
         exact Env.agreeOn_update (Env.agreeOn_remove hag_eval)
-      have hpost_transport : Assertion.post W (fun () _ => Φ (result.eval ρ₂)) postBody
+      have hpost_transport : Assertion.post (TinyML.ValHasType W) (fun () _ => Φ (result.eval ρ₂)) postBody
           (((σ₁.subst.eval ρ₁).updateConst .value postName (result.eval ρ₂))) ⊢
-          Assertion.post W (fun () _ => Φ (result.eval ρ₂)) postBody
+          Assertion.post (TinyML.ValHasType W) (fun () _ => Φ (result.eval ρ₂)) postBody
             ((σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))) := by
-        exact Assertion.post_env_agree W hwf_postBody'
+        exact Assertion.post_env_agree (TinyML.ValHasType W) hwf_postBody'
           (by
             simpa [Env.agreeOn, ]
               using (Env.agreeOn_symm (Env.agreeOn_trans hag_rename hag_eval')))
@@ -310,7 +310,7 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans TinyML.Ty
             (Env.agreeOn_update_fresh_const hfresh_decls)).1
       have hpre_final :
           st₂.sl W ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
-            Assertion.pre W (fun () _ => Φ (result.eval ρ₂) -∗ S) postBody
+            Assertion.pre (TinyML.ValHasType W) (fun () _ => Φ (result.eval ρ₂) -∗ S) postBody
               ((σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))) := by
         have hinput :
             st₂.sl W ρ₂ ∗ (Φ (result.eval ρ₂) -∗ S) ⊢
@@ -323,11 +323,11 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans TinyML.Ty
         exact hinput.trans hpre
       have hpost_final :
           OuterQ ⟨postName, postBody⟩ ((σ₁.subst.eval ρ₁)) ⊢
-            Assertion.post W (fun () _ => Φ (result.eval ρ₂)) postBody
+            Assertion.post (TinyML.ValHasType W) (fun () _ => Φ (result.eval ρ₂)) postBody
               ((σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂)))) := by
         exact (forall_elim (result.eval ρ₂)).trans hpost_transport
       iintro ⟨Howns, HQ, Hwand⟩
-      iapply (Assertion.pre_post_combine W
+      iapply (Assertion.pre_post_combine (TinyML.ValHasType W)
         (ρ := (σ₂.subst.eval (ρ₂.updateConst .value resVar.name (result.eval ρ₂))))
         (m := postBody)
         (Φ := fun () _ => Φ (result.eval ρ₂) -∗ S)
@@ -344,16 +344,16 @@ theorem PredTrans.implement_correct (W : TinyML.World) (pt : PredTrans TinyML.Ty
         iexact HQ
       )
   have hpre :
-      PredTrans.apply W Φ pt ((σ.subst.eval ρ)) =
-      Assertion.pre W OuterQ pt ((σ.subst.eval ρ)) := rfl
+      PredTrans.apply (TinyML.ValHasType W) Φ pt ((σ.subst.eval ρ)) =
+      Assertion.pre (TinyML.ValHasType W) OuterQ pt ((σ.subst.eval ρ)) := rfl
   rw [hpre]
   exact BIBase.Entails.trans
     (by
       have hpost' : st.sl W ρ ∗ emp ⊢
-          Assertion.post W Φpost pt ((σ.subst.eval ρ)) := by
+          Assertion.post (TinyML.ValHasType W) Φpost pt ((σ.subst.eval ρ)) := by
         simpa [] using hpost
       exact sep_comm.1.trans (sep_mono_right (sep_emp.2.trans hpost')))
-    (Assertion.pre_post_combine W
+    (Assertion.pre_post_combine (TinyML.ValHasType W)
       (ρ := (σ.subst.eval ρ))
       (m := pt)
       (Φ := OuterQ)

--- a/Mica/Verifier/PrimitiveLaws.lean
+++ b/Mica/Verifier/PrimitiveLaws.lean
@@ -677,20 +677,21 @@ theorem wp_fix {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Ex
       (wp pctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
   h.trans (wp.fix hlen)
 
-/-- Fixpoint unfolding with a continuation-indexed invariant. -/
+/-- Fixpoint unfolding with a guarded continuation-indexed invariant. -/
 theorem wp_fix' {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {Φ : (Runtime.Val → iProp) → List Runtime.Val → iProp}
     {R : iProp}
-    (hlen : ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-      Φ P vs ⊢ (⌜args.length = vs.length⌝ : iProp))
     (h : R ⊢
       □ (□ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp pctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
+          ⌜args.length = vs.length⌝ -∗ ▷ Φ P vs -∗
+            wp pctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) -∗
         ∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
+          ⌜args.length = vs.length⌝ -∗ Φ P vs -∗
+            wp pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
     R ⊢ □ (∀ (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-          Φ P vs -∗ wp pctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
-  h.trans (wp.fix' (Φ := Φ) hlen)
+          ⌜args.length = vs.length⌝ -∗ ▷ Φ P vs -∗
+            wp pctx (.app (.val (.fix f args e)) (vs.map Runtime.Expr.val)) P) :=
+  h.trans (wp.fix' (Φ := Φ))
 
 /-- Let-bindings: evaluate the bound expression, then continue in the body with
     the resulting value substituted. -/

--- a/Mica/Verifier/SpecMaps.lean
+++ b/Mica/Verifier/SpecMaps.lean
@@ -28,7 +28,7 @@ structure SpecEntry where
     argument and result types off the entry. Reducible so it unifies definitionally
     with the underlying `Spec.isPrecondFor`. -/
 @[reducible] def SpecEntry.isPrecondFor (W : TinyML.World) (e : SpecEntry) (f : Runtime.Val) : iProp :=
-  e.spec.isPrecondFor W e.argTys e.retTy f
+  e.spec.isPrecondFor W (TinyML.ValHasType W) e.argTys e.retTy f
 
 instance : Iris.BI.Persistent (SpecEntry.isPrecondFor W e f) := by
   unfold SpecEntry.isPrecondFor; infer_instance

--- a/Mica/Verifier/Specifications.lean
+++ b/Mica/Verifier/Specifications.lean
@@ -95,19 +95,20 @@ section Precondition
 
 /-- Fold `wp_fix'`'s tupled recursive obligation into a spec precondition;
     the two differ only by currying the typing hypothesis and the predicate transformer. -/
-theorem isPrecondFor_intro (W : TinyML.World)
+theorem isPrecondFor_intro (W : TinyML.World) (V : TinyML.ValueRelation)
     (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (s : Spec TinyML.Typ)
     (f : Runtime.Val) :
     iprop(□ ∀ (ρ : Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
-      (⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ ∗
-        TinyML.ValsHaveTypes W vs argTys ∗
-        PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ P r) s.pred
+      (⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ ∗ ⌜vs.length = argTys.length⌝ ∗
+        ▷ TinyML.ValsRel V vs argTys ∗
+        ▷ PredTrans.apply V (fun r => V r retTy -∗ P r) s.pred
           (argsEnv ρ s.args vs)) -∗
-        wp W.pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢ s.isPrecondFor W argTys retTy f := by
+        wp W.pctx (Runtime.Expr.app (.val f) (vs.map Runtime.Expr.val)) P) ⊢
+      s.isPrecondFor W V argTys retTy f := by
   unfold isPrecondFor
   iintro #H
   imodintro
-  iintro %ρ %Φ %vs Hagree Htyped Hpred
+  iintro %ρ %Φ %vs Hagree Hlen Htyped Hpred
   ispecialize H $$ %ρ %vs %Φ
   iapply H
   iframe
@@ -115,60 +116,60 @@ theorem isPrecondFor_intro (W : TinyML.World)
 /-- Löb-style rule for spec preconditions on `fix`: to prove
     `s.isPrecondFor W (.fix f args e)`, assume it as the recursive hypothesis and
     prove the `wp` of the body (after the usual fix-substitution). -/
-theorem isPrecondFor_fix {W : TinyML.World}
+theorem isPrecondFor_fix {W : TinyML.World} {V : TinyML.ValueRelation}
     {argTys : List TinyML.Typ} {retTy : TinyML.Typ} {s : Spec TinyML.Typ}
     {f : Runtime.Binder} {args : List Runtime.Binder} {e : Runtime.Expr}
     {R : iProp}
     (hargs : args.length = s.args.length)
     (hargTys : argTys.length = s.args.length)
-    (h : R ⊢ □ (s.isPrecondFor W argTys retTy (.fix f args e) -∗
+    (h : R ⊢ □ (s.isPrecondFor W V argTys retTy (.fix f args e) -∗
         ∀ (ρ : Env) (vs : List Runtime.Val) (P : Runtime.Val → iProp),
           ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ -∗
-          TinyML.ValsHaveTypes W vs argTys -∗
-          PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ P r) s.pred
+          TinyML.ValsRel V vs argTys -∗
+          PredTrans.apply V (fun r => V r retTy -∗ P r) s.pred
               (argsEnv ρ s.args vs) -∗
           wp W.pctx (e.subst ((Runtime.Subst.id.updateBinder f (.fix f args e)).updateAllBinder args vs)) P)) :
-    R ⊢ s.isPrecondFor W argTys retTy (.fix f args e) := by
+    R ⊢ s.isPrecondFor W V argTys retTy (.fix f args e) := by
   refine (SpatialContext.wp_fix' (pctx := W.pctx) (f := f) (args := args) (e := e) (Φ := fun P vs =>
       iprop(∃ ρ : Env,
         ⌜Env.agreeOn W.Δ_spec W.ρ_spec ρ⌝ ∗
-          TinyML.ValsHaveTypes W vs argTys ∗
-          PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ P r) s.pred
-            (argsEnv ρ s.args vs))) ?_ (h.trans ?_)).trans ?_
-  · intro vs P
-    istart
-    iintro ⟨%ρ, %hagr, Htyped, -⟩
-    ihave %Hlen := TinyML.ValsHaveTypes.length_eq $$ Htyped
-    ipureintro
-    simp at Hlen
-    omega
+          TinyML.ValsRel V vs argTys ∗
+          PredTrans.apply V (fun r => V r retTy -∗ P r) s.pred
+            (argsEnv ρ s.args vs))) (h.trans ?_)).trans ?_
   · istart
     iintro #HR
     imodintro
-    iintro #IH %vs %P Hpre
+    iintro #IH %vs %P %hlen Hpre
     ispecialize HR $$ [IH]
     · unfold isPrecondFor
       imodintro
-      iintro %ρ %Φ %vs Hagree Htyped Hpred
-      ispecialize IH $$ %vs %Φ
+      iintro %ρ %Φ %vs' %hagr' %hlen' Htyped Hpred
+      ispecialize IH $$ %vs' %Φ
       iapply IH
-      iexists ρ
-      iframe
-    icases Hpre with ⟨%ρ, %hagr0, #Htyped0, Hpred0⟩
+      · ipureintro; omega
+      · inext
+        iexists ρ
+        iframe
+        ipureintro
+        exact hagr'
+    icases Hpre with ⟨%ρ, %hagr0, Htyped0, Hpred0⟩
     ispecialize HR $$ %ρ %vs %P
-    iapply HR
+    ispecialize HR $$ [] Htyped0 Hpred0
     · ipureintro
       exact hagr0
-    · iexact Htyped0
-    · iexact Hpred0
+    iexact HR
   · unfold isPrecondFor
     iintro #Hfix
     imodintro
-    iintro %ρ %Φ %vs Hagree Htyped Hpred
+    iintro %ρ %Φ %vs %hagr %hlen Htyped Hpred
     ispecialize Hfix $$ %vs %Φ
     iapply Hfix
-    iexists ρ
-    iframe
+    · ipureintro; omega
+    · inext
+      iexists ρ
+      iframe
+      ipureintro
+      exact hagr
 end Precondition
 
 /-! ## Well-Formedness Proofs -/
@@ -350,7 +351,7 @@ theorem call_correct (W : TinyML.World)
     (∀ v st' ρ' t, Ψ (retTy, t) st' ρ' → t.wfIn st'.decls → t.eval ρ' = v →
       st'.sl W ρ' ∗ R ∗ TinyML.ValHasType W v retTy ⊢ Φ v) →
     @TinyML.Typ.SubList W.Θ (sargs.map Prod.fst) argTys ∧
-    (st.sl W ρ ∗ R ⊢ PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
+    (st.sl W ρ ∗ R ⊢ PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
       (Spec.argsEnv ((σ.subst.eval ρ)) s.args
         (sargs.map fun p => p.2.eval ρ))) := by
   intro hlen hwf hσwf hsargs heval hΨ
@@ -380,7 +381,7 @@ theorem call_correct (W : TinyML.World)
       iapply (hΨ v st₃ ρ'' t (VerifM.eval_ret hret) (hst₃_decls ▸ htwf) hteval) $$ Harg)
   exact (sep_mono_left (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf hragree).1).trans <|
     (by simpa [howns] using hcall : st.sl W ρ' ∗ R ⊢ _).trans <|
-    PredTrans.apply_env_agree W hwf hagree
+    PredTrans.apply_env_agree (TinyML.ValHasType W) hwf hagree
 
 end CallCorrectness
 
@@ -550,7 +551,7 @@ theorem implement_correct (W : TinyML.World)
             st''.sl W ρ'' ∗ Q ∗ ((TinyML.ValHasType W (result.eval ρ'') retTy -∗ Φ (result.eval ρ'')) -∗ S) ⊢ S) →
       st'.sl W ρ' ∗ Q ⊢ R) →
     st.sl W ρ ∗ TinyML.ValsHaveTypes W vs argTys ∗
-      PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
+      PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
         (Spec.argsEnv W.ρ_spec s.args vs) ⊢ R := by
   intro hlen hswf hwf hag heval hbody
   simp only [Spec.implement] at heval
@@ -578,7 +579,7 @@ theorem implement_correct (W : TinyML.World)
       (by omega)
   have hst'_wf : st'.decls.wf := (VerifM.eval.wf hΨ).namesDisjoint
   iapply (show st'.sl W ρ' ∗
-        PredTrans.apply W (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
+        PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r retTy -∗ Φ r) s.pred
           ((σ'.subst.eval ρ')) ⊢ R from
     PredTrans.implement_correct W s.pred W.Δ_spec σ' (body argVars) st' ρ'
       (fun r => TinyML.ValHasType W r retTy -∗ Φ r) R
@@ -603,7 +604,7 @@ theorem implement_correct (W : TinyML.World)
       simpa [TransState.sl] using
         (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf hragree).1)
     iexact Howns
-  · iapply (PredTrans.apply_env_agree W hswf (Env.agreeOn_trans hag_base (by
+  · iapply (PredTrans.apply_env_agree (TinyML.ValHasType W) hswf (Env.agreeOn_trans hag_base (by
         simpa [FiniteSubst.base, Signature.declVars] using Env.agreeOn_symm hagree)))
     iexact Happ
 


### PR DESCRIPTION
The value relation now distinguishes the two arrow cases: an unspecified arrow stays uninterpreted, while a specified arrow is interpreted by the specification predicate of the spec it carries, guarded by a later. For that, the specification semantics is parameterized by the value relation it interprets types through — which also moves it below the logical relation — and proved non-expansive in that parameter, so the guarded predicate is contractive and the recursive relation may interpret an arrow through its own approximation. The four commits behind this are squashed into one, since the last of them revises what the earlier ones set up.

Stacked on #143.