### PR TITLE
Store specifications in function types

### DIFF
--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -192,8 +192,8 @@ def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyM
     let dom' ← Typ.elaborate env dom
     let cod' ← Typ.elaborate env cod
     match cod' with
-    | .arrow args ret => .ok (.arrow (dom' :: args) ret)
-    | _ => .ok (.arrow [dom'] cod')
+    | .arrow args ret none => .ok (.arrow (dom' :: args) ret none)
+    | _ => .ok (.arrow [dom'] cod' none)
   | .tuple ts => do
     let ts' ← Typ.elaborateList env ts
     .ok (.tuple ts')

--- a/Mica/SourceTinyML/LogicalRelation.lean
+++ b/Mica/SourceTinyML/LogicalRelation.lean
@@ -67,7 +67,7 @@ mutual
     | .prim p     => p.valRelBody v
     | .value      => iprop(True)
     | .empty      => iprop(False)
-    | .arrow _ _  => iprop(False)
+    | .arrow ..  => iprop(False)
     | .tvar _     => iprop(False)
     | .ref t      => iprop(∃ l, ⌜v = .loc l⌝ ∗ locinv l (fun w => R w t))
     | .array t    => iprop(∃ len l, ⌜v = .array len l⌝ ∗ arrayinv len l (fun w => R w t))
@@ -136,7 +136,7 @@ mutual
     | .prim _ =>
         iintro _ H
         iexact H
-    | .value | .empty | .arrow _ _ | .tvar _ | .ref _ | .array _ | .ownedArray _ | .owned _ =>
+    | .value | .empty | .arrow .. | .tvar _ | .ref _ | .array _ | .ownedArray _ | .owned _ =>
         iintro _ H
         iexact H
 
@@ -224,7 +224,7 @@ mutual
         exact ValSumRelBody.dist hR hk ts tag payload
     | .prim _ =>
         exact Dist.rfl
-    | .value | .empty | .arrow _ _ | .tvar _ | .owned _ =>
+    | .value | .empty | .arrow .. | .tvar _ | .owned _ =>
         exact Dist.rfl
 
   private theorem ValsRelBody.dist {n : Nat} {R S : ValShape} {k k' : RecCont}
@@ -373,7 +373,7 @@ mutual
     match t with
     | .prim _ =>
         exact PrimitiveType.valRelBody_persistent _ v
-    | .value | .empty | .arrow _ _ | .tvar _ | .owned _ | .ownedArray _ =>
+    | .value | .empty | .arrow .. | .tvar _ | .owned _ | .ownedArray _ =>
         infer_instance
     | .ref _ =>
         have := locinv_persistent
@@ -498,9 +498,10 @@ theorem ValHasType.empty (W : World) (v : Runtime.Val) :
     ValHasType W v .empty ⊣⊢ iprop(False) := by
   exact equiv_iff.mp (ValHasType.unfold W v .empty)
 
-theorem ValHasType.arrow (W : World) (v : Runtime.Val) (args : List Typ) (ret : Typ) :
-    ValHasType W v (.arrow args ret) ⊣⊢ iprop(False) := by
-  exact equiv_iff.mp (ValHasType.unfold W v (.arrow args ret))
+theorem ValHasType.arrow (W : World) (v : Runtime.Val) (args : List Typ) (ret : Typ)
+    (spec : Option (Spec Typ)) :
+    ValHasType W v (.arrow args ret spec) ⊣⊢ iprop(False) := by
+  exact equiv_iff.mp (ValHasType.unfold W v (.arrow args ret spec))
 
 theorem ValHasType.tvar (W : World) (v : Runtime.Val) (x : TyVar) :
     ValHasType W v (.tvar x) ⊣⊢ iprop(False) := by
@@ -777,8 +778,8 @@ mutual
           rw [heq, hlen]
         · iapply (ValSumRel.sub hlist payload tag)
           iexact Hsum
-    | .arrow _ _ =>
-        exact (ValHasType.arrow W v _ _).1.trans false_elim
+    | .arrow .. =>
+        exact (ValHasType.arrow W v _ _ _).1.trans false_elim
     | .tuple hlist =>
         refine (ValHasType.tuple W v _).1.trans ?_
         refine .trans ?_ (ValHasType.tuple W v _).2
@@ -1243,7 +1244,7 @@ mutual
         exact htail φ hφ
     | sum _ | ref _ | value | named _ _ =>
       iintro _; ipureintro; simp [typeConstraints]
-    | arrow args ret => exact (TinyML.ValHasType.arrow W v args ret).1.trans false_elim
+    | arrow args ret spec => exact (TinyML.ValHasType.arrow W v args ret spec).1.trans false_elim
     | empty => exact (TinyML.ValHasType.empty W v).1.trans false_elim
     | tvar x => exact (TinyML.ValHasType.tvar W v x).1.trans false_elim
 

--- a/Mica/SourceTinyML/Printer.lean
+++ b/Mica/SourceTinyML/Printer.lean
@@ -12,7 +12,7 @@ namespace TinyML
 def Typ.print : Typ → String
   | .prim p => p.print
   | .sum ts => s!"sum ({", ".intercalate (ts.map Typ.print)})"
-  | .arrow args ret =>
+  | .arrow args ret _ =>
       " -> ".intercalate ((args.map fun arg => wrapArg arg (Typ.print arg)) ++ [Typ.print ret])
   | .ref t => s!"ref {wrapArg t (Typ.print t)}"
   | .array t => s!"array {wrapArg t (Typ.print t)}"

--- a/Mica/SourceTinyML/Typed.lean
+++ b/Mica/SourceTinyML/Typed.lean
@@ -8,7 +8,7 @@ namespace Typed
 open TinyML
 
 structure Binder where
-  name : Option Var
+  name : Option TinyML.Var
   ty : Typ
   deriving Repr
 
@@ -27,7 +27,7 @@ instance : DecidableEq Binder := by
 
 def Binder.none (ty : Typ) : Binder := ⟨Option.none, ty⟩
 
-def Binder.named (name : Var) (ty : Typ) : Binder := ⟨some name, ty⟩
+def Binder.named (name : TinyML.Var) (ty : Typ) : Binder := ⟨some name, ty⟩
 
 instance : BEq Binder := ⟨fun a b => decide (a = b)⟩
 
@@ -39,7 +39,7 @@ instance : LawfulBEq Binder where
 
 inductive Expr where
   | const (c : Const)
-  | var (name : Var) (ty : Typ)
+  | var (name : TinyML.Var) (ty : Typ)
   /-- Reference to a built-in primitive, indexed by name. `inst` is the
       type-variable instantiation solved at the use site; `ty` is the
       instantiated arrow type derived from the registry's scheme. -/
@@ -228,7 +228,7 @@ instance : DecidableEq Expr := Expr.decEq
 deriving instance Repr for Expr
 deriving instance BEq for Expr
 
-abbrev Vars := List Var
+abbrev Vars := List TinyML.Var
 abbrev Exprs := List Expr
 abbrev Binders := List Binder
 
@@ -246,7 +246,7 @@ def Expr.ty : Expr → Typ
   | .prim _ _ ty => ty
   | .unop _ _ ty => ty
   | .binop _ _ _ ty => ty
-  | .fix _ args retTy _ => .arrow (args.map Binder.ty) retTy
+  | .fix _ args retTy _ => .arrow (args.map Binder.ty) retTy none
   | .app _ _ ty => ty
   | .ifThenElse _ _ _ ty => ty
   | .letIn _ _ body => body.ty

--- a/Mica/SourceTinyML/Types.lean
+++ b/Mica/SourceTinyML/Types.lean
@@ -575,8 +575,11 @@ mutual
         | .empty, _ => true
         | _, .value => true
         | .sum ss, .sum ts => Typ.subListBody Θ recur ss ts
-        | .arrow ss s sp, .arrow ts t sp' =>
-            sp == sp' && Typ.subListBody Θ recur ts ss && Typ.subBody Θ recur s t
+        | .arrow ss s none, .arrow ts t none =>
+            Typ.subListBody Θ recur ts ss && Typ.subBody Θ recur s t
+        | .arrow ss s (some p), .arrow ts t (some q) =>
+            ss == ts && s == t && p == q
+        | .arrow .., .arrow .. => false
         | .tuple ss, .tuple ts => Typ.subListBody Θ recur ss ts
         | _, _ =>
             if s == t then true
@@ -635,9 +638,12 @@ mutual
     | trans : Typ.Sub Θ s t → Typ.Sub Θ t u → Typ.Sub Θ s u
     | sum   : Typ.SubList Θ ss ts
             → Typ.Sub Θ (.sum ss) (.sum ts)
+    /-- Only unspecified arrows are structural. A specified arrow is invariant
+    in its whole signature and specification, so it is related to another type
+    only by `refl` (or through `top`/`bot`). -/
     | arrow : Typ.SubList Θ ts ss
             → Typ.Sub Θ s t
-            → Typ.Sub Θ (.arrow ss s sp) (.arrow ts t sp)
+            → Typ.Sub Θ (.arrow ss s none) (.arrow ts t none)
     | tuple : Typ.SubList Θ ss ts
             → Typ.Sub Θ (.tuple ss) (.tuple ts)
     | named_left : TypeName.unfold Θ T args = some ty
@@ -667,9 +673,12 @@ mutual
     · exact .top
     · exact .sum (subListBody_sound hrecur h)
     · simp [Bool.and_eq_true] at h
-      obtain ⟨⟨hsp, h1⟩, h2⟩ := h
-      subst hsp
-      exact .arrow (subListBody_sound hrecur h1) (subBody_sound hrecur h2)
+      exact .arrow (subListBody_sound hrecur h.1) (subBody_sound hrecur h.2)
+    · simp [Bool.and_eq_true] at h
+      obtain ⟨⟨hargs, hret⟩, hspec⟩ := h
+      subst hargs; subst hret; subst hspec
+      exact .refl
+    · exact absurd h (by simp)
     · exact .tuple (subListBody_sound hrecur h)
     · -- catchall: if s == t then true else match (s, t) for named
       split at h
@@ -756,9 +765,12 @@ mutual
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
                                     then .sum (Typ.joinList Θ ss ts)
                                     else .value
-    | .arrow ss s sp, .arrow ts t sp' => if ss.length == ts.length && sp == sp'
-                                  then .arrow (Typ.meetList Θ ss ts) (Typ.join Θ s t) sp
+    | .arrow ss s none, .arrow ts t none => if ss.length == ts.length
+                                  then .arrow (Typ.meetList Θ ss ts) (Typ.join Θ s t) none
                                   else .value
+    | .arrow ss s (some p), .arrow ts t (some q) =>
+        if ss == ts && s == t && p == q then .arrow ss s (some p) else .value
+    | .arrow .., .arrow .. => .value
     | .ref s,       .ref t       => if s == t then .ref s else .value
     | .array s,     .array t     => if s == t then .array s else .value
     | .ownedArray s, .ownedArray t => if s == t then .ownedArray s else .value
@@ -778,9 +790,12 @@ mutual
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
                                     then .sum (Typ.meetList Θ ss ts)
                                     else .empty
-    | .arrow ss s sp, .arrow ts t sp' => if ss.length == ts.length && sp == sp'
-                                  then .arrow (Typ.joinList Θ ss ts) (Typ.meet Θ s t) sp
+    | .arrow ss s none, .arrow ts t none => if ss.length == ts.length
+                                  then .arrow (Typ.joinList Θ ss ts) (Typ.meet Θ s t) none
                                   else .empty
+    | .arrow ss s (some p), .arrow ts t (some q) =>
+        if ss == ts && s == t && p == q then .arrow ss s (some p) else .empty
+    | .arrow .., .arrow .. => .empty
     | .ref s,       .ref t       => if s == t then .ref s else .empty
     | .array s,     .array t     => if s == t then .array s else .empty
     | .ownedArray s, .ownedArray t => if s == t then .ownedArray s else .empty

--- a/Mica/SourceTinyML/Types.lean
+++ b/Mica/SourceTinyML/Types.lean
@@ -421,32 +421,89 @@ instance : LawfulBEq Typ where
   eq_of_beq h := of_decide_eq_true h
   rfl := by simp [BEq.beq]
 
-/--
-Substitution over `Typ`.
+/-! ### Substitution and closedness
 
-This is currently structural-only scaffolding. It becomes meaningfully
-variable-sensitive once `Typ` grows `tvar`/`named`.
--/
-def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
+Both descend into an arrow's specification: the `own` and `arr` atoms of a
+specification mention types, so a type variable can occur inside one. Each
+traversal is spelled out over the specification syntax the same way `Typ.decEq`
+is, since `Typ` nests those types and a generic map over them would not be
+structurally recursive. -/
+
+mutual
+
+/-- Substitution over `Typ`, replacing each type variable by `σ`. -/
+def Typ.subst (σ : TyVar → Typ) : Typ → Typ
   | .prim p => .prim p
-  | .sum ts => .sum (ts.map (Typ.subst _σ))
-  | .arrow args ret spec => .arrow (args.map (Typ.subst _σ)) (Typ.subst _σ ret) spec
-  | .ref t => .ref (Typ.subst _σ t)
-  | .array t => .array (Typ.subst _σ t)
-  | .ownedArray t => .ownedArray (Typ.subst _σ t)
-  | .vec t => .vec (Typ.subst _σ t)
-  | .owned t => .owned (Typ.subst _σ t)
+  | .sum ts => .sum (Typ.substList σ ts)
+  | .arrow args ret spec =>
+    .arrow (Typ.substList σ args) (Typ.subst σ ret) (Typ.substSpec? σ spec)
+  | .ref t => .ref (Typ.subst σ t)
+  | .array t => .array (Typ.subst σ t)
+  | .ownedArray t => .ownedArray (Typ.subst σ t)
+  | .vec t => .vec (Typ.subst σ t)
+  | .owned t => .owned (Typ.subst σ t)
   | .empty => .empty
   | .value => .value
-  | .tuple ts => .tuple (ts.map (Typ.subst _σ))
-  | .tvar v => _σ v
-  | .named T args => .named T (args.map (Typ.subst _σ))
+  | .tuple ts => .tuple (Typ.substList σ ts)
+  | .tvar v => σ v
+  | .named T args => .named T (Typ.substList σ args)
+termination_by structural t => t
+
+/-- Substitution over a list of types, mutually with `Typ.subst`. -/
+def Typ.substList (σ : TyVar → Typ) : List Typ → List Typ
+  | [] => []
+  | t :: ts => Typ.subst σ t :: Typ.substList σ ts
+termination_by structural ts => ts
+
+/-- Substitution in the types an atom mentions, mutually with `Typ.subst`. -/
+def Typ.substAtom (σ : TyVar → Typ) : {s : Srt} → Atom Typ s → Atom Typ s
+  | _, .isint t => .isint t
+  | _, .isbool t => .isbool t
+  | _, .isinj tag arity t => .isinj tag arity t
+  | _, .own t ty => .own t (Typ.subst σ ty)
+  | _, .arr t ty => .arr t (Typ.subst σ ty)
+  | _, .rel n t => .rel n t
+termination_by structural _ a => a
+
+/-- Substitution in a postcondition assertion, mutually with `Typ.subst`. -/
+def Typ.substPost (σ : TyVar → Typ) : Assertion Typ Unit → Assertion Typ Unit
+  | .ret () => .ret ()
+  | .assert φ k => .assert φ (Typ.substPost σ k)
+  | .let_ v t k => .let_ v t (Typ.substPost σ k)
+  | .pred v p k => .pred v (Typ.substAtom σ p) (Typ.substPost σ k)
+  | .ite φ kt ke => .ite φ (Typ.substPost σ kt) (Typ.substPost σ ke)
+termination_by structural a => a
+
+/-- Substitution in a predicate transformer, mutually with `Typ.subst`. -/
+def Typ.substPredTrans (σ : TyVar → Typ) :
+    Assertion Typ (Post Typ) → Assertion Typ (Post Typ)
+  | .ret p => .ret ⟨p.name, Typ.substPost σ p.body⟩
+  | .assert φ k => .assert φ (Typ.substPredTrans σ k)
+  | .let_ v t k => .let_ v t (Typ.substPredTrans σ k)
+  | .pred v p k => .pred v (Typ.substAtom σ p) (Typ.substPredTrans σ k)
+  | .ite φ kt ke => .ite φ (Typ.substPredTrans σ kt) (Typ.substPredTrans σ ke)
+termination_by structural a => a
+
+/-- Substitution in a specification, mutually with `Typ.subst`. -/
+def Typ.substSpec (σ : TyVar → Typ) : Spec Typ → Spec Typ
+  | s => { args := s.args, pred := Typ.substPredTrans σ s.pred }
+termination_by structural s => s
+
+/-- Substitution in an optional specification, mutually with `Typ.subst`. -/
+def Typ.substSpec? (σ : TyVar → Typ) : Option (Spec Typ) → Option (Spec Typ)
+  | none => none
+  | some s => some (Typ.substSpec σ s)
+termination_by structural s => s
+
+end
+
+mutual
 
 /-- A type is closed when it contains no type variables. -/
 def Typ.closed : Typ → Bool
   | .prim _ => true
-  | .sum ts => (ts.map Typ.closed).all id
-  | .arrow args ret _ => (args.map Typ.closed).all id && Typ.closed ret
+  | .sum ts => Typ.closedList ts
+  | .arrow args ret spec => Typ.closedList args && Typ.closed ret && Typ.closedSpec? spec
   | .ref t => Typ.closed t
   | .array t => Typ.closed t
   | .ownedArray t => Typ.closed t
@@ -454,9 +511,66 @@ def Typ.closed : Typ → Bool
   | .owned t => Typ.closed t
   | .empty => true
   | .value => true
-  | .tuple ts => (ts.map Typ.closed).all id
+  | .tuple ts => Typ.closedList ts
   | .tvar _ => false
-  | .named _ args => (args.map Typ.closed).all id
+  | .named _ args => Typ.closedList args
+termination_by structural t => t
+
+/-- Closedness of a list of types, mutually with `Typ.closed`. -/
+def Typ.closedList : List Typ → Bool
+  | [] => true
+  | t :: ts => Typ.closed t && Typ.closedList ts
+termination_by structural ts => ts
+
+/-- Closedness of the types an atom mentions, mutually with `Typ.closed`. -/
+def Typ.closedAtom : {s : Srt} → Atom Typ s → Bool
+  | _, .isint _ | _, .isbool _ | _, .isinj .. | _, .rel .. => true
+  | _, .own _ ty => Typ.closed ty
+  | _, .arr _ ty => Typ.closed ty
+termination_by structural _ a => a
+
+/-- Closedness of a postcondition assertion, mutually with `Typ.closed`. -/
+def Typ.closedPost : Assertion Typ Unit → Bool
+  | .ret () => true
+  | .assert _ k => Typ.closedPost k
+  | .let_ _ _ k => Typ.closedPost k
+  | .pred _ p k => Typ.closedAtom p && Typ.closedPost k
+  | .ite _ kt ke => Typ.closedPost kt && Typ.closedPost ke
+termination_by structural a => a
+
+/-- Closedness of a predicate transformer, mutually with `Typ.closed`. -/
+def Typ.closedPredTrans : Assertion Typ (Post Typ) → Bool
+  | .ret p => Typ.closedPost p.body
+  | .assert _ k => Typ.closedPredTrans k
+  | .let_ _ _ k => Typ.closedPredTrans k
+  | .pred _ p k => Typ.closedAtom p && Typ.closedPredTrans k
+  | .ite _ kt ke => Typ.closedPredTrans kt && Typ.closedPredTrans ke
+termination_by structural a => a
+
+/-- Closedness of a specification, mutually with `Typ.closed`. -/
+def Typ.closedSpec : Spec Typ → Bool
+  | s => Typ.closedPredTrans s.pred
+termination_by structural s => s
+
+/-- Closedness of an optional specification, mutually with `Typ.closed`. -/
+def Typ.closedSpec? : Option (Spec Typ) → Bool
+  | none => true
+  | some s => Typ.closedSpec s
+termination_by structural s => s
+
+end
+
+@[simp] theorem Typ.substList_eq (σ : TyVar → Typ) (ts : List Typ) :
+    Typ.substList σ ts = ts.map (Typ.subst σ) := by
+  induction ts with
+  | nil => rfl
+  | cons t ts ih => simp [Typ.substList, ih]
+
+@[simp] theorem Typ.closedList_eq (ts : List Typ) :
+    Typ.closedList ts = (ts.map Typ.closed).all id := by
+  induction ts with
+  | nil => rfl
+  | cons t ts ih => simp [Typ.closedList, ih]
 
 structure DataDecl where
   tparams : List TyVar
@@ -520,7 +634,11 @@ def TypeName.unfold (Θ : TypeEnv) (T : TypeName) (args : List Typ) : Option Typ
     TypeName.unfold Θ (.predef p) args =
       if args.length = p.arity then some (p.decl.instantiate args) else none := rfl
 
-/-! ## Weight and depth measures -/
+/-! ## Weight and depth measures
+
+Both skip an arrow's specification. They exist to justify termination of
+subtyping, joins, and meets, and none of those descend into a specification: a
+specified arrow is invariant, so two are compared by equality. -/
 
 mutual
   @[reducible]

--- a/Mica/SourceTinyML/Types.lean
+++ b/Mica/SourceTinyML/Types.lean
@@ -1,5 +1,6 @@
 -- SUMMARY: TinyML types, type declarations, and subtyping structure.
 import Mica.TinyML.Common
+import Mica.SourceTinyML.Assertions
 
 namespace TinyML
 
@@ -128,7 +129,9 @@ theorem PrimitiveType.unOpTypeOf_bool {op : UnOp} {p p' : PrimitiveType}
 inductive Typ where
   | prim (p : PrimitiveType)
   | sum (ts : List Typ)
-  | arrow (args : List Typ) (ret : Typ)
+  /-- A function type. `spec` is the specification the function was verified
+  against, if it has one; only specified functions are inhabited values. -/
+  | arrow (args : List Typ) (ret : Typ) (spec : Option (Spec Typ))
   | ref (t: Typ)
   /-- Shared array whose elements have type `t`. -/
   | array (t : Typ)
@@ -172,17 +175,20 @@ def Typ.primDecEq (p q : PrimitiveType) : Decidable (Typ.prim p = Typ.prim q) :=
   | isTrue h => isTrue (by subst h; rfl)
   | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
 
+mutual
+
 def Typ.decEq : (a b : Typ) → Decidable (a = b)
   | .prim p, .prim q => Typ.primDecEq p q
   | .empty, .empty | .value, .value => isTrue rfl
-  | .sum ss, .sum ts => match typesDecEq ss ts with
+  | .sum ss, .sum ts => match Typ.decEqList ss ts with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .arrow ss s, .arrow ts t =>
-    match typesDecEq ss ts, s.decEq t with
-    | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
-    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
-    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .arrow ss s sp, .arrow ts t sp' =>
+    match Typ.decEqList ss ts, s.decEq t, Typ.decEqSpec? sp sp' with
+    | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
+    | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .ref s, .ref t => match s.decEq t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -198,22 +204,22 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
   | .owned s, .owned t => match s.decEq t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .tuple ss, .tuple ts => match typesDecEq ss ts with
+  | .tuple ss, .tuple ts => match Typ.decEqList ss ts with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .tvar v, .tvar w => match (inferInstance : DecidableEq TyVar) v w with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .named T args, .named U params =>
-    match (inferInstance : DecidableEq TypeName) T U, typesDecEq args params with
+    match (inferInstance : DecidableEq TypeName) T U, Typ.decEqList args params with
     | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
     | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
     | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .ownedArray .., .prim _ | .ownedArray .., .sum _ | .ownedArray .., .arrow _ _
+  | .ownedArray .., .prim _ | .ownedArray .., .sum _ | .ownedArray .., .arrow ..
   | .ownedArray .., .ref _ | .ownedArray .., .array _ | .ownedArray .., .vec _
   | .ownedArray .., .owned _ | .ownedArray .., .empty | .ownedArray .., .value
   | .ownedArray .., .tuple _ | .ownedArray .., .tvar _ | .ownedArray .., .named _ _
-  | .prim _, .ownedArray .. | .sum _, .ownedArray .. | .arrow _ _, .ownedArray ..
+  | .prim _, .ownedArray .. | .sum _, .ownedArray .. | .arrow .., .ownedArray ..
   | .ref _, .ownedArray .. | .array _, .ownedArray .. | .vec _, .ownedArray ..
   | .owned _, .ownedArray .. | .empty, .ownedArray .. | .value, .ownedArray ..
   | .tuple _, .ownedArray .. | .tvar _, .ownedArray .. | .named _ _, .ownedArray .. =>
@@ -257,14 +263,156 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
   | .named .., .arrow .. | .named .., .ref .. | .named .., .owned .. | .named .., .empty
   | .named .., .array .. | .named .., .vec ..
   | .named .., .value | .named .., .tuple .. | .named .., .tvar .. => isFalse (by intro h; cases h)
-where
-  typesDecEq : (as bs : List Typ) → Decidable (as = bs)
-    | [], [] => isTrue rfl
-    | [], _ :: _ | _ :: _, [] => isFalse (by intro h; cases h)
-    | a :: as, b :: bs => match a.decEq b, typesDecEq as bs with
-      | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
-      | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
-      | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+termination_by structural a _ => a
+
+/-- Equality of type lists, mutually with `Typ.decEq`. -/
+def Typ.decEqList : (as bs : List Typ) → Decidable (as = bs)
+  | [], [] => isTrue rfl
+  | [], _ :: _ | _ :: _, [] => isFalse (by intro h; cases h)
+  | a :: as, b :: bs => match a.decEq b, Typ.decEqList as bs with
+    | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+
+-- The remaining members of the block decide equality of the specification a
+-- function type carries. They cannot go through the generic instances in
+-- `Mica/SourceTinyML/Assertions.lean`: those take `DecidableEq Typ` as an instance
+-- argument, which is what this block is defining.
+termination_by structural a _ => a
+
+/-- Equality of atoms over TinyML types, mutually with `Typ.decEq`. -/
+def Typ.decEqAtom {s : Srt} : (a b : Atom Typ s) → Decidable (a = b)
+  | .isint t, .isint u | .isbool t, .isbool u =>
+    match _root_.decEq t u with
+    | isTrue h => isTrue (by subst h; rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .isinj tag arity t, .isinj tag' arity' u =>
+    match _root_.decEq tag tag', _root_.decEq arity arity', _root_.decEq t u with
+    | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
+    | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .own t x, .own u y | .arr t x, .arr u y =>
+    match _root_.decEq t u, Typ.decEq x y with
+    | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .rel n t, .rel m u =>
+    match _root_.decEq n m, _root_.decEq t u with
+    | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .isinj .., .own .. | .isinj .., .arr .. | .isinj .., .rel ..
+  | .own .., .isinj .. | .own .., .arr .. | .own .., .rel ..
+  | .arr .., .isinj .. | .arr .., .own .. | .arr .., .rel ..
+  | .rel .., .isinj .. | .rel .., .own .. | .rel .., .arr .. =>
+    isFalse (by intro h; cases h)
+termination_by structural a _ => a
+
+/-- Equality of postcondition assertions, mutually with `Typ.decEq`. -/
+def Typ.decEqPost : (a b : Assertion Typ Unit) → Decidable (a = b)
+  | .ret (), .ret () => isTrue rfl
+  | .assert φ k, .assert ψ k' =>
+    match _root_.decEq φ ψ, Typ.decEqPost k k' with
+    | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .let_ v t k, .let_ w u k' =>
+    match _root_.decEq v w with
+    | isTrue hv => by
+        subst hv
+        exact match _root_.decEq t u, Typ.decEqPost k k' with
+          | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+          | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+          | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .pred v p k, .pred w q k' =>
+    match _root_.decEq v w with
+    | isTrue hv => by
+        subst hv
+        exact match Typ.decEqAtom p q, Typ.decEqPost k k' with
+          | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+          | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+          | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .ite φ kt ke, .ite ψ kt' ke' =>
+    match _root_.decEq φ ψ, Typ.decEqPost kt kt', Typ.decEqPost ke ke' with
+    | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
+    | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .ret _, .assert .. | .ret _, .let_ .. | .ret _, .pred .. | .ret _, .ite ..
+  | .assert .., .ret _ | .assert .., .let_ .. | .assert .., .pred .. | .assert .., .ite ..
+  | .let_ .., .ret _ | .let_ .., .assert .. | .let_ .., .pred .. | .let_ .., .ite ..
+  | .pred .., .ret _ | .pred .., .assert .. | .pred .., .let_ .. | .pred .., .ite ..
+  | .ite .., .ret _ | .ite .., .assert .. | .ite .., .let_ .. | .ite .., .pred .. =>
+    isFalse (by intro h; cases h)
+termination_by structural a _ => a
+
+/-- Equality of predicate transformers, mutually with `Typ.decEq`. -/
+def Typ.decEqPredTrans : (a b : Assertion Typ (Post Typ)) → Decidable (a = b)
+  | .ret p, .ret q =>
+    match _root_.decEq p.name q.name, Typ.decEqPost p.body q.body with
+    | isTrue h1, isTrue h2 => isTrue (by cases p; cases q; simp_all)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .assert φ k, .assert ψ k' =>
+    match _root_.decEq φ ψ, Typ.decEqPredTrans k k' with
+    | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .let_ v t k, .let_ w u k' =>
+    match _root_.decEq v w with
+    | isTrue hv => by
+        subst hv
+        exact match _root_.decEq t u, Typ.decEqPredTrans k k' with
+          | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+          | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+          | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .pred v p k, .pred w q k' =>
+    match _root_.decEq v w with
+    | isTrue hv => by
+        subst hv
+        exact match Typ.decEqAtom p q, Typ.decEqPredTrans k k' with
+          | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+          | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+          | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .ite φ kt ke, .ite ψ kt' ke' =>
+    match _root_.decEq φ ψ, Typ.decEqPredTrans kt kt', Typ.decEqPredTrans ke ke' with
+    | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
+    | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+  | .ret _, .assert .. | .ret _, .let_ .. | .ret _, .pred .. | .ret _, .ite ..
+  | .assert .., .ret _ | .assert .., .let_ .. | .assert .., .pred .. | .assert .., .ite ..
+  | .let_ .., .ret _ | .let_ .., .assert .. | .let_ .., .pred .. | .let_ .., .ite ..
+  | .pred .., .ret _ | .pred .., .assert .. | .pred .., .let_ .. | .pred .., .ite ..
+  | .ite .., .ret _ | .ite .., .assert .. | .ite .., .let_ .. | .ite .., .pred .. =>
+    isFalse (by intro h; cases h)
+termination_by structural a _ => a
+
+/-- Equality of specifications, mutually with `Typ.decEq`. -/
+def Typ.decEqSpec : (a b : Spec Typ) → Decidable (a = b)
+  | ⟨as, p⟩, ⟨bs, q⟩ =>
+    match _root_.decEq as bs, Typ.decEqPredTrans p q with
+    | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
+    | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+    | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+termination_by structural a _ => a
+
+/-- Equality of optional specifications, mutually with `Typ.decEq`. -/
+def Typ.decEqSpec? : (a b : Option (Spec Typ)) → Decidable (a = b)
+  | none, none => isTrue rfl
+  | none, some _ | some _, none => isFalse (by intro h; cases h)
+  | some s, some t =>
+    match Typ.decEqSpec s t with
+    | isTrue h => isTrue (by subst h; rfl)
+    | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+termination_by structural a _ => a
+
+end
 
 instance : DecidableEq Typ := Typ.decEq
 
@@ -282,7 +430,7 @@ variable-sensitive once `Typ` grows `tvar`/`named`.
 def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
   | .prim p => .prim p
   | .sum ts => .sum (ts.map (Typ.subst _σ))
-  | .arrow args ret => .arrow (args.map (Typ.subst _σ)) (Typ.subst _σ ret)
+  | .arrow args ret spec => .arrow (args.map (Typ.subst _σ)) (Typ.subst _σ ret) spec
   | .ref t => .ref (Typ.subst _σ t)
   | .array t => .array (Typ.subst _σ t)
   | .ownedArray t => .ownedArray (Typ.subst _σ t)
@@ -298,7 +446,7 @@ def Typ.subst (_σ : TyVar → Typ) : Typ → Typ
 def Typ.closed : Typ → Bool
   | .prim _ => true
   | .sum ts => (ts.map Typ.closed).all id
-  | .arrow args ret => (args.map Typ.closed).all id && Typ.closed ret
+  | .arrow args ret _ => (args.map Typ.closed).all id && Typ.closed ret
   | .ref t => Typ.closed t
   | .array t => Typ.closed t
   | .ownedArray t => Typ.closed t
@@ -379,7 +527,7 @@ mutual
   def Typ.weight : Typ → Nat
     | .prim _ | .empty | .value | .tvar _ => 1
     | .sum ts => 1 + Typ.weights ts
-    | .arrow args ret => 1 + Typ.weights args + Typ.weight ret
+    | .arrow args ret _ => 1 + Typ.weights args + Typ.weight ret
     | .ref t => 1 + Typ.weight t
     | .array t => 1 + Typ.weight t
     | .ownedArray t => 1 + Typ.weight t
@@ -399,7 +547,7 @@ mutual
   def Typ.depth : Typ → Nat
     | .prim _ | .empty | .value | .tvar _ => 1
     | .sum ts => 1 + Typ.depths ts
-    | .arrow args ret => 1 + max (Typ.depths args) (Typ.depth ret)
+    | .arrow args ret _ => 1 + max (Typ.depths args) (Typ.depth ret)
     | .ref t => 1 + Typ.depth t
     | .array t => 1 + Typ.depth t
     | .ownedArray t => 1 + Typ.depth t
@@ -427,8 +575,8 @@ mutual
         | .empty, _ => true
         | _, .value => true
         | .sum ss, .sum ts => Typ.subListBody Θ recur ss ts
-        | .arrow ss s, .arrow ts t =>
-            Typ.subListBody Θ recur ts ss && Typ.subBody Θ recur s t
+        | .arrow ss s sp, .arrow ts t sp' =>
+            sp == sp' && Typ.subListBody Θ recur ts ss && Typ.subBody Θ recur s t
         | .tuple ss, .tuple ts => Typ.subListBody Θ recur ss ts
         | _, _ =>
             if s == t then true
@@ -489,7 +637,7 @@ mutual
             → Typ.Sub Θ (.sum ss) (.sum ts)
     | arrow : Typ.SubList Θ ts ss
             → Typ.Sub Θ s t
-            → Typ.Sub Θ (.arrow ss s) (.arrow ts t)
+            → Typ.Sub Θ (.arrow ss s sp) (.arrow ts t sp)
     | tuple : Typ.SubList Θ ss ts
             → Typ.Sub Θ (.tuple ss) (.tuple ts)
     | named_left : TypeName.unfold Θ T args = some ty
@@ -519,7 +667,9 @@ mutual
     · exact .top
     · exact .sum (subListBody_sound hrecur h)
     · simp [Bool.and_eq_true] at h
-      exact .arrow (subListBody_sound hrecur h.1) (subBody_sound hrecur h.2)
+      obtain ⟨⟨hsp, h1⟩, h2⟩ := h
+      subst hsp
+      exact .arrow (subListBody_sound hrecur h1) (subBody_sound hrecur h2)
     · exact .tuple (subListBody_sound hrecur h)
     · -- catchall: if s == t then true else match (s, t) for named
       split at h
@@ -606,8 +756,8 @@ mutual
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
                                     then .sum (Typ.joinList Θ ss ts)
                                     else .value
-    | .arrow ss s, .arrow ts t => if ss.length == ts.length
-                                  then .arrow (Typ.meetList Θ ss ts) (Typ.join Θ s t)
+    | .arrow ss s sp, .arrow ts t sp' => if ss.length == ts.length && sp == sp'
+                                  then .arrow (Typ.meetList Θ ss ts) (Typ.join Θ s t) sp
                                   else .value
     | .ref s,       .ref t       => if s == t then .ref s else .value
     | .array s,     .array t     => if s == t then .array s else .value
@@ -628,8 +778,8 @@ mutual
     | .sum  ss,     .sum  ts     => if ss.length == ts.length
                                     then .sum (Typ.meetList Θ ss ts)
                                     else .empty
-    | .arrow ss s, .arrow ts t => if ss.length == ts.length
-                                  then .arrow (Typ.joinList Θ ss ts) (Typ.meet Θ s t)
+    | .arrow ss s sp, .arrow ts t sp' => if ss.length == ts.length && sp == sp'
+                                  then .arrow (Typ.joinList Θ ss ts) (Typ.meet Θ s t) sp
                                   else .empty
     | .ref s,       .ref t       => if s == t then .ref s else .empty
     | .array s,     .array t     => if s == t then .array s else .empty

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -12,11 +12,11 @@ namespace TinyML
 
 /-! ## Type contexts -/
 
-abbrev TyCtx := Var → Option Typ
+abbrev TyCtx := TinyML.Var → Option Typ
 
 def TyCtx.empty : TyCtx := fun _ => none
 
-def TyCtx.extend (Γ : TyCtx) (x : Var) (t : Typ) : TyCtx :=
+def TyCtx.extend (Γ : TyCtx) (x : TinyML.Var) (t : Typ) : TyCtx :=
   fun y => if y == x then some t else Γ y
 
 def TyCtx.extendBinder (Γ : TyCtx) (b : Typed.Binder) (t : Typ) : TyCtx :=
@@ -24,10 +24,10 @@ def TyCtx.extendBinder (Γ : TyCtx) (b : Typed.Binder) (t : Typ) : TyCtx :=
   | none => Γ
   | some x => Γ.extend x t
 
-@[simp] theorem TyCtx.extend_eq (Γ : TyCtx) (x : Var) (t : Typ) :
+@[simp] theorem TyCtx.extend_eq (Γ : TyCtx) (x : TinyML.Var) (t : Typ) :
     (Γ.extend x t) x = some t := by simp [TyCtx.extend]
 
-@[simp] theorem TyCtx.extend_ne (Γ : TyCtx) (x y : Var) (t : Typ) (h : y ≠ x) :
+@[simp] theorem TyCtx.extend_ne (Γ : TyCtx) (x y : TinyML.Var) (t : Typ) (h : y ≠ x) :
     (Γ.extend x t) y = Γ y := by
   simp [TyCtx.extend, h]
 
@@ -57,7 +57,7 @@ theorem TyCtx.le_extendBinder_congr {Γ Γ' : TyCtx} (b : Typed.Binder) (t : Typ
 
 -- foldl extend doesn't change the value at x if x doesn't appear in the list.
 theorem TyCtx.foldl_extend_stable
-    (args : List (Var × Typ)) (Γ : TyCtx) (x : Var)
+    (args : List (TinyML.Var × Typ)) (Γ : TyCtx) (x : TinyML.Var)
     (hx : ∀ a ∈ args, a.1 ≠ x) :
     (args.foldl (fun ctx a => ctx.extend a.1 a.2) Γ) x = Γ x := by
   induction args generalizing Γ with
@@ -215,7 +215,7 @@ structure SpecEnv (σ : Type) where
     error, not a partial application. -/
 def domains (ty : Typ) (arity : Nat) : Except TypeError (List Typ × Typ) :=
   match ty with
-  | .arrow doms ret =>
+  | .arrow doms ret _ =>
       if doms.length == arity then .ok (doms, ret)
       else .error (.arityMismatch doms.length arity)
   | _ => .error (.notAFunction ty)
@@ -292,7 +292,7 @@ mutual
     | .fix self args retTy body => do
         let retTy := retTy.getD .value
         let typedArgs := args.map (fun b => Typed.Binder.ofUntyped b (Typed.Binder.expectedTy b .value))
-        let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy
+        let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy none
         let typedSelf := Typed.Binder.ofUntyped self selfTy
         let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
         let body' ← check env Θ Γ' body retTy
@@ -725,7 +725,7 @@ mutual
     | .fix self args retTy body => by
         let retTy' := retTy.getD .value
         let typedArgs := args.map (fun b => Typed.Binder.ofUntyped b (Typed.Binder.expectedTy b .value))
-        let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy'
+        let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy' none
         let typedSelf := Typed.Binder.ofUntyped self selfTy
         let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
         let ih := check_runtime env Θ Γ' body retTy'

--- a/Mica/SourceTinyML/Untyped.lean
+++ b/Mica/SourceTinyML/Untyped.lean
@@ -9,7 +9,7 @@ open TinyML
 
 inductive Binder where
   | none
-  | named (name : Var) (ty : Option Typ)
+  | named (name : TinyML.Var) (ty : Option Typ)
   deriving Repr, Inhabited, DecidableEq
 
 instance : BEq Binder := ⟨fun a b => decide (a = b)⟩
@@ -20,7 +20,7 @@ instance : LawfulBEq Binder where
 
 inductive Expr where
   | const (c : Const)
-  | var (name : Var)
+  | var (name : TinyML.Var)
   /-- Reference to a built-in primitive, indexed by name. Resolved from a
       qualified path by the frontend; the registry (threaded through typing)
       is the source of its type scheme. -/
@@ -187,7 +187,7 @@ instance : DecidableEq Expr := Expr.decEq
 deriving instance Repr for Expr
 deriving instance BEq for Expr
 
-abbrev Vars := List Var
+abbrev Vars := List TinyML.Var
 abbrev Exprs := List Expr
 abbrev Binders := List Binder
 

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -353,7 +353,7 @@ def matchType (inst : List (TinyML.TyVar × TinyML.Typ))
     match pattern, actual with
     | .tvar v, t => .ok (if inst.lookup v |>.isSome then inst else (v, t) :: inst)
     | .sum ps, .sum ts => matchTypes inst ps ts
-    | .arrow ps p, .arrow ts t => do
+    | .arrow ps p _, .arrow ts t _ => do
         let inst ← matchTypes inst ps ts
         matchType inst p t
     | .ref p, .ref t | .array p, .array t | .vec p, .vec t | .owned p, .owned t =>

--- a/Mica/Verifier/BoundedQuantifier.lean
+++ b/Mica/Verifier/BoundedQuantifier.lean
@@ -181,7 +181,7 @@ def intrinsic (name : String) (path : String) : Verifier.Intrinsic where
   path := some ("Range", [path])
   reduce := fun _ _ _ _ => False
   wp := fun _ _ => iprop(False)
-  argTys := [.int, .int, .arrow [.int] .bool]
+  argTys := [.int, .int, .arrow [.int] .bool none]
   retTy := .bool
   spec :=
     { args := ["lo", "hi", "body"]
@@ -342,7 +342,7 @@ private def lift (all : Bool) (binder : Typed.Binder)
       if existing == entry then pure ()
       else throw s!"bounded-quantifier digest collision on '{name}'"
   | none => set ({ syms := st.syms ++ [entry] } : LiftState)
-  pure (.app (.var name (.arrow [.value] .bool))
+  pure (.app (.var name (.arrow [.value] .bool none))
     [.tuple (lo :: hi :: captured.map (fun x => Typed.Expr.var x .value))] .bool)
 
 /-- Rewrite every bounded-quantifier occurrence in a spec leaf, bottom-up:

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -277,7 +277,7 @@ mutual
         let sargs := (args.map Expr.ty).zip sterms
         VerifM.expectEq "app type annotation mismatch" e.retTy aty
         VerifM.expectEq "app type annotation mismatch"
-          fty (.arrow e.argTys e.retTy)
+          fty (.arrow e.argTys e.retTy none)
         let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) e.argTys e.retTy e.spec sargs
         pure result
     | .app (.prim n inst _) args aty => do

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -365,7 +365,7 @@ def resultTy (i : Intrinsic) : TinyML.Typ :=
 
 /-- The intrinsic's full arrow (scheme) type. -/
 def arrowType (i : Intrinsic) : TinyML.Typ :=
-  .arrow i.argTysList i.resultTy
+  .arrow i.argTysList i.resultTy none
 
 /-- The typing face of an intrinsic, consumed by the elaborator. -/
 def sig (i : Intrinsic) : Typed.PrimSig :=


### PR DESCRIPTION
Re-land of #140, whose commits never reached main: it was merged into `assertion-syntax-parametric` after that branch had already been squash-merged as #139. Same three commits, rebased onto the code moves.

A function type may now carry the specification of the function it describes: `Typ.arrow` gains an optional `Spec`, which makes types and the assertion syntax mutually defined and their decidable equalities mutually decided. The type-level operations follow suit — substitution and the closedness check descend into a stored specification, and structural subtyping is restricted to unspecified arrows, so specified arrows are invariant. Nothing interprets the stored specification yet; the value relation and the verifier still ignore it.

Stacked on #141.