### PR TITLE
Give specified declarations the specified arrow and bind them as values

### DIFF
--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -593,12 +593,10 @@ spec's arguments on top of the program's global bindings `Γbase`. The argument
 and return types recovered here type the spec's leaf expressions; the `Spec`
 itself keeps only the argument names, since the types belong to the function's
 arrow. -/
-def elabSpecBody (env : SpecEnv σ) (Θ : TypeEnv) (Γbase : TyCtx) (body : Typed.Expr)
+def elabSpecBody (env : SpecEnv σ) (Θ : TypeEnv) (Γbase : TyCtx)
+    (argBinders : List Typed.Binder) (retTy : Typ)
     (rb : Spec.Body Untyped.Expr) : TypeM σ (Spec Typ) := do
   let (names, pre) := rb
-  let (argBinders, retTy) ← match body with
-    | .fix _ args retTy _ _ => pure (args, retTy)
-    | _ => TypeM.error (.spec "attached to a non-function declaration")
   let argTys ← TypeM.ofExcept (specArgTypes argBinders names)
   let Γ₀ : TyCtx := argTys.foldl (fun Γ p => Γ.extend p.1 p.2) Γbase
   let pred ← elabAssert env Θ
@@ -608,35 +606,54 @@ def elabSpecBody (env : SpecEnv σ) (Θ : TypeEnv) (Γbase : TyCtx) (body : Type
     Γ₀ names pre
   pure { args := names, pred := pred }
 
-/-- Elaborate a declaration's optional spec against the typed function `body`. -/
-def elabSpec (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TyCtx) (body : Typed.Expr) :
-    Option (Spec.Body Untyped.Expr) → TypeM σ (Option (Spec Typ))
-  | none => pure none
-  | some rb => do
-    let s ← elabSpecBody env Θ Γ body rb
-    pure (some s)
+/-- Elaborate a specified function literal: its signature and specification
+first, then its body. Doing the spec before the body is what lets the recursive
+self-reference — and hence every call in the body — be typed at the specified
+arrow, so a recursive call resolves through the type it is annotated with rather
+than through a side table. -/
+def elabSpecifiedFix (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
+    (rb : Spec.Body Untyped.Expr) : Untyped.Expr → TypeM σ (Spec Typ × Typed.Expr)
+  | .fix self args retTy body => do
+      let retTy := retTy.getD .value
+      let typedArgs := args.map (fun b => Typed.Binder.ofUntyped b (Typed.Binder.expectedTy b .value))
+      let s ← elabSpecBody env Θ Γ typedArgs retTy rb
+      let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy (some s)
+      let typedSelf := Typed.Binder.ofUntyped self selfTy
+      let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
+      let body' ← check env Θ Γ' body retTy
+      pure (s, .fix typedSelf typedArgs retTy (some s) body')
+  | _ => TypeM.error (.spec "attached to a non-function declaration")
+
+/-- Check a declaration binder's annotation against the type elaborated for its
+body. A specified declaration's type carries its specification, which no
+annotation mentions, so the annotation is matched against the bare type. -/
+private def checkDeclAnnotation (b : Untyped.Binder) (ty : Typ) : TypeM σ Unit :=
+  match b with
+  | .named _ (some ann) =>
+      if ty.unspec == ann then pure () else TypeM.error (.subsumptionFailure ty ann)
+  | _ => pure ()
 
 def ValDecl.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (d : Untyped.ValDecl (Spec.Body Untyped.Expr)) :
     TypeM σ (Typed.ValDecl (Spec Typ)) := do
-  let (bodyTy, body') ←
-    match d.name with
-    | .named _ (some ty) => do
-        let body' ← check env Θ Γ d.body ty
-        pure (ty, body')
-    | _ => infer env Θ Γ d.body
-  let nameTy := match d.name with
-    | .named _ (some ty) => ty
-    | _ => bodyTy
-  let spec' ← elabSpec env Θ Γ body' d.declMeta.spec
-  -- A specified declaration's literal records its specification, so the
-  -- declaration's own type — and hence the type every later use is annotated
-  -- with — is the specified arrow.
-  let (body'', nameTy') := match spec' with
-    | some s => let b := body'.withSpec s; (b, b.ty)
-    | none => (body', nameTy)
-  pure { name := Typed.Binder.ofUntyped d.name nameTy', body := body'',
-         declMeta := { spec := spec', relation := d.declMeta.relation } }
+  match d.declMeta.spec with
+  | some rb => do
+      -- A specified declaration's literal records its specification, so the
+      -- declaration's own type — and hence the type every later use is
+      -- annotated with — is the specified arrow.
+      let (s, body') ← elabSpecifiedFix env Θ Γ rb d.body
+      checkDeclAnnotation d.name body'.ty
+      pure { name := Typed.Binder.ofUntyped d.name body'.ty, body := body',
+             declMeta := { spec := some s, relation := d.declMeta.relation } }
+  | none => do
+      let (bodyTy, body') ←
+        match d.name with
+        | .named _ (some ty) => do
+            let body' ← check env Θ Γ d.body ty
+            pure (ty, body')
+        | _ => infer env Θ Γ d.body
+      pure { name := Typed.Binder.ofUntyped d.name bodyTy, body := body',
+             declMeta := { spec := none, relation := d.declMeta.relation } }
 
 def Program.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
     Untyped.Program (Spec.Body Untyped.Expr) → TypeM σ (TypeEnv × Typed.Program (Spec Typ))
@@ -1147,33 +1164,57 @@ mutual
           · simp [Typed.inferBranches, binderTy, hsub] at h
 end
 
+/-- The specification a function literal is elaborated against does not change
+what it runs. -/
+theorem elabSpecifiedFix_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
+    (rb : Spec.Body Untyped.Expr) (e : Untyped.Expr) :
+    ∀ {s : σ} {r : Spec Typ × Typed.Expr} {s' : σ},
+      Typed.elabSpecifiedFix env Θ Γ rb e s = .ok (r, s') →
+      r.2.runtime = e.runtime := by
+  intro s r s' h
+  cases e
+  case fix self args retTy body =>
+    simp only [elabSpecifiedFix] at h
+    -- The spec's own elaboration stays opaque: `StateT.bind_ok` recovers it
+    -- without naming the arguments `elabSpecBody` is applied to.
+    have ⟨_spec, s₀, _hspec, hcont⟩ := StateT.bind_ok h
+    have ⟨body', s₁, hbody, hcont⟩ := StateT.bind_ok hcont
+    rcases hcont with ⟨rfl, rfl⟩
+    simp [Expr.runtime, Untyped.Expr.runtime, Binder.ofUntyped_runtime,
+      check_runtime env Θ _ body _ _ _ _ hbody]
+  all_goals simp [elabSpecifiedFix, TypeM.error] at h
+
 theorem ValDecl.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (d : Untyped.ValDecl (Spec.Body Untyped.Expr)) :
     ∀ {s : σ} {d' : Typed.ValDecl (Spec Typ)} {s' : σ},
       Typed.ValDecl.elaborate env Θ Γ d s = .ok (d', s') →
       d'.runtime = d.runtime := by
   intro s d' s' helab
-  -- Split only on whether there is an annotation; the unannotated cases are identical.
-  -- The spec's own elaboration stays opaque: `StateT.bind_ok` recovers it without
-  -- naming the arguments `elabSpec` is applied to.
-  match hname : d.name with
-  | .named x (some ty) =>
-    simp only [ValDecl.elaborate, hname] at helab
-    have ⟨body', s₀, hcheck, hcont⟩ := StateT.bind_ok helab
-    have ⟨y, s₂, hy, hcont⟩ := StateT.bind_ok hcont
-    rcases (by simpa using hy) with ⟨rfl, rfl⟩
-    have ⟨spec', s₁, hspec, hcont⟩ := StateT.bind_ok hcont
+  -- Split on whether there is a specification, and then — in its absence — only
+  -- on whether there is an annotation; the unannotated cases are identical.
+  match hspec : d.declMeta.spec with
+  | some rb =>
+    simp only [ValDecl.elaborate, hspec] at helab
+    have ⟨r, s₀, hfix, hcont⟩ := StateT.bind_ok helab
+    have ⟨_, s₁, _, hcont⟩ := StateT.bind_ok hcont
     rcases hcont with ⟨rfl, rfl⟩
-    cases spec' <;>
+    simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime, Binder.ofUntyped_runtime,
+      elabSpecifiedFix_runtime env Θ Γ rb d.body hfix]
+  | none =>
+    match hname : d.name with
+    | .named x (some ty) =>
+      simp only [ValDecl.elaborate, hspec, hname] at helab
+      have ⟨body', s₀, hcheck, hcont⟩ := StateT.bind_ok helab
+      have ⟨y, s₂, hy, hcont⟩ := StateT.bind_ok hcont
+      rcases (by simpa using hy) with ⟨rfl, rfl⟩
+      rcases hcont with ⟨rfl, rfl⟩
       simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
         check_runtime env Θ Γ d.body ty _ _ _ hcheck, Binder.ofUntyped_runtime, hname]
-  | .none | .named _ none =>
-    simp only [ValDecl.elaborate, hname] at helab
-    have ⟨p, s₀, hinfer, hcont⟩ := StateT.bind_ok helab
-    obtain ⟨bodyTy, body'⟩ := p
-    have ⟨spec', s₁, hspec, hcont⟩ := StateT.bind_ok hcont
-    rcases hcont with ⟨rfl, rfl⟩
-    cases spec' <;>
+    | .none | .named _ none =>
+      simp only [ValDecl.elaborate, hspec, hname] at helab
+      have ⟨p, s₀, hinfer, hcont⟩ := StateT.bind_ok helab
+      obtain ⟨bodyTy, body'⟩ := p
+      rcases hcont with ⟨rfl, rfl⟩
       simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
         infer_runtime env Θ Γ d.body _ _ _ hinfer, Binder.ofUntyped_runtime, hname]
 

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -629,7 +629,13 @@ def ValDecl.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     | .named _ (some ty) => ty
     | _ => bodyTy
   let spec' ← elabSpec env Θ Γ body' d.declMeta.spec
-  pure { name := Typed.Binder.ofUntyped d.name nameTy, body := body',
+  -- A specified declaration's literal records its specification, so the
+  -- declaration's own type — and hence the type every later use is annotated
+  -- with — is the specified arrow.
+  let (body'', nameTy') := match spec' with
+    | some s => let b := body'.withSpec s; (b, b.ty)
+    | none => (body', nameTy)
+  pure { name := Typed.Binder.ofUntyped d.name nameTy', body := body'',
          declMeta := { spec := spec', relation := d.declMeta.relation } }
 
 def Program.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
@@ -1158,16 +1164,18 @@ theorem ValDecl.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML
     rcases (by simpa using hy) with ⟨rfl, rfl⟩
     have ⟨spec', s₁, hspec, hcont⟩ := StateT.bind_ok hcont
     rcases hcont with ⟨rfl, rfl⟩
-    simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
-      check_runtime env Θ Γ d.body ty _ _ _ hcheck, Binder.ofUntyped_runtime, hname]
+    cases spec' <;>
+      simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
+        check_runtime env Θ Γ d.body ty _ _ _ hcheck, Binder.ofUntyped_runtime, hname]
   | .none | .named _ none =>
     simp only [ValDecl.elaborate, hname] at helab
     have ⟨p, s₀, hinfer, hcont⟩ := StateT.bind_ok helab
     obtain ⟨bodyTy, body'⟩ := p
     have ⟨spec', s₁, hspec, hcont⟩ := StateT.bind_ok hcont
     rcases hcont with ⟨rfl, rfl⟩
-    simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
-      infer_runtime env Θ Γ d.body _ _ _ hinfer, Binder.ofUntyped_runtime, hname]
+    cases spec' <;>
+      simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime,
+        infer_runtime env Θ Γ d.body _ _ _ hinfer, Binder.ofUntyped_runtime, hname]
 
 theorem Program.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (prog : Untyped.Program (Spec.Body Untyped.Expr)) :

--- a/Mica/Verifier/Bindings.lean
+++ b/Mica/Verifier/Bindings.lean
@@ -16,6 +16,51 @@ abbrev Bindings := List (TinyML.Var × FOL.Const)
 
 def Bindings.empty : Bindings := []
 
+/-- Drop a name's binding. A declaration that shadows a bound name without
+    binding a value of its own must remove it, or the old constant would stand
+    for the new value. -/
+def Bindings.remove : Bindings → TinyML.Var → Bindings
+  | [], _ => []
+  | (y, c) :: B, x => if y == x then Bindings.remove B x else (y, c) :: Bindings.remove B x
+
+omit [MicaGS HasLC.hasLC Sig] in
+@[simp] theorem Bindings.lookup_remove (B : Bindings) (x y : TinyML.Var) :
+    (B.remove x).lookup y = if y == x then none else B.lookup y := by
+  induction B with
+  | nil => simp [Bindings.remove]
+  | cons p B ih =>
+    obtain ⟨z, c⟩ := p
+    by_cases hzx : z = x
+    · subst hzx
+      simp only [Bindings.remove, beq_self_eq_true, if_true, ih]
+      by_cases hyz : y = z
+      · subst hyz; simp only [List.lookup, beq_self_eq_true, if_true]
+      · have hb : (y == z) = false := by simp [hyz]
+        simp only [List.lookup, hb, Bool.false_eq_true, if_false]
+    · have hzb : (z == x) = false := by simp [hzx]
+      simp only [Bindings.remove, hzb, Bool.false_eq_true, if_false]
+      by_cases hyz : y = z
+      · subst hyz
+        have hyx : (y == x) = false := by simp [hzx]
+        simp only [List.lookup, beq_self_eq_true, hyx, Bool.false_eq_true, if_false]
+      · have hb : (y == z) = false := by simp [hyz]
+        simp only [List.lookup, hb, ih]
+
+omit [MicaGS HasLC.hasLC Sig] in
+theorem Bindings.mem_of_mem_remove {B : Bindings} {x : TinyML.Var} {p : TinyML.Var × FOL.Const}
+    (h : p ∈ B.remove x) : p ∈ B := by
+  induction B with
+  | nil => simp [Bindings.remove] at h
+  | cons q B ih =>
+    obtain ⟨z, c⟩ := q
+    by_cases hzx : z = x
+    · simp [Bindings.remove, hzx] at h
+      exact List.mem_cons_of_mem _ (ih h)
+    · simp [Bindings.remove, hzx, List.mem_cons] at h ⊢
+      rcases h with rfl | h
+      · exact .inl rfl
+      · exact .inr (ih h)
+
 -- Every variable in Bindings is now declared at sort `.value`.
 def Bindings.agreeOnLinked (B : Bindings) (ρ : Env) (γ : Runtime.Subst) :=
   ∀ x x', B.lookup x = some x' →
@@ -46,6 +91,25 @@ theorem Bindings.wfIn_cons {B : Bindings} {decls : Signature} {x : TinyML.Var} {
   rcases hp with rfl | hp
   · exact List.Mem.head _
   · exact List.Mem.tail _ (hbwf p hp)
+
+omit [MicaGS HasLC.hasLC Sig] in
+theorem Bindings.wfIn_remove {B : Bindings} {decls : Signature} (h : B.wfIn decls)
+    (x : TinyML.Var) : (B.remove x).wfIn decls :=
+  fun _ hp => h _ (Bindings.mem_of_mem_remove hp)
+
+omit [MicaGS HasLC.hasLC Sig] in
+/-- Dropping a name's binding survives that name being rebound at runtime: the
+    remaining bindings are all for other names. -/
+theorem Bindings.agreeOnLinked_remove {B : Bindings} {ρ : Env} {γ : Runtime.Subst}
+    (hagree : B.agreeOnLinked ρ γ) (x : TinyML.Var) (v : Runtime.Val) :
+    (B.remove x).agreeOnLinked ρ (Runtime.Subst.update γ x v) := by
+  intro y y' hmem
+  rw [Bindings.lookup_remove] at hmem
+  by_cases hyx : y == x
+  · simp [hyx] at hmem
+  · simp only [hyx, Bool.false_eq_true, if_false] at hmem
+    obtain ⟨hsort, hγ⟩ := hagree y y' hmem
+    exact ⟨hsort, by simp [Runtime.Subst.update, hyx, hγ]⟩
 
 /-- The substitution `γ` maps every binding to a value well-typed by `Γ`. -/
 def Bindings.typedSubst (W : TinyML.World) (B : Bindings) (Γ : TinyML.TyCtx) (γ : Runtime.Subst) : iProp :=
@@ -95,6 +159,44 @@ theorem Bindings.typedSubst_cons {B : Bindings} {Γ : TinyML.TyCtx} {γ : Runtim
     · ipureintro
       simp [Runtime.Subst.update, hyx, hw']
     · iexact Hw'
+
+/-- Typing survives dropping a name's binding and rebinding that name at
+    runtime: no claim is made about the dropped name, and every other binding
+    reads the same value. -/
+theorem Bindings.typedSubst_remove {B : Bindings} {Γ : TinyML.TyCtx} {γ : Runtime.Subst}
+    {x : TinyML.Var} {v : Runtime.Val} :
+    B.typedSubst W Γ γ ⊢ (B.remove x).typedSubst W Γ (Runtime.Subst.update γ x v) := by
+  unfold Bindings.typedSubst
+  iintro #Hts
+  imodintro
+  iintro %y %y' %t %hmem %hΓ
+  rw [Bindings.lookup_remove] at hmem
+  by_cases hyx : y == x
+  · simp [hyx] at hmem
+  · simp only [hyx, Bool.false_eq_true, if_false] at hmem
+    ispecialize Hts $$ %y %y' %t %hmem %hΓ
+    icases Hts with ⟨%w, %hw, Hw⟩
+    iexists w
+    isplitr
+    · ipureintro
+      simp [Runtime.Subst.update, hyx, hw]
+    · iexact Hw
+
+omit [MicaGS HasLC.hasLC Sig] in
+/-- Bind a name to a constant that already denotes the value the name is being
+    bound to. -/
+theorem Bindings.agreeOnLinked_cons_update {B : Bindings} {ρ : Env} {γ : Runtime.Subst}
+    {x : TinyML.Var} {c : FOL.Const} {v : Runtime.Val}
+    (hagree : B.agreeOnLinked ρ γ) (hsort : c.sort = .value)
+    (hval : ρ.consts .value c.name = v) :
+    Bindings.agreeOnLinked ((x, c) :: B) ρ (Runtime.Subst.update γ x v) := by
+  intro y y' hmem
+  by_cases hyx : y == x
+  · simp [List.lookup, hyx] at hmem; subst hmem
+    exact ⟨hsort, by simp [Runtime.Subst.update, hyx, hval]⟩
+  · simp [List.lookup, hyx] at hmem
+    obtain ⟨hsort', hγ⟩ := hagree y y' hmem
+    exact ⟨hsort', by simp [Runtime.Subst.update, hyx, hγ]⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
 theorem Bindings.agreeOnLinked_cons {B : Bindings} {ρ ρ' : Env} {γ : Runtime.Subst}

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -478,7 +478,8 @@ end RelationSpec
     function takes. The compilation runs inside a `seq` bracket so its
     declarations and assertions don't pollute subsequent verifications. -/
 def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature)
-    (S : SpecMap) (d : Typed.ValDecl (Spec TinyML.Typ)) : VerifM SpecEntry := do
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (d : Typed.ValDecl (Spec TinyML.Typ)) : VerifM SpecEntry := do
   let spec ← match d.declMeta.spec with
     | some s => .ret s
     | none => .fatal "declaration has no spec"
@@ -489,44 +490,53 @@ def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Sig
     | .ok () => .ret ()
     | .error msg => .fatal msg
   VerifM.seq
-    (do let _ ← compile reg Θ Δ_spec S [] TinyML.TyCtx.empty (d.body.withSpec e.spec); pure ())
+    (do let _ ← compile reg Θ Δ_spec S B Γ (d.body.withSpec e.spec); pure ())
     (pure e)
 
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
-def ValDecl.checkExpr (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (S : SpecMap) (d : Typed.ValDecl (Spec TinyML.Typ)) : VerifM Unit :=
-  VerifM.seq (do let _ ← compile reg Θ Δ_spec S [] TinyML.TyCtx.empty d.body; pure ()) (pure ())
+def ValDecl.checkExpr (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature)
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (d : Typed.ValDecl (Spec TinyML.Typ)) : VerifM Unit :=
+  VerifM.seq (do let _ ← compile reg Θ Δ_spec S B Γ d.body; pure ()) (pure ())
 
-/-- Verify all declarations in a program, accumulating specs as we go. -/
+/-- Verify all declarations in a program, binding each verified one so later
+    declarations can use it as a value. -/
 def Program.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) :
-    SpecMap → Typed.Program (Spec TinyML.Typ) → VerifM Unit
-  | _, [] => pure ()
-  | S, d :: ds => do
+    SpecMap → Bindings → TinyML.TyCtx → Typed.Program (Spec TinyML.Typ) → VerifM Unit
+  | _, _, _, [] => pure ()
+  | S, B, Γ, d :: ds => do
     match d.name.name, d.declMeta.spec with
     | none, none =>
-      ValDecl.checkExpr reg Θ Δ_spec S d
-      Program.check reg Θ Δ_spec S ds
+      ValDecl.checkExpr reg Θ Δ_spec S B Γ d
+      Program.check reg Θ Δ_spec S B Γ ds
     | some n, none =>
     -- Named declaration without a spec: skip if it's a function definition
-    -- (no code executes), otherwise check it. Erase any old spec for this
-    -- name since the new binding shadows it.
+    -- (no code executes), otherwise check it. The new binding shadows any
+    -- earlier one of the same name, which is therefore dropped: nothing here
+    -- gives the new value a specification.
       if d.body.isFunc then
-        Program.check reg Θ Δ_spec (S.erase n) ds
+        Program.check reg Θ Δ_spec (S.erase n) (B.remove n) Γ ds
       else
-        ValDecl.checkExpr reg Θ Δ_spec S d
-        Program.check reg Θ Δ_spec (S.erase n) ds
+        ValDecl.checkExpr reg Θ Δ_spec S B Γ d
+        Program.check reg Θ Δ_spec (S.erase n) (B.remove n) Γ ds
     | _, _ =>
-      let spec ← ValDecl.check reg Θ Δ_spec S d
-      let S' := match d.name.name with
-        | some name => S.insert name spec
-        | none => S
-      Program.check reg Θ Δ_spec S' ds
+      let e ← ValDecl.check reg Θ Δ_spec S B Γ d
+      match d.name.name with
+      | some n =>
+        -- The declaration's value is a specified function: declare a constant
+        -- for it and bind the name, so later declarations can apply it through
+        -- its type or pass it as a value.
+        let fv ← VerifM.decl (some n) .value
+        Program.check reg Θ Δ_spec (S.insert n e) ((n, fv) :: B)
+          (Γ.extend n (.arrow e.argTys e.retTy (some e.spec))) ds
+      | none => Program.check reg Θ Δ_spec S B Γ ds
 
 def Program.verify (reg : Verifier.Registry) (prog : Untyped.Program (Spec.Body Untyped.Expr)) : Smt.Strategy Smt.Strategy.Outcome :=
   VerifM.strategy do
     let (Θ, typed, liftSt) ← Program.prepare (Program.specEnv reg (Program.relationMap prog)) {} prog
     Verifier.Registry.introduceRegistry reg
     let relations ← RelationSpec.assemble typed liftSt.syms
-    Program.check reg Θ relations.delta ∅ typed
+    Program.check reg Θ relations.delta ∅ [] TinyML.TyCtx.empty typed
 
 /-! ## Correctness -/
 
@@ -552,28 +562,31 @@ theorem Program.prepare_correct (env : Typed.SpecEnv σ) (s : σ)
 
 theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
-    (S : SpecMap) (d : Typed.ValDecl (Spec TinyML.Typ)) (γ : Runtime.Subst)
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (d : Typed.ValDecl (Spec TinyML.Typ)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
+    (hagree : B.agreeOnLinked ρ γ) (hbwf : B.wfIn st.decls)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
     {Q : Unit → TransState → Env → Prop}
-    (heval : VerifM.eval (ValDecl.checkExpr reg W.Θ W.Δ_spec S d) st ρ Q) :
-    (□ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ Φ) →
-    □ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun _ => Φ) := by
+    (heval : VerifM.eval (ValDecl.checkExpr reg W.Θ W.Δ_spec S B Γ d) st ρ Q) :
+    (□ st.sl W ρ ∗ S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ⊢ Φ) →
+    □ st.sl W ρ ∗ S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ⊢
+      wp W.pctx (d.body.runtime.subst γ) (fun _ => Φ) := by
   intro Hent
   simp only [ValDecl.checkExpr] at heval
   have ⟨hinner, _⟩ := VerifM.eval_seq heval
   have hcompile := VerifM.eval_bind hinner
   have hcomp :=
-    compile_correct reg hSound d.body W iprop(□ st.sl W ρ ∗ Φ) S [] TinyML.TyCtx.empty st ρ γ
+    compile_correct reg hSound d.body W iprop(□ st.sl W ρ ∗ Φ) S B Γ st ρ γ
     (fun x st' ρ' => VerifM.eval (pure ()) st' ρ' (fun _ _ _ => True))
     (fun _ => Φ)
     hW
     hcompile
-    (fun _ _ h => by simp at h)
-    (fun _ h => by simp at h)
+    hagree
+    hbwf
     hSwf hwf
     hag
     hΔreg
@@ -585,32 +598,37 @@ theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.R
       iexact HΦ)
   refine (BIBase.Entails.trans ?_ hcomp)
   istart
-  iintro ⟨#Hsl, #Hspec⟩
+  iintro ⟨#Hsl, #Hspec, #HT⟩
   isplitl [Hsl]
   · iexact Hsl
   · isplitl []
     · iexact Hspec
     · isplitl []
-      · iapply Bindings.typedSubst_nil
+      · iexact HT
       · isplitl [Hsl]
         · iexact Hsl
         · iapply Hent
           isplitl [Hsl]
           · iexact Hsl
-          · iexact Hspec
+          · isplitl []
+            · iexact Hspec
+            · iexact HT
 
 theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
-    (S : SpecMap) (d : Typed.ValDecl (Spec TinyML.Typ)) (γ : Runtime.Subst)
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (d : Typed.ValDecl (Spec TinyML.Typ)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
+    (hagree : B.agreeOnLinked ρ γ) (hbwf : B.wfIn st.decls)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec)
     {Q : SpecEntry → TransState → Env → Prop}
-    (heval : VerifM.eval (ValDecl.check reg W.Θ W.Δ_spec S d) st ρ Q) :
+    (heval : VerifM.eval (ValDecl.check reg W.Θ W.Δ_spec S B Γ d) st ρ Q) :
     ∃ spec, spec.wfIn W.Δ_spec ∧
-            (□ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ wp W.pctx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor W v)) ∧
+            (□ st.sl W ρ ∗ S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ⊢
+              wp W.pctx (d.body.runtime.subst γ) (fun v => spec.isPrecondFor W v)) ∧
             Q spec st ρ := by
   simp only [ValDecl.check] at heval
   cases hspec : d.declMeta.spec with
@@ -642,12 +660,12 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         -- own interpretation is exactly the entry's precondition predicate.
         have hcompile :
             st.sl W ρ ∗ (S.satisfiedBy W γ ∗
-              Bindings.typedSubst W [] TinyML.TyCtx.empty γ ∗ iprop(emp)) ⊢
+              Bindings.typedSubst W B Γ γ ∗ iprop(emp)) ⊢
               wp W.pctx ((d.body.withSpec spec.spec).runtime.subst γ)
                 (fun v => spec.isPrecondFor W v) :=
-          compile_correct reg hSound (d.body.withSpec spec.spec) W iprop(emp) S []
-            TinyML.TyCtx.empty st ρ γ _ _ hW (VerifM.eval_bind hcompileSeq)
-            (by intro x x' h; simp at h) (by intro p hp; simp at hp)
+          compile_correct reg hSound (d.body.withSpec spec.spec) W iprop(emp) S B
+            Γ st ρ γ _ _ hW (VerifM.eval_bind hcompileSeq)
+            hagree hbwf
             hSwf hwf hag hΔreg hρreg
             (fun v ρ' st' se _ _ _ => by
               rw [SpecEntry.ofFunction_shape hentry]
@@ -658,26 +676,29 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         rw [Typed.Expr.withSpec_runtime] at hcompile
         refine BIBase.Entails.trans ?_ hcompile
         istart
-        iintro ⟨#Hsl, #Hspec⟩
+        iintro ⟨#Hsl, #Hspec, #HT⟩
         isplitl [Hsl]
         · iexact Hsl
         · isplitl []
           · iexact Hspec
           · isplitl []
-            · iapply Bindings.typedSubst_nil
+            · iexact HT
             · iempintro
 
 theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
-    (S : SpecMap) (prog : Typed.Program (Spec TinyML.Typ)) (γ : Runtime.Subst)
+    (S : SpecMap) (B : Bindings) (Γ : TinyML.TyCtx)
+    (prog : Typed.Program (Spec TinyML.Typ)) (γ : Runtime.Subst)
     (hSwf : S.wfIn W.Δ_spec) (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
+    (hagree : B.agreeOnLinked ρ γ) (hbwf : B.wfIn st.decls)
     (hΔreg : Verifier.Registry.symSubset reg W.Δ_spec)
     (hρreg : Verifier.Registry.symAgree reg W.ρ_spec) :
-    VerifM.eval (Program.check reg W.Θ W.Δ_spec S prog) st ρ (fun _ _ _ => True) →
-    □ st.sl W ρ ∗ S.satisfiedBy W γ ⊢ pwp W.pctx ((Typed.Program.runtime prog).subst γ) := by
-  induction prog generalizing S γ st ρ with
+    VerifM.eval (Program.check reg W.Θ W.Δ_spec S B Γ prog) st ρ (fun _ _ _ => True) →
+    □ st.sl W ρ ∗ S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ ⊢
+      pwp W.pctx ((Typed.Program.runtime prog).subst γ) := by
+  induction prog generalizing S B Γ γ st ρ with
   | nil =>
     intro _
     simp only [Typed.Program.runtime, List.map_nil, Runtime.Program.subst]
@@ -709,16 +730,18 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         simp only [hname, hspec] at heval
         have hbind := VerifM.eval_bind heval
         have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-        have hih := ih S γ hSwf st ρ hag (VerifM.eval_ret hcont)
-        have hwp := ValDecl.checkExpr_correct reg hSound W hW S d γ hSwf hwf st ρ hag hΔreg hρreg hbind hih
+        have hih := ih S B Γ γ hSwf st ρ hag hagree hbwf (VerifM.eval_ret hcont)
+        have hwp := ValDecl.checkExpr_correct reg hSound W hW S B Γ d γ hSwf hwf st ρ hag
+          hagree hbwf hΔreg hρreg hbind hih
         refine hwp.trans (wp.mono ?_)
         intro v; rw [hupd v]; exact .rfl
       | some _ =>
         -- unnamed, with spec
         simp only [hname, hspec] at heval
         obtain ⟨spec, _, hwp, hcont⟩ :=
-          ValDecl.check_correct reg hSound W hW S d γ hSwf hwf st ρ hag hΔreg hρreg (VerifM.eval_bind heval)
-        have hih := ih S γ hSwf st ρ hag hcont
+          ValDecl.check_correct reg hSound W hW S B Γ d γ hSwf hwf st ρ hag hagree hbwf
+            hΔreg hρreg (VerifM.eval_bind heval)
+        have hih := ih S B Γ γ hSwf st ρ hag hagree hbwf hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
@@ -749,59 +772,105 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
               (args.map (·.runtime))))
           apply SpatialContext.wp_func
           rw [hupd fval]
-          have heval' : VerifM.eval (Program.check reg W.Θ W.Δ_spec (S.erase n) ds) st ρ (fun _ _ _ => True) := by
+          have heval' : VerifM.eval
+              (Program.check reg W.Θ W.Δ_spec (S.erase n) (B.remove n) Γ ds) st ρ
+              (fun _ _ _ => True) := by
             convert heval
-          have hih := ih (S.erase n) (γ.update n fval)
-            (SpecMap.wfIn_erase hSwf) st ρ hag heval'
+          have hih := ih (S.erase n) (B.remove n) Γ (γ.update n fval)
+            (SpecMap.wfIn_erase hSwf) st ρ hag
+            (Bindings.agreeOnLinked_remove hagree n fval) (Bindings.wfIn_remove hbwf n) heval'
           refine BIBase.Entails.trans ?_ hih
           istart
-          iintro ⟨#Hsl, #Hspec⟩
+          iintro ⟨#Hsl, #Hspec, #HT⟩
           isplitl [Hsl]
           · iexact Hsl
-          · iapply SpecMap.satisfiedBy_erase
-            iexact Hspec
+          · isplitl [Hspec]
+            · iapply SpecMap.satisfiedBy_erase
+              iexact Hspec
+            · iapply Bindings.typedSubst_remove
+              iexact HT
         · -- named, no spec, not a function
           have hbind := VerifM.eval_bind heval
           have ⟨_, hcont⟩ := VerifM.eval_seq hbind
-          have hcont' : VerifM.eval (Program.check reg W.Θ W.Δ_spec (S.erase n) ds) st ρ (fun _ _ _ => True) :=
+          have hcont' : VerifM.eval
+              (Program.check reg W.Θ W.Δ_spec (S.erase n) (B.remove n) Γ ds) st ρ
+              (fun _ _ _ => True) :=
             VerifM.eval_ret hcont
-          have hwp := ValDecl.checkExpr_correct reg hSound W hW S d γ hSwf hwf st ρ hag hΔreg hρreg hbind
+          have hwp := ValDecl.checkExpr_correct reg hSound W hW S B Γ d γ hSwf hwf st ρ hag
+            hagree hbwf hΔreg hρreg hbind
             (Φ := iprop(emp)) (by istart; iintro _; iempintro)
           refine SpatialContext.wp_strengthen_persistent hwp ?_
           intro v
           rw [hupd v]
-          have hih := ih (S.erase n) (γ.update n v) (SpecMap.wfIn_erase hSwf) st ρ hag hcont'
+          have hih := ih (S.erase n) (B.remove n) Γ (γ.update n v) (SpecMap.wfIn_erase hSwf)
+            st ρ hag (Bindings.agreeOnLinked_remove hagree n v) (Bindings.wfIn_remove hbwf n) hcont'
           exact wand_intro (sep_elim_left.trans <| by
             refine BIBase.Entails.trans ?_ hih
             istart
-            iintro ⟨#Hsl, #Hspec⟩
+            iintro ⟨#Hsl, #Hspec, #HT⟩
             isplitl [Hsl]
             · iexact Hsl
-            · iapply SpecMap.satisfiedBy_erase
-              iexact Hspec)
+            · isplitl [Hspec]
+              · iapply SpecMap.satisfiedBy_erase
+                iexact Hspec
+              · iapply Bindings.typedSubst_remove
+                iexact HT)
       | some _ =>
         simp only [hname, hspec] at heval
         obtain ⟨spec, hswf, hwp, hcont⟩ :=
-          ValDecl.check_correct reg hSound W hW S d γ hSwf hwf st ρ hag hΔreg hρreg (VerifM.eval_bind heval)
-        have hcont' : VerifM.eval (Program.check reg W.Θ W.Δ_spec (S.insert n spec) ds) st ρ (fun _ _ _ => True) := by
+          ValDecl.check_correct reg hSound W hW S B Γ d γ hSwf hwf st ρ hag hagree hbwf
+            hΔreg hρreg (VerifM.eval_bind heval)
+        set selfTy := TinyML.Typ.arrow spec.argTys spec.retTy (some spec.spec) with hselfTy_def
+        have hcont' : VerifM.eval
+            (do let fv ← VerifM.decl (some n) .value
+                Program.check reg W.Θ W.Δ_spec (S.insert n spec) ((n, fv) :: B)
+                  (Γ.extend n selfTy) ds) st ρ (fun _ _ _ => True) := by
           convert hcont
         refine SpatialContext.wp_strengthen_persistent hwp ?_
         intro v
         rw [hupd v]
-        have hih := ih (S.insert n spec) (γ.update n v)
-          (SpecMap.wfIn_insert hSwf hswf) st ρ hag hcont'
-        have hstep : (□ st.sl W ρ ∗ S.satisfiedBy W γ) ∗ spec.isPrecondFor W v ⊢
+        -- The declaration's value gets a constant of its own, so later
+        -- declarations can use the name as a value.
+        set fv := st.freshConst (some n) .value with hfv_def
+        set st₁ : TransState := { st with decls := st.decls.addConst fv } with hst₁_def
+        set ρ₁ := ρ.updateConst .value fv.name v with hρ₁_def
+        have hdecl := VerifM.eval_decl (VerifM.eval_bind hcont') v
+        have hfresh : fv.name ∉ st.decls.allNames := st.freshConst_fresh (some n) .value
+        have hρ_st₁ : Env.agreeOn st.decls ρ ρ₁ := Env.agreeOn_update_fresh_const hfresh
+        have hst_sub₁ : st.decls.Subset st₁.decls := Signature.Subset.subset_addConst _ _
+        have hag₁ : W.agrees st₁.decls ρ₁ := hag.step hst_sub₁ hρ_st₁
+        have hval₁ : ρ₁.consts .value fv.name = v := by
+          simp [hρ₁_def, Env.updateConst]
+        have hagree₁ : Bindings.agreeOnLinked ((n, fv) :: B) ρ₁ (γ.update n v) :=
+          Bindings.agreeOnLinked_cons_update
+            (Bindings.agreeOnLinked_env_agree hagree hρ_st₁ hbwf) rfl hval₁
+        have hbwf₁ : Bindings.wfIn ((n, fv) :: B) st₁.decls := Bindings.wfIn_cons hbwf
+        have hih := ih (S.insert n spec) ((n, fv) :: B) (Γ.extend n selfTy) (γ.update n v)
+          (SpecMap.wfIn_insert hSwf hswf) st₁ ρ₁ hag₁ hagree₁ hbwf₁ hdecl
+        have hsl₁ : st.sl W ρ ⊢ st₁.sl W ρ₁ := by
+          simp only [TransState.sl_eq, hst₁_def]
+          exact (SpatialContext.interp_env_agree W (VerifM.eval.wf heval).ownsWf hρ_st₁).1
+        have hstep : (□ st.sl W ρ ∗ S.satisfiedBy W γ ∗ Bindings.typedSubst W B Γ γ) ∗
+            spec.isPrecondFor W v ⊢
             pwp W.pctx ((Typed.Program.runtime ds).subst (γ.update n v)) := by
           refine BIBase.Entails.trans ?_ hih
           istart
-          iintro ⟨Hctx, Hpre⟩
-          icases Hctx with ⟨#Hsl, #Hspec⟩
+          iintro ⟨Hctx, #Hpre⟩
+          icases Hctx with ⟨#Hsl, #Hspec, #HT⟩
           isplitl [Hsl]
-          · iexact Hsl
-          · iapply SpecMap.satisfiedBy_insert_update
-            isplitl [Hspec]
-            · iexact Hspec
-            · iexact Hpre
+          · imodintro
+            iapply hsl₁
+            iexact Hsl
+          · isplitl [Hspec Hpre]
+            · iapply SpecMap.satisfiedBy_insert_update
+              isplitl [Hspec]
+              · iexact Hspec
+              · iexact Hpre
+            · iapply (Bindings.typedSubst_cons (W := W) (B := B) (Γ := Γ) (γ := γ)
+                (x := n) (v := fv) (te := selfTy) (w := v))
+              · iexact HT
+              · iapply (TinyML.ValHasType.arrow_some W v spec.argTys spec.retTy spec.spec).2
+                iexact Hpre
         exact wand_intro hstep
 
 
@@ -830,7 +899,7 @@ theorem Program.verify_correct (reg : Verifier.Registry)
                           Program.prepare (Program.specEnv reg (Program.relationMap p)) {} p
                         Verifier.Registry.introduceRegistry reg
                         let relations ← RelationSpec.assemble typed liftSt.syms
-                        Program.check reg Θ relations.delta ∅ typed)
+                        Program.check reg Θ relations.delta ∅ [] TinyML.TyCtx.empty typed)
                       TransState.init Env.init ctx_mid
                       (ScopedM.eval_declareConst hverif)
                       TransState.init_holdsFor TransState.init_wf
@@ -864,23 +933,28 @@ theorem Program.verify_correct (reg : Verifier.Registry)
     let W : TinyML.World :=
       { pctx := reg.primCtx, Θ, Δ_spec := stRel.decls, ρ_spec := ρRel }
     have hcorrect := Program.check_correct reg hSound W rfl
-                       ∅ typed Runtime.Subst.id
+                       ∅ [] TinyML.TyCtx.empty typed Runtime.Subst.id
                        (SpecMap.empty_wfIn _)
                        ⟨hcheck_eval.1.namesDisjoint, hvars⟩
                        stRel ρRel
                        ⟨Signature.Subset.refl _, Env.agreeOn_refl⟩
+                       (by intro x x' h; simp at h)
+                       (by intro p hp; simp at hp)
                        hΔreg
                        hρreg
                        hcheck_eval
     rw [Runtime.Program.subst_id] at hcorrect
     have hctx0 : (⊢ □ stRel.sl W ρRel ∗
-        SpecMap.satisfiedBy W (∅ : SpecMap) Runtime.Subst.id) := by
+        SpecMap.satisfiedBy W (∅ : SpecMap) Runtime.Subst.id ∗
+        Bindings.typedSubst W [] TinyML.TyCtx.empty Runtime.Subst.id) := by
       istart
       isplitl []
       · simp [TransState.sl, howns]
         imodintro
         iempintro
-      · iapply SpecMap.empty_satisfiedBy
+      · isplitl []
+        · iapply SpecMap.empty_satisfiedBy
+        · iapply Bindings.typedSubst_nil
     simpa [hrt] using hctx0.trans hcorrect
 
 omit [MicaGS HasLC.hasLC Sig] in

--- a/Tests/arith/smt_script.out
+++ b/Tests/arith/smt_script.out
@@ -206,3 +206,4 @@
 (pop)
 (pop)
 (pop)
+(declare-const id_ Value)

--- a/Tests/functions/recursive_function_value.ml
+++ b/Tests/functions/recursive_function_value.ml
@@ -1,0 +1,12 @@
+open Mica
+
+(* A recursive self-reference has the declaration's specified arrow type, so it
+   can be captured as a value and then called through that specification. *)
+let rec count (n : int) : int =
+  if n <= 0 then 0
+  else
+    let recur = count in
+    recur (n - 1) + 1
+[@@spec fun n ->
+  assert (n >= 0);
+  ret (fun r -> assert (r = n))];;

--- a/Tests/functions/top_level_alias.ml
+++ b/Tests/functions/top_level_alias.ml
@@ -1,0 +1,12 @@
+open Mica
+
+(* A top-level alias currently does not retain a verifier value binding. The
+   following use therefore documents the present boundary of top-level
+   declaration threading. *)
+let id (x : int) : int = x
+[@@spec fun x -> ret (fun v -> assert (v = x))];;
+
+let alias = id;;
+
+let use_alias (x : int) : int = alias x
+[@@spec fun x -> ret (fun v -> assert (v = x))];;

--- a/Tests/functions/top_level_alias.out
+++ b/Tests/functions/top_level_alias.out
@@ -1,0 +1,2 @@
+Status: failed: undefined variable: alias
+[1]


### PR DESCRIPTION
A specified declaration's type is now the specified arrow, and the declaration binds a value, so both routes an application can take reach the same specification.

On the elaborator side, `ValDecl.elaborate` splits on whether there is a specification. A specified declaration goes through the new `elabSpecifiedFix`, which elaborates the literal's signature and its specification *before* its body. That ordering is the point: the recursive self-reference — and hence every call in the body — is typed at the specified arrow, so a recursive call resolves through the type it is annotated with rather than through a side table. The declaration's own type is that arrow too, so every later use is annotated with it. Since no written annotation mentions a specification, `checkDeclAnnotation` matches the annotation against the bare type. The first commit gets there by attaching the specification after the fact; the third replaces that with the reordered elaboration, which is what the code ends up as.

On the verifier side, `Program.check` threads `Bindings` and a `TyCtx` through the program. A verified declaration declares a constant, binds its name to it, and extends the context at the specified arrow, so later declarations can apply it through its type or pass it as a value. A declaration that shadows a bound name without binding a value of its own drops the old binding, which the new `Bindings.remove` supports, along with the lemmas saying that dropping a name survives that name being rebound at runtime.

Third of four PRs putting function values on the type-carried specification. Stacked on #145.
