### PR TITLE
Accept a specification in any type position

### DIFF
--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -80,7 +80,7 @@ inductive BinOp where
   | semi | pipeRight | atAt | assign | concat | append | cons
   deriving Repr, BEq
 
--- Types
+-- Types, patterns, expressions, match arms
 
 mutual
   inductive TypKind where
@@ -89,15 +89,14 @@ mutual
     | arrow (dom cod : Typ)
     | tuple (components : List Typ)
 
+  /-- A type together with its attributes `T [@name payload]`. A type attribute
+  carries a payload for the same reason an expression attribute does: `[@spec]`
+  is written in any type position, and its payload is an expression. -/
   structure Typ where
     loc   : Location
     kind  : TypKind
-    attrs : List String := []   -- type attributes `T [@name]` (name-only, e.g. `[@owned]`)
-end
+    attrs : List Attribute := []
 
--- Patterns, expressions, match arms
-
-mutual
   inductive PatternKind where
     | wildcard
     | binder (name : Option Var) (ty : Option Typ)

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -129,125 +129,6 @@ private def ElabEnv.bindBinder (env : ElabEnv) : Untyped.Binder → ElabEnv
 private def ElabEnv.isLocal (env : ElabEnv) (name : Var) : Bool :=
   env.locals.elem name
 
--- ---------------------------------------------------------------------------
--- Type elaboration
-
-/-- Apply a single type attribute to an already-elaborated core type. `[@owned]`
-turns a shared `ref A` into an owned `owned A`; unknown names are rejected
-(mirroring how the expression-level `[@owned]` validates `ref`). -/
-private def applyTypAttr (loc : Location) (t : TinyML.Typ) : String → ElabM TinyML.Typ
-  | "owned" =>
-    match t with
-    | .ref inner => .ok (.owned inner)
-    | .array inner => .ok (.ownedArray inner)
-    | _ => err loc (.unsupportedFeature "[@owned] only applies to a 'ref' or 'array' type")
-  | name => err loc (.unsupportedFeature s!"unknown type attribute [@{name}]")
-
-mutual
-def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM TinyML.Typ
-  | .var v => .ok (.tvar v)
-  | .con path args => do
-    let args' ← Typ.elaborateList env args
-    -- Qualified paths route through the resolver; an alias must point to a
-    -- single-segment target (avoids unbounded chasing).
-    let name ← if path.isQualified then
-      match env.resolver.type_ path with
-      | some (.alias aliasPath) =>
-        if aliasPath.isQualified then
-          err loc (.unsupportedPath path)
-        else .ok aliasPath.head
-      | none => err loc (.unsupportedPath path)
-    else .ok path.head
-    match name with
-    | "int"  => if args'.isEmpty then .ok .int  else err loc (.arityMismatch 0 args'.length)
-    | "bool" => if args'.isEmpty then .ok .bool else err loc (.arityMismatch 0 args'.length)
-    | "unit" => if args'.isEmpty then .ok .unit else err loc (.arityMismatch 0 args'.length)
-    | "char" => if args'.isEmpty then .ok .char else err loc (.arityMismatch 0 args'.length)
-    | "string" => if args'.isEmpty then .ok .string else err loc (.arityMismatch 0 args'.length)
-    | "float" => if args'.isEmpty then .ok .float else err loc (.arityMismatch 0 args'.length)
-    | "ref" =>
-      match args' with
-      | [arg] => .ok (.ref arg)
-      | _ => err loc (.arityMismatch 1 args'.length)
-    | "array" =>
-      match args' with
-      | [arg] => .ok (.array arg)
-      | _ => err loc (.arityMismatch 1 args'.length)
-    | "vec" =>
-      match args' with
-      | [arg] => .ok (.vec arg)
-      | _ => err loc (.arityMismatch 1 args'.length)
-    | _ =>
-      match List.lookup name env.records with
-      | some fields =>
-          if args'.isEmpty then .ok (.tuple (fields.map Prod.snd))
-          else err loc (.arityMismatch 0 args'.length)
-      | none =>
-      match List.lookup name env.types with
-      | some info =>
-          if args'.length = info.arity then .ok (.named info.core args')
-          else err loc (.arityMismatch info.arity args'.length)
-      | none => err loc (.unknownType name)
-  | .arrow dom cod => do
-    let dom' ← Typ.elaborate env dom
-    let cod' ← Typ.elaborate env cod
-    match cod' with
-    | .arrow args ret none => .ok (.arrow (dom' :: args) ret none)
-    | _ => .ok (.arrow [dom'] cod' none)
-  | .tuple ts => do
-    let ts' ← Typ.elaborateList env ts
-    .ok (.tuple ts')
-termination_by k => sizeOf k
-
-/-- Elaborate a surface type: lower its kind, then apply any type attributes
-(`T [@name]`) left-to-right. Single entry point for every type position. -/
-def Typ.elaborate (env : ElabEnv) (ty : Typ) : ElabM TinyML.Typ := do
-  let t ← TypKind.elaborate env ty.loc ty.kind
-  ty.attrs.foldlM (applyTypAttr ty.loc) t
-termination_by sizeOf ty
-decreasing_by cases ty; simp_wf; omega
-
-def Typ.elaborateList (env : ElabEnv) : List Typ → ElabM (List TinyML.Typ)
-  | [] => .ok []
-  | ty :: ts => do
-    let t' ← Typ.elaborate env ty
-    let ts' ← Typ.elaborateList env ts
-    .ok (t' :: ts')
-termination_by ts => sizeOf ts
-end
-
-/-- Elaborate an optional annotation into the untyped IR's type language. -/
-private def elaborateOptTyp (env : ElabEnv) : Option Typ → ElabM (Option Untyped.Typ)
-  | none => .ok none
-  | some ty => do let ty' ← Typ.elaborate env ty; .ok (some (.core ty'))
-
--- ---------------------------------------------------------------------------
--- Pattern helpers
-
-private def patternToBinder (pat : Pattern) : ElabM Untyped.Binder :=
-  match pat.kind with
-  | .wildcard => .ok .none
-  | .binder (some name) _ => .ok (.named name none)
-  | .binder none _ => .ok .none
-  | _ => err pat.loc (.unsupportedPattern "expected a simple binder (variable or wildcard)")
-
-private def patternToBinderTyped (env : ElabEnv) (pat : Pattern) : ElabM Untyped.Binder :=
-  match pat.kind with
-  | .wildcard => .ok .none
-  | .binder none _ => .ok .none
-  | .binder (some n) ty => do
-    let ty' ← elaborateOptTyp env ty
-    .ok (.named n ty')
-  | _ => err pat.loc (.unsupportedPattern "expected a simple binder (variable or wildcard)")
-
-private def patternListToAnnotatedBinders (env : ElabEnv) :
-    List Pattern → ElabM (List Untyped.Binder)
-  | [] => .ok []
-  | p :: ps => do
-    let b ← patternToBinderTyped env p
-    let bs ← patternListToAnnotatedBinders env ps
-    .ok (b :: bs)
-
 private def checkRecordFieldSet (loc : Location) (fieldOrder : List FieldName) :
     List (FieldName × α) → ElabM Unit
   | [] => .ok ()
@@ -282,76 +163,6 @@ private def recordFieldsFor (env : ElabEnv) (loc : Location) (fields : List (Fie
           | some fieldInfo => do
               checkRecordFieldSet loc (fieldInfo.map Prod.fst) fields
               .ok fieldInfo
-
-private def patternRecordFieldsToBinders (env : ElabEnv)
-    : List (FieldName × Pattern) → ElabM (List (FieldName × Untyped.Binder))
-  | [] => .ok []
-  | (name, pat) :: rest => do
-      let binder ← patternToBinderTyped env pat
-      let binders ← patternRecordFieldsToBinders env rest
-      .ok ((name, binder) :: binders)
-
-private def patternToProductBinders (env : ElabEnv) (pat : Pattern) :
-    ElabM (List Untyped.Binder) :=
-  match pat.kind with
-  | .tuple pats => patternListToAnnotatedBinders env pats
-  | .record fields => do
-      let fieldInfo ← recordFieldsFor env pat.loc fields
-      let binders ← patternRecordFieldsToBinders env fields
-      reorderFields pat.loc binders (fieldInfo.map Prod.fst)
-  | _ => err pat.loc (.unsupportedPattern "expected a flat product binder")
-
-private def patternComponentType? (env : ElabEnv) (pat : Pattern) : ElabM (Option TinyML.Typ) :=
-  match pat.kind with
-  | .binder _ (some ty) => do
-      let ty' ← Typ.elaborate env ty
-      .ok (some ty')
-  | .binder _ none | .wildcard => .ok none
-  | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
-
-private def patternComponentTypes? (env : ElabEnv) :
-    List Pattern → ElabM (Option (List TinyML.Typ))
-  | [] => .ok (some [])
-  | p :: ps => do
-      let ty? ← patternComponentType? env p
-      let tys? ← patternComponentTypes? env ps
-      match ty?, tys? with
-      | some ty, some tys => .ok (some (ty :: tys))
-      | _, _ => .ok none
-
-private def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM TinyML.Typ :=
-  match pat.kind with
-  | .tuple pats => do
-      match ← patternComponentTypes? env pats with
-      | some tys => .ok (TinyML.Typ.tuple tys)
-      | none =>
-          err pat.loc (.unsupportedPattern "tuple function arguments must annotate each component")
-  | .record fields => do
-      let fieldInfo ← recordFieldsFor env pat.loc fields
-      .ok (TinyML.Typ.tuple (fieldInfo.map Prod.snd))
-  | _ => err pat.loc (.unsupportedPattern "expected a flat product binder")
-
-private def isProductPattern (pat : Pattern) : Bool :=
-  match pat.kind with
-  | .tuple (_ :: _) | .record _ => true
-  | _ => false
-
-private def productArgumentName (stem : String) (idx : Nat) : String :=
-  s!"{stem}{idx}"
-
-private def elaborateFunctionArgs (env : ElabEnv) (stem : String) :
-    Nat → List Pattern → Untyped.Expr → ElabM (List Untyped.Binder × Untyped.Expr)
-  | _, [], body => .ok ([], body)
-  | idx, pat :: pats, body => do
-      let (restArgs, restBody) ← elaborateFunctionArgs env stem (idx + 1) pats body
-      if isProductPattern pat then
-        let argName := productArgumentName stem idx
-        let argTy ← patternToProductType env pat
-        let names ← patternToProductBinders env pat
-        .ok (.named argName (some (.core argTy)) :: restArgs, .letProd names (.var argName) restBody)
-      else
-        let arg ← patternToBinderTyped env pat
-        .ok (arg :: restArgs, restBody)
 
 -- ---------------------------------------------------------------------------
 -- Match branch assembly
@@ -429,16 +240,219 @@ private partial def Pattern.lowerLists (pat : Pattern) : Pattern :=
     | kind => kind
   { pat with kind }
 
+private def isProductPattern (pat : Pattern) : Bool :=
+  match pat.kind with
+  | .tuple (_ :: _) | .record _ => true
+  | _ => false
+
+private def productArgumentName (stem : String) (idx : Nat) : String :=
+  s!"{stem}{idx}"
+
 mutual
+partial def elaborateOptTyp (env : ElabEnv) : Option Typ → ElabM (Option Untyped.Typ)
+  | none => .ok none
+  | some ty => do let ty' ← Typ.elaborate env ty; .ok (some ty')
+
+-- ---------------------------------------------------------------------------
+-- Pattern helpers
+
+partial def patternToBinder (pat : Pattern) : ElabM Untyped.Binder :=
+  match pat.kind with
+  | .wildcard => .ok .none
+  | .binder (some name) _ => .ok (.named name none)
+  | .binder none _ => .ok .none
+  | _ => err pat.loc (.unsupportedPattern "expected a simple binder (variable or wildcard)")
+
+partial def patternToBinderTyped (env : ElabEnv) (pat : Pattern) : ElabM Untyped.Binder :=
+  match pat.kind with
+  | .wildcard => .ok .none
+  | .binder none _ => .ok .none
+  | .binder (some n) ty => do
+    let ty' ← elaborateOptTyp env ty
+    .ok (.named n ty')
+  | _ => err pat.loc (.unsupportedPattern "expected a simple binder (variable or wildcard)")
+
+partial def patternListToAnnotatedBinders (env : ElabEnv) :
+    List Pattern → ElabM (List Untyped.Binder)
+  | [] => .ok []
+  | p :: ps => do
+    let b ← patternToBinderTyped env p
+    let bs ← patternListToAnnotatedBinders env ps
+    .ok (b :: bs)
+
+partial def patternRecordFieldsToBinders (env : ElabEnv)
+    : List (FieldName × Pattern) → ElabM (List (FieldName × Untyped.Binder))
+  | [] => .ok []
+  | (name, pat) :: rest => do
+      let binder ← patternToBinderTyped env pat
+      let binders ← patternRecordFieldsToBinders env rest
+      .ok ((name, binder) :: binders)
+
+partial def patternToProductBinders (env : ElabEnv) (pat : Pattern) :
+    ElabM (List Untyped.Binder) :=
+  match pat.kind with
+  | .tuple pats => patternListToAnnotatedBinders env pats
+  | .record fields => do
+      let fieldInfo ← recordFieldsFor env pat.loc fields
+      let binders ← patternRecordFieldsToBinders env fields
+      reorderFields pat.loc binders (fieldInfo.map Prod.fst)
+  | _ => err pat.loc (.unsupportedPattern "expected a flat product binder")
+
+partial def patternComponentType? (env : ElabEnv) (pat : Pattern) : ElabM (Option Untyped.Typ) :=
+  match pat.kind with
+  | .binder _ (some ty) => do
+      let ty' ← Typ.elaborate env ty
+      .ok (some ty')
+  | .binder _ none | .wildcard => .ok none
+  | _ => err pat.loc (.unsupportedPattern "expected a flat tuple binder")
+
+partial def patternComponentTypes? (env : ElabEnv) :
+    List Pattern → ElabM (Option (List Untyped.Typ))
+  | [] => .ok (some [])
+  | p :: ps => do
+      let ty? ← patternComponentType? env p
+      let tys? ← patternComponentTypes? env ps
+      match ty?, tys? with
+      | some ty, some tys => .ok (some (ty :: tys))
+      | _, _ => .ok none
+
+partial def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM Untyped.Typ :=
+  match pat.kind with
+  | .tuple pats => do
+      match ← patternComponentTypes? env pats with
+      | some tys => .ok (Untyped.Typ.tuple tys)
+      | none =>
+          err pat.loc (.unsupportedPattern "tuple function arguments must annotate each component")
+  | .record fields => do
+      let fieldInfo ← recordFieldsFor env pat.loc fields
+      .ok (Untyped.Typ.tuple (fieldInfo.map (fun f => Untyped.Typ.core f.2)))
+  | _ => err pat.loc (.unsupportedPattern "expected a flat product binder")
+
+partial def elaborateFunctionArgs (env : ElabEnv) (stem : String) :
+    Nat → List Pattern → Untyped.Expr → ElabM (List Untyped.Binder × Untyped.Expr)
+  | _, [], body => .ok ([], body)
+  | idx, pat :: pats, body => do
+      let (restArgs, restBody) ← elaborateFunctionArgs env stem (idx + 1) pats body
+      if isProductPattern pat then
+        let argName := productArgumentName stem idx
+        let argTy ← patternToProductType env pat
+        let names ← patternToProductBinders env pat
+        .ok (.named argName (some argTy) :: restArgs, .letProd names (.var argName) restBody)
+      else
+        let arg ← patternToBinderTyped env pat
+        .ok (arg :: restArgs, restBody)
+
+/-- Elaborate a surface type into the untyped IR's type language: lower its
+kind, then apply any type attributes (`T [@name payload]`) left-to-right.
+Single entry point for every type position, so `[@spec]` is honored wherever a
+type may be written. -/
+partial def Typ.elaborate (env : ElabEnv) : Typ → ElabM Untyped.Typ
+  | ⟨loc, kind, attrs⟩ => do
+      let t ← TypKind.elaborate env loc kind
+      Typ.applyAttrs env loc t attrs
+
+partial def Typ.applyAttrs (env : ElabEnv) (loc : Location) (t : Untyped.Typ) :
+    List Attribute → ElabM Untyped.Typ
+  | [] => .ok t
+  | attr :: attrs => do
+    let t' ← Typ.applyAttr env loc t attr
+    Typ.applyAttrs env loc t' attrs
+
+/-- Apply a single type attribute. `[@owned]` turns a shared `ref A` into an
+owned `owned A` (mirroring how the expression-level `[@owned]` validates
+`ref`); `[@spec]` records a specification on the arrow it annotates, exactly as
+`[@@spec]` does on a declaration. -/
+partial def Typ.applyAttr (env : ElabEnv) (loc : Location) (t : Untyped.Typ) :
+    Attribute → ElabM Untyped.Typ
+  | ⟨"owned", none⟩ =>
+    match t with
+    | .ref inner => .ok (.owned inner)
+    | .array inner => .ok (.ownedArray inner)
+    | _ => err loc (.unsupportedFeature "[@owned] only applies to a 'ref' or 'array' type")
+  | ⟨"owned", some payload⟩ => err payload.loc (.unsupportedFeature "[@owned] takes no payload")
+  | ⟨"spec", none⟩ => err loc (.unsupportedFeature "[@spec] expects a specification payload")
+  | ⟨"spec", some payload⟩ => do
+    let e ← Expr.elaborate env payload
+    match Spec.parse e with
+    | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@spec]: {msg}")
+    | .ok body =>
+      match t with
+      | .arrow args ret none => .ok (.arrow args ret (some body))
+      | .arrow _ _ (some _) =>
+        err loc (.unsupportedFeature "a function type carries at most one [@spec]")
+      | _ => err loc (.unsupportedFeature "[@spec] only applies to a function type")
+  | ⟨name, _⟩ => err loc (.unsupportedFeature s!"unknown type attribute [@{name}]")
+
+partial def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM Untyped.Typ
+  | .var v => .ok (.core (.tvar v))
+  | .con path args => do
+    let args' ← Typ.elaborateList env args
+    -- Qualified paths route through the resolver; an alias must point to a
+    -- single-segment target (avoids unbounded chasing).
+    let name ← if path.isQualified then
+      match env.resolver.type_ path with
+      | some (.alias aliasPath) =>
+        if aliasPath.isQualified then
+          err loc (.unsupportedPath path)
+        else .ok aliasPath.head
+      | none => err loc (.unsupportedPath path)
+    else .ok path.head
+    match name with
+    | "int"  => if args'.isEmpty then .ok (.core .int)  else err loc (.arityMismatch 0 args'.length)
+    | "bool" => if args'.isEmpty then .ok (.core .bool) else err loc (.arityMismatch 0 args'.length)
+    | "unit" => if args'.isEmpty then .ok (.core .unit) else err loc (.arityMismatch 0 args'.length)
+    | "char" => if args'.isEmpty then .ok (.core .char) else err loc (.arityMismatch 0 args'.length)
+    | "string" => if args'.isEmpty then .ok (.core .string) else err loc (.arityMismatch 0 args'.length)
+    | "float" => if args'.isEmpty then .ok (.core .float) else err loc (.arityMismatch 0 args'.length)
+    | "ref" =>
+      match args' with
+      | [arg] => .ok (.ref arg)
+      | _ => err loc (.arityMismatch 1 args'.length)
+    | "array" =>
+      match args' with
+      | [arg] => .ok (.array arg)
+      | _ => err loc (.arityMismatch 1 args'.length)
+    | "vec" =>
+      match args' with
+      | [arg] => .ok (.vec arg)
+      | _ => err loc (.arityMismatch 1 args'.length)
+    | _ =>
+      match List.lookup name env.records with
+      | some fields =>
+          if args'.isEmpty then .ok (.tuple (fields.map (fun f => Untyped.Typ.core f.2)))
+          else err loc (.arityMismatch 0 args'.length)
+      | none =>
+      match List.lookup name env.types with
+      | some info =>
+          if args'.length = info.arity then .ok (.named info.core args')
+          else err loc (.arityMismatch info.arity args'.length)
+      | none => err loc (.unknownType name)
+  | .arrow dom cod => do
+    let dom' ← Typ.elaborate env dom
+    let cod' ← Typ.elaborate env cod
+    match cod' with
+    | .arrow args ret none => .ok (.arrow (dom' :: args) ret none)
+    | _ => .ok (.arrow [dom'] cod' none)
+  | .tuple ts => do
+    let ts' ← Typ.elaborateList env ts
+    .ok (.tuple ts')
+
+partial def Typ.elaborateList (env : ElabEnv) : List Typ → ElabM (List Untyped.Typ)
+  | [] => .ok []
+  | ty :: ts => do
+    let t' ← Typ.elaborate env ty
+    let ts' ← Typ.elaborateList env ts
+    .ok (t' :: ts')
+
 /-- Elaborate an expression: lower its kind, then apply any expression
 attributes (`e [@name payload]`) left-to-right. This is the single entry point
 for every expression position, so attributes are honored everywhere. -/
-def Expr.elaborate (env : ElabEnv) : Expr → ElabM Untyped.Expr
+partial def Expr.elaborate (env : ElabEnv) : Expr → ElabM Untyped.Expr
   | ⟨loc, kind, attrs⟩ => do
       let e ← ExprKind.elaborate env loc kind
       attrs.foldlM (applyAttr loc) e
 
-def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Untyped.Expr
+partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Untyped.Expr
   | .const (.int n)  => .ok (.const (.int n))
   | .const (.float f) => .ok (.const (.float f.toBits))
   | .const (.bool b) => .ok (.const (.bool b))
@@ -720,14 +734,14 @@ def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Unt
 
   | .annot e _ => Expr.elaborate env e
 
-def Expr.elaborateList (env : ElabEnv) : List Expr → ElabM (List Untyped.Expr)
+partial def Expr.elaborateList (env : ElabEnv) : List Expr → ElabM (List Untyped.Expr)
   | [] => .ok []
   | e :: es => do
     let e' ← Expr.elaborate env e
     let es' ← Expr.elaborateList env es
     .ok (e' :: es')
 
-def Expr.elaborateRecordFields (env : ElabEnv)
+partial def Expr.elaborateRecordFields (env : ElabEnv)
     : List (FieldName × Expr) → ElabM (List (FieldName × Untyped.Expr))
   | [] => .ok []
   | (name, e) :: rest => do
@@ -735,7 +749,7 @@ def Expr.elaborateRecordFields (env : ElabEnv)
     let rest' ← Expr.elaborateRecordFields env rest
     .ok ((name, e') :: rest')
 
-def MatchArm.elaborateList (env : ElabEnv)
+partial def MatchArm.elaborateList (env : ElabEnv)
     : List MatchArm → ElabM (List (Constructor × Option Untyped.Binder × Untyped.Expr))
   | [] => .ok []
   | ⟨pat, body⟩ :: arms => do
@@ -778,7 +792,7 @@ def MatchArm.elaborateList (env : ElabEnv)
     let rest ← MatchArm.elaborateList env arms
     .ok ((ctorName, binder, body'') :: rest)
 
-def Pattern.toAnnotatedBinders (env : ElabEnv)
+partial def Pattern.toAnnotatedBinders (env : ElabEnv)
     : List Pattern → ElabM (List Untyped.Binder)
   | [] => .ok []
   | p :: ps => do
@@ -790,6 +804,37 @@ end
 -- ---------------------------------------------------------------------------
 -- Type declaration elaboration
 
+mutual
+  /-- The core type an elaborated type is, provided no pending specification
+  occurs in it. -/
+  private def core? : Untyped.Typ → Option TinyML.Typ
+    | .core t => some t
+    | .sum ts => do pure (.sum (← coreList? ts))
+    | .arrow _ _ (some _) => none
+    | .arrow args ret none => do pure (.arrow (← coreList? args) (← core? ret) none)
+    | .ref t => do pure (.ref (← core? t))
+    | .array t => do pure (.array (← core? t))
+    | .ownedArray t => do pure (.ownedArray (← core? t))
+    | .vec t => do pure (.vec (← core? t))
+    | .owned t => do pure (.owned (← core? t))
+    | .tuple ts => do pure (.tuple (← coreList? ts))
+    | .named n args => do pure (.named n (← coreList? args))
+
+  private def coreList? : List Untyped.Typ → Option (List TinyML.Typ)
+    | [] => some []
+    | t :: ts => do pure ((← core? t) :: (← coreList? ts))
+end
+
+/-- Elaborate a type that must be fully resolved on the spot. A data
+declaration's payloads and fields are stored as core types, and a
+specification's leaves cannot be typechecked before the declaration they
+belong to exists, so `[@spec]` has no meaning here. -/
+private def Typ.elaborateCore (env : ElabEnv) (ty : Typ) : ElabM TinyML.Typ := do
+  let t ← Typ.elaborate env ty
+  match core? t with
+  | some c => .ok c
+  | none => err ty.loc (.unsupportedFeature "[@spec] is not allowed in a type declaration")
+
 private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
     (ctorDefs : List (Constructor × Option Typ)) (tag : Nat) (arity : Nat)
     : ElabM (List TinyML.Typ × List (Constructor × (Nat × Nat × TinyML.Typ))) :=
@@ -800,7 +845,7 @@ private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
       err loc (.duplicateConstructor ctorName)
     else do
     let payloadTy' ← match payloadTy with
-      | some ty => Typ.elaborate env ty
+      | some ty => Typ.elaborateCore env ty
       | none => .ok .unit
     let (restTypes, restCtors) ← elaborateCtorDefs env loc rest (tag + 1) arity
     .ok (payloadTy' :: restTypes,
@@ -841,7 +886,7 @@ private def elaborateRecordDecl (env : ElabEnv) (loc : Location) (name : TypeCon
   let envWithSelf := { env with types := (name, ⟨coreName, 0⟩) :: env.types }
   let newFields ← elaborateFieldDefs env loc name fieldDefs 0
   let fieldTypes ← fieldDefs.mapM (fun (fieldName, ty) => do
-    let ty' ← Typ.elaborate envWithSelf ty
+    let ty' ← Typ.elaborateCore envWithSelf ty
     pure (fieldName, ty'))
   .ok { env with
     types := (name, ⟨coreName, 0⟩) :: env.types

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -913,11 +913,23 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
   match binders with
   | [] => err loc (.unsupportedFeature "declaration with no binders")
   | [pat] =>
+    -- A declaration with no arguments: its annotation is the declaration's own
+    -- type, which is where a `[@spec]` on it belongs.
     let name ← patternToBinder pat
-    let body' ← Expr.elaborate env body
+    let annot ← elaborateOptTyp env retTy
+    let name := match name, annot with
+      | .named n none, some ty => .named n (some ty)
+      | b, _ => b
     if isRec then
-      err loc (.unsupportedFeature "let rec requires function arguments")
-    else
+      -- `let rec f : T = fun x -> ...`: the literal's self-reference is the
+      -- declaration's own name, so recursive calls go through its type.
+      let body' ← Expr.elaborate (env.bindPattern pat) body
+      match body' with
+      | .fix .none args retTy' inner =>
+        .ok { name, body := .fix name args retTy' inner, declMeta := md }
+      | _ => err loc (.unsupportedFeature "let rec requires a function")
+    else do
+      let body' ← Expr.elaborate env body
       .ok { name, body := body', declMeta := md }
   | pat :: args =>
     let name ← patternToBinder pat

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -170,26 +170,35 @@ private partial def parseLAssoc (ops : List (Token × BinOp)) (sub : Parser Expr
 -- ---------------------------------------------------------------------------
 -- Type parsing
 
--- `[@name]` — single `@`, name only (type attributes carry no payload).
-private def parseTypeAttr : Parser String := fun st => do
+private def isPatStart : Token → Bool
+  | .ident _ | .underscore | .lparen | .lbrace | .intLit _ | .kw_true | .kw_false => true
+  | _ => false
+
+mutual
+-- `[@name expr]` — single `@`, optional expression payload.
+private partial def parseTypeAttr : Parser Attribute := fun st => do
   let st ← expect .lbracket st
   let st ← expect .at st
   let (name, st) ← expectIdent st
+  let (payload, st) ← match peekTok st with
+    | .rbracket => .ok (none, st)
+    | _ => do
+      let (e, st) ← parseExpr st
+      .ok (some e, st)
   let st ← expect .rbracket st
-  .ok (name, st)
+  .ok ({ name, payload }, st)
 
--- Fold trailing type attributes `T [@name]` into `T.attrs`.
+-- Fold trailing type attributes `T [@name payload]` into `T.attrs`.
 private partial def parseTypeAttrSuffix (t : Typ) : Parser Typ := fun st =>
   match peekTok st with
   | .lbracket =>
     match peekTok (advance st) with
     | .at => do
-      let (name, st) ← parseTypeAttr st
-      parseTypeAttrSuffix { t with attrs := t.attrs ++ [name] } st
+      let (attr, st) ← parseTypeAttr st
+      parseTypeAttrSuffix { t with attrs := t.attrs ++ [attr] } st
     | _ => .ok (t, st)  -- not a type attribute (e.g. `[@@...]`), leave `[`
   | _ => .ok (t, st)
 
-mutual
 private partial def parseTypeAtom : Parser Typ := fun st =>
   let p := peekLoc st
   match peekTok st with
@@ -275,11 +284,10 @@ private partial def parseType : Parser Typ := fun st => do
     let loc : Location := { start := t.loc.start, stop := u.loc.stop }
     .ok ({ loc, kind := .arrow t u }, st)
   | _ => .ok (t, st)
-end
 
 /-- Parse a type expression, excluding arrows.
     Used for return type annotations where `->` is ambiguous with the function arrow. -/
-private def parseTypeNoArrow : Parser Typ := parseTypeProd
+private partial def parseTypeNoArrow : Parser Typ := parseTypeProd
 
 -- ---------------------------------------------------------------------------
 -- Pattern parsing
@@ -340,49 +348,48 @@ private partial def parsePattern : Parser Pattern := fun st =>
     | t => .error { loc := peekLoc st', kind := .unexpectedToken "']' in pattern" t }
   | t =>
     .error { loc := peekLoc st, kind := .unexpectedToken "pattern" t }
-where
-  -- pattern inside parens: allows `(x : T)` annotated binder
-  parsePatternInner : Parser Pattern := fun st =>
-    let p := peekLoc st
-    match peekTok st with
-    | .ident name =>
-      let st' := advance st
-      match peekTok st' with
-      | .colon => do
-        let (ty, st') ← parseType (advance st')
-        .ok (mkPat p st' (.binder (some name) (some ty)), st')
-      | _ =>
-        .ok (mkPat p st' (.binder (some name) none), st')
-    | .underscore =>
-      let st' := advance st
-      match peekTok st' with
-      | .colon => do
-        let (ty, st') ← parseType (advance st')
-        .ok (mkPat p st' (.binder none (some ty)), st')
-      | _ =>
-        .ok (mkPat p st' .wildcard, st')
-    | _ => parsePattern st
+-- pattern inside parens: allows `(x : T)` annotated binder
+private partial def parsePatternInner : Parser Pattern := fun st =>
+  let p := peekLoc st
+  match peekTok st with
+  | .ident name =>
+    let st' := advance st
+    match peekTok st' with
+    | .colon => do
+      let (ty, st') ← parseType (advance st')
+      .ok (mkPat p st' (.binder (some name) (some ty)), st')
+    | _ =>
+      .ok (mkPat p st' (.binder (some name) none), st')
+  | .underscore =>
+    let st' := advance st
+    match peekTok st' with
+    | .colon => do
+      let (ty, st') ← parseType (advance st')
+      .ok (mkPat p st' (.binder none (some ty)), st')
+    | _ =>
+      .ok (mkPat p st' .wildcard, st')
+  | _ => parsePattern st
 
-  parseTuplePatRest : Parser (List Pattern) := fun st =>
-    match peekTok st with
-    | .comma => do
-      let (p, st) ← parsePattern (advance st)
-      let (rest, st) ← parseTuplePatRest st
-      .ok (p :: rest, st)
-    | _ => .ok ([], st)
+private partial def parseTuplePatRest : Parser (List Pattern) := fun st =>
+  match peekTok st with
+  | .comma => do
+    let (p, st) ← parsePattern (advance st)
+    let (rest, st) ← parseTuplePatRest st
+    .ok (p :: rest, st)
+  | _ => .ok ([], st)
 
-  parseRecordPatFields : Parser (List (FieldName × Pattern)) := fun st => do
-    let (name, st) ← expectIdent st
-    let st ← expect .eq st
-    let (pat, st) ← parsePattern st
-    match peekTok st with
-    | .semi =>
-      if peekTok (advance st) == .rbrace then
-        .ok ([(name, pat)], advance st)
-      else do
-        let (rest, st) ← parseRecordPatFields (advance st)
-        .ok ((name, pat) :: rest, st)
-    | _ => .ok ([(name, pat)], st)
+private partial def parseRecordPatFields : Parser (List (FieldName × Pattern)) := fun st => do
+  let (name, st) ← expectIdent st
+  let st ← expect .eq st
+  let (pat, st) ← parsePattern st
+  match peekTok st with
+  | .semi =>
+    if peekTok (advance st) == .rbrace then
+      .ok ([(name, pat)], advance st)
+    else do
+      let (rest, st) ← parseRecordPatFields (advance st)
+      .ok ((name, pat) :: rest, st)
+  | _ => .ok ([(name, pat)], st)
 
 /-- Pattern with infix `::` (right-assoc): `p1 :: p2` is the prelude cons
     constructor applied to the pair pattern `(p1, p2)`. Constructor payloads
@@ -401,10 +408,6 @@ private partial def parsePatternCons : Parser Pattern := fun st => do
 -- These are top-level so both parseExpr (parseLet/parseFun) and parseDecl
 -- (parseValDecl) can call them directly.
 
-private def isPatStart : Token → Bool
-  | .ident _ | .underscore | .lparen | .lbrace | .intLit _ | .kw_true | .kw_false => true
-  | _ => false
-
 private partial def parsePatternBinder : Parser Pattern := fun st =>
   let p := peekLoc st
   match peekTok st with
@@ -416,10 +419,10 @@ private partial def parsePatternBinder : Parser Pattern := fun st =>
     if peekTok st' == .rparen then
       .ok (mkPat p (advance st') (.const .unit), advance st')
     else do
-      let (pat, st') ← parsePattern.parsePatternInner st'
+      let (pat, st') ← parsePatternInner st'
       match peekTok st' with
       | .comma =>
-        let (rest, st') ← parsePattern.parseTuplePatRest st'
+        let (rest, st') ← parseTuplePatRest st'
         let st' ← expect .rparen st'
         .ok (mkPat p st' (.tuple (pat :: rest)), st')
       | .rparen => .ok (pat, advance st')
@@ -427,7 +430,7 @@ private partial def parsePatternBinder : Parser Pattern := fun st =>
         .error { loc := peekLoc st', kind := .unexpectedToken "')' in binder" t }
   | .lbrace => do
     let st' := advance st
-    let (fields, st') ← parsePattern.parseRecordPatFields st'
+    let (fields, st') ← parseRecordPatFields st'
     let st' ← expect .rbrace st'
     .ok (mkPat p st' (.record fields), st')
   | t =>
@@ -450,7 +453,6 @@ private partial def parseOptRetTy : Parser (Option Typ) := fun st =>
 -- ---------------------------------------------------------------------------
 -- Expression parsing
 
--- Forward declaration for mutual recursion via partial
 private partial def parseExpr : Parser Expr := fun st => do
   let (lhs, st) ← parseExprNoSemi st
   match peekTok st with
@@ -838,6 +840,8 @@ where
 
 -- ---------------------------------------------------------------------------
 -- Declaration parsing
+
+end
 
 /-- Parse a single top-level declaration. -/
 private partial def parseDecl : Parser Decl := fun st =>

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -90,11 +90,16 @@ private partial def BinOp.rightAssoc : BinOp → Bool
 -- ---------------------------------------------------------------------------
 -- Type printing
 
+-- ---------------------------------------------------------------------------
+-- Pattern printing
+
+mutual
+
 partial def Typ.print (t : Typ) : String :=
   let base := match t.kind with
     | .var name => s!"'{name}"
     | .con path [] => path.toString
-    | .con path [arg] => s!"{printAppArg arg} {path.toString}"
+    | .con path [arg] => s!"{Typ.printAppArg arg} {path.toString}"
     | .con path args => s!"({joinWith ", " (args.map Typ.print)}) {path.toString}"
     | .arrow dom cod =>
       let domStr := match dom.kind with
@@ -102,17 +107,28 @@ partial def Typ.print (t : Typ) : String :=
         | _ => Typ.print dom
       s!"{domStr} -> {Typ.print cod}"
     | .tuple components => joinWith " * " (components.map Typ.print)
-  base ++ joinWith "" (t.attrs.map (fun a => s!" [@{a}]"))
-where
-  -- Type constructor arguments that are themselves applications need parens
-  printAppArg (t : Typ) : String :=
-    match t.kind with
-    | .arrow _ _ => parens (Typ.print t)
-    | .tuple (_ :: _ :: _) => parens (Typ.print t)
-    | _ => Typ.print t
+  -- A type attribute binds to the preceding application, so a compound base
+  -- has to be parenthesized to round-trip with the parser.
+  let baseStr := if t.attrs.isEmpty then base else parenIf (Typ.needsParens t) base
+  baseStr ++ joinWith "" (t.attrs.map Typ.printAttr)
 
--- ---------------------------------------------------------------------------
--- Pattern printing
+/-- Type constructor arguments that are themselves applications need parens. -/
+private partial def Typ.printAppArg (t : Typ) : String :=
+  match t.kind with
+  | .arrow _ _ => parens (Typ.print t)
+  | .tuple (_ :: _ :: _) => parens (Typ.print t)
+  | _ => Typ.print t
+
+private partial def Typ.needsParens (t : Typ) : Bool :=
+  match t.kind with
+  | .arrow _ _ | .tuple (_ :: _ :: _) => true
+  | _ => false
+
+/-- Type attribute `[@name]` or `[@name payload]` (single `@`). -/
+private partial def Typ.printAttr (attr : Attribute) : String :=
+  match attr.payload with
+  | none         => s!" [@{attr.name}]"
+  | some payload => s!" [@{attr.name} {Expr.printPrec payload 0}]"
 
 private partial def Pattern.isAtom (p : Pattern) : Bool :=
   match p.kind with
@@ -242,6 +258,8 @@ where
       let lhsStr := parenIf lhsNeedsParens (Expr.printPrec lhs p)
       let rhsStr := parenIf rhsNeedsParens (Expr.printPrec rhs p)
       parenIf (outerPrec > p) (lhsStr ++ " " ++ BinOp.print op ++ " " ++ rhsStr)
+
+end
 
 partial def Expr.print (e : Expr) : String := Expr.printPrec e 0
 

--- a/Tests/spec_types/spec_in_type_decl.ml
+++ b/Tests/spec_types/spec_in_type_decl.ml
@@ -1,0 +1,5 @@
+open Mica
+
+(* A data declaration's field types are elaborated before any specification
+   could be typechecked, so [@spec] is not accepted there. *)
+type box = { run : (int -> int) [@spec fun x -> ret (fun r -> assert (r > x))] }

--- a/Tests/spec_types/spec_in_type_decl.out
+++ b/Tests/spec_types/spec_in_type_decl.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/spec_types/spec_in_type_decl.ml:5:21: unsupported feature: [@spec] is not allowed in a type declaration
+[1]


### PR DESCRIPTION
Type attributes gain a payload, so `[@spec ...]` can be written wherever a type can: the parser folds type parsing into the expression mutual block, since an attribute's payload is an expression, and elaboration turns the attribute into the specification on an `Untyped.Typ.arrow`. A data declaration's payloads are elaborated before any specification could be typechecked, so `[@spec]` is still rejected there — `Tests/spec_types/spec_in_type_decl.ml` pins that. The second commit takes an argument-less declaration's annotation as the declaration's own type, so `let rec f : T = fun x -> ...` is specified through the arrow it is annotated with.

Third of five PRs accepting `[@spec ...]` in any type position.
