### PR TITLE
Read a declaration's specification off its function literal

### DIFF
--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -908,7 +908,7 @@ def TypeDecl.elaborate (env : ElabEnv) (loc : Location) (decl : TypeDecl)
 
 def ValDecl.elaborate (env : ElabEnv) (loc : Location)
     (isRec : Bool) (binders : List Pattern) (retTy : Option Typ) (body : Expr)
-    (md : TinyML.DeclMeta Untyped.SpecBody)
+    (spec : Option Untyped.SpecBody)
     : ElabM (Untyped.ValDecl Untyped.SpecBody) := do
   match binders with
   | [] => err loc (.unsupportedFeature "declaration with no binders")
@@ -926,11 +926,11 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
       let body' ← Expr.elaborate (env.bindPattern pat) body
       match body' with
       | .fix .none args retTy' inner =>
-        .ok { name, body := .fix name args retTy' inner, declMeta := md }
+        .ok { name, body := .fix name args retTy' inner, spec }
       | _ => err loc (.unsupportedFeature "let rec requires a function")
     else do
       let body' ← Expr.elaborate env body
-      .ok { name, body := body', declMeta := md }
+      .ok { name, body := body', spec }
   | pat :: args =>
     let name ← patternToBinder pat
     let self := if isRec then name else .none
@@ -939,7 +939,7 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
     let bodyEnv := if isRec then bodyEnv.bindPattern pat else bodyEnv
     let body' ← Expr.elaborate bodyEnv body
     let (args', body'') ← elaborateFunctionArgs env "$param" 0 args body'
-    .ok { name, body := .fix self args' retTy' body'', declMeta := md }
+    .ok { name, body := .fix self args' retTy' body'', spec }
 
 -- ---------------------------------------------------------------------------
 -- Program elaboration
@@ -983,14 +983,14 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
   | .val_ isRec binders retTy body => do
     let spec ← elaborateAttrSpec env decl.attrs
     let fn ← hasAttrRelation decl.attrs
-    let d ← ValDecl.elaborate env decl.loc isRec binders retTy body { spec }
+    let d ← ValDecl.elaborate env decl.loc isRec binders retTy body spec
     -- A `[@@fn]` declaration uses its own name for the derived relation.
     let relation ← if fn then
       match d.name with
       | .named x _ => .ok (some x)
       | .none => err decl.loc (.unsupportedFeature "[@@fn] requires a named declaration")
     else .ok none
-    .ok (env.bindBinder d.name, some (.val_ { d with declMeta := { d.declMeta with relation } }))
+    .ok (env.bindBinder d.name, some (.val_ { d with relation }))
 
 private def elaborateDecls (env : ElabEnv) :
     List Decl → ElabM (List (Untyped.Decl Untyped.SpecBody))

--- a/Mica/SourceTinyML/Printer.lean
+++ b/Mica/SourceTinyML/Printer.lean
@@ -243,10 +243,10 @@ def ValDecl.print {S : Type} [SpecPayloadPrinter S] (d : Untyped.ValDecl S) : St
       let (allArgs, innerBody) := collectAnonArgs args inner
       s!"let {d.name.print} {argsStr allArgs} = {printExpr innerBody}"
     | body => s!"let {d.name.print} = {printExpr body}"
-  let withSpec := match d.declMeta.spec with
+  let withSpec := match d.spec with
     | .none => decl
     | .some e => s!"{decl} [@@spec {SpecPayloadPrinter.print e}]"
-  match d.declMeta.relation with
+  match d.relation with
   | .none => withSpec
   | .some _ => s!"{withSpec} [@@fn]"
 

--- a/Mica/SourceTinyML/Typed.lean
+++ b/Mica/SourceTinyML/Typed.lean
@@ -271,13 +271,6 @@ def Expr.ty : Expr → Typ
   | .match_ _ _ ty => ty
   | .cast _ ty => ty
 
-/-- Attach a specification to a function literal; anything else is unchanged.
-    A declaration's `[@@spec]` is completed only in the verifier, so this is how
-    it reaches the `fix` node that verification discharges it against. -/
-def Expr.withSpec (s : Spec Typ) : Expr → Expr
-  | .fix self args retTy _ body => .fix self args retTy (some s) body
-  | e => e
-
 /-- The specification a function literal was elaborated against, if any. This
 is where a declaration's specification lives, together with its arrow type. -/
 def Expr.spec? : Expr → Option (Spec Typ)
@@ -287,10 +280,6 @@ def Expr.spec? : Expr → Option (Spec Typ)
 @[simp] theorem Expr.spec?_fix (self : Binder) (args : List Binder) (retTy : Typ)
     (spec : Option (Spec Typ)) (body : Expr) :
     (Expr.fix self args retTy spec body).spec? = spec := rfl
-
-@[simp] theorem Expr.withSpec_fix (s : Spec Typ) (self : Binder) (args : List Binder)
-    (retTy : Typ) (spec : Option (Spec Typ)) (body : Expr) :
-    (Expr.fix self args retTy spec body).withSpec s = .fix self args retTy (some s) body := rfl
 
 /-- A checked declaration. It carries no specification of its own: the literal
 it binds records the specification it was elaborated against, and so does the
@@ -366,11 +355,6 @@ def ValDecl.runtime (d : Typed.ValDecl) : Runtime.Decl :=
 
 def Program.runtime (prog : Typed.Program) : Runtime.Program :=
   prog.map ValDecl.runtime
-
-/-- Attaching a specification does not change what a function literal runs. -/
-@[simp] theorem Expr.withSpec_runtime (s : Spec Typ) (e : Expr) :
-    (e.withSpec s).runtime = e.runtime := by
-  cases e <;> simp [Expr.withSpec, Expr.runtime]
 
 theorem Expr.branchListRuntime_eq_map (branches : List (Typed.Binder × Typed.Expr)) :
     Expr.branchListRuntime branches =

--- a/Mica/SourceTinyML/Typed.lean
+++ b/Mica/SourceTinyML/Typed.lean
@@ -278,22 +278,31 @@ def Expr.withSpec (s : Spec Typ) : Expr → Expr
   | .fix self args retTy _ body => .fix self args retTy (some s) body
   | e => e
 
+/-- The specification a function literal was elaborated against, if any. This
+is where a declaration's specification lives, together with its arrow type. -/
+def Expr.spec? : Expr → Option (Spec Typ)
+  | .fix _ _ _ spec _ => spec
+  | _ => none
+
+@[simp] theorem Expr.spec?_fix (self : Binder) (args : List Binder) (retTy : Typ)
+    (spec : Option (Spec Typ)) (body : Expr) :
+    (Expr.fix self args retTy spec body).spec? = spec := rfl
+
 @[simp] theorem Expr.withSpec_fix (s : Spec Typ) (self : Binder) (args : List Binder)
     (retTy : Typ) (spec : Option (Spec Typ)) (body : Expr) :
     (Expr.fix self args retTy spec body).withSpec s = .fix self args retTy (some s) body := rfl
 
-structure ValDecl (S : Type) where
+/-- A checked declaration. It carries no specification of its own: the literal
+it binds records the specification it was elaborated against, and so does the
+declaration's arrow type. -/
+structure ValDecl where
   name : Binder
   body : Expr
-  declMeta : DeclMeta S
-  deriving Repr, BEq
+  /-- The spec-level relation this declaration is registered as, if `[@@fn]`. -/
+  relation : Option String := none
+  deriving Repr, BEq, Inhabited
 
-instance [Inhabited S] : Inhabited (ValDecl S) := ⟨{ name := default, body := default, declMeta := default }⟩
-
-def ValDecl.mapSpec {S T : Type} (f : S → Option T) (d : ValDecl S) : ValDecl T :=
-  { name := d.name, body := d.body, declMeta := d.declMeta.mapSpec f }
-
-abbrev Program (S : Type) := List (ValDecl S)
+abbrev Program := List ValDecl
 
 def Binder.runtime : Typed.Binder → Runtime.Binder
   | ⟨Option.none, _⟩ => .none
@@ -352,10 +361,10 @@ mutual
     | (b, e) :: rest => Runtime.Expr.fix .none [b.runtime] e.runtime :: Expr.branchListRuntime rest
 end
 
-def ValDecl.runtime {S : Type} (d : Typed.ValDecl S) : Runtime.Decl :=
+def ValDecl.runtime (d : Typed.ValDecl) : Runtime.Decl :=
   { name := d.name.runtime, body := d.body.runtime }
 
-def Program.runtime {S : Type} (prog : Typed.Program S) : Runtime.Program :=
+def Program.runtime (prog : Typed.Program) : Runtime.Program :=
   prog.map ValDecl.runtime
 
 /-- Attaching a specification does not change what a function literal runs. -/

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -756,16 +756,16 @@ private def checkDeclAnnotation (env : SpecEnv σ) (Θ : TypeEnv) (b : Untyped.B
 
 def ValDecl.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (d : Untyped.ValDecl Untyped.SpecBody) :
-    TypeM σ (Typed.ValDecl (Spec Typ)) := do
-  match d.declMeta.spec with
+    TypeM σ Typed.ValDecl := do
+  match d.spec with
   | some rb => do
       -- A specified declaration's literal records its specification, so the
       -- declaration's own type — and hence the type every later use is
       -- annotated with — is the specified arrow.
-      let (s, body') ← elabSpecifiedFix env Θ Γ rb d.body
+      let (_, body') ← elabSpecifiedFix env Θ Γ rb d.body
       checkDeclAnnotation env Θ d.name body'.ty
       pure { name := Typed.Binder.ofUntyped d.name body'.ty, body := body',
-             declMeta := { spec := some s, relation := d.declMeta.relation } }
+             relation := d.relation }
   | none => do
       let (bodyTy, body') ←
         match d.name with
@@ -775,10 +775,10 @@ def ValDecl.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
             pure (ty', body')
         | _ => infer env Θ Γ d.body
       pure { name := Typed.Binder.ofUntyped d.name bodyTy, body := body',
-             declMeta := { spec := none, relation := d.declMeta.relation } }
+             relation := d.relation }
 
 def Program.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
-    Untyped.Program Untyped.SpecBody → TypeM σ (TypeEnv × Typed.Program (Spec Typ))
+    Untyped.Program Untyped.SpecBody → TypeM σ (TypeEnv × Typed.Program)
   | [] => pure (Θ, [])
   | d :: ds => do
       match d with
@@ -1312,13 +1312,13 @@ theorem elabSpecifiedFix_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.
 
 theorem ValDecl.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (d : Untyped.ValDecl Untyped.SpecBody) :
-    ∀ {s : σ} {d' : Typed.ValDecl (Spec Typ)} {s' : σ},
+    ∀ {s : σ} {d' : Typed.ValDecl} {s' : σ},
       Typed.ValDecl.elaborate env Θ Γ d s = .ok (d', s') →
       d'.runtime = d.runtime := by
   intro s d' s' helab
   -- Split on whether there is a specification, and then — in its absence — only
   -- on whether there is an annotation; the unannotated cases are identical.
-  match hspec : d.declMeta.spec with
+  match hspec : d.spec with
   | some rb =>
     simp only [ValDecl.elaborate, hspec] at helab
     have ⟨r, s₀, hfix, hcont⟩ := StateT.bind_ok helab
@@ -1347,7 +1347,7 @@ theorem ValDecl.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML
 
 theorem Program.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (prog : Untyped.Program Untyped.SpecBody) :
-    ∀ {s : σ} {Θ' : TypeEnv} {prog' : Typed.Program (Spec Typ)} {s' : σ},
+    ∀ {s : σ} {Θ' : TypeEnv} {prog' : Typed.Program} {s' : σ},
       Typed.Program.elaborate env Θ Γ prog s = .ok ((Θ', prog'), s') →
       prog'.runtime = prog.runtime := by
   induction prog generalizing Θ Γ with

--- a/Mica/SourceTinyML/Untyped.lean
+++ b/Mica/SourceTinyML/Untyped.lean
@@ -144,11 +144,11 @@ abbrev Binders := List Binder
 structure ValDecl (S : Type) where
   name : Binder
   body : Expr
-  declMeta : DeclMeta S
+  /-- The specification written as `[@@spec]`, still unelaborated. -/
+  spec : Option S := none
+  /-- The spec-level relation this declaration is registered as, if `[@@fn]`. -/
+  relation : Option String := none
   deriving Repr, Inhabited
-
-def ValDecl.mapSpec {S T : Type} (f : S → Option T) (d : ValDecl S) : ValDecl T :=
-  { name := d.name, body := d.body, declMeta := d.declMeta.mapSpec f }
 
 structure TypeDecl where
   name : TypeName
@@ -159,10 +159,6 @@ inductive Decl (S : Type) where
   | val_ (d : ValDecl S)
   | type_ (d : TypeDecl)
   deriving Repr, Inhabited
-
-def Decl.mapSpec {S T : Type} (f : S → Option T) : Decl S → Decl T
-  | .val_ d => .val_ (d.mapSpec f)
-  | .type_ d => .type_ d
 
 abbrev Program (S : Type) := List (Decl S)
 

--- a/Mica/TinyML/Common.lean
+++ b/Mica/TinyML/Common.lean
@@ -11,14 +11,6 @@ inductive Ownership where
   | shared
   deriving Repr, BEq, Inhabited, DecidableEq
 
-structure DeclMeta (S : Type) where
-  spec : Option S := none
-  relation : Option String := none
-  deriving Repr, BEq, Inhabited
-
-def DeclMeta.mapSpec {S T : Type} (f : S -> Option T) (m : DeclMeta S) : DeclMeta T :=
-  { spec := m.spec.bind f, relation := m.relation }
-
 inductive BinOp where
   | add | sub | mul | div | mod
   | eq | lt | le | gt | ge

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -467,10 +467,9 @@ def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Sig
   let () ← match Spec.checkWf spec Δ_spec with
     | .ok () => .ret ()
     | .error msg => .fatal msg
-  let body := d.body.withSpec spec
   VerifM.seq
-    (do let _ ← compile reg Θ Δ_spec B Γ body; pure ())
-    (pure body.ty)
+    (do let _ ← compile reg Θ Δ_spec B Γ d.body; pure ())
+    (pure d.body.ty)
 
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
 def ValDecl.checkExpr (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature)
@@ -626,21 +625,20 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
         simp only [hcheckWf] at h3
         have h4 := VerifM.eval_ret (VerifM.eval_bind h3)
         have ⟨hcompileSeq, hpure⟩ := VerifM.eval_seq h4
-        refine ⟨(d.body.withSpec s).ty, ?_, VerifM.eval_ret hpure⟩
+        refine ⟨d.body.ty, ?_, VerifM.eval_ret hpure⟩
         -- The body is compiled as an ordinary specified function literal, so
         -- its value is typed at the specified arrow the literal carries.
         have hcompile :
             st.sl W ρ ∗ (Bindings.typedSubst W B Γ γ ∗ iprop(emp)) ⊢
-              wp W.pctx ((d.body.withSpec s).runtime.subst γ)
-                (fun v => TinyML.ValHasType W v (d.body.withSpec s).ty) :=
-          compile_correct reg hSound (d.body.withSpec s) W iprop(emp) B
+              wp W.pctx (d.body.runtime.subst γ)
+                (fun v => TinyML.ValHasType W v d.body.ty) :=
+          compile_correct reg hSound d.body W iprop(emp) B
             Γ st ρ γ _ _ hW (VerifM.eval_bind hcompileSeq)
             hagree hbwf
             hwf hag hΔreg hρreg
             (fun v ρ' st' se _ _ _ => by
               iintro ⟨_, Hty, _⟩
               iexact Hty)
-        rw [Typed.Expr.withSpec_runtime] at hcompile
         refine BIBase.Entails.trans ?_ hcompile
         istart
         iintro ⟨#Hsl, #HT⟩

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -43,7 +43,7 @@ trusted. -/
 def Program.relationMap (prog : Untyped.Program Untyped.SpecBody) : FunCtx :=
   prog.filterMap fun
     | .val_ d =>
-      match d.name, d.declMeta.relation with
+      match d.name, d.relation with
       | .named f _, some rel => some (f, rel)
       | _, _ => none
     | .type_ _ => none
@@ -85,7 +85,7 @@ its specifications already translated, and the final elaboration state (which
 carries the lifted bounded quantifiers). -/
 def Program.prepare (env : Typed.SpecEnv σ) (s : σ)
     (prog : Untyped.Program Untyped.SpecBody) :
-    VerifM (TinyML.TypeEnv × Typed.Program (Spec TinyML.Typ) × σ) :=
+    VerifM (TinyML.TypeEnv × Typed.Program × σ) :=
   match Typed.Program.elaborate env TinyML.TypeEnv.empty TinyML.TyCtx.empty prog s with
   | .ok ((Θ, typed), s') => .ret (Θ, typed, s')
   | .error err => .fatal (toString err)
@@ -114,9 +114,9 @@ private structure RelationDecl where
   body : Typed.Expr
   bv : Skolemize.DefVal
 
-private def validateDecl (d : Typed.ValDecl (Spec TinyML.Typ)) :
+private def validateDecl (d : Typed.ValDecl) :
     Except String (TinyML.Var × TinyML.Var × Typed.Expr) := do
-  if d.declMeta.spec.isSome then
+  if d.body.spec?.isSome then
     .error s!"declaration cannot have both [@@spec] and [@@fn]"
   let f ← match d.name.name with
     | some f => .ok f
@@ -129,9 +129,9 @@ private def validateDecl (d : Typed.ValDecl (Spec TinyML.Typ)) :
   | .fix _ _ _ _ _ => .error s!"[@@fn] requires a unary function"
   | _ => .error s!"[@@fn] requires a function body"
 
-private def extend (acc : RelationSpec) (d : Typed.ValDecl (Spec TinyML.Typ)) :
+private def extend (acc : RelationSpec) (d : Typed.ValDecl) :
     Except String RelationDecl := do
-  match d.declMeta.relation with
+  match d.relation with
   | none => .error "internal error: expected relation declaration"
   | some rel => do
       let (f, arg, body) ← validateDecl d
@@ -161,9 +161,9 @@ private def extend (acc : RelationSpec) (d : Typed.ValDecl (Spec TinyML.Typ)) :
                                   (SpecFn.func rel)).addUnaryRel (SpecFn.defined rel) }
         .ok { spec, res, axs, f, rel, arg, body, bv }
 
-private def declareAndAssume (acc : RelationSpec) (d : Typed.ValDecl (Spec TinyML.Typ)) :
+private def declareAndAssume (acc : RelationSpec) (d : Typed.ValDecl) :
     VerifM RelationSpec := do
-  match d.declMeta.relation with
+  match d.relation with
   | none => pure acc
   | some rel =>
       match extend acc d with
@@ -190,7 +190,7 @@ private def declareLifting (acc : RelationSpec) (s : Verifier.BoundedQuantifier.
                  functionMap := acc.functionMap ++ [(s.name, s.name)],
                  delta := s.extendSignature acc.delta }
 
-private def assembleFrom : RelationSpec → Typed.Program (Spec TinyML.Typ) → VerifM RelationSpec
+private def assembleFrom : RelationSpec → Typed.Program → VerifM RelationSpec
   | acc, [] => pure acc
   | acc, d :: ds => do
       let acc' ← declareAndAssume acc d
@@ -210,7 +210,7 @@ Quantifier symbols are declared after all program declarations: assembly never
 consults specs, and the only cross-references between lifted bodies — inner
 occurrences captured by outer ones — respect the lift order, which elaboration
 preserves. -/
-def assemble (prog : Typed.Program (Spec TinyML.Typ))
+def assemble (prog : Typed.Program)
     (liftings : List Verifier.BoundedQuantifier.Lifting) : VerifM RelationSpec := do
   let Δ ← VerifM.ctx (fun st => (st.decls, st.owns))
   let acc ← assembleFrom { RelationSpec.empty with delta := Δ } prog
@@ -233,7 +233,7 @@ omit [MicaGS HasLC.hasLC Sig] in
 /-- Declaring one relation-marked declaration preserves the assembly
 invariants; the signature only grows and the environment is only extended
 with fresh interpretations. -/
-private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec TinyML.Typ))
+private theorem declareAndAssume_correct (d : Typed.ValDecl)
     (acc : RelationSpec) (st : TransState) (ρ : Env)
     {Q : RelationSpec → TransState → Env → Prop}
     (hinv : Inv acc st ρ)
@@ -243,7 +243,7 @@ private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec TinyML.Typ))
       Q acc' st' ρ' := by
   obtain ⟨hacc, howns, hvars, hwf, hΓwf, hsplit, hdet⟩ := hinv
   simp only [declareAndAssume] at heval
-  cases hrel : d.declMeta.relation with
+  cases hrel : d.relation with
   | none =>
     simp only [hrel] at heval
     exact ⟨acc, st, ρ, ⟨hacc, howns, hvars, hwf, hΓwf, hsplit, hdet⟩,
@@ -321,7 +321,7 @@ private theorem declareAndAssume_correct (d : Typed.ValDecl (Spec TinyML.Typ))
         hsub4, hagree4, VerifM.eval_ret hcont⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
-private theorem assembleFrom_correct (prog : Typed.Program (Spec TinyML.Typ)) :
+private theorem assembleFrom_correct (prog : Typed.Program) :
     ∀ (acc : RelationSpec) (st : TransState) (ρ : Env)
       {Q : RelationSpec → TransState → Env → Prop},
       Inv acc st ρ →
@@ -409,7 +409,7 @@ private theorem assembleLiftings_correct (ss : List Verifier.BoundedQuantifier.L
       Env.agreeOn_trans hag1 (Env.agreeOn_mono hsub1 hagRel), hQ⟩
 
 omit [MicaGS HasLC.hasLC Sig] in
-theorem assemble_correct (prog : Typed.Program (Spec TinyML.Typ))
+theorem assemble_correct (prog : Typed.Program)
     (liftings : List Verifier.BoundedQuantifier.Lifting)
     {st : TransState} {ρ : Env}
     {Q : RelationSpec → TransState → Env → Prop}
@@ -457,8 +457,8 @@ end RelationSpec
     name for the declarations that follow. -/
 def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature)
     (B : Bindings) (Γ : TinyML.TyCtx)
-    (d : Typed.ValDecl (Spec TinyML.Typ)) : VerifM TinyML.Typ := do
-  let spec ← match d.declMeta.spec with
+    (d : Typed.ValDecl) : VerifM TinyML.Typ := do
+  let spec ← match d.body.spec? with
     | some s => .ret s
     | none => .fatal "declaration has no spec"
   let () ← match checkSpecArity spec d.body with
@@ -475,16 +475,16 @@ def ValDecl.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Sig
 /-- Check a `let _ = e` declaration: just compile `e` for safety, no spec. -/
 def ValDecl.checkExpr (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature)
     (B : Bindings) (Γ : TinyML.TyCtx)
-    (d : Typed.ValDecl (Spec TinyML.Typ)) : VerifM Unit :=
+    (d : Typed.ValDecl) : VerifM Unit :=
   VerifM.seq (do let _ ← compile reg Θ Δ_spec B Γ d.body; pure ()) (pure ())
 
 /-- Verify all declarations in a program, binding each verified one so later
     declarations can use it as a value. -/
 def Program.check (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) :
-    Bindings → TinyML.TyCtx → Typed.Program (Spec TinyML.Typ) → VerifM Unit
+    Bindings → TinyML.TyCtx → Typed.Program → VerifM Unit
   | _, _, [] => pure ()
   | B, Γ, d :: ds => do
-    match d.name.name, d.declMeta.spec with
+    match d.name.name, d.body.spec? with
     | none, none =>
       ValDecl.checkExpr reg Θ Δ_spec B Γ d
       Program.check reg Θ Δ_spec B Γ ds
@@ -522,7 +522,7 @@ omit [MicaGS HasLC.hasLC Sig] in
 theorem Program.prepare_correct (env : Typed.SpecEnv σ) (s : σ)
     (prog : Untyped.Program Untyped.SpecBody)
     (st : TransState) (ρ : Env)
-    {Q : (TinyML.TypeEnv × Typed.Program (Spec TinyML.Typ) × σ) → TransState → Env → Prop}
+    {Q : (TinyML.TypeEnv × Typed.Program × σ) → TransState → Env → Prop}
     (heval : VerifM.eval (Program.prepare env s prog) st ρ Q) :
     ∃ Θ typed s', Typed.Program.runtime typed = Untyped.Program.runtime prog ∧
       Q (Θ, typed, s') st ρ := by
@@ -541,7 +541,7 @@ theorem Program.prepare_correct (env : Typed.SpecEnv σ) (s : σ)
 theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
     (B : Bindings) (Γ : TinyML.TyCtx)
-    (d : Typed.ValDecl (Spec TinyML.Typ)) (γ : Runtime.Subst)
+    (d : Typed.ValDecl) (γ : Runtime.Subst)
     (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
@@ -591,7 +591,7 @@ theorem ValDecl.checkExpr_correct (reg : Verifier.Registry) (hSound : Verifier.R
 theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
     (B : Bindings) (Γ : TinyML.TyCtx)
-    (d : Typed.ValDecl (Spec TinyML.Typ)) (γ : Runtime.Subst)
+    (d : Typed.ValDecl) (γ : Runtime.Subst)
     (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
@@ -604,7 +604,7 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
               wp W.pctx (d.body.runtime.subst γ) (fun v => TinyML.ValHasType W v ty)) ∧
           Q ty st ρ := by
   simp only [ValDecl.check] at heval
-  cases hspec : d.declMeta.spec with
+  cases hspec : d.body.spec? with
   | none =>
     simp only [hspec] at heval
     exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
@@ -653,7 +653,7 @@ theorem ValDecl.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
 theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.Sound reg)
     (W : TinyML.World) (hW : W.pctx = reg.primCtx)
     (B : Bindings) (Γ : TinyML.TyCtx)
-    (prog : Typed.Program (Spec TinyML.Typ)) (γ : Runtime.Subst)
+    (prog : Typed.Program) (γ : Runtime.Subst)
     (hwf : W.wf)
     (st : TransState) (ρ : Env)
     (hag : W.agrees st.decls ρ)
@@ -689,7 +689,7 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
       -- unnamed: pwp continuation does not depend on `v`
       have hupd : ∀ v, Runtime.Subst.updateBinder d.name.runtime v γ = γ := by
         intro v; simp [Binder.runtime_of_name_none hname, Runtime.Subst.updateBinder]
-      cases hspec : d.declMeta.spec with
+      cases hspec : d.body.spec? with
       | none =>
         -- unnamed, no spec
         simp only [hname, hspec] at heval
@@ -715,7 +715,7 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
       have hname_rt : d.name.runtime = .named n := Binder.runtime_of_name_some hname
       have hupd : ∀ v, Runtime.Subst.updateBinder d.name.runtime v γ = γ.update n v := by
         intro v; simp [hname_rt, Runtime.Subst.updateBinder]
-      cases hspec : d.declMeta.spec with
+      cases hspec : d.body.spec? with
       | none =>
         simp only [hname, hspec] at heval
         split at heval


### PR DESCRIPTION
A specified declaration's function literal already records the specification it was elaborated against, so `DeclMeta.spec` on the typed side was a second copy of it. `Typed.ValDecl` drops that field — and with it its type parameter, which propagates through `Typed.Program` and the verifier — and reads the specification off the literal through `Expr.spec?`. That leaves `DeclMeta` shared between two declarations that no longer want the same fields, so it goes too: `Untyped.ValDecl` names `spec` and `relation` directly, `Typed.ValDecl` names `relation`. The `mapSpec` family, which existed only to move a specification across the dropped field, goes with it. A second commit drops `Expr.withSpec`: its one caller read the specification off a literal and wrote it straight back.

Fourth of five PRs accepting `[@spec ...]` in any type position.
