### PR TITLE
Check a function literal against the specified arrow it is passed at

### DIFF
--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -800,6 +800,18 @@ def elabSpecifiedFix (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
       pure (s, ← check env Θ Γ e (.arrow (typedArgs.map Binder.ty) ret (some s)))
   | _ => TypeM.error (.spec "attached to a non-function declaration")
 
+/-- A declaration is specified once. `[@@spec]` and a specification on the
+declaration's own type are the same mechanism, so giving both would ask for two
+specifications of one function. -/
+private def checkSingleSpec (b : Untyped.Binder) : TypeM σ Unit :=
+  match b with
+  | .named _ (some ann) =>
+      if ann.isSpecified then
+        TypeM.error (.spec
+          "a declaration carries either [@@spec] or a specification on its own type, not both")
+      else pure ()
+  | _ => pure ()
+
 /-- Check a declaration binder's annotation against the type elaborated for its
 body. A specified declaration's type carries its specification, which no
 annotation mentions, so the annotation is matched against the bare type. -/
@@ -816,6 +828,7 @@ def ValDecl.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     TypeM σ Typed.ValDecl := do
   match d.spec with
   | some rb => do
+      checkSingleSpec d.name
       -- A specified declaration's literal records its specification, so the
       -- declaration's own type — and hence the type every later use is
       -- annotated with — is the specified arrow.
@@ -1394,7 +1407,8 @@ theorem ValDecl.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML
   match hspec : d.spec with
   | some rb =>
     simp only [ValDecl.elaborate, hspec] at helab
-    have ⟨r, s₀, hfix, hcont⟩ := StateT.bind_ok helab
+    have ⟨_, sg, _, helab'⟩ := StateT.bind_ok helab
+    have ⟨r, s₀, hfix, hcont⟩ := StateT.bind_ok helab'
     have ⟨_, s₁, _, hcont⟩ := StateT.bind_ok hcont
     rcases hcont with ⟨rfl, rfl⟩
     simp [Typed.ValDecl.runtime, Untyped.ValDecl.runtime, Binder.ofUntyped_runtime,

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -548,15 +548,52 @@ mutual
         | _ => TypeM.error (.notASum scrutTy)
   termination_by e => (sizeOf e, 0)
 
-  def check (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) (e : Untyped.Expr) (expected : Typ) : TypeM σ Typed.Expr := do
-    let (actual, e') ← infer env Θ Γ e
-    if actual == expected then
-      pure e'
-    else if Typ.sub Θ actual expected then
-      pure (.cast e' expected)
-    else
-      TypeM.error (.subsumptionFailure actual expected)
-  termination_by (sizeOf e, 1)
+  def check (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
+      Untyped.Expr → Typ → TypeM σ Typed.Expr
+    -- A function literal checked against a specified arrow is elaborated at that
+    -- arrow: it takes the expected signature, records the specification, and its
+    -- self-reference is typed at the specified arrow — the same shape a specified
+    -- declaration gets. Inferring the literal first could never reach a specified
+    -- arrow, since those are invariant and an inferred literal carries no spec.
+    | .fix self args retTy body, .arrow doms ret (some s) => do
+        let typedArgs ← checkBinders env Θ args doms
+        let ann ← translateOpt env Θ retTy
+        if ann.any (· != ret) then
+          TypeM.error (.subsumptionFailure ret (ann.getD ret))
+        else
+          -- The self-reference is typed at the specified arrow, so a recursive
+          -- call goes through the specification.
+          let typedSelf :=
+            Typed.Binder.ofUntyped self (.arrow (typedArgs.map Binder.ty) ret (some s))
+          let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
+          let body' ← check env Θ Γ' body ret
+          pure (.fix typedSelf typedArgs ret (some s) body')
+    -- Everything else is checked by inference, subsuming into the expected type.
+    | e, expected => do
+        let (actual, e') ← infer env Θ Γ e
+        if actual == expected then
+          pure e'
+        else if Typ.sub Θ actual expected then
+          pure (.cast e' expected)
+        else
+          TypeM.error (.subsumptionFailure actual expected)
+  termination_by e => (sizeOf e, 1)
+
+  /-- Type a function literal's binders at the domains its expected arrow
+  supplies. An annotation is allowed, but it has to agree: a specified arrow is
+  invariant, so there is nothing to subsume. -/
+  def checkBinders (env : SpecEnv σ) (Θ : TypeEnv) :
+      List Untyped.Binder → List Typ → TypeM σ (List Typed.Binder)
+    | [], [] => pure []
+    | b :: bs, ty :: tys => do
+        let annotated ← Binder.expectedTy env Θ b ty
+        if annotated == ty then do
+          let rest ← checkBinders env Θ bs tys
+          pure (Typed.Binder.ofUntyped b ty :: rest)
+        else
+          TypeM.error (.subsumptionFailure ty annotated)
+    | bs, tys => TypeM.error (.arityMismatch tys.length bs.length)
+  termination_by bs _ => (sizeOf bs, 0)
 
   def inferList (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) : List Untyped.Expr → TypeM σ (List (Typ × Typed.Expr))
     | [] => pure []
@@ -693,6 +730,27 @@ theorem typedBinders_runtime (env : SpecEnv σ) (Θ : TypeEnv) :
       rcases (by simpa using hcont) with ⟨rfl, rfl⟩
       simp [Binder.ofUntyped_runtime, typedBinders_runtime env Θ bs rest s₀ s₁ hrest]
 
+theorem checkBinders_runtime (env : SpecEnv σ) (Θ : TypeEnv) :
+    ∀ (binders : List Untyped.Binder) (tys : List Typ) (typed : List Typed.Binder) (s s' : σ),
+      checkBinders env Θ binders tys s = .ok (typed, s') →
+        typed.map Typed.Binder.runtime = binders.map Untyped.Binder.runtime
+  | [], [], typed, s, s', h => by
+      simp [checkBinders] at h
+      rcases h with ⟨rfl, rfl⟩
+      rfl
+  | b :: bs, ty :: tys, typed, s, s', h => by
+      unfold checkBinders at h
+      have ⟨annotated, s₀, _hty, hcont⟩ := StateT.bind_ok h
+      split at hcont
+      · have ⟨rest, s₁, hrest, hcont⟩ := StateT.bind_ok hcont
+        rcases (by simpa using hcont) with ⟨rfl, rfl⟩
+        simp [Binder.ofUntyped_runtime, checkBinders_runtime env Θ bs tys rest s₀ s₁ hrest]
+      · simp at hcont
+  | [], _ :: _, typed, s, s', h => by
+      simp [checkBinders] at h
+  | _ :: _, [], typed, s, s', h => by
+      simp [checkBinders] at h
+
 theorem inferProductBinders_runtime (env : SpecEnv σ) (Θ : TypeEnv) :
     ∀ (binders : List Untyped.Binder) (tys : List Typ) (typed : List Typed.Binder) (s s' : σ),
       inferProductBinders env Θ binders tys s = .ok (typed, s') →
@@ -732,15 +790,14 @@ arrow, so a recursive call resolves through the type it is annotated with rather
 than through a side table. -/
 def elabSpecifiedFix (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
     (rb : Untyped.SpecBody) : Untyped.Expr → TypeM σ (Spec Typ × Typed.Expr)
-  | .fix self args retTy body => do
-      let retTy := (← translateOpt env Θ retTy).getD .value
+  | e@(.fix _ args retTy _) => do
+      -- The specification needs the literal's signature, and checking the
+      -- literal needs the specification, so the signature is elaborated first
+      -- and the literal is then checked at the arrow the two describe.
+      let ret := (← translateOpt env Θ retTy).getD .value
       let typedArgs ← typedBinders env Θ args
-      let s ← elabSpecBody env Θ Γ typedArgs retTy rb
-      let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy (some s)
-      let typedSelf := Typed.Binder.ofUntyped self selfTy
-      let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
-      let body' ← check env Θ Γ' body retTy
-      pure (s, .fix typedSelf typedArgs retTy (some s) body')
+      let s ← elabSpecBody env Θ Γ typedArgs ret rb
+      pure (s, ← check env Θ Γ e (.arrow (typedArgs.map Binder.ty) ret (some s)))
   | _ => TypeM.error (.spec "attached to a non-function declaration")
 
 /-- Check a declaration binder's annotation against the type elaborated for its
@@ -1190,18 +1247,35 @@ mutual
           | _ =>
             simp at hcont
 
-  theorem check_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) (e : Untyped.Expr)
-      (expected : Typ) :
-      ∀ s e' s', Typed.check env Θ Γ e expected s = .ok (e', s') → e'.runtime = e.runtime := by
-      intro s e' s' h
-      unfold Typed.check at h
+  theorem check_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) (e : Untyped.Expr) :
+      ∀ (expected : Typ) s e' s',
+        Typed.check env Θ Γ e expected s = .ok (e', s') → e'.runtime = e.runtime := by
+    intro expected s e' s' h
+    rw [Typed.check.eq_def] at h
+    split at h
+    -- A function literal at a specified arrow. Its binders are checked against
+    -- the arrow's domains, so they erase to the literal's own; the arrow and the
+    -- specification leave no trace.
+    case _ self args retTy body doms ret sp =>
+      have ⟨typedArgs, s₀, hargs, hcont⟩ := StateT.bind_ok h
+      have ⟨ann, s₁, _hret, hcont⟩ := StateT.bind_ok hcont
+      by_cases hann : ann.any (· != ret)
+      · simp [hann] at hcont
+      · simp only [hann, if_false, Bool.false_eq_true] at hcont
+        have ⟨body', s₂, hbody, hcont⟩ := StateT.bind_ok hcont
+        rcases (by simpa using hcont) with ⟨rfl, rfl⟩
+        simp [Expr.runtime, Untyped.Expr.runtime, Binder.ofUntyped_runtime,
+          check_runtime env Θ _ body ret _ _ _ hbody,
+          checkBinders_runtime env Θ args doms typedArgs s s₀ hargs]
+    -- Everything else is inference followed by subsumption.
+    case _ =>
       have ⟨p, s₀, hinfer, hcont⟩ := StateT.bind_ok h
       cases p with
       | mk actual e1 =>
         by_cases heq : actual == expected
         · simp [heq] at hcont
           rcases hcont with ⟨rfl, rfl⟩
-          simpa using infer_runtime env Θ Γ e _ _ _ hinfer
+          exact infer_runtime env Θ Γ e _ _ _ hinfer
         · by_cases hsub : Typ.sub Θ actual expected
           · simp [heq, hsub] at hcont
             rcases hcont with ⟨rfl, rfl⟩
@@ -1298,16 +1372,15 @@ theorem elabSpecifiedFix_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.
   cases e
   case fix self args retTy body =>
     simp only [elabSpecifiedFix] at h
-    -- The spec's own elaboration stays opaque: `StateT.bind_ok` recovers it
-    -- without naming the arguments `elabSpecBody` is applied to.
+    -- The signature and the spec's own elaboration stay opaque: `StateT.bind_ok`
+    -- recovers them without naming what they are applied to. The literal is then
+    -- checked as it stands, so erasure is exactly `check_runtime`.
     have ⟨_retTy, s₀, _hret, hcont⟩ := StateT.bind_ok h
-    have ⟨typedArgs, s₁, hargs, hcont⟩ := StateT.bind_ok hcont
+    have ⟨_typedArgs, s₁, _hargs, hcont⟩ := StateT.bind_ok hcont
     have ⟨_spec, s₂, _hspec, hcont⟩ := StateT.bind_ok hcont
-    have ⟨body', s₃, hbody, hcont⟩ := StateT.bind_ok hcont
+    have ⟨body', s₃, hchecked, hcont⟩ := StateT.bind_ok hcont
     rcases hcont with ⟨rfl, rfl⟩
-    simp [Expr.runtime, Untyped.Expr.runtime, Binder.ofUntyped_runtime,
-      check_runtime env Θ _ body _ _ _ _ hbody,
-      typedBinders_runtime env Θ args typedArgs s₀ s₁ hargs]
+    exact check_runtime env Θ Γ _ _ _ _ _ hchecked
   all_goals simp [elabSpecifiedFix, TypeM.error] at h
 
 theorem ValDecl.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)

--- a/Mica/SourceTinyML/Untyped.lean
+++ b/Mica/SourceTinyML/Untyped.lean
@@ -137,6 +137,11 @@ deriving instance Repr for Expr
 untyped terms, and binder annotations are untyped types. -/
 abbrev SpecBody := Spec.Body Expr Typ
 
+/-- Whether this type is an arrow carrying a specification of its own. -/
+def Typ.isSpecified : Typ → Bool
+  | .arrow _ _ (some _) => true
+  | _ => false
+
 abbrev Vars := List TinyML.Var
 abbrev Exprs := List Expr
 abbrev Binders := List Binder

--- a/Tests/spec_types/spec_binds_tightly.ml
+++ b/Tests/spec_types/spec_binds_tightly.ml
@@ -1,0 +1,6 @@
+open Mica
+
+(* A type attribute binds to the type immediately to its left, exactly as
+   [@owned] does: this specification lands on the result type [int], not on the
+   arrow. A specified arrow has to be parenthesized. *)
+let f (g : int -> int [@spec fun x -> ret (fun r -> assert (r > x))]) (n : int) : int = g n

--- a/Tests/spec_types/spec_binds_tightly.out
+++ b/Tests/spec_types/spec_binds_tightly.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/spec_types/spec_binds_tightly.ml:6:19: unsupported feature: [@spec] only applies to a function type
+[1]

--- a/Tests/spec_types/spec_both_forms.ml
+++ b/Tests/spec_types/spec_both_forms.ml
@@ -1,0 +1,7 @@
+open Mica
+
+(* A declaration is specified once: either through [@@spec] or through the
+   specification on its own type, not both. *)
+let f : (int -> int) [@spec fun x -> ret (fun r -> assert (r > x))] =
+  fun x -> x + 1
+[@@spec fun x -> ret (fun r -> assert (r >= x))]

--- a/Tests/spec_types/spec_both_forms.out
+++ b/Tests/spec_types/spec_both_forms.out
@@ -1,0 +1,2 @@
+Status: failed: specification error: a declaration carries either [@@spec] or a specification on its own type, not both
+[1]

--- a/Tests/spec_types/spec_in_types.ml
+++ b/Tests/spec_types/spec_in_types.ml
@@ -1,0 +1,75 @@
+(* TEST: roundtrip *)
+
+open Mica
+
+(* A specification means the same thing wherever it is written: it is recorded
+   on the arrow it annotates. [@@spec] on a declaration and [@spec] in a type
+   position are one mechanism. *)
+
+(* The declaration form, unchanged: arguments in the binder list, [@@spec] on
+   the declaration. *)
+let rec sum_to (n : int) : int =
+  if n <= 0 then 0 else n + sum_to (n - 1)
+[@@spec fun n ->
+  assert (n >= 0);
+  ret (fun r -> assert (r >= 0))]
+
+(* A parameter's own type may carry a specification. The body may call the
+   parameter, assuming the specification it was annotated with. *)
+let apply (g : (int -> int) [@spec fun x ->
+                 assert (x >= 0);
+                 ret (fun r -> assert (r > x))])
+          (n : int) : int =
+  g n
+[@@spec fun g n ->
+  assert (n >= 0);
+  ret (fun r -> assert (r > n))]
+
+(* A function literal is checked against the specification of the parameter it
+   is passed at. *)
+let use_literal (m : int) : int =
+  if m >= 0 then apply (fun y -> y + 1) m else 0
+[@@spec fun m -> ret (fun r -> assert (r >= 0))]
+
+(* A declaration whose arrow is exactly the parameter's arrow passes by name. *)
+let incr (x : int) : int = x + 1
+[@@spec fun x ->
+  assert (x >= 0);
+  ret (fun r -> assert (r > x))]
+
+let use_named (m : int) : int =
+  if m >= 0 then apply incr m else 0
+[@@spec fun m -> ret (fun r -> assert (r >= 0))]
+
+(* A declaration with no arguments is specified through its own type. *)
+let double : (int -> int) [@spec fun x -> ret (fun r -> assert (r = x * 2))] =
+  fun x -> x * 2
+
+(* Recursion goes through the annotated type: the self-reference is typed at
+   the specified arrow. *)
+let rec fact : (int -> int) [@spec fun n ->
+                  assert (n >= 0);
+                  ret (fun r -> assert (r >= 1))] =
+  fun n -> if n <= 0 then 1 else n * fact (n - 1)
+
+(* A specification nests: the argument of a specified arrow may itself be a
+   specified arrow. *)
+let higher (h : ((((int -> int) [@spec fun x -> ret (fun r -> assert (r > x))]) -> int)
+                   [@spec fun k -> ret (fun r -> assert (r >= 0))])) : int =
+  h (fun y -> y + 1)
+[@@spec fun h -> ret (fun r -> assert (r >= 0))]
+
+(* A specification may sit under a type constructor. *)
+let ignore_fns (fs : (((int -> int) [@spec fun x -> ret (fun r -> assert (r >= x))]) list)) : int = 0
+[@@spec fun fs -> ret (fun r -> assert (r = 0))]
+
+(* Bounded quantifiers are lifted in a type-position specification, exactly as
+   in a declaration's. *)
+let call_bq (g : (int -> int) [@spec fun n ->
+                    assert (Range.all 0 n (fun (i : int) : bool -> i >= 0));
+                    ret (fun r -> assert (r >= 0))])
+            (m : int) : int =
+  g m
+[@@spec fun g m ->
+  assert (m >= 0);
+  ret (fun r -> assert (r >= 0))]

--- a/Tests/spec_types/spec_mismatch.ml
+++ b/Tests/spec_types/spec_mismatch.ml
@@ -1,0 +1,13 @@
+open Mica
+
+(* A specified arrow is invariant: a function passed by name has to have the
+   parameter's arrow, specification included. A weaker one is rejected. *)
+let apply (g : (int -> int) [@spec fun x -> ret (fun r -> assert (r > x))]) (n : int) : int =
+  g n
+[@@spec fun g n -> ret (fun r -> assert (r > n))]
+
+let same (x : int) : int = x
+[@@spec fun x -> ret (fun r -> assert (r = x))]
+
+let use (m : int) : int = apply same m
+[@@spec fun m -> ret (fun r -> assert (r > m))]

--- a/Tests/spec_types/spec_mismatch.out
+++ b/Tests/spec_types/spec_mismatch.out
@@ -1,0 +1,2 @@
+Status: failed: subsumption failed: TinyML.Typ.arrow [TinyML.Typ.prim (TinyML.PrimitiveType.int)] (TinyML.Typ.prim (TinyML.PrimitiveType.int)) (some <spec>) is not a subtype of TinyML.Typ.arrow [TinyML.Typ.prim (TinyML.PrimitiveType.int)] (TinyML.Typ.prim (TinyML.PrimitiveType.int)) (some <spec>)
+[1]

--- a/Tests/spec_types/spec_on_non_arrow.ml
+++ b/Tests/spec_types/spec_on_non_arrow.ml
@@ -1,0 +1,5 @@
+open Mica
+
+(* A specification describes a function. On any other type it has no meaning
+   and is rejected. *)
+let f (x : int [@spec fun y -> ret (fun r -> assert (r > y))]) : int = x

--- a/Tests/spec_types/spec_on_non_arrow.out
+++ b/Tests/spec_types/spec_on_non_arrow.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/spec_types/spec_on_non_arrow.ml:5:12: unsupported feature: [@spec] only applies to a function type
+[1]

--- a/Tests/spec_types/spec_out_of_scope.ml
+++ b/Tests/spec_types/spec_out_of_scope.ml
@@ -1,0 +1,7 @@
+open Mica
+
+(* A specification in a type position sees the program's globals and the arrow's
+   own arguments — never the binders around it. The type describes a function
+   that cannot mention [n]. *)
+let f (n : int) (g : (int -> int) [@spec fun x -> assert (x >= n); ret (fun r -> assert (r > x))]) : int =
+  g n

--- a/Tests/spec_types/spec_out_of_scope.out
+++ b/Tests/spec_types/spec_out_of_scope.out
@@ -1,0 +1,2 @@
+Status: failed: undefined variable: n
+[1]

--- a/Tests/spec_types/spec_twice.ml
+++ b/Tests/spec_types/spec_twice.ml
@@ -1,0 +1,5 @@
+open Mica
+
+(* An arrow carries at most one specification. *)
+let f (g : ((int -> int) [@spec fun x -> ret (fun r -> assert (r > x))])
+                         [@spec fun x -> ret (fun r -> assert (r >= x))]) (n : int) : int = g n

--- a/Tests/spec_types/spec_twice.out
+++ b/Tests/spec_types/spec_twice.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/spec_types/spec_twice.ml:4:14: unsupported feature: a function type carries at most one [@spec]
+[1]

--- a/Tests/spec_types/spec_unspecified_argument.ml
+++ b/Tests/spec_types/spec_unspecified_argument.ml
@@ -1,0 +1,11 @@
+open Mica
+
+(* An unspecified function is not a value of a specified arrow type. *)
+let apply (g : (int -> int) [@spec fun x -> ret (fun r -> assert (r > x))]) (n : int) : int =
+  g n
+[@@spec fun g n -> ret (fun r -> assert (r > n))]
+
+let plain (x : int) : int = x + 1
+
+let use (m : int) : int = apply plain m
+[@@spec fun m -> ret (fun r -> assert (r > m))]

--- a/Tests/spec_types/spec_unspecified_argument.out
+++ b/Tests/spec_types/spec_unspecified_argument.out
@@ -1,0 +1,2 @@
+Status: failed: subsumption failed: TinyML.Typ.arrow [TinyML.Typ.prim (TinyML.PrimitiveType.int)] (TinyML.Typ.prim (TinyML.PrimitiveType.int)) none is not a subtype of TinyML.Typ.arrow [TinyML.Typ.prim (TinyML.PrimitiveType.int)] (TinyML.Typ.prim (TinyML.PrimitiveType.int)) (some <spec>)
+[1]


### PR DESCRIPTION
A function literal checked against a specified arrow is now elaborated at that arrow — it takes the expected signature, records the specification, and types its self-reference at the specified arrow — so a specified parameter can be given an inline `fun` rather than only a declaration passed by name. Inferring the literal first could never reach a specified arrow, since those are invariant and an inferred literal carries no specification. The second commit adds `Tests/spec_types/`: one file exercising every position a specification may be written in, and seven pinning where one is rejected. It also adds the check the last of those wants — a declaration is specified by `[@@spec]` or by its own type, not both.

Last of five PRs accepting `[@spec ...]` in any type position.
