### PR TITLE
Accept a specification in a data declaration's payloads

### DIFF
--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -80,9 +80,9 @@ private structure TypeInfo where
 
 structure ElabEnv where
   types    : List (TypeConstructor × TypeInfo)                := []
-  ctors    : List (Constructor × (Nat × Nat × TinyML.Typ))   := []
+  ctors    : List (Constructor × (Nat × Nat × Untyped.Typ))  := []
   fields   : List (FieldName × (TypeConstructor × Nat))      := []
-  records  : List (TypeConstructor × List (FieldName × TinyML.Typ)) := []
+  records  : List (TypeConstructor × List (FieldName × Untyped.Typ)) := []
   locals   : List Var                                        := []
   resolver : Resolver
 
@@ -151,7 +151,7 @@ private def reorderFields (loc : Location) (provided : List (FieldName × α)) :
     | none => err loc (.missingField fieldName)
 
 private def recordFieldsFor (env : ElabEnv) (loc : Location) (fields : List (FieldName × α)) :
-    ElabM (List (FieldName × TinyML.Typ)) :=
+    ElabM (List (FieldName × Untyped.Typ)) :=
   match fields with
   | [] => err loc (.unsupportedFeature "empty record pattern")
   | (name, _) :: _ =>
@@ -325,7 +325,7 @@ partial def patternToProductType (env : ElabEnv) (pat : Pattern) : ElabM Untyped
           err pat.loc (.unsupportedPattern "tuple function arguments must annotate each component")
   | .record fields => do
       let fieldInfo ← recordFieldsFor env pat.loc fields
-      .ok (Untyped.Typ.tuple (fieldInfo.map (fun f => Untyped.Typ.core f.2)))
+      .ok (Untyped.Typ.tuple (fieldInfo.map Prod.snd))
   | _ => err pat.loc (.unsupportedPattern "expected a flat product binder")
 
 partial def elaborateFunctionArgs (env : ElabEnv) (stem : String) :
@@ -419,7 +419,7 @@ partial def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → Ela
     | _ =>
       match List.lookup name env.records with
       | some fields =>
-          if args'.isEmpty then .ok (.tuple (fields.map (fun f => Untyped.Typ.core f.2)))
+          if args'.isEmpty then .ok (.tuple (fields.map Prod.snd))
           else err loc (.arityMismatch 0 args'.length)
       | none =>
       match List.lookup name env.types with
@@ -768,7 +768,7 @@ partial def MatchArm.elaborateList (env : ElabEnv)
           | some p =>
             let body' ← Expr.elaborate (env.bindPattern p) body
             match payloadTy with
-            | .tuple _ =>
+            | .tuple _ | .core (.tuple _) =>
                 if isProductPattern p then do
                   let names ← patternToProductBinders env p
                   let argName := "$arg0"
@@ -785,7 +785,7 @@ partial def MatchArm.elaborateList (env : ElabEnv)
           | none =>
             let body' ← Expr.elaborate env body
             match payloadTy with
-            | .prim .unit => pure (none, body')
+            | .core .unit => pure (none, body')
             | _ => err pat.loc (.unsupportedPattern "constructor payload must be matched")
         pure (name, binder, body'')
       | _ => err pat.loc (.unsupportedPattern "only constructor patterns are allowed in match")
@@ -804,40 +804,9 @@ end
 -- ---------------------------------------------------------------------------
 -- Type declaration elaboration
 
-mutual
-  /-- The core type an elaborated type is, provided no pending specification
-  occurs in it. -/
-  private def core? : Untyped.Typ → Option TinyML.Typ
-    | .core t => some t
-    | .sum ts => do pure (.sum (← coreList? ts))
-    | .arrow _ _ (some _) => none
-    | .arrow args ret none => do pure (.arrow (← coreList? args) (← core? ret) none)
-    | .ref t => do pure (.ref (← core? t))
-    | .array t => do pure (.array (← core? t))
-    | .ownedArray t => do pure (.ownedArray (← core? t))
-    | .vec t => do pure (.vec (← core? t))
-    | .owned t => do pure (.owned (← core? t))
-    | .tuple ts => do pure (.tuple (← coreList? ts))
-    | .named n args => do pure (.named n (← coreList? args))
-
-  private def coreList? : List Untyped.Typ → Option (List TinyML.Typ)
-    | [] => some []
-    | t :: ts => do pure ((← core? t) :: (← coreList? ts))
-end
-
-/-- Elaborate a type that must be fully resolved on the spot. A data
-declaration's payloads and fields are stored as core types, and a
-specification's leaves cannot be typechecked before the declaration they
-belong to exists, so `[@spec]` has no meaning here. -/
-private def Typ.elaborateCore (env : ElabEnv) (ty : Typ) : ElabM TinyML.Typ := do
-  let t ← Typ.elaborate env ty
-  match core? t with
-  | some c => .ok c
-  | none => err ty.loc (.unsupportedFeature "[@spec] is not allowed in a type declaration")
-
 private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
     (ctorDefs : List (Constructor × Option Typ)) (tag : Nat) (arity : Nat)
-    : ElabM (List TinyML.Typ × List (Constructor × (Nat × Nat × TinyML.Typ))) :=
+    : ElabM (List Untyped.Typ × List (Constructor × (Nat × Nat × Untyped.Typ))) :=
   match ctorDefs with
   | [] => .ok ([], [])
   | (ctorName, payloadTy) :: rest => do
@@ -845,8 +814,8 @@ private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
       err loc (.duplicateConstructor ctorName)
     else do
     let payloadTy' ← match payloadTy with
-      | some ty => Typ.elaborateCore env ty
-      | none => .ok .unit
+      | some ty => Typ.elaborate env ty
+      | none => .ok (.core .unit)
     let (restTypes, restCtors) ← elaborateCtorDefs env loc rest (tag + 1) arity
     .ok (payloadTy' :: restTypes,
          (ctorName, (tag, arity, payloadTy')) :: restCtors)
@@ -886,7 +855,7 @@ private def elaborateRecordDecl (env : ElabEnv) (loc : Location) (name : TypeCon
   let envWithSelf := { env with types := (name, ⟨coreName, 0⟩) :: env.types }
   let newFields ← elaborateFieldDefs env loc name fieldDefs 0
   let fieldTypes ← fieldDefs.mapM (fun (fieldName, ty) => do
-    let ty' ← Typ.elaborateCore envWithSelf ty
+    let ty' ← Typ.elaborate envWithSelf ty
     pure (fieldName, ty'))
   .ok { env with
     types := (name, ⟨coreName, 0⟩) :: env.types
@@ -1015,12 +984,12 @@ private def requireOpenMica : List Decl → ElabM (List Decl)
 -- Predefined types
 
 private def predefCtorEntries (p : TinyML.Predef) :
-    List (Constructor × (Nat × Nat × TinyML.Typ)) :=
+    List (Constructor × (Nat × Nat × Untyped.Typ)) :=
   let arity := p.ctors.length
   let rec go : List (String × TinyML.Typ) → Nat →
-      List (Constructor × (Nat × Nat × TinyML.Typ))
+      List (Constructor × (Nat × Nat × Untyped.Typ))
     | [], _ => []
-    | (name, payload) :: rest, tag => (name, (tag, arity, payload)) :: go rest (tag + 1)
+    | (name, payload) :: rest, tag => (name, (tag, arity, .core payload)) :: go rest (tag + 1)
   go p.ctors 0
 
 /-- The initial frontend environment derived from the canonical predef catalog.

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -212,8 +212,11 @@ where
     parenIf (!Expr.isAtom e) (Expr.printPrec e 0)
   fmtBase (e : Expr) : String :=
     parenIf (!Expr.isAtom e) (Expr.printPrec e 0)
+  -- A field value ends at the `;` or `}` that follows it, so a `fun`, `let`,
+  -- `if` or `match` has to be parenthesized to parse back.
   fmtFields (fields : List (FieldName × Expr)) : String :=
-    joinWith "; " (fields.map fun (f, v) => f ++ " = " ++ Expr.printPrec v 0)
+    joinWith "; " (fields.map fun (f, v) =>
+      f ++ " = " ++ parenIf (Expr.isKeywordExpr v) (Expr.printPrec v 0))
   printUnop (op : UnOp) (inner : Expr) : String :=
     match op with
     | .proj n => fmtBase inner ++ s!".{n}"

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -568,6 +568,19 @@ mutual
           let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
           let body' ← check env Θ Γ' body ret
           pure (.fix typedSelf typedArgs ret (some s) body')
+    -- A tuple checked against a tuple type is checked componentwise. A record
+    -- literal is a tuple, so this is how a field declared at a specified arrow
+    -- receives one: inference alone could never produce a specified arrow, and
+    -- subsumption cannot repair that, since a specified arrow is invariant.
+    --
+    -- Tuples are the only type former that pushes the expected type inward.
+    -- Every other one that can hold a function has the same gap: a constructor
+    -- payload (`Fn (fun x -> ...)`), a reference (`ref (fun x -> ...)`), an
+    -- array element. Each needs its own rule here, and unlike this one they are
+    -- not exact — the type they build subsumes into the expected type rather
+    -- than matching it — so they also need the subsumption step below.
+    | .tuple es, .tuple tys => do
+        pure (.tuple (← checkArgs env Θ Γ tys es))
     -- Everything else is checked by inference, subsuming into the expected type.
     | e, expected => do
         let (actual, e') ← infer env Θ Γ e
@@ -711,6 +724,16 @@ mutual
   decreasing_by obtain ⟨args, pre⟩ := rb; simp; omega
 end
 
+/-- Lower a data declaration's payloads, elaborating any specification they
+carry. A constructor payload is a type like any other, so it may describe a
+specified function; its specification is elaborated once, against the bindings
+in scope where the declaration stands. (A record's fields take a different
+route: the frontend inlines a record type as a tuple, so a field's
+specification is elaborated at each mention of the record type instead.) -/
+def translateDataDecl (env : SpecEnv σ) (Θ : TypeEnv) (d : Untyped.DataDecl) :
+    TypeM σ TinyML.DataDecl := do
+  pure { tparams := d.tparams, payloads := ← translateList env Θ d.payloads }
+
 theorem Binder.ofUntyped_runtime (b : Untyped.Binder) (ty : Typ) :
     (Typed.Binder.ofUntyped b ty).runtime = b.runtime := by
   cases b <;> rfl
@@ -853,7 +876,8 @@ def Program.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
   | d :: ds => do
       match d with
       | .type_ dty =>
-          let Θ' ← TypeM.ofExcept (extendTypeEnv Θ dty.name dty.body)
+          let body ← translateDataDecl { env with globals := Γ } Θ dty.body
+          let Θ' ← TypeM.ofExcept (extendTypeEnv Θ dty.name body)
           Program.elaborate env Θ' Γ ds
       | .val_ dval =>
           let d' ← ValDecl.elaborate { env with globals := Γ } Θ Γ dval
@@ -1280,6 +1304,12 @@ mutual
         simp [Expr.runtime, Untyped.Expr.runtime, Binder.ofUntyped_runtime,
           check_runtime env Θ _ body ret _ _ _ hbody,
           checkBinders_runtime env Θ args doms typedArgs s s₀ hargs]
+    -- A tuple against a tuple type: the components erase one by one.
+    case _ es tys =>
+      have ⟨es', s₀, hes, hcont⟩ := StateT.bind_ok h
+      rcases (by simpa using hcont) with ⟨rfl, rfl⟩
+      simp [Expr.runtime, Untyped.Expr.runtime,
+        checkArgs_runtime env Θ Γ es tys s es' s₀ hes]
     -- Everything else is inference followed by subsumption.
     case _ =>
       have ⟨p, s₀, hinfer, hcont⟩ := StateT.bind_ok h
@@ -1448,12 +1478,15 @@ theorem Program.elaborate_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML
     cases d with
     | type_ dty =>
       unfold Typed.Program.elaborate at h
-      cases hext : extendTypeEnv Θ dty.name dty.body with
+      -- The payloads' own elaboration stays opaque; a type declaration
+      -- contributes nothing to the runtime program either way.
+      have ⟨body, s₀, _hbody, hcont⟩ := StateT.bind_ok h
+      cases hext : extendTypeEnv Θ dty.name body with
       | error err =>
-        simp [hext] at h
+        simp [hext] at hcont
       | ok Θ1 =>
-        simp [hext] at h
-        exact ih Θ1 Γ h
+        simp [hext] at hcont
+        exact ih Θ1 Γ hcont
     | val_ dval =>
       unfold Typed.Program.elaborate at h
       have ⟨dval', s₀, hdecl, hcont⟩ := StateT.bind_ok h

--- a/Mica/SourceTinyML/Untyped.lean
+++ b/Mica/SourceTinyML/Untyped.lean
@@ -155,9 +155,17 @@ structure ValDecl (S : Type) where
   relation : Option String := none
   deriving Repr, Inhabited
 
+/-- A data declaration as the frontend elaborates it. Its payloads are untyped
+types, so a constructor or field may carry a specification: only typing can
+elaborate one, and typing is also where the declaration reaches `TypeEnv`. -/
+structure DataDecl where
+  tparams : List TyVar
+  payloads : List Typ
+  deriving Repr, Inhabited
+
 structure TypeDecl where
   name : TypeName
-  body : DataDecl
+  body : Untyped.DataDecl
   deriving Repr, Inhabited
 
 inductive Decl (S : Type) where

--- a/Tests/spec_types/spec_in_type_decl.ml
+++ b/Tests/spec_types/spec_in_type_decl.ml
@@ -1,5 +1,47 @@
+(* TEST: roundtrip *)
+
 open Mica
 
-(* A data declaration's field types are elaborated before any specification
-   could be typechecked, so [@spec] is not accepted there. *)
-type box = { run : (int -> int) [@spec fun x -> ret (fun r -> assert (r > x))] }
+(* A data declaration's payloads are types like any other, so a record field or
+   a constructor payload may describe a specified function, and calling one
+   assumes the specification it was declared with. *)
+
+type box = { run : (int -> int) [@spec fun x ->
+                      assert (x >= 0);
+                      ret (fun r -> assert (r > x))] }
+
+let use_field (b : box) (n : int) : int =
+  if n >= 0 then b.run n else 0
+[@@spec fun b n -> ret (fun r -> assert (r >= 0))]
+
+(* A record literal is checked against the field's specified arrow, so the
+   function literal it carries is elaborated at that arrow. *)
+let build_box (n : int) : int = use_field { run = (fun x -> x + 1) } n
+[@@spec fun n -> ret (fun r -> assert (r >= 0))]
+
+type wrapped =
+  | Plain of int
+  | Fn of ((int -> int) [@spec fun x ->
+               assert (x >= 0);
+               ret (fun r -> assert (r > x))])
+
+let use_payload (w : wrapped) (n : int) : int =
+  if n >= 0 then
+    match w with
+    | Plain _ -> 0
+    | Fn f -> f n
+  else 0
+[@@spec fun w n -> ret (fun r -> assert (r >= 0))]
+
+let incr (x : int) : int = x + 1
+[@@spec fun x ->
+  assert (x >= 0);
+  ret (fun r -> assert (r > x))]
+
+(* Both constructors are built and passed on: the payload of [Fn] is a
+   declaration whose own type is the specified arrow the payload declares. *)
+let build_plain (n : int) : int = use_payload (Plain 7) n
+[@@spec fun n -> ret (fun r -> assert (r >= 0))]
+
+let build_fn (n : int) : int = use_payload (Fn incr) n
+[@@spec fun n -> ret (fun r -> assert (r >= 0))]

--- a/Tests/spec_types/spec_in_type_decl.out
+++ b/Tests/spec_types/spec_in_type_decl.out
@@ -1,2 +1,0 @@
-elaboration error: Tests/spec_types/spec_in_type_decl.ml:5:21: unsupported feature: [@spec] is not allowed in a type declaration
-[1]


### PR DESCRIPTION
A data declaration's payloads were elaborated to core types in the frontend, which is before a specification could be typechecked, so `[@spec]` was rejected there. They now stay untyped types — `Untyped.DataDecl` alongside the other untyped declarations — and `Program.elaborate` lowers them through `translate`, which is where every other specification is elaborated too. 

One asymmetry to know about: the frontend inlines a record type as a tuple at each mention, so a record field's specification is elaborated per use site and in that site's scope, while a constructor payload's is elaborated once where the declaration stands. Both verify; only the variant path goes through `translateDataDecl`.
