### PR TITLE
Carry a let expression's type annotation through to elaboration

### DIFF
--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -121,7 +121,7 @@ mutual
     | arraySet (arr idx val : Expr)
     | unop (op : UnOp) (e : Expr)
     | ite (cond thn els : Expr)
-    | letIn (rec : Bool) (binders : List Pattern) (bound body : Expr)
+    | letIn (rec : Bool) (binders : List Pattern) (retTy : Option Typ) (bound body : Expr)
     | fun_ (args : List Pattern) (retTy : Option Typ) (body : Expr)
     | match_ (scrutinee : Expr) (arms : List MatchArm)
     | tuple (es : List Expr)

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -663,7 +663,7 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
     let e' ← Expr.elaborate env e
     .ok (.ifThenElse c' t' e')
 
-  | .letIn isRec binders bound body =>
+  | .letIn isRec binders retTy bound body =>
     match binders with
     | [] => err loc (.unsupportedFeature "let with no binders")
     | [pat] => do
@@ -673,10 +673,19 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
       else
         let body' ← Expr.elaborate (env.bindPattern pat) body
         if isProductPattern pat then
-          let names ← patternToProductBinders env pat
-          .ok (.letProd names bound' body')
+          if retTy.isSome then
+            err loc (.unsupportedFeature "a destructuring let cannot be annotated")
+          else do
+            let names ← patternToProductBinders env pat
+            .ok (.letProd names bound' body')
         else do
+          -- With no arguments the annotation is the bound value's own type, so
+          -- it lands on the binder and the bound expression is checked at it.
           let name ← patternToBinder pat
+          let annot ← elaborateOptTyp env retTy
+          let name := match name, annot with
+            | .named n none, some ty => .named n (some ty)
+            | b, _ => b
           .ok (.letIn name bound' body')
     | pat :: args => do
       let name ← patternToBinder pat
@@ -686,7 +695,9 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
       let bound' ← Expr.elaborate boundEnv bound
       let (args', bound'') ← elaborateFunctionArgs env "$param" 0 args bound'
       let body' ← Expr.elaborate (env.bindPattern pat) body
-      .ok (.letIn name (.fix self args' none bound'') body')
+      -- With arguments the annotation is the function's return type.
+      let retTy' ← elaborateOptTyp env retTy
+      .ok (.letIn name (.fix self args' retTy' bound'') body')
 
   | .fun_ [] _ _ =>
     err loc (.unsupportedFeature "function expressions require at least one argument")

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -786,12 +786,12 @@ where
     let st := if isRec then advance st else st
     let (first, st) ← parsePatternBinder st
     let (rest, st) ← parseFunArgs st
-    let (_retTy, st) ← parseOptRetTy st
+    let (retTy, st) ← parseOptRetTy st
     let st ← expect .eq st
     let (bound, st) ← parseExpr st
     let st ← expect .kw_in st
     let (body, st) ← parseExpr st
-    .ok (mkExpr p st (.letIn isRec (first :: rest) bound body), st)
+    .ok (mkExpr p st (.letIn isRec (first :: rest) retTy bound body), st)
 
   -- `fun pat pat ... [: T] -> body`
   parseFun : Parser Expr := fun st => do

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -162,7 +162,7 @@ private partial def Expr.isAtom (e : Expr) : Bool :=
 
 private partial def Expr.isKeywordExpr (e : Expr) : Bool :=
   match e.kind with
-  | .letIn _ _ _ _ | .fun_ _ _ _ | .ite _ _ _ | .match_ _ _ => true
+  | .letIn _ _ _ _ _ | .fun_ _ _ _ | .ite _ _ _ | .match_ _ _ => true
   | _ => false
 
 private partial def Expr.printPrec (e : Expr) (outerPrec : Nat) : String :=
@@ -190,9 +190,10 @@ private partial def Expr.printPrec (e : Expr) (outerPrec : Nat) : String :=
   | .ite cond thn els =>
     "if " ++ Expr.printPrec cond 0 ++ " then " ++ Expr.printPrec thn 0 ++
     " else " ++ Expr.printPrec els 0
-  | .letIn isRec binders bound body =>
+  | .letIn isRec binders retTy bound body =>
     let recStr := if isRec then "rec " else ""
-    "let " ++ recStr ++ joinWith " " (binders.map Pattern.print) ++
+    let retStr := match retTy with | none => "" | some ty => " : " ++ Typ.print ty
+    "let " ++ recStr ++ joinWith " " (binders.map Pattern.print) ++ retStr ++
     " = " ++ Expr.printPrec bound 0 ++ " in\n" ++ Expr.printPrec body 0
   | .fun_ args retTy body =>
     let retStr := match retTy with | none => "" | some ty => " : " ++ Typ.print ty

--- a/Tests/frontend/let_annotation.ml
+++ b/Tests/frontend/let_annotation.ml
@@ -1,0 +1,16 @@
+(* TEST: roundtrip *)
+
+open Mica
+
+(* A `let` annotation is the bound value's own type when the let takes no
+   arguments. It means the same written on the pattern itself. *)
+
+let no_args (n : int) : int =
+  let b : int = n + 1 in
+  b
+[@@spec fun n -> ret (fun r -> assert (r = n + 1))]
+
+let on_pattern (n : int) : int =
+  let (b : int) = n + 1 in
+  b
+[@@spec fun n -> ret (fun r -> assert (r = n + 1))]

--- a/Tests/frontend/let_annotation_destructuring.ml
+++ b/Tests/frontend/let_annotation_destructuring.ml
@@ -1,0 +1,8 @@
+open Mica
+
+(* A destructuring let has no single binder to carry the annotation, so it is
+   rejected rather than silently dropped. *)
+let f (n : int) : int =
+  let (a, b) : int * int = (n, n) in
+  a + b
+[@@spec fun n -> ret (fun r -> assert (r = n + n))]

--- a/Tests/frontend/let_annotation_destructuring.out
+++ b/Tests/frontend/let_annotation_destructuring.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/let_annotation_destructuring.ml:6:3: unsupported feature: a destructuring let cannot be annotated
+[1]

--- a/Tests/frontend/let_annotation_mismatch.ml
+++ b/Tests/frontend/let_annotation_mismatch.ml
@@ -1,0 +1,9 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* The annotation is checked: the bound expression has to have that type. *)
+let f (n : int) : int =
+  let b : bool = n in
+  0
+[@@spec fun n -> ret (fun r -> assert (r = 0))]

--- a/Tests/frontend/let_annotation_mismatch.out
+++ b/Tests/frontend/let_annotation_mismatch.out
@@ -1,0 +1,2 @@
+Status: failed: subsumption failed: TinyML.Typ.prim (TinyML.PrimitiveType.int) is not a subtype of TinyML.Typ.prim (TinyML.PrimitiveType.bool)
+[1]

--- a/Tests/frontend/let_annotation_ret_mismatch.ml
+++ b/Tests/frontend/let_annotation_ret_mismatch.ml
@@ -1,0 +1,10 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* When the let takes arguments the annotation is the function's return type,
+   and the body is checked against it. *)
+let f (n : int) : int =
+  let bump (x : int) : bool = x + 1 in
+  n
+[@@spec fun n -> ret (fun r -> assert (r = n))]

--- a/Tests/frontend/let_annotation_ret_mismatch.out
+++ b/Tests/frontend/let_annotation_ret_mismatch.out
@@ -1,0 +1,2 @@
+Status: failed: subsumption failed: TinyML.Typ.prim (TinyML.PrimitiveType.int) is not a subtype of TinyML.Typ.prim (TinyML.PrimitiveType.bool)
+[1]


### PR DESCRIPTION
`parseLet` parsed the annotation in `let x : T = e in ...` and discarded it, so `let b : bool = n in 0` typechecked. `AST.Expr.letIn` now carries it, and elaboration uses it: with no arguments it is the bound value's own type and lands on the binder, so the bound expression is checked against it; with arguments it is the function's return type and lands on the `fix`. A destructuring `let` has no binder to carry it, so an annotation there is now rejected rather than dropped.

Found while writing a test that built a value at an annotated type. Independent of that work, so it is on its own.
