### PR TITLE
Fill in dropped annotations and unaccounted attributes in the frontend

### DIFF
--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -141,8 +141,10 @@ mutual
 
   /-- An OCaml attribute `[@name payload]` (expression-level, single `@`) or
   `[@@name payload]` (declaration-level, double `@`). The payload, when present,
-  is a surface expression. -/
+  is a surface expression. `loc` spans the brackets, so an error about the
+  attribute itself points at it rather than at what it is attached to. -/
   structure Attribute where
+    loc     : Location
     name    : String
     payload : Option Expr
 end

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -80,6 +80,36 @@ inductive BinOp where
   | semi | pipeRight | atAt | assign | concat | append | cons
   deriving Repr, BEq
 
+-- Attributes
+
+/-- The name of an attribute `[@name]`. Which names are meaningful depends on
+where the attribute is written, so an unrecognized one is carried through to
+elaboration, which rejects it by name for that position. -/
+inductive AttrName where
+  | spec
+  | fn
+  | owned
+  | unknown (name : String)
+  deriving Repr, Inhabited, BEq, DecidableEq
+
+namespace AttrName
+
+def ofString : String → AttrName
+  | "spec"  => .spec
+  | "fn"    => .fn
+  | "owned" => .owned
+  | name    => .unknown name
+
+def toString : AttrName → String
+  | .spec         => "spec"
+  | .fn           => "fn"
+  | .owned        => "owned"
+  | .unknown name => name
+
+instance : ToString AttrName := ⟨AttrName.toString⟩
+
+end AttrName
+
 -- Types, patterns, expressions, match arms
 
 mutual
@@ -145,7 +175,7 @@ mutual
   attribute itself points at it rather than at what it is attached to. -/
   structure Attribute where
     loc     : Location
-    name    : String
+    name    : AttrName
     payload : Option Expr
 end
 

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -933,30 +933,31 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
 -- ---------------------------------------------------------------------------
 -- Program elaboration
 
-private def elaborateAttrSpec (env : ElabEnv) (attrs : List Attribute)
-    : ElabM (Option Untyped.SpecBody) :=
-  match attrs.find? (·.name == "spec") with
-  | none => .ok none
-  | some attr =>
-    match attr.payload with
-    | none => err default (.unsupportedFeature "[@@spec] expects a specification payload")
-    | some payload => do
-      let e ← Expr.elaborate env payload
-      match Spec.parse e with
-      | .ok spec => .ok (some spec)
-      | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@@spec]: {msg}")
-
-/-- Whether the declaration is marked `[@@fn]`, registering it as a spec-level
-    function. The attribute carries no payload; the function's own name is used
-    for the derived relation. -/
-private def hasAttrRelation (attrs : List Attribute) : ElabM Bool :=
-  match attrs.find? (·.name == "fn") with
-  | none => .ok false
-  | some attr =>
-    match attr.payload with
-    | none => .ok true
-    | some payload => err payload.loc (.unsupportedFeature
+/-- The attributes of a value declaration: the specification `[@@spec]` carries,
+and whether `[@@fn]` marks it as a spec-level function. Every attribute is
+accounted for — an unknown name is rejected, and neither may be written twice,
+so no attribute is silently ignored. `[@@fn]` takes no payload; the function's
+own name is used for the derived relation. -/
+private def elaborateValAttrs (env : ElabEnv) (loc : Location) :
+    Option Untyped.SpecBody → Bool → List Attribute → ElabM (Option Untyped.SpecBody × Bool)
+  | spec, fn, [] => .ok (spec, fn)
+  | spec, fn, attr :: attrs =>
+    match attr.name, attr.payload with
+    | "spec", some payload =>
+      if spec.isSome then
+        err payload.loc (.unsupportedFeature "a declaration carries at most one [@@spec]")
+      else do
+        let e ← Expr.elaborate env payload
+        match Spec.parse e with
+        | .ok spec' => elaborateValAttrs env loc (some spec') fn attrs
+        | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@@spec]: {msg}")
+    | "spec", none => err loc (.unsupportedFeature "[@@spec] expects a specification payload")
+    | "fn", none =>
+      if fn then err loc (.unsupportedFeature "a declaration carries at most one [@@fn]")
+      else elaborateValAttrs env loc spec true attrs
+    | "fn", some payload => err payload.loc (.unsupportedFeature
         "[@@fn] takes no payload; the function's own name is used for the relation")
+    | name, _ => err loc (.unsupportedFeature s!"unknown declaration attribute [@@{name}]")
 
 def Decl.elaborate (env : ElabEnv) (decl : Decl)
     : ElabM (ElabEnv × Option (Untyped.Decl Untyped.SpecBody)) := do
@@ -970,8 +971,7 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
     let (env', tdecl') ← TypeDecl.elaborate env decl.loc tdecl
     .ok (env', tdecl'.map Untyped.Decl.type_)
   | .val_ isRec binders retTy body => do
-    let spec ← elaborateAttrSpec env decl.attrs
-    let fn ← hasAttrRelation decl.attrs
+    let (spec, fn) ← elaborateValAttrs env decl.loc none false decl.attrs
     let d ← ValDecl.elaborate env decl.loc isRec binders retTy body spec
     -- A `[@@fn]` declaration uses its own name for the derived relation.
     let relation ← if fn then

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -216,13 +216,15 @@ private def elaborateCtorLookup (env : ElabEnv) (loc : Location) (name : String)
 /-- Apply a single expression attribute to an already-elaborated term. One arm
 per supported expression attribute; unknown names are rejected here (mirroring
 how `[@@...]` names are validated). -/
-private def applyAttr (loc : Location) (e : Untyped.Expr) : Attribute → ElabM Untyped.Expr
-  | { name := "owned", payload := none } =>
+private def applyAttr (e : Untyped.Expr) (attr : Attribute) : ElabM Untyped.Expr :=
+  match attr.name, attr.payload with
+  | "owned", none =>
       match e with
       | .ref _ inner => .ok (.ref .owned inner)
       | .arrayMake _ len init => .ok (.arrayMake .owned len init)
-      | _ => err loc (.unsupportedFeature "[@owned] only applies to 'ref' or 'Array.make'")
-  | { name, .. } => err loc (.unsupportedFeature s!"unknown expression attribute [@{name}]")
+      | _ => err attr.loc (.unsupportedFeature "[@owned] only applies to 'ref' or 'Array.make'")
+  | "owned", some payload => err payload.loc (.unsupportedFeature "[@owned] takes no payload")
+  | name, _ => err attr.loc (.unsupportedFeature s!"unknown expression attribute [@{name}]")
 
 private def bareSpecial (loc : Location) (path : Path) : ElabM Untyped.Expr :=
   err loc (.bareSpecialIdentifier path.toString)
@@ -371,29 +373,30 @@ type may be written. -/
 partial def Typ.elaborate (env : ElabEnv) : Typ → ElabM Untyped.Typ
   | ⟨loc, kind, attrs⟩ => do
       let t ← TypKind.elaborate env loc kind
-      Typ.applyAttrs env loc t attrs
+      Typ.applyAttrs env t attrs
 
-partial def Typ.applyAttrs (env : ElabEnv) (loc : Location) (t : Untyped.Typ) :
+partial def Typ.applyAttrs (env : ElabEnv) (t : Untyped.Typ) :
     List Attribute → ElabM Untyped.Typ
   | [] => .ok t
   | attr :: attrs => do
-    let t' ← Typ.applyAttr env loc t attr
-    Typ.applyAttrs env loc t' attrs
+    let t' ← Typ.applyAttr env t attr
+    Typ.applyAttrs env t' attrs
 
 /-- Apply a single type attribute. `[@owned]` turns a shared `ref A` into an
 owned `owned A` (mirroring how the expression-level `[@owned]` validates
 `ref`); `[@spec]` records a specification on the arrow it annotates, exactly as
 `[@@spec]` does on a declaration. -/
-partial def Typ.applyAttr (env : ElabEnv) (loc : Location) (t : Untyped.Typ) :
-    Attribute → ElabM Untyped.Typ
-  | ⟨"owned", none⟩ =>
+partial def Typ.applyAttr (env : ElabEnv) (t : Untyped.Typ) (attr : Attribute) :
+    ElabM Untyped.Typ :=
+  match attr.name, attr.payload with
+  | "owned", none =>
     match t with
     | .ref inner => .ok (.owned inner)
     | .array inner => .ok (.ownedArray inner)
-    | _ => err loc (.unsupportedFeature "[@owned] only applies to a 'ref' or 'array' type")
-  | ⟨"owned", some payload⟩ => err payload.loc (.unsupportedFeature "[@owned] takes no payload")
-  | ⟨"spec", none⟩ => err loc (.unsupportedFeature "[@spec] expects a specification payload")
-  | ⟨"spec", some payload⟩ => do
+    | _ => err attr.loc (.unsupportedFeature "[@owned] only applies to a 'ref' or 'array' type")
+  | "owned", some payload => err payload.loc (.unsupportedFeature "[@owned] takes no payload")
+  | "spec", none => err attr.loc (.unsupportedFeature "[@spec] expects a specification payload")
+  | "spec", some payload => do
     let e ← Expr.elaborate env payload
     match Spec.parse e with
     | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@spec]: {msg}")
@@ -401,9 +404,9 @@ partial def Typ.applyAttr (env : ElabEnv) (loc : Location) (t : Untyped.Typ) :
       match t with
       | .arrow args ret none => .ok (.arrow args ret (some body))
       | .arrow _ _ (some _) =>
-        err loc (.unsupportedFeature "a function type carries at most one [@spec]")
-      | _ => err loc (.unsupportedFeature "[@spec] only applies to a function type")
-  | ⟨name, _⟩ => err loc (.unsupportedFeature s!"unknown type attribute [@{name}]")
+        err attr.loc (.unsupportedFeature "a function type carries at most one [@spec]")
+      | _ => err attr.loc (.unsupportedFeature "[@spec] only applies to a function type")
+  | name, _ => err attr.loc (.unsupportedFeature s!"unknown type attribute [@{name}]")
 
 partial def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM Untyped.Typ
   | .var v => .ok (.core (.tvar v))
@@ -472,7 +475,7 @@ for every expression position, so attributes are honored everywhere. -/
 partial def Expr.elaborate (env : ElabEnv) : Expr → ElabM Untyped.Expr
   | ⟨loc, kind, attrs⟩ => do
       let e ← ExprKind.elaborate env loc kind
-      attrs.foldlM (applyAttr loc) e
+      attrs.foldlM applyAttr e
 
 partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → ElabM Untyped.Expr
   | .const (.int n)  => .ok (.const (.int n))
@@ -938,26 +941,28 @@ and whether `[@@fn]` marks it as a spec-level function. Every attribute is
 accounted for — an unknown name is rejected, and neither may be written twice,
 so no attribute is silently ignored. `[@@fn]` takes no payload; the function's
 own name is used for the derived relation. -/
-private def elaborateValAttrs (env : ElabEnv) (loc : Location) :
+private def elaborateValAttrs (env : ElabEnv) :
     Option Untyped.SpecBody → Bool → List Attribute → ElabM (Option Untyped.SpecBody × Bool)
   | spec, fn, [] => .ok (spec, fn)
   | spec, fn, attr :: attrs =>
     match attr.name, attr.payload with
     | "spec", some payload =>
       if spec.isSome then
-        err payload.loc (.unsupportedFeature "a declaration carries at most one [@@spec]")
+        err attr.loc (.unsupportedFeature "a declaration carries at most one [@@spec]")
       else do
         let e ← Expr.elaborate env payload
         match Spec.parse e with
-        | .ok spec' => elaborateValAttrs env loc (some spec') fn attrs
+        | .ok spec' => elaborateValAttrs env (some spec') fn attrs
         | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@@spec]: {msg}")
-    | "spec", none => err loc (.unsupportedFeature "[@@spec] expects a specification payload")
+    | "spec", none =>
+      err attr.loc (.unsupportedFeature "[@@spec] expects a specification payload")
     | "fn", none =>
-      if fn then err loc (.unsupportedFeature "a declaration carries at most one [@@fn]")
-      else elaborateValAttrs env loc spec true attrs
+      if fn then err attr.loc (.unsupportedFeature "a declaration carries at most one [@@fn]")
+      else elaborateValAttrs env spec true attrs
     | "fn", some payload => err payload.loc (.unsupportedFeature
         "[@@fn] takes no payload; the function's own name is used for the relation")
-    | name, _ => err loc (.unsupportedFeature s!"unknown declaration attribute [@@{name}]")
+    | name, _ =>
+      err attr.loc (.unsupportedFeature s!"unknown declaration attribute [@@{name}]")
 
 def Decl.elaborate (env : ElabEnv) (decl : Decl)
     : ElabM (ElabEnv × Option (Untyped.Decl Untyped.SpecBody)) := do
@@ -971,7 +976,7 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
     let (env', tdecl') ← TypeDecl.elaborate env decl.loc tdecl
     .ok (env', tdecl'.map Untyped.Decl.type_)
   | .val_ isRec binders retTy body => do
-    let (spec, fn) ← elaborateValAttrs env decl.loc none false decl.attrs
+    let (spec, fn) ← elaborateValAttrs env none false decl.attrs
     let d ← ValDecl.elaborate env decl.loc isRec binders retTy body spec
     -- A `[@@fn]` declaration uses its own name for the derived relation.
     let relation ← if fn then

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -691,11 +691,21 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
   | .letIn isRec binders retTy bound body =>
     match binders with
     | [] => err loc (.unsupportedFeature "let with no binders")
-    | [pat] => do
-      let bound' ← Expr.elaborate env bound
-      if isRec then
-        err loc (.unsupportedFeature "let rec requires function arguments")
-      else
+    | [pat] =>
+      if isRec then do
+        -- `let rec f : T = fun x -> ... in ...`: the literal's self-reference
+        -- is the let's own name, so recursive calls go through its type. The
+        -- same shape a recursive declaration gets.
+        let name ← patternToBinder env pat
+        let name ← annotateBinder loc name (← elaborateOptTyp env retTy)
+        let bound' ← Expr.elaborate (env.bindPattern pat) bound
+        match bound' with
+        | .fix .none args retTy' inner => do
+          let body' ← Expr.elaborate (env.bindPattern pat) body
+          .ok (.letIn name (.fix name args retTy' inner) body')
+        | _ => err loc (.unsupportedFeature "let rec requires a function")
+      else do
+        let bound' ← Expr.elaborate env bound
         let body' ← Expr.elaborate (env.bindPattern pat) body
         if isProductPattern pat then
           if retTy.isSome then

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -946,29 +946,35 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
 -- ---------------------------------------------------------------------------
 -- Program elaboration
 
-/-- The attributes of a value declaration: the specification `[@@spec]` carries,
-and whether `[@@fn]` marks it as a spec-level function. Every attribute is
-accounted for — an unknown name is rejected, and neither may be written twice,
-so no attribute is silently ignored. `[@@fn]` takes no payload; the function's
-own name is used for the derived relation. -/
-private def elaborateValAttrs (env : ElabEnv) :
-    Option Untyped.SpecBody → Bool → List Attribute → ElabM (Option Untyped.SpecBody × Bool)
-  | spec, fn, [] => .ok (spec, fn)
-  | spec, fn, attr :: attrs =>
+/-- What a value declaration's attributes say about it. -/
+private structure ValAttrs where
+  /-- The specification `[@@spec]` carries. -/
+  spec : Option Untyped.SpecBody := none
+  /-- Whether `[@@fn]` registers it as a spec-level function. The attribute
+  takes no payload; the function's own name is used for the derived relation. -/
+  fn : Bool := false
+
+/-- Read a value declaration's attributes. Every attribute is accounted for —
+an unknown name is rejected, and neither may be written twice — so none is
+silently ignored. -/
+private def elaborateValAttrs (env : ElabEnv) (acc : ValAttrs) :
+    List Attribute → ElabM ValAttrs
+  | [] => .ok acc
+  | attr :: attrs =>
     match attr.name, attr.payload with
     | "spec", some payload =>
-      if spec.isSome then
+      if acc.spec.isSome then
         err attr.loc (.unsupportedFeature "a declaration carries at most one [@@spec]")
       else do
         let e ← Expr.elaborate env payload
         match Spec.parse e with
-        | .ok spec' => elaborateValAttrs env (some spec') fn attrs
+        | .ok spec => elaborateValAttrs env { acc with spec := some spec } attrs
         | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@@spec]: {msg}")
     | "spec", none =>
       err attr.loc (.unsupportedFeature "[@@spec] expects a specification payload")
     | "fn", none =>
-      if fn then err attr.loc (.unsupportedFeature "a declaration carries at most one [@@fn]")
-      else elaborateValAttrs env spec true attrs
+      if acc.fn then err attr.loc (.unsupportedFeature "a declaration carries at most one [@@fn]")
+      else elaborateValAttrs env { acc with fn := true } attrs
     | "fn", some payload => err payload.loc (.unsupportedFeature
         "[@@fn] takes no payload; the function's own name is used for the relation")
     | name, _ =>
@@ -986,10 +992,10 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
     let (env', tdecl') ← TypeDecl.elaborate env decl.loc tdecl
     .ok (env', tdecl'.map Untyped.Decl.type_)
   | .val_ isRec binders retTy body => do
-    let (spec, fn) ← elaborateValAttrs env none false decl.attrs
-    let d ← ValDecl.elaborate env decl.loc isRec binders retTy body spec
+    let attrs ← elaborateValAttrs env {} decl.attrs
+    let d ← ValDecl.elaborate env decl.loc isRec binders retTy body attrs.spec
     -- A `[@@fn]` declaration uses its own name for the derived relation.
-    let relation ← if fn then
+    let relation ← if attrs.fn then
       match d.name with
       | .named x _ => .ok (some x)
       | .none => err decl.loc (.unsupportedFeature "[@@fn] requires a named declaration")

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -265,6 +265,17 @@ private def nameBinder : Option Var → Untyped.Binder
   | none => .none
   | some name => .named name none
 
+/-- A `let` with no arguments has two places to write its type — on the binder
+pattern and after it — and they mean the same thing, so at most one may be
+used. -/
+private def annotateBinder (loc : Location) :
+    Untyped.Binder → Option Untyped.Typ → ElabM Untyped.Binder
+  | b, none => .ok b
+  | .named n none, some ty => .ok (.named n (some ty))
+  | .named _ (some _), some _ =>
+    err loc (.unsupportedFeature "a let is annotated once: on its binder or after it")
+  | .none, some _ => .ok .none
+
 mutual
 partial def elaborateOptTyp (env : ElabEnv) : Option Typ → ElabM (Option Untyped.Typ)
   | none => .ok none
@@ -693,10 +704,7 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
           -- With no arguments the annotation is the bound value's own type, so
           -- it lands on the binder and the bound expression is checked at it.
           let name ← patternToBinder env pat
-          let annot ← elaborateOptTyp env retTy
-          let name := match name, annot with
-            | .named n none, some ty => .named n (some ty)
-            | b, _ => b
+          let name ← annotateBinder loc name (← elaborateOptTyp env retTy)
           .ok (.letIn name bound' body')
     | pat :: args => do
       let name := nameBinder (← patternToName pat)
@@ -900,10 +908,7 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
     -- A declaration with no arguments: its annotation is the declaration's own
     -- type, which is where a `[@spec]` on it belongs.
     let name ← patternToBinder env pat
-    let annot ← elaborateOptTyp env retTy
-    let name := match name, annot with
-      | .named n none, some ty => .named n (some ty)
-      | b, _ => b
+    let name ← annotateBinder loc name (← elaborateOptTyp env retTy)
     if isRec then
       -- `let rec f : T = fun x -> ...`: the literal's self-reference is the
       -- declaration's own name, so recursive calls go through its type.

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -248,6 +248,23 @@ private def isProductPattern (pat : Pattern) : Bool :=
 private def productArgumentName (stem : String) (idx : Nat) : String :=
   s!"{stem}{idx}"
 
+/-- The name of a `let` that takes arguments — just the name, since there is no
+type to put on it: with arguments the annotation is the function's return type,
+written after them. An annotation here is rejected rather than silently dropped.
+(OCaml rejects the syntax outright.) -/
+def patternToName (pat : Pattern) : ElabM (Option Var) :=
+  match pat.kind with
+  | .wildcard => .ok none
+  | .binder _ (some _) =>
+    err pat.loc (.unsupportedFeature "a let with arguments cannot annotate its name")
+  | .binder name none => .ok name
+  | _ => err pat.loc (.unsupportedPattern "expected a simple binder (variable or wildcard)")
+
+/-- The binder a `let`'s name becomes: unannotated, by `patternToName`. -/
+private def nameBinder : Option Var → Untyped.Binder
+  | none => .none
+  | some name => .named name none
+
 mutual
 partial def elaborateOptTyp (env : ElabEnv) : Option Typ → ElabM (Option Untyped.Typ)
   | none => .ok none
@@ -256,14 +273,8 @@ partial def elaborateOptTyp (env : ElabEnv) : Option Typ → ElabM (Option Untyp
 -- ---------------------------------------------------------------------------
 -- Pattern helpers
 
-partial def patternToBinder (pat : Pattern) : ElabM Untyped.Binder :=
-  match pat.kind with
-  | .wildcard => .ok .none
-  | .binder (some name) _ => .ok (.named name none)
-  | .binder none _ => .ok .none
-  | _ => err pat.loc (.unsupportedPattern "expected a simple binder (variable or wildcard)")
-
-partial def patternToBinderTyped (env : ElabEnv) (pat : Pattern) : ElabM Untyped.Binder :=
+/-- A binder pattern together with the type it annotates, if any. -/
+partial def patternToBinder (env : ElabEnv) (pat : Pattern) : ElabM Untyped.Binder :=
   match pat.kind with
   | .wildcard => .ok .none
   | .binder none _ => .ok .none
@@ -276,7 +287,7 @@ partial def patternListToAnnotatedBinders (env : ElabEnv) :
     List Pattern → ElabM (List Untyped.Binder)
   | [] => .ok []
   | p :: ps => do
-    let b ← patternToBinderTyped env p
+    let b ← patternToBinder env p
     let bs ← patternListToAnnotatedBinders env ps
     .ok (b :: bs)
 
@@ -284,7 +295,7 @@ partial def patternRecordFieldsToBinders (env : ElabEnv)
     : List (FieldName × Pattern) → ElabM (List (FieldName × Untyped.Binder))
   | [] => .ok []
   | (name, pat) :: rest => do
-      let binder ← patternToBinderTyped env pat
+      let binder ← patternToBinder env pat
       let binders ← patternRecordFieldsToBinders env rest
       .ok ((name, binder) :: binders)
 
@@ -339,7 +350,7 @@ partial def elaborateFunctionArgs (env : ElabEnv) (stem : String) :
         let names ← patternToProductBinders env pat
         .ok (.named argName (some argTy) :: restArgs, .letProd names (.var argName) restBody)
       else
-        let arg ← patternToBinderTyped env pat
+        let arg ← patternToBinder env pat
         .ok (arg :: restArgs, restBody)
 
 /-- Elaborate a surface type into the untyped IR's type language: lower its
@@ -681,14 +692,14 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
         else do
           -- With no arguments the annotation is the bound value's own type, so
           -- it lands on the binder and the bound expression is checked at it.
-          let name ← patternToBinderTyped env pat
+          let name ← patternToBinder env pat
           let annot ← elaborateOptTyp env retTy
           let name := match name, annot with
             | .named n none, some ty => .named n (some ty)
             | b, _ => b
           .ok (.letIn name bound' body')
     | pat :: args => do
-      let name ← patternToBinder pat
+      let name := nameBinder (← patternToName pat)
       let self := if isRec then name else .none
       let boundEnv := env.bindPatterns args
       let boundEnv := if isRec then boundEnv.bindPattern pat else boundEnv
@@ -791,7 +802,7 @@ partial def MatchArm.elaborateList (env : ElabEnv)
                 if isProductPattern p then
                   err p.loc (.unsupportedPattern "constructor payload is not a product")
                 else do
-                  let b ← patternToBinderTyped env p
+                  let b ← patternToBinder env p
                   pure (some b, body')
           | none =>
             let body' ← Expr.elaborate env body
@@ -803,13 +814,6 @@ partial def MatchArm.elaborateList (env : ElabEnv)
     let rest ← MatchArm.elaborateList env arms
     .ok ((ctorName, binder, body'') :: rest)
 
-partial def Pattern.toAnnotatedBinders (env : ElabEnv)
-    : List Pattern → ElabM (List Untyped.Binder)
-  | [] => .ok []
-  | p :: ps => do
-    let b ← patternToBinderTyped env p
-    let bs ← Pattern.toAnnotatedBinders env ps
-    .ok (b :: bs)
 end
 
 -- ---------------------------------------------------------------------------
@@ -895,7 +899,7 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
   | [pat] =>
     -- A declaration with no arguments: its annotation is the declaration's own
     -- type, which is where a `[@spec]` on it belongs.
-    let name ← patternToBinderTyped env pat
+    let name ← patternToBinder env pat
     let annot ← elaborateOptTyp env retTy
     let name := match name, annot with
       | .named n none, some ty => .named n (some ty)
@@ -912,7 +916,7 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
       let body' ← Expr.elaborate env body
       .ok { name, body := body', spec }
   | pat :: args =>
-    let name ← patternToBinder pat
+    let name := nameBinder (← patternToName pat)
     let self := if isRec then name else .none
     let retTy' ← elaborateOptTyp env retTy
     let bodyEnv := env.bindPatterns args

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -681,7 +681,7 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
         else do
           -- With no arguments the annotation is the bound value's own type, so
           -- it lands on the binder and the bound expression is checked at it.
-          let name ← patternToBinder pat
+          let name ← patternToBinderTyped env pat
           let annot ← elaborateOptTyp env retTy
           let name := match name, annot with
             | .named n none, some ty => .named n (some ty)
@@ -791,7 +791,7 @@ partial def MatchArm.elaborateList (env : ElabEnv)
                 if isProductPattern p then
                   err p.loc (.unsupportedPattern "constructor payload is not a product")
                 else do
-                  let b ← patternToBinder p
+                  let b ← patternToBinderTyped env p
                   pure (some b, body')
           | none =>
             let body' ← Expr.elaborate env body
@@ -895,7 +895,7 @@ def ValDecl.elaborate (env : ElabEnv) (loc : Location)
   | [pat] =>
     -- A declaration with no arguments: its annotation is the declaration's own
     -- type, which is where a `[@spec]` on it belongs.
-    let name ← patternToBinder pat
+    let name ← patternToBinderTyped env pat
     let annot ← elaborateOptTyp env retTy
     let name := match name, annot with
       | .named n none, some ty => .named n (some ty)

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -218,12 +218,12 @@ per supported expression attribute; unknown names are rejected here (mirroring
 how `[@@...]` names are validated). -/
 private def applyAttr (e : Untyped.Expr) (attr : Attribute) : ElabM Untyped.Expr :=
   match attr.name, attr.payload with
-  | "owned", none =>
+  | .owned, none =>
       match e with
       | .ref _ inner => .ok (.ref .owned inner)
       | .arrayMake _ len init => .ok (.arrayMake .owned len init)
       | _ => err attr.loc (.unsupportedFeature "[@owned] only applies to 'ref' or 'Array.make'")
-  | "owned", some payload => err payload.loc (.unsupportedFeature "[@owned] takes no payload")
+  | .owned, some payload => err payload.loc (.unsupportedFeature "[@owned] takes no payload")
   | name, _ => err attr.loc (.unsupportedFeature s!"unknown expression attribute [@{name}]")
 
 private def bareSpecial (loc : Location) (path : Path) : ElabM Untyped.Expr :=
@@ -389,14 +389,14 @@ owned `owned A` (mirroring how the expression-level `[@owned]` validates
 partial def Typ.applyAttr (env : ElabEnv) (t : Untyped.Typ) (attr : Attribute) :
     ElabM Untyped.Typ :=
   match attr.name, attr.payload with
-  | "owned", none =>
+  | .owned, none =>
     match t with
     | .ref inner => .ok (.owned inner)
     | .array inner => .ok (.ownedArray inner)
     | _ => err attr.loc (.unsupportedFeature "[@owned] only applies to a 'ref' or 'array' type")
-  | "owned", some payload => err payload.loc (.unsupportedFeature "[@owned] takes no payload")
-  | "spec", none => err attr.loc (.unsupportedFeature "[@spec] expects a specification payload")
-  | "spec", some payload => do
+  | .owned, some payload => err payload.loc (.unsupportedFeature "[@owned] takes no payload")
+  | .spec, none => err attr.loc (.unsupportedFeature "[@spec] expects a specification payload")
+  | .spec, some payload => do
     let e ← Expr.elaborate env payload
     match Spec.parse e with
     | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@spec]: {msg}")
@@ -962,7 +962,7 @@ private def elaborateValAttrs (env : ElabEnv) (acc : ValAttrs) :
   | [] => .ok acc
   | attr :: attrs =>
     match attr.name, attr.payload with
-    | "spec", some payload =>
+    | .spec, some payload =>
       if acc.spec.isSome then
         err attr.loc (.unsupportedFeature "a declaration carries at most one [@@spec]")
       else do
@@ -970,12 +970,12 @@ private def elaborateValAttrs (env : ElabEnv) (acc : ValAttrs) :
         match Spec.parse e with
         | .ok spec => elaborateValAttrs env { acc with spec := some spec } attrs
         | .error msg => err payload.loc (.unsupportedFeature s!"invalid [@@spec]: {msg}")
-    | "spec", none =>
+    | .spec, none =>
       err attr.loc (.unsupportedFeature "[@@spec] expects a specification payload")
-    | "fn", none =>
+    | .fn, none =>
       if acc.fn then err attr.loc (.unsupportedFeature "a declaration carries at most one [@@fn]")
       else elaborateValAttrs env { acc with fn := true } attrs
-    | "fn", some payload => err payload.loc (.unsupportedFeature
+    | .fn, some payload => err payload.loc (.unsupportedFeature
         "[@@fn] takes no payload; the function's own name is used for the relation")
     | name, _ =>
       err attr.loc (.unsupportedFeature s!"unknown declaration attribute [@@{name}]")

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -187,7 +187,7 @@ private partial def parseTypeAttr : Parser Attribute := fun st => do
       let (e, st) ← parseExpr st
       .ok (some e, st)
   let st ← expect .rbracket st
-  .ok ({ loc := spanTo p st, name, payload }, st)
+  .ok ({ loc := spanTo p st, name := AttrName.ofString name, payload }, st)
 
 -- Fold trailing type attributes `T [@name payload]` into `T.attrs`.
 private partial def parseTypeAttrSuffix (t : Typ) : Parser Typ := fun st =>
@@ -614,7 +614,7 @@ where
         let (e, st) ← parseExpr st
         .ok (some e, st)
     let st ← expect .rbracket st
-    .ok ({ loc := spanTo p st, name, payload }, st)
+    .ok ({ loc := spanTo p st, name := AttrName.ofString name, payload }, st)
 
   parseAppRest (fn : Expr) : Parser Expr := fun st => do
     let (args, st) ← collectArgs st
@@ -985,7 +985,7 @@ where
             let (e, st') ← parseExpr st'
             .ok (some e, st')
         let st' ← expect .rbracket st'
-        let attr : Attribute := { loc := spanTo p st', name, payload }
+        let attr : Attribute := { loc := spanTo p st', name := AttrName.ofString name, payload }
         let (rest, st') ← parseAttrs st'
         .ok (attr :: rest, st')
       | _ => .ok ([], st)

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -177,6 +177,7 @@ private def isPatStart : Token → Bool
 mutual
 -- `[@name expr]` — single `@`, optional expression payload.
 private partial def parseTypeAttr : Parser Attribute := fun st => do
+  let p := peekLoc st
   let st ← expect .lbracket st
   let st ← expect .at st
   let (name, st) ← expectIdent st
@@ -186,7 +187,7 @@ private partial def parseTypeAttr : Parser Attribute := fun st => do
       let (e, st) ← parseExpr st
       .ok (some e, st)
   let st ← expect .rbracket st
-  .ok ({ name, payload }, st)
+  .ok ({ loc := spanTo p st, name, payload }, st)
 
 -- Fold trailing type attributes `T [@name payload]` into `T.attrs`.
 private partial def parseTypeAttrSuffix (t : Typ) : Parser Typ := fun st =>
@@ -603,6 +604,7 @@ where
 
   -- `[@name expr]` — single `@`, optional expression payload.
   parseExprAttr : Parser Attribute := fun st => do
+    let p := peekLoc st
     let st ← expect .lbracket st
     let st ← expect .at st
     let (name, st) ← expectIdent st
@@ -612,7 +614,7 @@ where
         let (e, st) ← parseExpr st
         .ok (some e, st)
     let st ← expect .rbracket st
-    .ok ({ name, payload }, st)
+    .ok ({ loc := spanTo p st, name, payload }, st)
 
   parseAppRest (fn : Expr) : Parser Expr := fun st => do
     let (args, st) ← collectArgs st
@@ -972,6 +974,7 @@ where
     | .lbracket =>
       match (advance st |> peekTok) with
       | .atat => do
+        let p := peekLoc st
         let st' := advance (advance st)  -- skip `[` and `@@`
         let (name, st') ← expectIdent st'
         -- An attribute may carry an expression payload (`[@@spec ...]`) or
@@ -982,8 +985,9 @@ where
             let (e, st') ← parseExpr st'
             .ok (some e, st')
         let st' ← expect .rbracket st'
+        let attr : Attribute := { loc := spanTo p st', name, payload }
         let (rest, st') ← parseAttrs st'
-        .ok ({ name, payload } :: rest, st')
+        .ok (attr :: rest, st')
       | _ => .ok ([], st)
     | _ => .ok ([], st)
 

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -273,8 +273,8 @@ partial def Expr.print (e : Expr) : String := Expr.printPrec e 0
 partial def Decl.print (d : Decl) : String :=
   let attrsStr := d.attrs.map fun attr =>
     match attr.payload with
-    | none => "\n[@@" ++ attr.name ++ "]"
-    | some payload => "\n[@@" ++ attr.name ++ " " ++ Expr.print payload ++ "]"
+    | none => "\n[@@" ++ toString attr.name ++ "]"
+    | some payload => "\n[@@" ++ toString attr.name ++ " " ++ Expr.print payload ++ "]"
   let attrsSuffix := joinWith "" attrsStr
   match d.kind with
   | .open_ path => "open " ++ path.toString

--- a/Tests/frontend/decl_annotation_twice.ml
+++ b/Tests/frontend/decl_annotation_twice.ml
@@ -1,0 +1,6 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* The same for a declaration. *)
+let (x : int) : bool = 3

--- a/Tests/frontend/decl_annotation_twice.out
+++ b/Tests/frontend/decl_annotation_twice.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/decl_annotation_twice.ml:6:1: unsupported feature: a let is annotated once: on its binder or after it
+[1]

--- a/Tests/frontend/decl_annotation_with_arguments.ml
+++ b/Tests/frontend/decl_annotation_with_arguments.ml
@@ -1,0 +1,8 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* A declaration that takes arguments annotates its return type after them, so
+   there is nothing for an annotation on its name to mean. It is rejected
+   rather than silently dropped. OCaml rejects the syntax outright. *)
+let (f : bool) (n : int) : int = n

--- a/Tests/frontend/decl_annotation_with_arguments.out
+++ b/Tests/frontend/decl_annotation_with_arguments.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/decl_annotation_with_arguments.ml:8:6: unsupported feature: a let with arguments cannot annotate its name
+[1]

--- a/Tests/frontend/decl_attribute_unknown.ml
+++ b/Tests/frontend/decl_attribute_unknown.ml
@@ -1,0 +1,8 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* Every declaration attribute is accounted for: an unknown name is rejected
+   rather than silently ignored. *)
+let f (n : int) : int = n
+[@@bogus]

--- a/Tests/frontend/decl_attribute_unknown.out
+++ b/Tests/frontend/decl_attribute_unknown.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/decl_attribute_unknown.ml:7:1: unsupported feature: unknown declaration attribute [@@bogus]
+[1]

--- a/Tests/frontend/decl_attribute_unknown.out
+++ b/Tests/frontend/decl_attribute_unknown.out
@@ -1,2 +1,2 @@
-elaboration error: Tests/frontend/decl_attribute_unknown.ml:7:1: unsupported feature: unknown declaration attribute [@@bogus]
+elaboration error: Tests/frontend/decl_attribute_unknown.ml:8:1: unsupported feature: unknown declaration attribute [@@bogus]
 [1]

--- a/Tests/frontend/decl_fn_twice.ml
+++ b/Tests/frontend/decl_fn_twice.ml
@@ -1,0 +1,8 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* The same for [@@fn]. *)
+let f (n : int) : int = n
+[@@fn]
+[@@fn]

--- a/Tests/frontend/decl_fn_twice.out
+++ b/Tests/frontend/decl_fn_twice.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/decl_fn_twice.ml:6:1: unsupported feature: a declaration carries at most one [@@fn]
+[1]

--- a/Tests/frontend/decl_fn_twice.out
+++ b/Tests/frontend/decl_fn_twice.out
@@ -1,2 +1,2 @@
-elaboration error: Tests/frontend/decl_fn_twice.ml:6:1: unsupported feature: a declaration carries at most one [@@fn]
+elaboration error: Tests/frontend/decl_fn_twice.ml:8:1: unsupported feature: a declaration carries at most one [@@fn]
 [1]

--- a/Tests/frontend/decl_spec_no_payload.ml
+++ b/Tests/frontend/decl_spec_no_payload.ml
@@ -1,0 +1,8 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* An attribute error points at the attribute: [@@spec] without a payload is
+   reported where it is written, not at the start of the file. *)
+let f (n : int) : int = n
+[@@spec]

--- a/Tests/frontend/decl_spec_no_payload.out
+++ b/Tests/frontend/decl_spec_no_payload.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/decl_spec_no_payload.ml:8:1: unsupported feature: [@@spec] expects a specification payload
+[1]

--- a/Tests/frontend/decl_spec_twice.ml
+++ b/Tests/frontend/decl_spec_twice.ml
@@ -1,0 +1,9 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* A declaration is specified once. A second [@@spec] is rejected rather than
+   ignored in favour of the first. *)
+let f (n : int) : int = n
+[@@spec fun n -> ret (fun r -> assert (r = n))]
+[@@spec fun n -> ret (fun r -> assert (r = n + 1))]

--- a/Tests/frontend/decl_spec_twice.out
+++ b/Tests/frontend/decl_spec_twice.out
@@ -1,2 +1,2 @@
-elaboration error: Tests/frontend/decl_spec_twice.ml:9:9: unsupported feature: a declaration carries at most one [@@spec]
+elaboration error: Tests/frontend/decl_spec_twice.ml:9:1: unsupported feature: a declaration carries at most one [@@spec]
 [1]

--- a/Tests/frontend/decl_spec_twice.out
+++ b/Tests/frontend/decl_spec_twice.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/decl_spec_twice.ml:9:9: unsupported feature: a declaration carries at most one [@@spec]
+[1]

--- a/Tests/frontend/expr_type_assignment.ml
+++ b/Tests/frontend/expr_type_assignment.ml
@@ -1,0 +1,11 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* KNOWN GAP (#155): a type assignment `(e : t)` is dropped during elaboration,
+   so the type it names is never checked and a [@spec] written in it is lost.
+   This file pins that behaviour: `(n : bool)` on an `int` is accepted, where
+   the same annotation on the binder is rejected (pattern_annotation_mismatch). *)
+let f (n : int) : int =
+  (n : bool)
+[@@spec fun n -> ret (fun r -> assert (r = n))]

--- a/Tests/frontend/expr_type_assignment.out
+++ b/Tests/frontend/expr_type_assignment.out
@@ -1,0 +1,1 @@
+Status: all declarations verified

--- a/Tests/frontend/let_annotation_twice.ml
+++ b/Tests/frontend/let_annotation_twice.ml
@@ -1,0 +1,11 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* A `let` with no arguments has two places to write its type — on the binder
+   pattern and after it — and they mean the same thing, so writing both is
+   rejected rather than one of them being dropped. *)
+let f (n : int) : int =
+  let (b : int) : bool = n in
+  0
+[@@spec fun n -> ret (fun r -> assert (r = 0))]

--- a/Tests/frontend/let_annotation_twice.out
+++ b/Tests/frontend/let_annotation_twice.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/let_annotation_twice.ml:9:3: unsupported feature: a let is annotated once: on its binder or after it
+[1]

--- a/Tests/frontend/let_annotation_with_arguments.ml
+++ b/Tests/frontend/let_annotation_with_arguments.ml
@@ -1,0 +1,9 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* The same for a local `let`. *)
+let f (n : int) : int =
+  let (bump : bool) (x : int) : int = x + 1 in
+  bump n
+[@@spec fun n -> ret (fun r -> assert (r = n + 1))]

--- a/Tests/frontend/let_annotation_with_arguments.out
+++ b/Tests/frontend/let_annotation_with_arguments.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/let_annotation_with_arguments.ml:7:8: unsupported feature: a let with arguments cannot annotate its name
+[1]

--- a/Tests/frontend/match_annotation_mismatch.ml
+++ b/Tests/frontend/match_annotation_mismatch.ml
@@ -1,0 +1,13 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* A constructor payload's annotation is checked against the payload type the
+   constructor was declared with. *)
+type option_int = Absent | Present of int
+
+let f (opt : option_int) : int =
+  match opt with
+  | Absent -> 0
+  | Present (x : bool) -> 0
+[@@spec fun opt -> ret (fun r -> assert (r = 0))]

--- a/Tests/frontend/match_annotation_mismatch.out
+++ b/Tests/frontend/match_annotation_mismatch.out
@@ -1,0 +1,2 @@
+Status: failed: subsumption failed: TinyML.Typ.prim (TinyML.PrimitiveType.int) is not a subtype of TinyML.Typ.prim (TinyML.PrimitiveType.bool)
+[1]

--- a/Tests/frontend/pattern_annotation.ml
+++ b/Tests/frontend/pattern_annotation.ml
@@ -1,0 +1,38 @@
+(* TEST: roundtrip *)
+
+open Mica
+
+(* An annotation written on the binder pattern is the annotation written after
+   the binder: both give the bound value's own type. *)
+
+let on_local (n : int) : int =
+  let (b : int) = n + 1 in
+  b
+[@@spec fun n -> ret (fun r -> assert (r = n + 1))]
+
+(* So a pattern annotation carries a [@spec] exactly as the keyword form does:
+   the specification lands on the arrow it annotates. *)
+
+let (double : (int -> int) [@spec fun x -> ret (fun r -> assert (r = x * 2))]) =
+  fun x -> x * 2
+
+let use_double (n : int) : int = double n
+[@@spec fun n -> ret (fun r -> assert (r = n * 2))]
+
+let on_local_spec (n : int) : int =
+  let (triple : (int -> int) [@spec fun x -> ret (fun r -> assert (r = x * 3))]) =
+    fun x -> x * 3 in
+  triple n
+[@@spec fun n -> ret (fun r -> assert (r = n * 3))]
+
+(* A constructor payload is annotated in the match arm itself. *)
+
+type option_int = Absent | Present of int
+
+let payload_or_zero (opt : option_int) : int =
+  match opt with
+  | Absent -> 0
+  | Present (x : int) -> x
+[@@spec fun opt ->
+  bind (isinj 1 2 opt) @@ fun (payload : int) ->
+  ret (fun v -> assert (v = payload))]

--- a/Tests/frontend/pattern_annotation_mismatch.ml
+++ b/Tests/frontend/pattern_annotation_mismatch.ml
@@ -1,0 +1,10 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* A pattern annotation is checked, like the annotation written after the
+   binder: the bound expression has to have that type. *)
+let f (n : int) : int =
+  let (b : bool) = n in
+  0
+[@@spec fun n -> ret (fun r -> assert (r = 0))]

--- a/Tests/frontend/pattern_annotation_mismatch.out
+++ b/Tests/frontend/pattern_annotation_mismatch.out
@@ -1,0 +1,2 @@
+Status: failed: subsumption failed: TinyML.Typ.prim (TinyML.PrimitiveType.int) is not a subtype of TinyML.Typ.prim (TinyML.PrimitiveType.bool)
+[1]

--- a/Tests/frontend/unit_parameter.ml
+++ b/Tests/frontend/unit_parameter.ml
@@ -1,0 +1,13 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* KNOWN GAP (#156): `()` is not accepted in a binder position — not as a parameter
+   (`let f () = e`, `fun () -> e`) and not as a `let` pattern (`let () = e`).
+   This file pins that behaviour.
+
+   The fix is to elaborate `()` as an empty product, which needs unit support
+   in `letProd`: the typing rule, the operational semantics, the weakest
+   precondition, and the verifier all key on a tuple value today. *)
+let f () : int = 3
+[@@spec fun u -> ret (fun r -> assert (r = 3))]

--- a/Tests/frontend/unit_parameter.out
+++ b/Tests/frontend/unit_parameter.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/unit_parameter.ml:12:7: unsupported pattern: expected a simple binder (variable or wildcard)
+[1]

--- a/Tests/functions/local_let_rec.ml
+++ b/Tests/functions/local_let_rec.ml
@@ -1,0 +1,14 @@
+(* TEST: roundtrip *)
+
+open Mica
+
+(* A local recursive function is specified through its own type, exactly as a
+   recursive declaration is: the self-reference is typed at the specified
+   arrow, so the recursive call goes through the specification. *)
+let count_down (n : int) : int =
+  let rec go : (int -> int) [@spec fun i ->
+                  assert (i >= 0);
+                  ret (fun r -> assert (r = 0))] =
+    fun i -> if i <= 0 then 0 else go (i - 1) in
+  if n >= 0 then go n else 0
+[@@spec fun n -> ret (fun r -> assert (r = 0))]

--- a/Tests/functions/local_let_rec_non_function.ml
+++ b/Tests/functions/local_let_rec_non_function.ml
@@ -1,0 +1,10 @@
+(* TEST: no-compile *)
+
+open Mica
+
+(* A `let rec` with no arguments has to bind a function literal; there is
+   nothing for the self-reference to mean otherwise. *)
+let f (n : int) : int =
+  let rec x = 3 in
+  x
+[@@spec fun n -> ret (fun r -> assert (r = 3))]

--- a/Tests/functions/local_let_rec_non_function.out
+++ b/Tests/functions/local_let_rec_non_function.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/functions/local_let_rec_non_function.ml:8:3: unsupported feature: let rec requires a function
+[1]

--- a/Tests/spec_types/spec_binds_tightly.out
+++ b/Tests/spec_types/spec_binds_tightly.out
@@ -1,2 +1,2 @@
-elaboration error: Tests/spec_types/spec_binds_tightly.ml:6:19: unsupported feature: [@spec] only applies to a function type
+elaboration error: Tests/spec_types/spec_binds_tightly.ml:6:23: unsupported feature: [@spec] only applies to a function type
 [1]

--- a/Tests/spec_types/spec_on_non_arrow.out
+++ b/Tests/spec_types/spec_on_non_arrow.out
@@ -1,2 +1,2 @@
-elaboration error: Tests/spec_types/spec_on_non_arrow.ml:5:12: unsupported feature: [@spec] only applies to a function type
+elaboration error: Tests/spec_types/spec_on_non_arrow.ml:5:16: unsupported feature: [@spec] only applies to a function type
 [1]

--- a/Tests/spec_types/spec_twice.out
+++ b/Tests/spec_types/spec_twice.out
@@ -1,2 +1,2 @@
-elaboration error: Tests/spec_types/spec_twice.ml:4:14: unsupported feature: a function type carries at most one [@spec]
+elaboration error: Tests/spec_types/spec_twice.ml:5:26: unsupported feature: a function type carries at most one [@spec]
 [1]


### PR DESCRIPTION
Closes the frontend gaps where an annotation or an attribute was silently dropped, and makes local recursion usable.

- A type annotation written on a `let` pattern (`let (x : T) = e`) or on a match-arm payload is honored instead of discarded, so a wrong type is caught and a `[@spec]` written there is not lost.
- An annotation on the name of a `let` that takes arguments is rejected rather than dropped, since the annotation there is the return type written after the arguments (and OCaml rejects the syntax outright).
- A `let` with no arguments that is annotated both on its binder and after it is rejected, instead of the second annotation being silently dropped.
- Every attribute on a value declaration is accounted for: an unknown name is rejected, and neither `[@@spec]` nor `[@@fn]` may be written twice.
- An attribute carries its own source location, so an attribute error points at the attribute rather than at the declaration or at `:0:0`.
- A local `let rec` binding a function literal is supported, which was the only way to give a local recursive function a specification and so the only way to write one at all.
- A declaration's attributes are collected in a record rather than threaded as separate arguments and returned as a tuple.
- Attribute names are a variant type rather than matched as strings.
- Two gaps are pinned by tests rather than fixed: a type assignment `(e : t)` is still dropped (#155) and `()` is still rejected in a binder position (#156).
