### PR TITLE
Rewrite the parser

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Run the testsuite
         run: opam exec -- lake run testsuite
 
+      # Differential parser tests: mica's parse of a generated corpus against
+      # OCaml's, with `Tests/parser/parser-diff.baseline` as the expected state.
+      - name: Run the differential parser tests
+        run: opam exec -- lake run parser-diff
+
   check-outlines:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ lake run testsuite                # run the test suite (Examples/ and Tests/)
 
 `Examples/` is reserved for case studies; everything else goes in `Tests/<feature>/`. When adding tests for new functionality, lean toward small targeted files in `Tests/`. A test is one `.ml` file; the runner (`Testsuite.lean`) compiles it with ocamlopt and runs mica on it. An optional first-line directive `(* TEST: <flags> [no-compile] [roundtrip] *)` passes flags to mica, skips the ocamlopt phase, or adds a print∘parse fixpoint check of `--print-ocaml`. Without a sibling `foo.out`, the mica run must exit 0; with one, the output must match it (nonzero exits end with a `[<code>]` line). `lake run testsuite --promote PATH` rewrites existing `.out` files with the actual output; create a new expected-output test with `touch foo.out` followed by `--promote`.
 
+### Differential parser tests
+
+`lake run parser-diff` checks mica's parse of a generated precedence corpus
+against OCaml's, using `ocamlc -stop-after parsing -dsource` as the oracle.
+`Tests/parser/parser-diff.baseline` records the expected state: a refactor that
+changes nothing must leave it untouched, and a fix must shrink it by exactly what
+it claims to fix. `--promote` rewrites it. See `Testsuite/ParserDiff.lean`.
+
 **MCP Tools**
 - `lean_diagnostic_messages` after proof work, check for errors (filter to the declaration)
 

--- a/Main.lean
+++ b/Main.lean
@@ -1,5 +1,6 @@
 import Mica.SourceTinyML.Untyped
 import Mica.SourceTinyML.Printer
+import Mica.Frontend.ParenPrinter
 import Mica.Frontend.Parser
 import Mica.Frontend.Printer
 import Mica.Frontend.Elaborate
@@ -16,6 +17,8 @@ private structure Options where
   ansi        : Bool := true
   printOcaml  : Bool := false
   printTinyML : Bool := false
+  parseOnly   : Bool := false
+  parens      : Bool := false
   smtCmdsOnly : Bool := false
   file        : Option String := none
   error       : Option String := none
@@ -34,6 +37,10 @@ private def parseArgs : List String → Options → Options
     parseArgs rest { opts with printOcaml := true }
   | "--print-tiny-ml" :: rest, opts =>
     parseArgs rest { opts with printTinyML := true }
+  | "--parse-only" :: rest, opts =>
+    parseArgs rest { opts with parseOnly := true, printOcaml := true }
+  | "--parens" :: rest, opts =>
+    parseArgs rest { opts with parens := true }
   | "--smt-commands-only" :: rest, opts =>
     parseArgs rest { opts with smtCmdsOnly := true }
   | arg :: rest, opts =>
@@ -61,7 +68,7 @@ def main (args : List String) : IO Unit := do
     IO.Process.exit 1
   match opts.file with
   | none => do
-    IO.eprintln "usage: mica [--verbose] [--no-check] [--ansi|--no-ansi] [--print-ocaml] [--print-tiny-ml] [--smt-commands-only] <file.ml>"
+    IO.eprintln "usage: mica [--verbose] [--no-check] [--ansi|--no-ansi] [--print-ocaml] [--print-tiny-ml] [--parse-only] [--parens] [--smt-commands-only] <file.ml>"
     IO.Process.exit 1
   | some filename => do
     let contents ← IO.FS.readFile filename
@@ -71,7 +78,11 @@ def main (args : List String) : IO Unit := do
         IO.eprintln s!"parse error: {e}"
         IO.Process.exit 1
     if opts.printOcaml then
-      IO.println (Frontend.Program.print frontendProg)
+      IO.println <|
+        if opts.parens then Frontend.Program.printParen frontendProg
+        else Frontend.Program.print frontendProg
+    if opts.parseOnly then
+      return
     let untypedProg ← match Frontend.Program.elaborate Stdlib.stdResolver frontendProg with
       | .ok prog => pure prog
       | .error e => do

--- a/Mica/Frontend.lean
+++ b/Mica/Frontend.lean
@@ -3,6 +3,7 @@
 import Mica.Frontend.AST
 import Mica.Frontend.Elaborate
 import Mica.Frontend.Lexer
+import Mica.Frontend.ParenPrinter
 import Mica.Frontend.Parser
 import Mica.Frontend.Printer
 import Mica.Frontend.Resolver

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -147,6 +147,18 @@ def Prec.access : Nat := Prec.app + 1
 `!r.contents` is `(!r).contents` and `!f x` is `(!f) x`. -/
 def Prec.prefixOp : Nat := Prec.access + 1
 
+/-! Patterns have their own two levels, numbered separately from the expression
+ones above: `::` and, tighter, a constructor payload. The parser spells them out
+as one function per level rather than climbing them, so these are for the
+printer to parenthesize against. -/
+
+/-- Infix `::` in a pattern, right-associative. -/
+def Prec.patCons : Nat := 1
+
+/-- Constructor application in a pattern. Its payload is an atom, so `A B x` is
+not a pattern. -/
+def Prec.patApp : Nat := 2
+
 -- Attributes
 
 /-- The name of an attribute `[@name]`. Which names are meaningful depends on

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -95,9 +95,9 @@ them. Keeping a second copy anywhere is what let the two drift apart.
 The levels are OCaml's, renumbered to start at 1, following the operator
 table in §7.1 of the OCaml manual.
 
-Two levels outside the table are named below because both consumers need them.
-OCaml's comma level, between `||` and `:=`, is absent: tuples are built by their
-own production rather than by the operator loop. -/
+The levels outside the binary table are named below because both consumers need
+them. OCaml's comma level, between `||` and `:=`, is absent: tuples are built by
+their own production rather than by the operator loop. -/
 
 /-- Precedence of a binary operator; a higher level binds tighter. -/
 def BinOp.level : BinOp → Nat
@@ -133,9 +133,19 @@ def BinOp.operandLevels (op : BinOp) : Nat × Nat :=
 puts `if` above `;`, so `if a then b else c; d` sequences the whole `if`. -/
 def Prec.noSemi : Nat := BinOp.level .semi + 1
 
-/-- Tighter than every binary operator: application, the prefix operators, and
-the postfix forms `e.f` and `e.(i)`. -/
+/-- Function application, and with it the two unary forms that bind exactly as
+loosely: prefix `-`, whose operand is an application, and `assert`, which sits
+here but takes a single operand at `Prec.access`. Tighter than every binary
+operator, so `- a * b` is `(- a) * b` and `- f a` is `- (f a)`. -/
 def Prec.app : Nat := BinOp.level .mul + 1
+
+/-- Postfix access: `e.f`, `e.n` and `e.(i)`. Tighter than application, so
+`f a.b` is `f (a.b)`. -/
+def Prec.access : Nat := Prec.app + 1
+
+/-- Prefix `!`. Tightest of all, above access as well as application, so
+`!r.contents` is `(!r).contents` and `!f x` is `(!f) x`. -/
+def Prec.prefixOp : Nat := Prec.access + 1
 
 -- Attributes
 

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -96,21 +96,22 @@ The levels are OCaml's, renumbered to start at 1, following the operator
 table in §7.1 of the OCaml manual.
 
 The levels outside the binary table are named below because both consumers need
-them. OCaml's comma level, between `||` and `:=`, is absent: tuples are built by
-their own production rather than by the operator loop. -/
+them. Level 3 is the comma: it belongs to the table by precedence but not by
+shape, a tuple being n-ary rather than a `BinOp`. -/
 
 /-- Precedence of a binary operator; a higher level binds tighter. -/
 def BinOp.level : BinOp → Nat
   | .semi                                     => 1
   | .assign                                   => 2
-  | .or                                       => 3
-  | .and                                      => 4
+  -- 3 is `Prec.comma`
+  | .or                                       => 4
+  | .and                                      => 5
   | .eq | .neq | .lt | .le | .gt | .ge
-  | .pipeRight                                => 5
-  | .concat | .append | .atAt                 => 6
-  | .cons                                     => 7
-  | .add | .sub | .fadd | .fsub               => 8
-  | .mul | .div | .mod | .fmul | .fdiv        => 9
+  | .pipeRight                                => 6
+  | .concat | .append | .atAt                 => 7
+  | .cons                                     => 8
+  | .add | .sub | .fadd | .fsub               => 9
+  | .mul | .div | .mod | .fmul | .fdiv        => 10
 
 /-- Associativity of a binary operator. -/
 def BinOp.assoc : BinOp → Assoc
@@ -132,6 +133,11 @@ def BinOp.operandLevels (op : BinOp) : Nat × Nat :=
 /-- The loosest level that stops at `;`. The branches of an `if` sit here: OCaml
 puts `if` above `;`, so `if a then b else c; d` sequences the whole `if`. -/
 def Prec.noSemi : Nat := BinOp.level .semi + 1
+
+/-- The comma, between `:=` and `||`: `r := a, b` is `r := (a, b)` and `a, b || c`
+is `a, (b || c)`. Needing no enclosing parentheses, it is the operator loop's own
+case rather than a `BinOp`, a tuple being n-ary. -/
+def Prec.comma : Nat := BinOp.level .assign + 1
 
 /-- Function application, and with it the two unary forms that bind exactly as
 loosely: prefix `-`, whose operand is an application, and `assert`, which sits

--- a/Mica/Frontend/AST.lean
+++ b/Mica/Frontend/AST.lean
@@ -80,6 +80,63 @@ inductive BinOp where
   | semi | pipeRight | atAt | assign | concat | append | cons
   deriving Repr, BEq
 
+/-- Associativity of an infix operator. -/
+inductive Assoc where
+  | left | right
+  deriving Repr, BEq
+
+/-! ### Operator precedence
+
+The definitions below are the grammar of infix expressions, and the parser and
+the printer are its only two consumers: `Parser.lean` drives one
+precedence-climbing loop from them and `Printer.lean` decides parentheses from
+them. Keeping a second copy anywhere is what let the two drift apart.
+
+The levels are OCaml's, renumbered to start at 1, following the operator
+table in §7.1 of the OCaml manual.
+
+Two levels outside the table are named below because both consumers need them.
+OCaml's comma level, between `||` and `:=`, is absent: tuples are built by their
+own production rather than by the operator loop. -/
+
+/-- Precedence of a binary operator; a higher level binds tighter. -/
+def BinOp.level : BinOp → Nat
+  | .semi                                     => 1
+  | .assign                                   => 2
+  | .or                                       => 3
+  | .and                                      => 4
+  | .eq | .neq | .lt | .le | .gt | .ge
+  | .pipeRight                                => 5
+  | .concat | .append | .atAt                 => 6
+  | .cons                                     => 7
+  | .add | .sub | .fadd | .fsub               => 8
+  | .mul | .div | .mod | .fmul | .fdiv        => 9
+
+/-- Associativity of a binary operator. -/
+def BinOp.assoc : BinOp → Assoc
+  | .eq | .neq | .lt | .le | .gt | .ge | .pipeRight
+  | .add | .sub | .fadd | .fsub
+  | .mul | .div | .mod | .fmul | .fdiv => .left
+  | _                                  => .right
+
+/-- The levels of an operator's left and right operands. The side the operator
+associates towards keeps the operator's own level, so a repeat of it nests
+there; the other side takes one level above, so a repeat of it ends the operand.
+This is the associativity rule itself, shared rather than restated: the parser
+descends to these levels and the printer parenthesizes against them. -/
+def BinOp.operandLevels (op : BinOp) : Nat × Nat :=
+  match BinOp.assoc op with
+  | .left  => (BinOp.level op, BinOp.level op + 1)
+  | .right => (BinOp.level op + 1, BinOp.level op)
+
+/-- The loosest level that stops at `;`. The branches of an `if` sit here: OCaml
+puts `if` above `;`, so `if a then b else c; d` sequences the whole `if`. -/
+def Prec.noSemi : Nat := BinOp.level .semi + 1
+
+/-- Tighter than every binary operator: application, the prefix operators, and
+the postfix forms `e.f` and `e.(i)`. -/
+def Prec.app : Nat := BinOp.level .mul + 1
+
 -- Attributes
 
 /-- The name of an attribute `[@name]`. Which names are meaningful depends on

--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -980,6 +980,16 @@ private def elaborateValAttrs (env : ElabEnv) (acc : ValAttrs) :
     | name, _ =>
       err attr.loc (.unsupportedFeature s!"unknown declaration attribute [@@{name}]")
 
+/-- Attributes are meaningful on a value declaration only. The parser accepts
+`[@@...]` after any declaration, so every other kind rejects them here rather
+than dropping them silently. -/
+def Decl.noAttrs (decl : Decl) (what : String) : ElabM Unit :=
+  match decl.attrs with
+  | [] => .ok ()
+  | attr :: _ =>
+    err attr.loc (.unsupportedFeature s!"{what} declaration takes no attributes, \
+      but carries [@@{attr.name}]")
+
 def Decl.elaborate (env : ElabEnv) (decl : Decl)
     : ElabM (ElabEnv × Option (Untyped.Decl Untyped.SpecBody)) := do
   match decl.kind with
@@ -989,6 +999,7 @@ def Decl.elaborate (env : ElabEnv) (decl : Decl)
     else
       err decl.loc (.unsupportedOpen path)
   | .type_ tdecl => do
+    Decl.noAttrs decl "a type"
     let (env', tdecl') ← TypeDecl.elaborate env decl.loc tdecl
     .ok (env', tdecl'.map Untyped.Decl.type_)
   | .val_ isRec binders retTy body => do
@@ -1017,7 +1028,7 @@ private def requireOpenMica : List Decl → ElabM (List Decl)
   | d :: ds =>
     match d.kind with
     | .open_ path =>
-      if path == Path.single "Mica" then .ok ds
+      if path == Path.single "Mica" then do Decl.noAttrs d "an open"; .ok ds
       else err d.loc (.unsupportedOpen path)
     | _ => err d.loc .missingOpenMica
 

--- a/Mica/Frontend/Lexer.lean
+++ b/Mica/Frontend/Lexer.lean
@@ -62,6 +62,7 @@ inductive Token where
   | kw_assert
   | kw_true | kw_false
   | kw_mod | kw_and
+  | kw_begin | kw_end
   -- punctuation and operators
   | plus | minus | star | slash
   | plusDot | minusDot | starDot | slashDot
@@ -96,6 +97,7 @@ def Token.toString : Token → String
   | .kw_assert => "assert"
   | .kw_true  => "true"  | .kw_false => "false"
   | .kw_mod   => "mod"   | .kw_and  => "and"
+  | .kw_begin => "begin" | .kw_end  => "end"
   | .plus     => "+"     | .minus   => "-"    | .star  => "*"  | .slash => "/"
   | .plusDot  => "+."    | .minusDot => "-."   | .starDot => "*." | .slashDot => "/."
   | .caret    => "^"
@@ -176,6 +178,7 @@ private def keyword (s : String) : Token :=
   | "assert" => .kw_assert
   | "true"   => .kw_true   | "false"  => .kw_false
   | "mod"    => .kw_mod    | "and"    => .kw_and
+  | "begin"  => .kw_begin  | "end"    => .kw_end
   | "_"      => .underscore
   | s        => .ident s
 

--- a/Mica/Frontend/OUTLINE.md
+++ b/Mica/Frontend/OUTLINE.md
@@ -3,6 +3,7 @@
 - `AST.lean` — Surface syntax trees and source locations for the OCaml frontend.
 - `Elaborate.lean` — Elaboration of surface syntax into the verifier's core language, with frontend-specific checks.
 - `Lexer.lean` — Lexical analysis for the OCaml frontend, including tokens and lexer errors.
+- `ParenPrinter.lean` — Precedence-free printing of frontend syntax, parenthesizing every compound node.
 - `Parser.lean` — Parsing of frontend tokens into surface syntax trees, with integrated frontend errors.
 - `Printer.lean` — Pretty-printing of frontend syntax back into OCaml-like concrete syntax.
 - `Resolver.lean` — Central registry resolving qualified prelude paths to values, types, and constructors.

--- a/Mica/Frontend/ParenPrinter.lean
+++ b/Mica/Frontend/ParenPrinter.lean
@@ -1,0 +1,178 @@
+-- SUMMARY: Precedence-free printing of frontend syntax, parenthesizing every compound node.
+import Mica.Frontend.AST
+import Mica.Frontend.Printer
+
+/-!
+This file prints the frontend AST with explicit parentheses around every compound
+node, never consulting a precedence table.
+
+It exists for the differential parser tests. Those compare mica's reading of a
+source file against OCaml's by re-printing the parsed program and handing both
+texts to `ocamlc -stop-after parsing -dsource`, which re-parenthesizes from the
+parse tree and so normalizes redundant parentheses away. For that comparison to
+mean anything, the printer used must not consult `BinOp.prec`: if it did, a
+precedence error in the parser and the matching error in `Printer.lean` would
+cancel out and the test would pass. Parenthesizing unconditionally has no
+precedence logic to get wrong, and it fails safe — a bug here makes `ocamlc` read
+something different, so the test fails rather than silently passing.
+
+The output is deliberately unreadable; `Printer.lean` remains the printer for
+user-facing output.
+
+Two constructs are outside what this can express faithfully, and the differential
+corpus therefore avoids them:
+
+* Constructor application prints in application form, which OCaml parses as a
+  `Pexp_apply` of a `Pexp_construct` rather than a saturated `Pexp_construct`.
+* Tuple projection `e.1` has no OCaml counterpart at all.
+-/
+
+namespace Frontend
+
+private def wrap (s : String) : String := "(" ++ s ++ ")"
+
+private def sepBy (sep : String) (parts : List String) : String :=
+  sep.intercalate parts
+
+/-- Constants print bare. Negative literals are wrapped because OCaml's lexer
+folds a leading `-` into the literal, which would change where the node sits. -/
+private def Const.printParen (c : Const) : String :=
+  match c with
+  | .int n => if n < 0 then wrap (toString n) else toString n
+  | c      => Const.print c
+
+mutual
+
+/-- Print a type, parenthesizing every compound node. -/
+partial def Typ.printParen (t : Typ) : String :=
+  let base := match t.kind with
+    | .var name        => s!"'{name}"
+    | .con path []     => path.toString
+    | .con path [arg]  => wrap (Typ.printParen arg ++ " " ++ path.toString)
+    | .con path args   =>
+      wrap ("(" ++ sepBy ", " (args.map Typ.printParen) ++ ") " ++ path.toString)
+    | .arrow dom cod   => wrap (Typ.printParen dom ++ " -> " ++ Typ.printParen cod)
+    | .tuple comps     => wrap (sepBy " * " (comps.map Typ.printParen))
+  base ++ sepBy "" (t.attrs.map Attribute.printParen)
+
+/-- Print a pattern, parenthesizing every compound node. -/
+partial def Pattern.printParen (p : Pattern) : String :=
+  match p.kind with
+  | .wildcard                     => "_"
+  | .binder none none             => "_"
+  | .binder (some name) none      => name
+  | .binder none (some ty)        => wrap ("_ : " ++ Typ.printParen ty)
+  | .binder (some name) (some ty) => wrap (name ++ " : " ++ Typ.printParen ty)
+  | .const c                      => Const.printParen c
+  | .nil                          => "[]"
+  | .cons head tail               =>
+    wrap (Pattern.printParen head ++ " :: " ++ Pattern.printParen tail)
+  | .ctor path none               => path.toString
+  | .ctor path (some payload)     =>
+    wrap (path.toString ++ " " ++ Pattern.printParen payload)
+  | .tuple pats                   => wrap (sepBy ", " (pats.map Pattern.printParen))
+  | .record fields                =>
+    "{ " ++ sepBy "; " (fields.map fun (n, q) => n ++ " = " ++ Pattern.printParen q) ++ " }"
+
+/-- An attribute `[@name]` or `[@name payload]`. -/
+partial def Attribute.printParen (a : Attribute) : String :=
+  match a.payload with
+  | none         => s!" [@{a.name}]"
+  | some payload => s!" [@{a.name} {Expr.printParen payload}]"
+
+/-- Print an expression, parenthesizing every compound node.
+
+A space always follows a prefix operator: OCaml's lexer builds longer prefix
+symbols out of adjacent operator characters, so `!` immediately followed by `=`
+would lex as `!=`. -/
+partial def Expr.printParen (e : Expr) : String :=
+  let base := match e.kind with
+    | .const c    => Const.printParen c
+    | .var path   => path.toString
+    | .ctor path  => path.toString
+    | .annot inner ty =>
+      wrap (Expr.printParen inner ++ " : " ++ Typ.printParen ty)
+    | .tuple es   => wrap (sepBy ", " (es.map Expr.printParen))
+    | .list es    => "[" ++ sepBy "; " (es.map Expr.printParen) ++ "]"
+    | .record fields => "{ " ++ Expr.printParenFields fields ++ " }"
+    | .recordUpdate b fields =>
+      wrap ("{ " ++ Expr.printParen b ++ " with " ++ Expr.printParenFields fields ++ " }")
+    | .app fn args =>
+      wrap (sepBy " " (Expr.printParen fn :: args.map Expr.printParen))
+    | .arrayGet arr idx =>
+      wrap (Expr.printParen arr ++ ".(" ++ Expr.printParen idx ++ ")")
+    | .arraySet arr idx val =>
+      wrap (Expr.printParen arr ++ ".(" ++ Expr.printParen idx ++ ") <- "
+            ++ Expr.printParen val)
+    | .unop op inner => Expr.printParenUnop op inner
+    | .binop .semi lhs rhs =>
+      wrap (Expr.printParen lhs ++ "; " ++ Expr.printParen rhs)
+    | .binop op lhs rhs =>
+      wrap (Expr.printParen lhs ++ " " ++ BinOp.print op ++ " " ++ Expr.printParen rhs)
+    | .ite cond thn els =>
+      wrap ("if " ++ Expr.printParen cond ++ " then " ++ Expr.printParen thn
+            ++ " else " ++ Expr.printParen els)
+    | .letIn isRec binders retTy bound body =>
+      let recStr := if isRec then "rec " else ""
+      wrap ("let " ++ recStr ++ sepBy " " (binders.map Pattern.printParen)
+            ++ Expr.printParenRetTy retTy ++ " = " ++ Expr.printParen bound
+            ++ " in " ++ Expr.printParen body)
+    | .fun_ args retTy body =>
+      wrap ("fun " ++ sepBy " " (args.map Pattern.printParen)
+            ++ Expr.printParenRetTy retTy ++ " -> " ++ Expr.printParen body)
+    | .match_ scrutinee arms =>
+      let armsStr := arms.map fun arm =>
+        "| " ++ Pattern.printParen arm.pat ++ " -> " ++ Expr.printParen arm.body
+      wrap ("match " ++ Expr.printParen scrutinee ++ " with " ++ sepBy " " armsStr)
+  base ++ sepBy "" (e.attrs.map Attribute.printParen)
+
+private partial def Expr.printParenUnop (op : UnOp) (inner : Expr) : String :=
+  match op with
+  | .proj n     => wrap (Expr.printParen inner ++ s!".{n}")
+  | .field name => wrap (Expr.printParen inner ++ "." ++ name)
+  | .neg        => wrap ("- " ++ Expr.printParen inner)
+  | .deref      => wrap ("! " ++ Expr.printParen inner)
+  | .assert     => wrap ("assert " ++ Expr.printParen inner)
+
+private partial def Expr.printParenFields (fields : List (FieldName × Expr)) : String :=
+  sepBy "; " (fields.map fun (f, v) => f ++ " = " ++ Expr.printParen v)
+
+private partial def Expr.printParenRetTy : Option Typ → String
+  | none    => ""
+  | some ty => " : " ++ Typ.printParen ty
+
+end
+
+/-- Print a declaration. The leading binder of a `let` stays unparenthesized:
+OCaml's function-definition form requires a bare identifier there. -/
+partial def Decl.printParen (d : Decl) : String :=
+  let attrsSuffix := sepBy "" (d.attrs.map fun a =>
+    match a.payload with
+    | none         => " [@@" ++ toString a.name ++ "]"
+    | some payload => " [@@" ++ toString a.name ++ " " ++ Expr.printParen payload ++ "]")
+  match d.kind with
+  | .open_ path => "open " ++ path.toString
+  | .val_ isRec binders retTy body =>
+    let recStr := if isRec then "rec " else ""
+    "let " ++ recStr ++ sepBy " " (binders.map Pattern.printParen)
+      ++ Expr.printParenRetTy retTy ++ " = " ++ Expr.printParen body ++ attrsSuffix
+  | .type_ td =>
+    let paramsStr := match td.params with
+      | []  => ""
+      | [p] => s!"'{p} "
+      | ps  => "(" ++ sepBy ", " (ps.map fun p => s!"'{p}") ++ ") "
+    let bodyStr := match td.body with
+      | .variant ctors =>
+        sepBy " " (ctors.map fun (name, payload) =>
+          match payload with
+          | none    => "| " ++ name
+          | some ty => "| " ++ name ++ " of " ++ Typ.printParen ty)
+      | .record fields =>
+        "{ " ++ sepBy "; " (fields.map fun (n, ty) => n ++ " : " ++ Typ.printParen ty) ++ " }"
+    "type " ++ paramsStr ++ td.name ++ " = " ++ bodyStr ++ attrsSuffix
+
+/-- Print a program, one declaration per line. -/
+partial def Program.printParen (prog : Program) : String :=
+  sepBy "\n" (prog.map Decl.printParen)
+
+end Frontend

--- a/Mica/Frontend/ParenPrinter.lean
+++ b/Mica/Frontend/ParenPrinter.lean
@@ -151,7 +151,7 @@ partial def Decl.printParen (d : Decl) : String :=
     | none         => " [@@" ++ toString a.name ++ "]"
     | some payload => " [@@" ++ toString a.name ++ " " ++ Expr.printParen payload ++ "]")
   match d.kind with
-  | .open_ path => "open " ++ path.toString
+  | .open_ path => "open " ++ path.toString ++ attrsSuffix
   | .val_ isRec binders retTy body =>
     let recStr := if isRec then "rec " else ""
     "let " ++ recStr ++ sepBy " " (binders.map Pattern.printParen)

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -165,19 +165,37 @@ private partial def collectPathTail (head : String) (acc : List String) : Parser
   | _, _ => return { head, tail := acc.reverse }
 
 -- ---------------------------------------------------------------------------
--- Left-assoc binary expression helper
+-- Infix operators
 
-private partial def parseLAssocLoop
-    (ops : List (Token × BinOp)) (sub : Parser Expr) (lhs : Expr) : Parser Expr := do
-  match ops.find? (·.1 == (← peek)) with
-  | some (_, op) =>
-    advance
-    let rhs ← sub
-    parseLAssocLoop ops sub { loc := between lhs.loc rhs.loc, kind := .binop op lhs rhs }
-  | none => return lhs
-
-private partial def parseLAssoc (ops : List (Token × BinOp)) (sub : Parser Expr) : Parser Expr := do
-  parseLAssocLoop ops sub (← sub)
+/-- The binary operator a token introduces. `<-` is absent: it shares `:=`'s
+level but builds an `arraySet` rather than a `binop`, so the loop handles it
+separately. -/
+private def binOpOf : Token → Option BinOp
+  | .semi       => some .semi
+  | .colonEq    => some .assign
+  | .pipepipe   => some .or
+  | .ampamp     => some .and
+  | .eq         => some .eq
+  | .neq        => some .neq
+  | .lt         => some .lt
+  | .le         => some .le
+  | .gt         => some .gt
+  | .ge         => some .ge
+  | .pipeGt     => some .pipeRight
+  | .caret      => some .concat
+  | .at         => some .append
+  | .atat       => some .atAt
+  | .coloncolon => some .cons
+  | .plus       => some .add
+  | .minus      => some .sub
+  | .plusDot    => some .fadd
+  | .minusDot   => some .fsub
+  | .star       => some .mul
+  | .slash      => some .div
+  | .kw_mod     => some .mod
+  | .starDot    => some .fmul
+  | .slashDot   => some .fdiv
+  | _           => none
 
 -- ---------------------------------------------------------------------------
 -- Type parsing
@@ -419,108 +437,48 @@ private partial def parseOptRetTy : Parser (Option Typ) := do
 -- ---------------------------------------------------------------------------
 -- Expression parsing
 
-private partial def parseExpr : Parser Expr := do
-  let lhs ← parseExprNoSemi
-  if ← consumeIf .semi then
-    let rhs ← parseExpr
-    return { loc := between lhs.loc rhs.loc, kind := .binop .semi lhs rhs }
-  else return lhs
+/-- A whole expression, `;` included. -/
+private partial def parseExpr : Parser Expr := parseExprAt (BinOp.level .semi)
 
--- Expression without top-level `;` — keywords and operators, but not `;`.
-private partial def parseExprNoSemi : Parser Expr := do
+/-- Precedence climbing over `BinOp.level` / `BinOp.assoc`: parse an operand,
+then extend it with every following operator at level `min` or tighter. -/
+private partial def parseExprAt (min : Nat) : Parser Expr := do
+  parseInfix min (← parseOperand)
+
+private partial def parseInfix (min : Nat) (lhs : Expr) : Parser Expr := do
+  match ← peek with
+  -- `a.(i) <- e`, at `:=`'s level and right-associative like it.
+  | .leftArrow =>
+    let lvl := BinOp.level .assign
+    if lvl < min then return lhs
+    advance
+    let rhs ← parseExprAt lvl
+    match lhs.kind with
+    | .arrayGet arr idx =>
+      parseInfix min { loc := between lhs.loc rhs.loc, kind := .arraySet arr idx rhs }
+    | _ => failAt lhs.loc .expectedArrayElementAssignTarget
+  | tok =>
+    let some op := binOpOf tok | return lhs
+    if BinOp.level op < min then return lhs
+    advance
+    let rhs ← parseExprAt (BinOp.operandLevels op).2
+    parseInfix min { loc := between lhs.loc rhs.loc, kind := .binop op lhs rhs }
+
+/-- The operand of the infix loop.
+
+A keyword expression is an operand at every level, matching OCaml, where the
+grammar admits `let`, `fun`, `if` and `match` after any operator even though
+they sit below all of them. Its trailing branch then extends as far right as it
+can, so `a + if b then c else d * e` reads as `a + (if b then c else (d * e))`.
+The loop needs no case for that: the branch is parsed at a fixed level, leaving
+only looser operators behind, which the loop already declines. -/
+private partial def parseOperand : Parser Expr := do
   match ← peek with
   | .kw_let   => parseLet
   | .kw_fun   => parseFun
   | .kw_if    => parseIf
   | .kw_match => parseMatch
-  | _         => parseAssign
-
--- `:=` (ref store) and `<-` (array set), both right-assoc
-private partial def parseAssign : Parser Expr := do
-  let lhs ← parseOr
-  match ← peek with
-  | .colonEq =>
-    advance
-    let rhs ← parseAssign
-    return { loc := between lhs.loc rhs.loc, kind := .binop .assign lhs rhs }
-  | .leftArrow =>
-    advance
-    let rhs ← parseAssign
-    match lhs.kind with
-    | .arrayGet arr idx =>
-      return { loc := between lhs.loc rhs.loc, kind := .arraySet arr idx rhs }
-    | _ => failAt lhs.loc .expectedArrayElementAssignTarget
-  | _ => return lhs
-
--- `||` right-assoc
-private partial def parseOr : Parser Expr := do
-  let lhs ← parseAnd
-  if ← consumeIf .pipepipe then
-    let rhs ← parseOr
-    return { loc := between lhs.loc rhs.loc, kind := .binop .or lhs rhs }
-  else return lhs
-
--- `&&` right-assoc
-private partial def parseAnd : Parser Expr := do
-  let lhs ← parsePipeGt
-  if ← consumeIf .ampamp then
-    let rhs ← parseAnd
-    return { loc := between lhs.loc rhs.loc, kind := .binop .and lhs rhs }
-  else return lhs
-
--- `|>` left-assoc
-private partial def parsePipeGt : Parser Expr := do
-  parsePipeGtRest (← parseAtAt)
-
-private partial def parsePipeGtRest (lhs : Expr) : Parser Expr := do
-  if ← consumeIf .pipeGt then
-    let rhs ← parseAtAt
-    parsePipeGtRest { loc := between lhs.loc rhs.loc, kind := .binop .pipeRight lhs rhs }
-  else return lhs
-
--- `@@` right-assoc
-private partial def parseAtAt : Parser Expr := do
-  let lhs ← parseCmp
-  if ← consumeIf .atat then
-    -- RHS is full expr so `f @@ fun x -> e` works
-    let rhs ← parseExpr
-    return { loc := between lhs.loc rhs.loc, kind := .binop .atAt lhs rhs }
-  else return lhs
-
--- comparison (left-assoc)
-private partial def parseCmp : Parser Expr :=
-  parseLAssoc [(.eq, .eq), (.neq, .neq), (.lt, .lt), (.le, .le), (.gt, .gt), (.ge, .ge)] parseConcat
-
--- `^`/`@` right-assoc, one shared level (matches OCaml: looser than `::`)
-private partial def parseConcat : Parser Expr := do
-  let lhs ← parseCons
-  match ← peek with
-  | .caret =>
-    advance
-    let rhs ← parseConcat
-    return { loc := between lhs.loc rhs.loc, kind := .binop .concat lhs rhs }
-  | .at =>
-    advance
-    let rhs ← parseConcat
-    return { loc := between lhs.loc rhs.loc, kind := .binop .append lhs rhs }
-  | _ => return lhs
-
--- `::` right-assoc, between `@`/`^` and `+`/`-` (matches OCaml)
-private partial def parseCons : Parser Expr := do
-  let lhs ← parseAdd
-  if ← consumeIf .coloncolon then
-    let rhs ← parseCons
-    return { loc := between lhs.loc rhs.loc, kind := .binop .cons lhs rhs }
-  else return lhs
-
--- `+` `-` left-assoc
-private partial def parseAdd : Parser Expr :=
-  parseLAssoc [(.plus, .add), (.minus, .sub), (.plusDot, .fadd), (.minusDot, .fsub)] parseMul
-
--- `*` `/` `mod` left-assoc
-private partial def parseMul : Parser Expr :=
-  parseLAssoc [(.star, .mul), (.slash, .div), (.starDot, .fmul), (.slashDot, .fdiv),
-               (.kw_mod, .mod)] parseUnary
+  | _         => parseUnary
 
 -- prefix unary operators
 private partial def parseUnary : Parser Expr := do
@@ -631,7 +589,7 @@ private partial def parseTupleRest : Parser (List Expr) := do
 
 -- `;`-separated list-literal elements, allowing a trailing `;`
 private partial def parseListElems : Parser (List Expr) := do
-  let e ← parseExprNoSemi
+  let e ← parseExprAt Prec.noSemi
   if ← consumeIf .semi then
     if (← peek) == .rbracket then return [e]
     else return e :: (← parseListElems)
@@ -658,7 +616,7 @@ private partial def parseRecord : Parser Expr := do
 private partial def parseRecordFields : Parser (List (FieldName × Expr)) := do
   let name ← expectIdent
   expect .eq
-  let e ← parseAssign
+  let e ← parseExprAt Prec.noSemi
   if ← consumeIf .semi then
     if (← peek) == .rbrace then return [(name, e)]  -- trailing semicolon
     else return (name, e) :: (← parseRecordFields)
@@ -688,15 +646,16 @@ private partial def parseFun : Parser Expr := exprOf do
   return .fun_ args retTy (← parseExpr)
 
 -- `if c then t else e`
--- Sub-expressions use parseExprNoSemi because `;` binds less tightly
--- than if/then/else in OCaml.
+-- The branches stop at `;`, which is looser than `if` in OCaml, so
+-- `if a then b else c; d` sequences the whole `if`. The condition is delimited
+-- by `then` instead, so it takes a full expression.
 private partial def parseIf : Parser Expr := exprOf do
   expect .kw_if
-  let cond ← parseExprNoSemi
+  let cond ← parseExpr
   expect .kw_then
-  let thn ← parseExprNoSemi
+  let thn ← parseExprAt Prec.noSemi
   expect .kw_else
-  return .ite cond thn (← parseExprNoSemi)
+  return .ite cond thn (← parseExprAt Prec.noSemi)
 
 -- `match e with | P -> e | ...`
 private partial def parseMatch : Parser Expr := exprOf do

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -216,12 +216,14 @@ private def isArgStart : Token → Bool
   | .lbracket | .kw_true | .kw_false | .bang | .kw_begin => true
   | _ => false
 
-/-- A record literal starts with `ident =` (a lowercase field name followed by
-`=`); anything else after `{` is the expression of a record update. -/
+/-- A record literal starts with a lowercase field name followed by `=`, or by
+the `;` or `}` that ends a punned field `{ a }`. Anything else after `{` is the
+expression of a record update. -/
 private def isRecordLiteral : Parser Bool := do
   match ← peek with
   | .ident name =>
-    if !name.front.isUpper && name.front != '\'' then return (← peek 1) == .eq else return false
+    if name.front.isUpper || name.front == '\'' then return false
+    return [Token.eq, .semi, .rbrace].contains (← peek 1)
   | _ => return false
 
 mutual
@@ -416,9 +418,11 @@ private partial def parseTuplePatRest : Parser (List Pattern) := do
   if ← consumeIf .comma then return p :: (← parseTuplePatRest) else return [p]
 
 private partial def parseRecordPatFields : Parser (List (FieldName × Pattern)) := do
+  let start ← loc
   let name ← expectIdent
-  expect .eq
-  let pat ← parsePattern
+  -- `{ a }` puns: with no `=`, the field's own name is the binder.
+  let pat ← if ← consumeIf .eq then parsePattern
+            else pure { loc := ← spanFrom start, kind := .binder (some name) none }
   if ← consumeIf .semi then
     -- A trailing `;` leaves the `}` for the caller's `expect .rbrace`.
     if (← peek) == .rbrace then return [(name, pat)]
@@ -649,9 +653,11 @@ private partial def parseRecord : Parser Expr := do
     return { loc := ← spanFrom start, kind := .recordUpdate e fields }
 
 private partial def parseRecordFields : Parser (List (FieldName × Expr)) := do
+  let start ← loc
   let name ← expectIdent
-  expect .eq
-  let e ← parseExprAt Prec.noSemi
+  -- `{ a }` puns: with no `=`, the field's own name is the expression.
+  let e ← if ← consumeIf .eq then parseExprAt Prec.noSemi
+          else pure { loc := ← spanFrom start, kind := .var (Path.single name) }
   if ← consumeIf .semi then
     if (← peek) == .rbrace then return [(name, e)]  -- trailing semicolon
     else return (name, e) :: (← parseRecordFields)

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -20,6 +20,7 @@ inductive ParseErrorKind where
   | funNoArgs
   | nonFinalLowercaseSegment (segment : String)
   | expectedArrayElementAssignTarget
+  | refutableBinder
   deriving Repr, Inhabited
 
 structure ParseError where
@@ -36,6 +37,7 @@ def ParseError.toString (e : ParseError) : String :=
   | .funNoArgs => s!"{loc}: function expressions require at least one argument"
   | .nonFinalLowercaseSegment seg => s!"{loc}: qualified path segment '{seg}' is lowercase, but only the final component of a module path may be lowercase"
   | .expectedArrayElementAssignTarget => s!"{loc}: `<-` expects an array element `a.(i)` on the left"
+  | .refutableBinder => s!"{loc}: this pattern can fail to match; a `let` or `fun` binder must not"
 
 instance : ToString ParseError := ⟨ParseError.toString⟩
 
@@ -200,8 +202,13 @@ private def binOpOf : Token → Option BinOp
 -- ---------------------------------------------------------------------------
 -- Type parsing
 
+/-- The first set of `parsePatternAtom`: what can begin a constructor payload,
+and what `parseFunArgs` treats as one more binder. It is maintained by hand and
+has to track that match — a token missing here becomes an error at whatever
+follows the pattern instead. -/
 private def isPatStart : Token → Bool
-  | .ident _ | .underscore | .lparen | .lbrace | .intLit _ | .kw_true | .kw_false => true
+  | .ident _ | .underscore | .lparen | .lbrace | .lbracket
+  | .intLit _ | .charLit _ | .kw_true | .kw_false => true
   | _ => false
 
 private def isArgStart : Token → Bool
@@ -315,71 +322,80 @@ private partial def parseTypeNoArrow : Parser Typ := parseTypeProd
 -- ---------------------------------------------------------------------------
 -- Pattern parsing
 
+/-- Pattern with infix `::` (right-assoc): `p1 :: p2` is the prelude cons
+constructor applied to the pair pattern `(p1, p2)`. The loosest pattern level. -/
 private partial def parsePattern : Parser Pattern := do
-  let start ← loc
+  let lhs ← parsePatternApp
+  if ← consumeIf .coloncolon then
+    let rhs ← parsePattern
+    return { loc := between lhs.loc rhs.loc, kind := .cons lhs rhs }
+  else return lhs
+
+/-- Constructor application `C p`, possibly qualified (`Option.Some x`). The
+payload is itself at this level rather than an atom, so `A B y` is `A (B y)`, as
+in OCaml. -/
+private partial def parsePatternApp : Parser Pattern := do
+  let head ← parsePatternAtom
+  match head.kind with
+  | .ctor path none =>
+    if isPatStart (← peek) then
+      let payload ← parsePatternApp
+      return { loc := ← spanFrom head.loc, kind := .ctor path (some payload) }
+    else return head
+  | _ => return head
+
+/-- A pattern atom. `isPatStart` is this match's first set and has to track it. -/
+private partial def parsePatternAtom : Parser Pattern := patOf do
   match ← peek with
-  | .underscore => advance; return { loc := ← spanFrom start, kind := .wildcard }
+  | .underscore => advance; return .wildcard
   | .ident name =>
     advance
-    if name.front.isUpper then
-      -- constructor pattern (possibly qualified, e.g. `Option.Some x`)
-      let path ← collectPathTail name []
-      match ← peek with
-      | .ident _ | .underscore | .intLit _ | .charLit _ | .kw_true | .kw_false
-      | .lparen | .lbrace =>
-        let payload ← parsePattern
-        return { loc := ← spanFrom start, kind := .ctor path (some payload) }
-      | _ => return { loc := ← spanFrom start, kind := .ctor path none }
-    else
-      -- plain binder (no type annotation here; annotated form is `(x : T)`)
-      return { loc := ← spanFrom start, kind := .binder (some name) none }
-  | .intLit n  => advance; return { loc := ← spanFrom start, kind := .const (.int n) }
-  | .charLit c => advance; return { loc := ← spanFrom start, kind := .const (.char c) }
-  | .kw_true   => advance; return { loc := ← spanFrom start, kind := .const (.bool true) }
-  | .kw_false  => advance; return { loc := ← spanFrom start, kind := .const (.bool false) }
-  | .lparen => advance; parseParenPattern start "')' or ',' in pattern"
+    if name.front.isUpper then return .ctor (← collectPathTail name []) none
+    else return .binder (some name) none
+  | .intLit n  => advance; return .const (.int n)
+  | .charLit c => advance; return .const (.char c)
+  | .kw_true   => advance; return .const (.bool true)
+  | .kw_false  => advance; return .const (.bool false)
+  | .lparen => advance; parseParenPattern
   | .lbrace =>
     advance
     let fields ← parseRecordPatFields
     expect .rbrace
-    return { loc := ← spanFrom start, kind := .record fields }
+    return .record fields
   | .lbracket =>
     -- `[]` — empty-list pattern (no general list-literal patterns)
     advance
-    if ← consumeIf .rbracket then return { loc := ← spanFrom start, kind := .nil }
-    else expected "']' in pattern"
+    if ← consumeIf .rbracket then return .nil else expected "']' in pattern"
   | _ => expected "pattern"
 
-/-- The body of a parenthesized pattern, with the `(` already consumed. `unclosed`
-names the error for a stray token where `)` or `,` was due. -/
-private partial def parseParenPattern (start : Location) (unclosed : String) : Parser Pattern := do
+/-- The body of a parenthesized pattern, with the `(` already consumed. -/
+private partial def parseParenPattern : Parser PatternKind := do
   -- `()` = unit constant
-  if ← consumeIf .rparen then return { loc := ← spanFrom start, kind := .const .unit }
-  let pat ← parsePatternInner
+  if ← consumeIf .rparen then return .const .unit
+  let pat ← parsePatternAnnot
   match ← peek with
   | .comma =>
     -- tuple pattern
     let rest ← parseTuplePatRest
     expect .rparen
-    return { loc := ← spanFrom start, kind := .tuple (pat :: rest) }
-  | .rparen => advance; return pat
-  | _ => expected unclosed
+    return .tuple (pat :: rest)
+  | .rparen => advance; return pat.kind
+  | _ => expected "')' or ',' in pattern"
 
--- pattern inside parens: allows `(x : T)` annotated binder
-private partial def parsePatternInner : Parser Pattern := do
-  let start ← loc
-  match ← peek with
-  | .ident name =>
+/-- A pattern carrying the annotation `p : T` that only a parenthesized position
+admits. `Pattern` has a slot for one on a binder alone, so `(C x : T)` is not a
+pattern mica can represent and the `:` is left to fail as an unclosed `(`. -/
+private partial def parsePatternAnnot : Parser Pattern := do
+  let pat ← parsePattern
+  let annotate (name : Option String) : Parser Pattern := do
     advance
-    let ty ← if ← consumeIf .colon then some <$> parseType else pure none
-    return { loc := ← spanFrom start, kind := .binder (some name) ty }
-  | .underscore =>
-    advance
-    if ← consumeIf .colon then
-      let ty ← parseType
-      return { loc := ← spanFrom start, kind := .binder none (some ty) }
-    else return { loc := ← spanFrom start, kind := .wildcard }
-  | _ => parsePattern
+    let ty ← parseType
+    return { loc := ← spanFrom pat.loc, kind := .binder name (some ty) }
+  if (← peek) != .colon then return pat
+  match pat.kind with
+  | .binder name none => annotate name
+  | .wildcard         => annotate none
+  | _                 => return pat
 
 private partial def parseTuplePatRest : Parser (List Pattern) := do
   if ← consumeIf .comma then
@@ -397,33 +413,19 @@ private partial def parseRecordPatFields : Parser (List (FieldName × Pattern)) 
     else return (name, pat) :: (← parseRecordPatFields)
   else return [(name, pat)]
 
-/-- Pattern with infix `::` (right-assoc): `p1 :: p2` is the prelude cons
-    constructor applied to the pair pattern `(p1, p2)`. Constructor payloads
-    bind tighter, so only match arms use this entry point. -/
-private partial def parsePatternCons : Parser Pattern := do
-  let lhs ← parsePattern
-  if ← consumeIf .coloncolon then
-    let rhs ← parsePatternCons
-    return { loc := between lhs.loc rhs.loc, kind := .cons lhs rhs }
-  else return lhs
-
 -- ---------------------------------------------------------------------------
 -- Shared binder helpers
 -- These are top-level so both parseExpr (parseLet/parseFun) and parseDecl
 -- (parseValDecl) can call them directly.
 
+/-- A `let` or `fun` binder: an atom that binds irrefutably. The refutable
+forms parse the same way as anywhere else and are rejected afterwards, so the
+error names the actual problem instead of the token that follows it. -/
 private partial def parsePatternBinder : Parser Pattern := do
-  let start ← loc
-  match ← peek with
-  | .underscore => advance; return { loc := ← spanFrom start, kind := .wildcard }
-  | .ident name => advance; return { loc := ← spanFrom start, kind := .binder (some name) none }
-  | .lparen => advance; parseParenPattern start "')' in binder"
-  | .lbrace =>
-    advance
-    let fields ← parseRecordPatFields
-    expect .rbrace
-    return { loc := ← spanFrom start, kind := .record fields }
-  | _ => expected "binder"
+  let pat ← parsePatternAtom
+  match pat.kind with
+  | .wildcard | .binder .. | .tuple .. | .record .. | .const .unit => return pat
+  | _ => failAt pat.loc .refutableBinder
 
 private partial def parseFunArgs : Parser (List Pattern) := do
   if isPatStart (← peek) then
@@ -675,7 +677,7 @@ private partial def parseMatch : Parser Expr := exprOf do
 
 private partial def parseMatchArms : Parser (List MatchArm) := do
   if ← consumeIf .pipe then
-    let pat ← parsePatternCons
+    let pat ← parsePattern
     expect .arrow
     let body ← parseExpr
     return { pat, body } :: (← parseMatchArms)
@@ -771,21 +773,18 @@ private partial def parseDeclAttrs : Parser (List Attribute) := do
     return attr :: (← parseDeclAttrs)
   else return []
 
-/-- Parse a single top-level declaration.
-
-Only `let` declarations take `[@@...]` attributes today; `type` and `open` reject
-a following `[`. That is a language-scope question rather than a parsing one, so
-it is left as-is here. -/
+/-- Parse a single top-level declaration. Every kind takes the same trailing
+`[@@...]` attributes; which of them are meaningful where is elaboration's call,
+and it rejects the ones that are not. -/
 private def parseDecl : Parser Decl := do
   let start ← loc
-  match ← peek with
-  | .kw_let =>
-    let kind ← parseValDecl
-    let attrs ← parseDeclAttrs
-    return { loc := ← spanFrom start, kind, attrs }
-  | .kw_open => return { loc := ← spanFrom start, kind := ← parseOpenDecl, attrs := [] }
-  | .kw_type => return { loc := ← spanFrom start, kind := ← parseTypeDecl, attrs := [] }
-  | _ => expected "declaration (open, let, or type)"
+  let kind ← match ← peek with
+    | .kw_let  => parseValDecl
+    | .kw_open => parseOpenDecl
+    | .kw_type => parseTypeDecl
+    | _        => expected "declaration (open, let, or type)"
+  let attrs ← parseDeclAttrs
+  return { loc := ← spanFrom start, kind, attrs }
 
 -- ---------------------------------------------------------------------------
 -- Top-level program parsing

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -16,9 +16,7 @@ namespace Frontend
 inductive ParseErrorKind where
   | unexpectedToken (expected : String) (got : Token)
   | unexpectedEof
-  | invalidRecordField
   | nonPositiveProjIndex
-  | letRecNoArgs
   | funNoArgs
   | nonFinalLowercaseSegment (segment : String)
   | expectedArrayElementAssignTarget
@@ -34,9 +32,7 @@ def ParseError.toString (e : ParseError) : String :=
   match e.kind with
   | .unexpectedToken exp got => s!"{loc}: expected {exp}, got '{got}'"
   | .unexpectedEof => s!"{loc}: unexpected end of file"
-  | .invalidRecordField => s!"{loc}: expected field name (identifier) before '=' in record literal"
   | .nonPositiveProjIndex => s!"{loc}: projection index must be at least 1 (projections are 1-based)"
-  | .letRecNoArgs => s!"{loc}: let rec without arguments is not supported"
   | .funNoArgs => s!"{loc}: function expressions require at least one argument"
   | .nonFinalLowercaseSegment seg => s!"{loc}: qualified path segment '{seg}' is lowercase, but only the final component of a module path may be lowercase"
   | .expectedArrayElementAssignTarget => s!"{loc}: `<-` expects an array element `a.(i)` on the left"
@@ -64,37 +60,83 @@ structure ParserState where
   tokens : Array (Location × Token)
   pos    : Nat
 
-abbrev Parser (α : Type) := ParserState → Except ParseError (α × ParserState)
+/-- A parser reads from a token cursor and fails with a `ParseError`. The state
+is threaded by the monad; nothing below passes a `ParserState` by hand. -/
+abbrev Parser (α : Type) := StateT ParserState (Except ParseError) α
 
 -- ---------------------------------------------------------------------------
 -- Primitive combinators
 
-private def peekTok (st : ParserState) : Token :=
-  (st.tokens.getD st.pos (default, .eof)).2
+/-- The located token `n` positions ahead of the cursor, `eof` past the end. -/
+private def peekAt (n : Nat) : Parser (Location × Token) := fun st =>
+  .ok (st.tokens.getD (st.pos + n) (default, .eof), st)
 
-private def peekLoc (st : ParserState) : Location :=
-  (st.tokens.getD st.pos (default, .eof)).1
+/-- The token `n` positions ahead of the cursor. -/
+private def peek (n : Nat := 0) : Parser Token := (·.2) <$> peekAt n
 
-private def advance (st : ParserState) : ParserState :=
-  { st with pos := st.pos + 1 }
+/-- The source location of the token `n` positions ahead of the cursor. -/
+private def loc (n : Nat := 0) : Parser Location := (·.1) <$> peekAt n
 
-private def expect (tok : Token) (st : ParserState) : Except ParseError ParserState :=
-  let t := peekTok st
-  if t == tok then .ok (advance st)
-  else .error { loc := peekLoc st, kind := .unexpectedToken s!"'{tok}'" t }
+/-- Move the cursor past one token. -/
+private def advance : Parser Unit := fun st => .ok ((), { st with pos := st.pos + 1 })
 
-private def expectIdent (st : ParserState) : Except ParseError (String × ParserState) :=
-  match peekTok st with
-  | .ident name => .ok (name, advance st)
-  | t => .error { loc := peekLoc st, kind := .unexpectedToken "identifier" t }
+/-- Fail at `l`. -/
+private def failAt (l : Location) (kind : ParseErrorKind) : Parser α :=
+  throw { loc := l, kind }
+
+/-- Fail at the token under the cursor. -/
+private def fail (kind : ParseErrorKind) : Parser α := do
+  failAt (← loc) kind
+
+/-- Fail reporting that `expected` was wanted where the current token stands. -/
+private def expected (what : String) : Parser α := do
+  fail (.unexpectedToken what (← peek))
+
+/-- Consume `tok`, or fail naming it. -/
+private def expect (tok : Token) : Parser Unit := do
+  if (← peek) == tok then advance else expected s!"'{tok}'"
+
+/-- Consume the current token if it is `tok`; report whether it was. -/
+private def consumeIf (tok : Token) : Parser Bool := do
+  if (← peek) == tok then advance; return true else return false
+
+private def expectIdent : Parser String := do
+  match ← peek with
+  | .ident name => advance; return name
+  | _ => expected "identifier"
 
 /-- Expect an identifier whose first character is uppercase (a constructor name). -/
-private def expectConstructor (st : ParserState) : Except ParseError (String × ParserState) :=
-  match peekTok st with
+private def expectConstructor : Parser String := do
+  match ← peek with
   | .ident name =>
-    if name.front.isUpper then .ok (name, advance st)
-    else .error { loc := peekLoc st, kind := .unexpectedToken "constructor name (uppercase)" (.ident name) }
-  | t => .error { loc := peekLoc st, kind := .unexpectedToken "constructor name" t }
+    if name.front.isUpper then advance; return name
+    else fail (.unexpectedToken "constructor name (uppercase)" (.ident name))
+  | _ => expected "constructor name"
+
+/-- The span from `start` to the end of the last token consumed so far. -/
+private def spanFrom (start : Location) : Parser Location := fun st =>
+  let stop :=
+    if st.pos == 0 then start
+    else (st.tokens.getD (st.pos - 1) (default, .eof)).1
+  .ok ({ start := start.start, stop := stop.stop }, st)
+
+/-- Run `p`, pairing its result with the span it consumed. -/
+private def spanned (p : Parser α) : Parser (Location × α) := do
+  let start ← loc
+  let a ← p
+  return (← spanFrom start, a)
+
+/-- Build a node out of the kind `p` produces and the span `p` consumed. -/
+private def node (mk : Location → κ → α) (p : Parser κ) : Parser α := do
+  let (l, k) ← spanned p
+  return mk l k
+
+private def exprOf : Parser ExprKind → Parser Expr := node fun loc kind => { loc, kind }
+private def patOf  : Parser PatternKind → Parser Pattern := node fun loc kind => { loc, kind }
+private def typOf  : Parser TypKind → Parser Typ := node fun loc kind => { loc, kind }
+
+/-- The span covering two already-built nodes. -/
+private def between (a b : Location) : Location := { start := a.start, stop := b.stop }
 
 /-- Gather a (possibly qualified) path starting with an already-consumed `head`
 identifier. If `head` is uppercase, look ahead for `.dot .ident` runs and append
@@ -107,65 +149,35 @@ In a module path only the final component may be lowercase (it is the
 value/type/constructor name); every earlier segment is a module and must be
 uppercase. So a lowercase segment terminates the path, and a lowercase segment
 followed by a further `.ident` (e.g. `Foo.bar.baz`) is rejected. -/
-private partial def collectPathTail
-    (head : String) (acc : List String) : ParserState → Except ParseError (Path × ParserState)
-  | st =>
-    if !head.front.isUpper then .ok ({ head, tail := acc.reverse }, st)
+private partial def collectPathTail (head : String) (acc : List String) : Parser Path := do
+  if !head.front.isUpper then return { head, tail := acc.reverse }
+  match ← peek, ← peek 1 with
+  | .dot, .ident next =>
+    let segLoc ← loc 1
+    advance; advance
+    if next.front.isUpper then
+      collectPathTail head (next :: acc)
     else
-      match peekTok st with
-      | .dot =>
-        match peekTok (advance st) with
-        | .ident next =>
-          let st' := advance (advance st)
-          if next.front.isUpper then
-            collectPathTail head (next :: acc) st'
-          else
-            -- A lowercase segment must be the final component of the path.
-            match peekTok st' with
-            | .dot =>
-              match peekTok (advance st') with
-              | .ident _ =>
-                .error { loc := peekLoc (advance st), kind := .nonFinalLowercaseSegment next }
-              | _ => .ok ({ head, tail := (next :: acc).reverse }, st')
-            | _ => .ok ({ head, tail := (next :: acc).reverse }, st')
-        | _ => .ok ({ head, tail := acc.reverse }, st)
-      | _ => .ok ({ head, tail := acc.reverse }, st)
-
-/-- Span from `start` location to the end of the last consumed token. -/
-private def spanTo (start : Location) (st : ParserState) : Location :=
-  -- The last consumed token is at pos - 1
-  let stopLoc :=
-    if st.pos == 0 then start
-    else (st.tokens.getD (st.pos - 1) (default, .eof)).1
-  { start := start.start, stop := stopLoc.stop }
-
-private def mkExpr (start : Location) (st : ParserState) (k : ExprKind) : Expr :=
-  { loc := spanTo start st, kind := k }
-
-private def mkPat (start : Location) (st : ParserState) (k : PatternKind) : Pattern :=
-  { loc := spanTo start st, kind := k }
-
-private def mkTyp (start : Location) (st : ParserState) (k : TypKind) : Typ :=
-  { loc := spanTo start st, kind := k }
+      -- A lowercase segment must be the final component of the path.
+      match ← peek, ← peek 1 with
+      | .dot, .ident _ => failAt segLoc (.nonFinalLowercaseSegment next)
+      | _, _ => return { head, tail := (next :: acc).reverse }
+  | _, _ => return { head, tail := acc.reverse }
 
 -- ---------------------------------------------------------------------------
 -- Left-assoc binary expression helper
 
 private partial def parseLAssocLoop
-    (ops : List (Token × BinOp)) (sub : Parser Expr) (lhs : Expr) : Parser Expr :=
-  fun st =>
-    match ops.find? (·.1 == peekTok st) with
-    | some (_, op) => do
-      let st' := advance st
-      let (rhs, st') ← sub st'
-      let e : Expr := { loc := { start := lhs.loc.start, stop := rhs.loc.stop }, kind := .binop op lhs rhs }
-      parseLAssocLoop ops sub e st'
-    | none => .ok (lhs, st)
+    (ops : List (Token × BinOp)) (sub : Parser Expr) (lhs : Expr) : Parser Expr := do
+  match ops.find? (·.1 == (← peek)) with
+  | some (_, op) =>
+    advance
+    let rhs ← sub
+    parseLAssocLoop ops sub { loc := between lhs.loc rhs.loc, kind := .binop op lhs rhs }
+  | none => return lhs
 
-private partial def parseLAssoc (ops : List (Token × BinOp)) (sub : Parser Expr) : Parser Expr :=
-  fun st => do
-    let (lhs, st) ← sub st
-    parseLAssocLoop ops sub lhs st
+private partial def parseLAssoc (ops : List (Token × BinOp)) (sub : Parser Expr) : Parser Expr := do
+  parseLAssocLoop ops sub (← sub)
 
 -- ---------------------------------------------------------------------------
 -- Type parsing
@@ -174,117 +186,109 @@ private def isPatStart : Token → Bool
   | .ident _ | .underscore | .lparen | .lbrace | .intLit _ | .kw_true | .kw_false => true
   | _ => false
 
+private def isArgStart : Token → Bool
+  | .intLit _ | .floatLit _ | .charLit _ | .stringLit _ | .ident _ | .lparen | .lbrace
+  | .lbracket | .kw_true | .kw_false => true
+  | _ => false
+
+/-- A record literal starts with `ident =` (a lowercase field name followed by
+`=`); anything else after `{` is the expression of a record update. -/
+private def isRecordLiteral : Parser Bool := do
+  match ← peek with
+  | .ident name =>
+    if !name.front.isUpper && name.front != '\'' then return (← peek 1) == .eq else return false
+  | _ => return false
+
 mutual
 -- `[@name expr]` — single `@`, optional expression payload.
-private partial def parseTypeAttr : Parser Attribute := fun st => do
-  let p := peekLoc st
-  let st ← expect .lbracket st
-  let st ← expect .at st
-  let (name, st) ← expectIdent st
-  let (payload, st) ← match peekTok st with
-    | .rbracket => .ok (none, st)
-    | _ => do
-      let (e, st) ← parseExpr st
-      .ok (some e, st)
-  let st ← expect .rbracket st
-  .ok ({ loc := spanTo p st, name := AttrName.ofString name, payload }, st)
+private partial def parseAttr (marker : Token) : Parser Attribute := do
+  let start ← loc
+  expect .lbracket
+  expect marker
+  let name ← expectIdent
+  let payload ← if (← peek) == .rbracket then pure none else some <$> parseExpr
+  expect .rbracket
+  return { loc := ← spanFrom start, name := AttrName.ofString name, payload }
 
--- Fold trailing type attributes `T [@name payload]` into `T.attrs`.
-private partial def parseTypeAttrSuffix (t : Typ) : Parser Typ := fun st =>
-  match peekTok st with
-  | .lbracket =>
-    match peekTok (advance st) with
-    | .at => do
-      let (attr, st) ← parseTypeAttr st
-      parseTypeAttrSuffix { t with attrs := t.attrs ++ [attr] } st
-    | _ => .ok (t, st)  -- not a type attribute (e.g. `[@@...]`), leave `[`
-  | _ => .ok (t, st)
+/-- Fold trailing `[@name payload]` attributes into a node. A `[` that opens
+anything else (notably a declaration attribute `[@@...]`) is left alone. -/
+private partial def parseAttrSuffix (attach : α → Attribute → α) (x : α) : Parser α := do
+  if (← peek) == .lbracket && (← peek 1) == .at then
+    let attr ← parseAttr .at
+    parseAttrSuffix attach (attach x attr)
+  else return x
 
-private partial def parseTypeAtom : Parser Typ := fun st =>
-  let p := peekLoc st
-  match peekTok st with
+private partial def parseTypeAttrSuffix (t : Typ) : Parser Typ :=
+  parseAttrSuffix (fun t a => { t with attrs := t.attrs ++ [a] }) t
+
+private partial def parseTypeAtom : Parser Typ := do
+  let start ← loc
+  match ← peek with
   | .ident name =>
+    advance
     if name.front == '\'' then
-      let varName := name.toRawSubstring.drop 1 |>.toString
-      .ok (mkTyp p (advance st) (.var varName), advance st)
-    else do
-      let (path, st') ← collectPathTail name [] (advance st)
-      .ok (mkTyp p st' (.con path []), st')
+      return { loc := ← spanFrom start, kind := .var (name.toRawSubstring.drop 1 |>.toString) }
+    else
+      let path ← collectPathTail name []
+      return { loc := ← spanFrom start, kind := .con path [] }
   | .lparen =>
-    let st' := advance st
-    if peekTok st' == .rparen then
-      .ok (mkTyp p (advance st') (.con (Path.single "unit") []), advance st')
-    else do
-      let (t1, st') ← parseType st'
-      match peekTok st' with
-      | .rparen =>
-        let st'' := advance st'
-        parseTypeAppSuffix t1 st''
-      | .comma =>
-        let (rest, st') ← parseTypeArgList st'
-        let st' ← expect .rparen st'
-        match peekTok st' with
-        | .ident name =>
-          let args := t1 :: rest
-          let (path, st'') ← collectPathTail name [] (advance st')
-          let loc : Location := { start := p.start, stop := (spanTo p st'').stop }
-          .ok ({ loc, kind := .con path args }, st'')
-        | t => .error { loc := peekLoc st', kind := .unexpectedToken "type constructor after '(T1,T2,...)'" t }
-      | t => .error { loc := peekLoc st', kind := .unexpectedToken "')' or ',' in type" t }
-  | t =>
-    .error { loc := peekLoc st, kind := .unexpectedToken "type" t }
+    advance
+    if ← consumeIf .rparen then
+      return { loc := ← spanFrom start, kind := .con (Path.single "unit") [] }
+    let t1 ← parseType
+    match ← peek with
+    | .rparen =>
+      advance
+      parseTypeAppSuffix t1
+    | .comma =>
+      let rest ← parseTypeArgList
+      expect .rparen
+      match ← peek with
+      | .ident name =>
+        advance
+        let path ← collectPathTail name []
+        return { loc := ← spanFrom start, kind := .con path (t1 :: rest) }
+      | _ => expected "type constructor after '(T1,T2,...)'"
+    | _ => expected "')' or ',' in type"
+  | _ => expected "type"
 
-private partial def parseTypeAppSuffix (arg : Typ) : Parser Typ := fun st =>
-  match peekTok st with
+private partial def parseTypeAppSuffix (arg : Typ) : Parser Typ := do
+  match ← peek with
   | .ident name =>
     if !name.front.isUpper && name.front != '\'' then
-      let startLoc := arg.loc
-      let st' := advance st
-      let loc : Location := { start := startLoc.start, stop := (spanTo startLoc st').stop }
-      parseTypeAppSuffix { loc, kind := .con (Path.single name) [arg] } st'
-    else .ok (arg, st)
-  | _ => .ok (arg, st)
+      advance
+      let loc ← spanFrom arg.loc
+      parseTypeAppSuffix { loc, kind := .con (Path.single name) [arg] }
+    else return arg
+  | _ => return arg
 
-private partial def parseTypeApp : Parser Typ := fun st => do
-  let (t, st) ← parseTypeAtom st
-  let (t, st) ← parseTypeAppSuffix t st
-  parseTypeAttrSuffix t st
+private partial def parseTypeApp : Parser Typ := do
+  parseTypeAttrSuffix (← parseTypeAppSuffix (← parseTypeAtom))
 
-private partial def parseTypeProdRest : Parser (List Typ) := fun st => do
-  let (t, st) ← parseTypeApp st
-  match peekTok st with
-  | .star =>
-    let (rest, st) ← parseTypeProdRest (advance st)
-    .ok (t :: rest, st)
-  | _ => .ok ([t], st)
+private partial def parseTypeProdRest : Parser (List Typ) := do
+  let t ← parseTypeApp
+  if ← consumeIf .star then return t :: (← parseTypeProdRest) else return [t]
 
-private partial def parseTypeProd : Parser Typ := fun st => do
-  let (t, st) ← parseTypeApp st
-  match peekTok st with
-  | .star =>
-    let (rest, st) ← parseTypeProdRest (advance st)
-    let components := t :: rest
-    let loc : Location := { start := t.loc.start, stop := (spanTo t.loc st).stop }
-    .ok ({ loc, kind := .tuple components }, st)
-  | _ => .ok (t, st)
+private partial def parseTypeProd : Parser Typ := do
+  let start ← loc
+  let comps ← parseTypeProdRest
+  match comps with
+  | [t] => return t
+  | _   => return { loc := ← spanFrom start, kind := .tuple comps }
 
-private partial def parseTypeArgList : Parser (List Typ) := fun st =>
-  match peekTok st with
-  | .comma => do
-    let (t, st) ← parseType (advance st)
-    let (rest, st) ← parseTypeArgList st
-    .ok (t :: rest, st)
-  | _ => .ok ([], st)
+private partial def parseTypeArgList : Parser (List Typ) := do
+  if ← consumeIf .comma then
+    let t ← parseType
+    return t :: (← parseTypeArgList)
+  else return []
 
 /-- Parse a type expression (including arrows). -/
-private partial def parseType : Parser Typ := fun st => do
-  let (t, st) ← parseTypeProd st
-  match peekTok st with
-  | .arrow =>
-    let (u, st) ← parseType (advance st)
-    let loc : Location := { start := t.loc.start, stop := u.loc.stop }
-    .ok ({ loc, kind := .arrow t u }, st)
-  | _ => .ok (t, st)
+private partial def parseType : Parser Typ := do
+  let t ← parseTypeProd
+  if ← consumeIf .arrow then
+    let u ← parseType
+    return { loc := between t.loc u.loc, kind := .arrow t u }
+  else return t
 
 /-- Parse a type expression, excluding arrows.
     Used for return type annotations where `->` is ambiguous with the function arrow. -/
@@ -293,729 +297,548 @@ private partial def parseTypeNoArrow : Parser Typ := parseTypeProd
 -- ---------------------------------------------------------------------------
 -- Pattern parsing
 
-private partial def parsePattern : Parser Pattern := fun st =>
-  let p := peekLoc st
-  match peekTok st with
-  | .underscore =>
-    .ok (mkPat p (advance st) .wildcard, advance st)
+private partial def parsePattern : Parser Pattern := do
+  let start ← loc
+  match ← peek with
+  | .underscore => advance; return { loc := ← spanFrom start, kind := .wildcard }
   | .ident name =>
-    if name.front.isUpper then do
+    advance
+    if name.front.isUpper then
       -- constructor pattern (possibly qualified, e.g. `Option.Some x`)
-      let (path, st') ← collectPathTail name [] (advance st)
-      match peekTok st' with
-      | .ident _ | .underscore | .intLit _ | .charLit _ | .kw_true | .kw_false | .lparen | .lbrace => do
-        let (payload, st'') ← parsePattern st'
-        .ok (mkPat p st'' (.ctor path (some payload)), st'')
-      | _ =>
-        .ok (mkPat p st' (.ctor path none), st')
+      let path ← collectPathTail name []
+      match ← peek with
+      | .ident _ | .underscore | .intLit _ | .charLit _ | .kw_true | .kw_false
+      | .lparen | .lbrace =>
+        let payload ← parsePattern
+        return { loc := ← spanFrom start, kind := .ctor path (some payload) }
+      | _ => return { loc := ← spanFrom start, kind := .ctor path none }
     else
       -- plain binder (no type annotation here; annotated form is `(x : T)`)
-      .ok (mkPat p (advance st) (.binder (some name) none), advance st)
-  | .intLit n =>
-    .ok (mkPat p (advance st) (.const (.int n)), advance st)
-  | .charLit c =>
-    .ok (mkPat p (advance st) (.const (.char c)), advance st)
-  | .kw_true =>
-    .ok (mkPat p (advance st) (.const (.bool true)), advance st)
-  | .kw_false =>
-    .ok (mkPat p (advance st) (.const (.bool false)), advance st)
-  | .lparen =>
-    let st' := advance st
-    -- `()` = unit constant
-    if peekTok st' == .rparen then
-      .ok (mkPat p (advance st') (.const .unit), advance st')
-    else do
-      let (pat, st') ← parsePatternInner st'
-      match peekTok st' with
-      | .comma =>
-        -- tuple pattern
-        let (rest, st') ← parseTuplePatRest st'
-        let st' ← expect .rparen st'
-        .ok (mkPat p st' (.tuple (pat :: rest)), st')
-      | .rparen =>
-        .ok (pat, advance st')
-      | t =>
-        .error { loc := peekLoc st', kind := .unexpectedToken "')' or ',' in pattern" t }
-  | .lbrace => do
-    let st' := advance st
-    let (fields, st') ← parseRecordPatFields st'
-    let st' ← expect .rbrace st'
-    .ok (mkPat p st' (.record fields), st')
+      return { loc := ← spanFrom start, kind := .binder (some name) none }
+  | .intLit n  => advance; return { loc := ← spanFrom start, kind := .const (.int n) }
+  | .charLit c => advance; return { loc := ← spanFrom start, kind := .const (.char c) }
+  | .kw_true   => advance; return { loc := ← spanFrom start, kind := .const (.bool true) }
+  | .kw_false  => advance; return { loc := ← spanFrom start, kind := .const (.bool false) }
+  | .lparen => advance; parseParenPattern start "')' or ',' in pattern"
+  | .lbrace =>
+    advance
+    let fields ← parseRecordPatFields
+    expect .rbrace
+    return { loc := ← spanFrom start, kind := .record fields }
   | .lbracket =>
     -- `[]` — empty-list pattern (no general list-literal patterns)
-    let st' := advance st
-    match peekTok st' with
-    | .rbracket => .ok (mkPat p (advance st') .nil, advance st')
-    | t => .error { loc := peekLoc st', kind := .unexpectedToken "']' in pattern" t }
-  | t =>
-    .error { loc := peekLoc st, kind := .unexpectedToken "pattern" t }
+    advance
+    if ← consumeIf .rbracket then return { loc := ← spanFrom start, kind := .nil }
+    else expected "']' in pattern"
+  | _ => expected "pattern"
+
+/-- The body of a parenthesized pattern, with the `(` already consumed. `unclosed`
+names the error for a stray token where `)` or `,` was due. -/
+private partial def parseParenPattern (start : Location) (unclosed : String) : Parser Pattern := do
+  -- `()` = unit constant
+  if ← consumeIf .rparen then return { loc := ← spanFrom start, kind := .const .unit }
+  let pat ← parsePatternInner
+  match ← peek with
+  | .comma =>
+    -- tuple pattern
+    let rest ← parseTuplePatRest
+    expect .rparen
+    return { loc := ← spanFrom start, kind := .tuple (pat :: rest) }
+  | .rparen => advance; return pat
+  | _ => expected unclosed
+
 -- pattern inside parens: allows `(x : T)` annotated binder
-private partial def parsePatternInner : Parser Pattern := fun st =>
-  let p := peekLoc st
-  match peekTok st with
+private partial def parsePatternInner : Parser Pattern := do
+  let start ← loc
+  match ← peek with
   | .ident name =>
-    let st' := advance st
-    match peekTok st' with
-    | .colon => do
-      let (ty, st') ← parseType (advance st')
-      .ok (mkPat p st' (.binder (some name) (some ty)), st')
-    | _ =>
-      .ok (mkPat p st' (.binder (some name) none), st')
+    advance
+    let ty ← if ← consumeIf .colon then some <$> parseType else pure none
+    return { loc := ← spanFrom start, kind := .binder (some name) ty }
   | .underscore =>
-    let st' := advance st
-    match peekTok st' with
-    | .colon => do
-      let (ty, st') ← parseType (advance st')
-      .ok (mkPat p st' (.binder none (some ty)), st')
-    | _ =>
-      .ok (mkPat p st' .wildcard, st')
-  | _ => parsePattern st
+    advance
+    if ← consumeIf .colon then
+      let ty ← parseType
+      return { loc := ← spanFrom start, kind := .binder none (some ty) }
+    else return { loc := ← spanFrom start, kind := .wildcard }
+  | _ => parsePattern
 
-private partial def parseTuplePatRest : Parser (List Pattern) := fun st =>
-  match peekTok st with
-  | .comma => do
-    let (p, st) ← parsePattern (advance st)
-    let (rest, st) ← parseTuplePatRest st
-    .ok (p :: rest, st)
-  | _ => .ok ([], st)
+private partial def parseTuplePatRest : Parser (List Pattern) := do
+  if ← consumeIf .comma then
+    let p ← parsePattern
+    return p :: (← parseTuplePatRest)
+  else return []
 
-private partial def parseRecordPatFields : Parser (List (FieldName × Pattern)) := fun st => do
-  let (name, st) ← expectIdent st
-  let st ← expect .eq st
-  let (pat, st) ← parsePattern st
-  match peekTok st with
-  | .semi =>
-    if peekTok (advance st) == .rbrace then
-      .ok ([(name, pat)], advance st)
-    else do
-      let (rest, st) ← parseRecordPatFields (advance st)
-      .ok ((name, pat) :: rest, st)
-  | _ => .ok ([(name, pat)], st)
+private partial def parseRecordPatFields : Parser (List (FieldName × Pattern)) := do
+  let name ← expectIdent
+  expect .eq
+  let pat ← parsePattern
+  if ← consumeIf .semi then
+    -- A trailing `;` leaves the `}` for the caller's `expect .rbrace`.
+    if (← peek) == .rbrace then return [(name, pat)]
+    else return (name, pat) :: (← parseRecordPatFields)
+  else return [(name, pat)]
 
 /-- Pattern with infix `::` (right-assoc): `p1 :: p2` is the prelude cons
     constructor applied to the pair pattern `(p1, p2)`. Constructor payloads
     bind tighter, so only match arms use this entry point. -/
-private partial def parsePatternCons : Parser Pattern := fun st => do
-  let (lhs, st) ← parsePattern st
-  match peekTok st with
-  | .coloncolon => do
-    let (rhs, st') ← parsePatternCons (advance st)
-    let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-    .ok ({ loc, kind := .cons lhs rhs }, st')
-  | _ => .ok (lhs, st)
+private partial def parsePatternCons : Parser Pattern := do
+  let lhs ← parsePattern
+  if ← consumeIf .coloncolon then
+    let rhs ← parsePatternCons
+    return { loc := between lhs.loc rhs.loc, kind := .cons lhs rhs }
+  else return lhs
 
 -- ---------------------------------------------------------------------------
 -- Shared binder helpers
 -- These are top-level so both parseExpr (parseLet/parseFun) and parseDecl
 -- (parseValDecl) can call them directly.
 
-private partial def parsePatternBinder : Parser Pattern := fun st =>
-  let p := peekLoc st
-  match peekTok st with
-  | .underscore => .ok (mkPat p (advance st) .wildcard, advance st)
-  | .ident name => .ok (mkPat p (advance st) (.binder (some name) none), advance st)
-  | .lparen =>
-    let st' := advance st
-    -- `()` is unit
-    if peekTok st' == .rparen then
-      .ok (mkPat p (advance st') (.const .unit), advance st')
-    else do
-      let (pat, st') ← parsePatternInner st'
-      match peekTok st' with
-      | .comma =>
-        let (rest, st') ← parseTuplePatRest st'
-        let st' ← expect .rparen st'
-        .ok (mkPat p st' (.tuple (pat :: rest)), st')
-      | .rparen => .ok (pat, advance st')
-      | t =>
-        .error { loc := peekLoc st', kind := .unexpectedToken "')' in binder" t }
-  | .lbrace => do
-    let st' := advance st
-    let (fields, st') ← parseRecordPatFields st'
-    let st' ← expect .rbrace st'
-    .ok (mkPat p st' (.record fields), st')
-  | t =>
-    .error { loc := peekLoc st, kind := .unexpectedToken "binder" t }
+private partial def parsePatternBinder : Parser Pattern := do
+  let start ← loc
+  match ← peek with
+  | .underscore => advance; return { loc := ← spanFrom start, kind := .wildcard }
+  | .ident name => advance; return { loc := ← spanFrom start, kind := .binder (some name) none }
+  | .lparen => advance; parseParenPattern start "')' in binder"
+  | .lbrace =>
+    advance
+    let fields ← parseRecordPatFields
+    expect .rbrace
+    return { loc := ← spanFrom start, kind := .record fields }
+  | _ => expected "binder"
 
-private partial def parseFunArgs : Parser (List Pattern) := fun st =>
-  if isPatStart (peekTok st) then do
-    let (p, st) ← parsePatternBinder st
-    let (rest, st) ← parseFunArgs st
-    .ok (p :: rest, st)
-  else .ok ([], st)
+private partial def parseFunArgs : Parser (List Pattern) := do
+  if isPatStart (← peek) then
+    let p ← parsePatternBinder
+    return p :: (← parseFunArgs)
+  else return []
 
-private partial def parseOptRetTy : Parser (Option Typ) := fun st =>
-  match peekTok st with
-  | .colon => do
-    let (ty, st) ← parseTypeNoArrow (advance st)
-    .ok (some ty, st)
-  | _ => .ok (none, st)
+private partial def parseOptRetTy : Parser (Option Typ) := do
+  if ← consumeIf .colon then some <$> parseTypeNoArrow else pure none
 
 -- ---------------------------------------------------------------------------
 -- Expression parsing
 
-private partial def parseExpr : Parser Expr := fun st => do
-  let (lhs, st) ← parseExprNoSemi st
-  match peekTok st with
-  | .semi => do
-    let (rhs, st) ← parseExpr (advance st)
-    let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-    .ok ({ loc, kind := .binop .semi lhs rhs }, st)
-  | _ => .ok (lhs, st)
+private partial def parseExpr : Parser Expr := do
+  let lhs ← parseExprNoSemi
+  if ← consumeIf .semi then
+    let rhs ← parseExpr
+    return { loc := between lhs.loc rhs.loc, kind := .binop .semi lhs rhs }
+  else return lhs
 
-where
-  -- Expression without top-level `;` — keywords and operators, but not `;`.
-  parseExprNoSemi : Parser Expr := fun st =>
-    match peekTok st with
-    | .kw_let   => parseLet st
-    | .kw_fun   => parseFun st
-    | .kw_if    => parseIf st
-    | .kw_match => parseMatch st
-    | _         => parseAssign st
+-- Expression without top-level `;` — keywords and operators, but not `;`.
+private partial def parseExprNoSemi : Parser Expr := do
+  match ← peek with
+  | .kw_let   => parseLet
+  | .kw_fun   => parseFun
+  | .kw_if    => parseIf
+  | .kw_match => parseMatch
+  | _         => parseAssign
 
-  -- `:=` (ref store) and `<-` (array set), both right-assoc
-  parseAssign : Parser Expr := fun st => do
-    let (lhs, st) ← parseOr st
-    match peekTok st with
-    | .colonEq => do
-      let (rhs, st) ← parseAssign (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      .ok ({ loc, kind := .binop .assign lhs rhs }, st)
-    | .leftArrow => do
-      let (rhs, st) ← parseAssign (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      match lhs.kind with
-      | .arrayGet arr idx => .ok ({ loc, kind := .arraySet arr idx rhs }, st)
-      | _ => .error { loc := lhs.loc, kind := .expectedArrayElementAssignTarget }
-    | _ => .ok (lhs, st)
+-- `:=` (ref store) and `<-` (array set), both right-assoc
+private partial def parseAssign : Parser Expr := do
+  let lhs ← parseOr
+  match ← peek with
+  | .colonEq =>
+    advance
+    let rhs ← parseAssign
+    return { loc := between lhs.loc rhs.loc, kind := .binop .assign lhs rhs }
+  | .leftArrow =>
+    advance
+    let rhs ← parseAssign
+    match lhs.kind with
+    | .arrayGet arr idx =>
+      return { loc := between lhs.loc rhs.loc, kind := .arraySet arr idx rhs }
+    | _ => failAt lhs.loc .expectedArrayElementAssignTarget
+  | _ => return lhs
 
-  -- `||` right-assoc
-  parseOr : Parser Expr := fun st => do
-    let (lhs, st) ← parseAnd st
-    match peekTok st with
-    | .pipepipe => do
-      let (rhs, st) ← parseOr (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      .ok ({ loc, kind := .binop .or lhs rhs }, st)
-    | _ => .ok (lhs, st)
+-- `||` right-assoc
+private partial def parseOr : Parser Expr := do
+  let lhs ← parseAnd
+  if ← consumeIf .pipepipe then
+    let rhs ← parseOr
+    return { loc := between lhs.loc rhs.loc, kind := .binop .or lhs rhs }
+  else return lhs
 
-  -- `&&` right-assoc
-  parseAnd : Parser Expr := fun st => do
-    let (lhs, st) ← parsePipeGt st
-    match peekTok st with
-    | .ampamp => do
-      let (rhs, st) ← parseAnd (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      .ok ({ loc, kind := .binop .and lhs rhs }, st)
-    | _ => .ok (lhs, st)
+-- `&&` right-assoc
+private partial def parseAnd : Parser Expr := do
+  let lhs ← parsePipeGt
+  if ← consumeIf .ampamp then
+    let rhs ← parseAnd
+    return { loc := between lhs.loc rhs.loc, kind := .binop .and lhs rhs }
+  else return lhs
 
-  -- `|>` left-assoc
-  parsePipeGt : Parser Expr := fun st => do
-    let (lhs, st) ← parseAtAt st
-    parsePipeGtRest lhs st
+-- `|>` left-assoc
+private partial def parsePipeGt : Parser Expr := do
+  parsePipeGtRest (← parseAtAt)
 
-  parsePipeGtRest (lhs : Expr) : Parser Expr := fun st =>
-    match peekTok st with
-    | .pipeGt => do
-      let (rhs, st) ← parseAtAt (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      parsePipeGtRest { loc, kind := .binop .pipeRight lhs rhs } st
-    | _ => .ok (lhs, st)
+private partial def parsePipeGtRest (lhs : Expr) : Parser Expr := do
+  if ← consumeIf .pipeGt then
+    let rhs ← parseAtAt
+    parsePipeGtRest { loc := between lhs.loc rhs.loc, kind := .binop .pipeRight lhs rhs }
+  else return lhs
 
-  -- `@@` right-assoc
-  parseAtAt : Parser Expr := fun st => do
-    let (lhs, st) ← parseCmp st
-    match peekTok st with
-    | .atat => do
-      -- RHS is full expr so `f @@ fun x -> e` works
-      let (rhs, st) ← parseExpr (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      .ok ({ loc, kind := .binop .atAt lhs rhs }, st)
-    | _ => .ok (lhs, st)
+-- `@@` right-assoc
+private partial def parseAtAt : Parser Expr := do
+  let lhs ← parseCmp
+  if ← consumeIf .atat then
+    -- RHS is full expr so `f @@ fun x -> e` works
+    let rhs ← parseExpr
+    return { loc := between lhs.loc rhs.loc, kind := .binop .atAt lhs rhs }
+  else return lhs
 
-  -- comparison (left-assoc)
-  parseCmp : Parser Expr :=
-    parseLAssoc [(.eq, .eq), (.neq, .neq), (.lt, .lt), (.le, .le), (.gt, .gt), (.ge, .ge)] parseConcat
+-- comparison (left-assoc)
+private partial def parseCmp : Parser Expr :=
+  parseLAssoc [(.eq, .eq), (.neq, .neq), (.lt, .lt), (.le, .le), (.gt, .gt), (.ge, .ge)] parseConcat
 
-  -- `^`/`@` right-assoc, one shared level (matches OCaml: looser than `::`)
-  parseConcat : Parser Expr := fun st => do
-    let (lhs, st) ← parseCons st
-    match peekTok st with
-    | .caret => do
-      let (rhs, st) ← parseConcat (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      .ok ({ loc, kind := .binop .concat lhs rhs }, st)
-    | .at => do
-      let (rhs, st) ← parseConcat (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      .ok ({ loc, kind := .binop .append lhs rhs }, st)
-    | _ => .ok (lhs, st)
+-- `^`/`@` right-assoc, one shared level (matches OCaml: looser than `::`)
+private partial def parseConcat : Parser Expr := do
+  let lhs ← parseCons
+  match ← peek with
+  | .caret =>
+    advance
+    let rhs ← parseConcat
+    return { loc := between lhs.loc rhs.loc, kind := .binop .concat lhs rhs }
+  | .at =>
+    advance
+    let rhs ← parseConcat
+    return { loc := between lhs.loc rhs.loc, kind := .binop .append lhs rhs }
+  | _ => return lhs
 
-  -- `::` right-assoc, between `@`/`^` and `+`/`-` (matches OCaml)
-  parseCons : Parser Expr := fun st => do
-    let (lhs, st) ← parseAdd st
-    match peekTok st with
-    | .coloncolon => do
-      let (rhs, st) ← parseCons (advance st)
-      let loc : Location := { start := lhs.loc.start, stop := rhs.loc.stop }
-      .ok ({ loc, kind := .binop .cons lhs rhs }, st)
-    | _ => .ok (lhs, st)
+-- `::` right-assoc, between `@`/`^` and `+`/`-` (matches OCaml)
+private partial def parseCons : Parser Expr := do
+  let lhs ← parseAdd
+  if ← consumeIf .coloncolon then
+    let rhs ← parseCons
+    return { loc := between lhs.loc rhs.loc, kind := .binop .cons lhs rhs }
+  else return lhs
 
-  -- `+` `-` left-assoc
-  parseAdd : Parser Expr :=
-    parseLAssoc [(.plus, .add), (.minus, .sub), (.plusDot, .fadd), (.minusDot, .fsub)] parseMul
+-- `+` `-` left-assoc
+private partial def parseAdd : Parser Expr :=
+  parseLAssoc [(.plus, .add), (.minus, .sub), (.plusDot, .fadd), (.minusDot, .fsub)] parseMul
 
-  -- `*` `/` `mod` left-assoc
-  parseMul : Parser Expr :=
-    parseLAssoc [(.star, .mul), (.slash, .div), (.starDot, .fmul), (.slashDot, .fdiv), (.kw_mod, .mod)] parseUnary
+-- `*` `/` `mod` left-assoc
+private partial def parseMul : Parser Expr :=
+  parseLAssoc [(.star, .mul), (.slash, .div), (.starDot, .fmul), (.slashDot, .fdiv),
+               (.kw_mod, .mod)] parseUnary
 
-  -- prefix unary operators
-  parseUnary : Parser Expr := fun st =>
-    let p := peekLoc st
-    match peekTok st with
-    | .minus => do
-      let (e, st) ← parseUnary (advance st)
-      .ok (mkExpr p st (.unop .neg e), st)
-    | .kw_assert => do
-      let (e, st) ← parseUnary (advance st)
-      .ok (mkExpr p st (.unop .assert e), st)
-    | .bang => do
-      let (e, st) ← parseUnary (advance st)
-      .ok (mkExpr p st (.unop .deref e), st)
-    | _ => parseApp st
+-- prefix unary operators
+private partial def parseUnary : Parser Expr := do
+  let unop (op : UnOp) : Parser Expr := exprOf do
+    advance
+    return .unop op (← parseUnary)
+  match ← peek with
+  | .minus     => unop .neg
+  | .kw_assert => unop .assert
+  | .bang      => unop .deref
+  | _          => parseApp
 
-  -- function application (left-assoc, juxtaposition), then any expression
-  -- attributes `[@name payload]` attached as a postfix to the whole application.
-  parseApp : Parser Expr := fun st => do
-    let (fn, st) ← parsePostfix st
-    let (app, st) ← parseAppRest fn st
-    parseAttrSuffix app st
+-- function application (left-assoc, juxtaposition), then any expression
+-- attributes `[@name payload]` attached as a postfix to the whole application.
+private partial def parseApp : Parser Expr := do
+  let fn ← parsePostfix
+  let app ← parseAppRest fn
+  parseAttrSuffix (fun e a => { e with attrs := e.attrs ++ [a] }) app
 
-  -- Fold trailing expression attributes `e [@name payload]` into `e.attrs`.
-  parseAttrSuffix (e : Expr) : Parser Expr := fun st =>
-    match peekTok st with
-    | .lbracket =>
-      match peekTok (advance st) with
-      | .at => do
-        let (attr, st) ← parseExprAttr st
-        parseAttrSuffix { e with attrs := e.attrs ++ [attr] } st
-      | _ => .ok (e, st)  -- not an expression attribute (e.g. `[@@...]`), leave `[`
-    | _ => .ok (e, st)
+private partial def parseAppRest (fn : Expr) : Parser Expr := do
+  let args ← collectArgs
+  if args.isEmpty then return fn
+  else return { loc := ← spanFrom fn.loc, kind := .app fn args }
 
-  -- `[@name expr]` — single `@`, optional expression payload.
-  parseExprAttr : Parser Attribute := fun st => do
-    let p := peekLoc st
-    let st ← expect .lbracket st
-    let st ← expect .at st
-    let (name, st) ← expectIdent st
-    let (payload, st) ← match peekTok st with
-      | .rbracket => .ok (none, st)
-      | _ => do
-        let (e, st) ← parseExpr st
-        .ok (some e, st)
-    let st ← expect .rbracket st
-    .ok ({ loc := spanTo p st, name := AttrName.ofString name, payload }, st)
+private partial def collectArgs : Parser (List Expr) := do
+  -- `[` starts a list-literal argument unless it opens an attribute `[@...]`
+  let t ← peek
+  let isAttr := t == .lbracket && ((← peek 1) == .at || (← peek 1) == .atat)
+  if isArgStart t && !isAttr then
+    let arg ← parsePostfix
+    return arg :: (← collectArgs)
+  else return []
 
-  parseAppRest (fn : Expr) : Parser Expr := fun st => do
-    let (args, st) ← collectArgs st
-    if args.isEmpty then .ok (fn, st)
+-- postfix: `.n` tuple projection, `.field` field access
+private partial def parsePostfix : Parser Expr := do
+  parsePostfixRest (← parseAtom)
+
+private partial def parsePostfixRest (e : Expr) : Parser Expr := do
+  if (← peek) != .dot then return e
+  match ← peek 1 with
+  | .lparen =>
+    advance; advance
+    let idx ← parseExpr
+    expect .rparen
+    parsePostfixRest { loc := ← spanFrom e.loc, kind := .arrayGet e idx }
+  | .intLit n =>
+    if n ≥ 1 then
+      advance; advance
+      parsePostfixRest { loc := ← spanFrom e.loc, kind := .unop (.proj n.toNat) e }
     else
-      let loc : Location := { start := fn.loc.start, stop := (spanTo fn.loc st).stop }
-      .ok ({ loc, kind := .app fn args }, st)
+      failAt (← loc 1) .nonPositiveProjIndex
+  | .ident fname =>
+    advance; advance
+    parsePostfixRest { loc := ← spanFrom e.loc, kind := .unop (.field fname) e }
+  | _ => return e  -- lone dot, leave it
 
-  collectArgs : Parser (List Expr) := fun st =>
-    -- `[` starts a list-literal argument unless it opens an attribute `[@...]`
-    let isAttr := peekTok st == .lbracket &&
-      (peekTok (advance st) == .at || peekTok (advance st) == .atat)
-    if isArgStart (peekTok st) && !isAttr then do
-      let (arg, st) ← parsePostfix st
-      let (rest, st) ← collectArgs st
-      .ok (arg :: rest, st)
-    else .ok ([], st)
+-- atom: constants, variables, constructors, parens, records
+private partial def parseAtom : Parser Expr := do
+  let start ← loc
+  let const (c : Const) : Parser Expr := do
+    advance; return { loc := ← spanFrom start, kind := .const c }
+  match ← peek with
+  | .intLit n    => const (.int n)
+  | .floatLit f  => const (.float f)
+  | .charLit c   => const (.char c)
+  | .stringLit s => const (.string s)
+  | .kw_true     => const (.bool true)
+  | .kw_false    => const (.bool false)
+  | .ident name =>
+    advance
+    let path ← collectPathTail name []
+    return { loc := ← spanFrom start
+           , kind := if path.last.front.isUpper then .ctor path else .var path }
+  | .lbrace => parseRecord
+  | .lbracket =>
+    -- list literal `[]` / `[e1; e2; ...]`; elaboration lowers it to constructors
+    advance
+    if ← consumeIf .rbracket then return { loc := ← spanFrom start, kind := .list [] }
+    let elems ← parseListElems
+    expect .rbracket
+    return { loc := ← spanFrom start, kind := .list elems }
+  | .lparen =>
+    advance
+    -- `()` = unit
+    if ← consumeIf .rparen then return { loc := ← spanFrom start, kind := .const .unit }
+    let e ← parseExpr
+    match ← peek with
+    | .comma =>
+      -- tuple
+      let rest ← parseTupleRest
+      expect .rparen
+      return { loc := ← spanFrom start, kind := .tuple (e :: rest) }
+    | .colon =>
+      -- type annotation `(e : T)`
+      advance
+      let ty ← parseType
+      expect .rparen
+      return { loc := ← spanFrom start, kind := .annot e ty }
+    | .rparen => advance; return e
+    | _ => expected "')' or ',' in expression"
+  | _ => expected "expression"
 
-  isArgStart : Token → Bool
-    | .intLit _ | .floatLit _ | .charLit _ | .stringLit _ | .ident _ | .lparen | .lbrace
-    | .lbracket | .kw_true | .kw_false => true
-    | _ => false
+private partial def parseTupleRest : Parser (List Expr) := do
+  if ← consumeIf .comma then
+    let e ← parseExpr
+    return e :: (← parseTupleRest)
+  else return []
 
-  -- postfix: `.n` tuple projection, `.field` field access
-  parsePostfix : Parser Expr := fun st => do
-    let (e, st) ← parseAtom st
-    parsePostfixRest e st
+-- `;`-separated list-literal elements, allowing a trailing `;`
+private partial def parseListElems : Parser (List Expr) := do
+  let e ← parseExprNoSemi
+  if ← consumeIf .semi then
+    if (← peek) == .rbracket then return [e]
+    else return e :: (← parseListElems)
+  else return [e]
 
-  parsePostfixRest (e : Expr) : Parser Expr := fun st =>
-    match peekTok st with
-    | .dot =>
-      let st' := advance st
-      match peekTok st' with
-      | .lparen => do
-        let (idx, st'') ← parseExpr (advance st')
-        let st'' ← expect .rparen st''
-        let loc : Location := { start := e.loc.start, stop := (spanTo e.loc st'').stop }
-        parsePostfixRest { loc, kind := .arrayGet e idx } st''
-      | .intLit n =>
-        if n ≥ 1 then
-          let st'' := advance st'
-          let loc : Location := { start := e.loc.start, stop := (spanTo e.loc st'').stop }
-          parsePostfixRest { loc, kind := .unop (.proj n.toNat) e } st''
-        else
-          .error { loc := peekLoc st', kind := .nonPositiveProjIndex }
-      | .ident fname =>
-        let st'' := advance st'
-        let loc : Location := { start := e.loc.start, stop := (spanTo e.loc st'').stop }
-        parsePostfixRest { loc, kind := .unop (.field fname) e } st''
-      | _ => .ok (e, st)  -- lone dot, leave it
-    | _ => .ok (e, st)
+-- `{ f1 = e1; f2 = e2 }` or `{ e with f1 = e1; ... }`
+-- Lookahead approach: peek to distinguish record literal from record update.
+-- A record literal starts with `ident =` (lowercase field name followed by `=`).
+-- Anything else is treated as an expression for record update.
+private partial def parseRecord : Parser Expr := do
+  let start ← loc
+  expect .lbrace
+  if ← isRecordLiteral then
+    let fields ← parseRecordFields
+    expect .rbrace
+    return { loc := ← spanFrom start, kind := .record fields }
+  else
+    let e ← parseExpr
+    expect .kw_with
+    let fields ← parseRecordFields
+    expect .rbrace
+    return { loc := ← spanFrom start, kind := .recordUpdate e fields }
 
-  -- atom: constants, variables, constructors, parens, records
-  parseAtom : Parser Expr := fun st =>
-    let p := peekLoc st
-    match peekTok st with
-    | .intLit n  => .ok (mkExpr p (advance st) (.const (.int n)), advance st)
-    | .floatLit f => .ok (mkExpr p (advance st) (.const (.float f)), advance st)
-    | .charLit c => .ok (mkExpr p (advance st) (.const (.char c)), advance st)
-    | .stringLit s => .ok (mkExpr p (advance st) (.const (.string s)), advance st)
-    | .kw_true   => .ok (mkExpr p (advance st) (.const (.bool true)), advance st)
-    | .kw_false  => .ok (mkExpr p (advance st) (.const (.bool false)), advance st)
-    | .ident name => do
-      let (path, st') ← collectPathTail name [] (advance st)
-      if path.last.front.isUpper then
-        .ok (mkExpr p st' (.ctor path), st')
-      else
-        .ok (mkExpr p st' (.var path), st')
-    | .lbrace => parseRecord st
-    | .lbracket =>
-      -- list literal `[]` / `[e1; e2; ...]`; elaboration lowers it to constructors
-      let st' := advance st
-      if peekTok st' == .rbracket then
-        .ok (mkExpr p (advance st') (.list []), advance st')
-      else do
-        let (elems, st') ← parseListElems st'
-        let st' ← expect .rbracket st'
-        .ok (mkExpr p st' (.list elems), st')
-    | .lparen =>
-      let st' := advance st
-      -- `()` = unit
-      if peekTok st' == .rparen then
-        .ok (mkExpr p (advance st') (.const .unit), advance st')
-      else do
-        let (e, st') ← parseExpr st'
-        match peekTok st' with
-        | .comma =>
-          -- tuple
-          let (rest, st') ← parseTupleRest st'
-          let st' ← expect .rparen st'
-          let loc : Location := { start := p.start, stop := (spanTo p st').stop }
-          .ok ({ loc, kind := .tuple (e :: rest) }, st')
-        | .colon =>
-          -- type annotation `(e : T)`
-          let (ty, st') ← parseType (advance st')
-          let st' ← expect .rparen st'
-          let loc : Location := { start := p.start, stop := (spanTo p st').stop }
-          .ok ({ loc, kind := .annot e ty }, st')
-        | .rparen =>
-          .ok (e, advance st')
-        | t =>
-          .error { loc := peekLoc st', kind := .unexpectedToken "')' or ',' in expression" t }
-    | t =>
-      .error { loc := peekLoc st, kind := .unexpectedToken "expression" t }
+private partial def parseRecordFields : Parser (List (FieldName × Expr)) := do
+  let name ← expectIdent
+  expect .eq
+  let e ← parseAssign
+  if ← consumeIf .semi then
+    if (← peek) == .rbrace then return [(name, e)]  -- trailing semicolon
+    else return (name, e) :: (← parseRecordFields)
+  else return [(name, e)]
 
-  parseTupleRest : Parser (List Expr) := fun st =>
-    match peekTok st with
-    | .comma => do
-      let (e, st) ← parseExpr (advance st)
-      let (rest, st) ← parseTupleRest st
-      .ok (e :: rest, st)
-    | _ => .ok ([], st)
+-- `let [rec] pat pat ... [: T] = e in body`
+private partial def parseLet : Parser Expr := exprOf do
+  expect .kw_let
+  let isRec ← consumeIf .kw_rec
+  let first ← parsePatternBinder
+  let rest ← parseFunArgs
+  let retTy ← parseOptRetTy
+  expect .eq
+  let bound ← parseExpr
+  expect .kw_in
+  let body ← parseExpr
+  return .letIn isRec (first :: rest) retTy bound body
 
-  -- `;`-separated list-literal elements, allowing a trailing `;`
-  parseListElems : Parser (List Expr) := fun st => do
-    let (e, st) ← parseExprNoSemi st
-    match peekTok st with
-    | .semi =>
-      let st' := advance st
-      if peekTok st' == .rbracket then .ok ([e], st')
-      else do
-        let (rest, st') ← parseListElems st'
-        .ok (e :: rest, st')
-    | _ => .ok ([e], st)
+-- `fun pat pat ... [: T] -> body`
+private partial def parseFun : Parser Expr := exprOf do
+  let start ← loc
+  expect .kw_fun
+  let args ← parseFunArgs
+  if args.isEmpty then failAt start .funNoArgs
+  let retTy ← parseOptRetTy
+  expect .arrow
+  return .fun_ args retTy (← parseExpr)
 
-  -- `{ f1 = e1; f2 = e2 }` or `{ e with f1 = e1; ... }`
-  -- Lookahead approach: peek to distinguish record literal from record update.
-  -- A record literal starts with `ident =` (lowercase field name followed by `=`).
-  -- Anything else is treated as an expression for record update.
-  parseRecord : Parser Expr := fun st => do
-    let p := peekLoc st
-    let st ← expect .lbrace st
-    if isRecordLiteral st then do
-      let (fields, st) ← parseRecordFields st
-      let st ← expect .rbrace st
-      .ok (mkExpr p st (.record fields), st)
-    else do
-      let (e, st) ← parseExpr st
-      let st ← expect .kw_with st
-      let (fields, st) ← parseRecordFields st
-      let st ← expect .rbrace st
-      .ok (mkExpr p st (.recordUpdate e fields), st)
+-- `if c then t else e`
+-- Sub-expressions use parseExprNoSemi because `;` binds less tightly
+-- than if/then/else in OCaml.
+private partial def parseIf : Parser Expr := exprOf do
+  expect .kw_if
+  let cond ← parseExprNoSemi
+  expect .kw_then
+  let thn ← parseExprNoSemi
+  expect .kw_else
+  return .ite cond thn (← parseExprNoSemi)
 
-  isRecordLiteral (st : ParserState) : Bool :=
-    match peekTok st with
-    | .ident name =>
-      if !name.front.isUpper && name.front != '\'' then
-        peekTok (advance st) == .eq
-      else false
-    | _ => false
+-- `match e with | P -> e | ...`
+private partial def parseMatch : Parser Expr := exprOf do
+  expect .kw_match
+  let scrut ← parseExpr
+  expect .kw_with
+  return .match_ scrut (← parseMatchArms)
 
-  parseRecordFields : Parser (List (FieldName × Expr)) := fun st => do
-    let (name, st) ← expectIdent st
-    let st ← expect .eq st
-    let (e, st) ← parseExpr.parseAssign st
-    match peekTok st with
-    | .semi =>
-      let st' := advance st
-      match peekTok st' with
-      | .rbrace => .ok ([(name, e)], st')  -- trailing semicolon
-      | _ => do
-        let (rest, st') ← parseRecordFields st'
-        .ok ((name, e) :: rest, st')
-    | _ => .ok ([(name, e)], st)
+private partial def parseMatchArms : Parser (List MatchArm) := do
+  if ← consumeIf .pipe then
+    let pat ← parsePatternCons
+    expect .arrow
+    let body ← parseExpr
+    return { pat, body } :: (← parseMatchArms)
+  else return []
 
-  -- `let [rec] pat pat ... [: T] = e in body`
-  parseLet : Parser Expr := fun st => do
-    let p := peekLoc st
-    let st ← expect .kw_let st
-    let isRec := peekTok st == .kw_rec
-    let st := if isRec then advance st else st
-    let (first, st) ← parsePatternBinder st
-    let (rest, st) ← parseFunArgs st
-    let (retTy, st) ← parseOptRetTy st
-    let st ← expect .eq st
-    let (bound, st) ← parseExpr st
-    let st ← expect .kw_in st
-    let (body, st) ← parseExpr st
-    .ok (mkExpr p st (.letIn isRec (first :: rest) retTy bound body), st)
-
-  -- `fun pat pat ... [: T] -> body`
-  parseFun : Parser Expr := fun st => do
-    let p := peekLoc st
-    let st ← expect .kw_fun st
-    let (args, st) ← parseFunArgs st
-    if args.isEmpty then
-      .error { loc := p, kind := .funNoArgs }
-    let (retTy, st) ← parseOptRetTy st
-    let st ← expect .arrow st
-    let (body, st) ← parseExpr st
-    .ok (mkExpr p st (.fun_ args retTy body), st)
-
-  -- `if c then t else e`
-  -- Sub-expressions use parseExprNoSemi because `;` binds less tightly
-  -- than if/then/else in OCaml.
-  parseIf : Parser Expr := fun st => do
-    let p := peekLoc st
-    let st ← expect .kw_if st
-    let (cond, st) ← parseExprNoSemi st
-    let st ← expect .kw_then st
-    let (thn, st) ← parseExprNoSemi st
-    let st ← expect .kw_else st
-    let (els, st) ← parseExprNoSemi st
-    .ok (mkExpr p st (.ite cond thn els), st)
-
-  -- `match e with | P -> e | ...`
-  parseMatch : Parser Expr := fun st => do
-    let p := peekLoc st
-    let st ← expect .kw_match st
-    let (scrut, st) ← parseExpr st
-    let st ← expect .kw_with st
-    let (arms, st) ← parseMatchArms st
-    .ok (mkExpr p st (.match_ scrut arms), st)
-
-  parseMatchArms : Parser (List MatchArm) := fun st =>
-    match peekTok st with
-    | .pipe => do
-      let st' := advance st
-      let (pat, st') ← parsePatternCons st'
-      let st' ← expect .arrow st'
-      let (body, st') ← parseExpr st'
-      let (rest, st') ← parseMatchArms st'
-      .ok ({ pat, body } :: rest, st')
-    | _ => .ok ([], st)
+end
 
 -- ---------------------------------------------------------------------------
 -- Declaration parsing
 
-end
+private def parseOpenDecl : Parser DeclKind := do
+  expect .kw_open
+  let head ← expectIdent
+  return .open_ (← collectPathTail head [])
 
-/-- Parse a single top-level declaration. -/
-private partial def parseDecl : Parser Decl := fun st =>
-  let p := peekLoc st
-  match peekTok st with
-  | .kw_open => parseOpenDecl p st
-  | .kw_type => parseTypeDecl p st
-  | .kw_let  => parseValDecl p st
-  | t =>
-    .error { loc := peekLoc st, kind := .unexpectedToken "declaration (open, let, or type)" t }
-where
-  parseOpenDecl (p : Location) : Parser Decl := fun st => do
-    let st ← expect .kw_open st
-    let (head, st) ← expectIdent st
-    let (path, st) ← collectPathTail head [] st
-    .ok ({ loc := spanTo p st, kind := .open_ path, attrs := [] }, st)
+private partial def parseTypeParamList : Parser (List TypeVariable) := do
+  match ← peek with
+  | .ident name =>
+    if name.front == '\'' then
+      advance
+      let varName := name.toRawSubstring.drop 1 |>.toString
+      if ← consumeIf .comma then return varName :: (← parseTypeParamList)
+      else return [varName]
+    else return []
+  | _ => return []
 
-  parseTypeDecl (p : Location) : Parser Decl := fun st => do
-    let st ← expect .kw_type st
-    -- optional type parameters: `'a`, `('a, 'b)`, etc.
-    let (params, st) ← parseTypeParams st
-    let (name, st) ← expectIdent st
-    let st ← expect .eq st
-    -- try to figure out if this is a variant or record
-    let (body, st) ← parseTypeDeclBody st
-    let decl : TypeDecl := { params, name, body }
-    let attrs := #[]
-    .ok ({ loc := spanTo p st, kind := .type_ decl, attrs := attrs.toList }, st)
-
-  parseTypeParams : Parser (List TypeVariable) := fun st =>
-    match peekTok st with
-    | .ident name =>
-      -- type variable: starts with `'`
-      if name.front == '\'' then
-        let varName := name.toRawSubstring.drop 1 |>.toString
-        .ok ([varName], advance st)
-      else .ok ([], st)
-    | .lparen =>
-      let st' := advance st
-      -- check if next is a type variable
-      match peekTok st' with
-      | .ident name =>
-        if name.front == '\'' then do
-          let (params, st') ← parseTypeParamList st'
-          let st' ← expect .rparen st'
-          .ok (params, st')
-        else .ok ([], st)  -- not type params, leave paren
-      | _ => .ok ([], st)  -- not type params, leave paren
-    | _ => .ok ([], st)
-
-  parseTypeParamList : Parser (List TypeVariable) := fun st =>
-    match peekTok st with
+/-- Optional type parameters: `'a`, `('a, 'b)`, etc. A `(` that does not open a
+parameter list is left for the caller. -/
+private def parseTypeParams : Parser (List TypeVariable) := do
+  match ← peek with
+  | .ident name =>
+    if name.front == '\'' then
+      advance
+      return [name.toRawSubstring.drop 1 |>.toString]
+    else return []
+  | .lparen =>
+    match ← peek 1 with
     | .ident name =>
       if name.front == '\'' then
-        let varName := name.toRawSubstring.drop 1 |>.toString
-        let st' := advance st
-        match peekTok st' with
-        | .comma => do
-          let (rest, st') ← parseTypeParamList (advance st')
-          .ok (varName :: rest, st')
-        | _ => .ok ([varName], st')
-      else .ok ([], st)
-    | _ => .ok ([], st)
+        advance
+        let params ← parseTypeParamList
+        expect .rparen
+        return params
+      else return []
+    | _ => return []
+  | _ => return []
 
-  parseTypeDeclBody : Parser TypeDeclBody := fun st =>
-    match peekTok st with
-    | .lbrace => parseRecordBody st
-    | _ => parseVariantBody st
+private partial def parseRecordBodyFields : Parser (List (FieldName × Typ)) := do
+  let name ← expectIdent
+  expect .colon
+  let ty ← parseType
+  if ← consumeIf .semi then
+    if (← peek) == .rbrace then return [(name, ty)]  -- trailing semicolon
+    else return (name, ty) :: (← parseRecordBodyFields)
+  else return [(name, ty)]
 
-  parseRecordBody : Parser TypeDeclBody := fun st => do
-    let st ← expect .lbrace st
-    let (fields, st) ← parseRecordBodyFields st
-    let st ← expect .rbrace st
-    .ok (.record fields, st)
+private partial def parseCtors : Parser (List (Constructor × Option Typ)) := do
+  let name ← expectConstructor
+  let payload ← if ← consumeIf .kw_of then some <$> parseType else pure none
+  if ← consumeIf .pipe then return (name, payload) :: (← parseCtors)
+  else return [(name, payload)]
 
-  parseRecordBodyFields : Parser (List (FieldName × Typ)) := fun st => do
-    let (name, st) ← expectIdent st
-    let st ← expect .colon st
-    let (ty, st) ← parseType st
-    match peekTok st with
-    | .semi =>
-      let st' := advance st
-      match peekTok st' with
-      | .rbrace => .ok ([(name, ty)], st')  -- trailing semicolon
-      | _ => do
-        let (rest, st') ← parseRecordBodyFields st'
-        .ok ((name, ty) :: rest, st')
-    | _ => .ok ([(name, ty)], st)
-
-  parseVariantBody : Parser TypeDeclBody := fun st => do
+private def parseTypeDeclBody : Parser TypeDeclBody := do
+  if ← consumeIf .lbrace then
+    let fields ← parseRecordBodyFields
+    expect .rbrace
+    return .record fields
+  else
     -- optional leading `|`
-    let st := if peekTok st == .pipe then advance st else st
-    let (ctors, st) ← parseCtors st
-    .ok (.variant ctors, st)
+    let _ ← consumeIf .pipe
+    return .variant (← parseCtors)
 
-  parseCtors : Parser (List (Constructor × Option Typ)) := fun st => do
-    let (name, st) ← expectConstructor st
-    let (payload, st) ← parseCtorPayload st
-    match peekTok st with
-    | .pipe => do
-      let (rest, st) ← parseCtors (advance st)
-      .ok ((name, payload) :: rest, st)
-    | _ => .ok ([(name, payload)], st)
+private def parseTypeDecl : Parser DeclKind := do
+  expect .kw_type
+  let params ← parseTypeParams
+  let name ← expectIdent
+  expect .eq
+  return .type_ { params, name, body := ← parseTypeDeclBody }
 
-  parseCtorPayload : Parser (Option Typ) := fun st =>
-    match peekTok st with
-    | .kw_of => do
-      let (ty, st) ← parseType (advance st)
-      .ok (some ty, st)
-    | _ => .ok (none, st)
+private def parseValDecl : Parser DeclKind := do
+  expect .kw_let
+  let isRec ← consumeIf .kw_rec
+  let first ← parsePatternBinder
+  let rest ← parseFunArgs
+  let retTy ← parseOptRetTy
+  expect .eq
+  return .val_ isRec (first :: rest) retTy (← parseExpr)
 
-  parseValDecl (p : Location) : Parser Decl := fun st => do
-    let st ← expect .kw_let st
-    let isRec := peekTok st == .kw_rec
-    let st := if isRec then advance st else st
-    let (first, st) ← parsePatternBinder st
-    let (rest, st) ← parseFunArgs st
-    let (retTy, st) ← parseOptRetTy st
-    let st ← expect .eq st
-    let (body, st) ← parseExpr st
-    -- optional `[@@name expr]` attribute(s)
-    let (attrs, st) ← parseAttrs st
-    .ok ({ loc := spanTo p st, kind := .val_ isRec (first :: rest) retTy body, attrs }, st)
+/-- Trailing `[@@name payload]` attributes on a declaration. -/
+private partial def parseDeclAttrs : Parser (List Attribute) := do
+  if (← peek) == .lbracket && (← peek 1) == .atat then
+    let attr ← parseAttr .atat
+    return attr :: (← parseDeclAttrs)
+  else return []
 
-  -- `[@@name expr]` repeated
-  parseAttrs : Parser (List Attribute) := fun st =>
-    match peekTok st with
-    | .lbracket =>
-      match (advance st |> peekTok) with
-      | .atat => do
-        let p := peekLoc st
-        let st' := advance (advance st)  -- skip `[` and `@@`
-        let (name, st') ← expectIdent st'
-        -- An attribute may carry an expression payload (`[@@spec ...]`) or
-        -- stand alone with none (`[@@fn]`).
-        let (payload, st') ← match peekTok st' with
-          | .rbracket => .ok (none, st')
-          | _ => do
-            let (e, st') ← parseExpr st'
-            .ok (some e, st')
-        let st' ← expect .rbracket st'
-        let attr : Attribute := { loc := spanTo p st', name := AttrName.ofString name, payload }
-        let (rest, st') ← parseAttrs st'
-        .ok (attr :: rest, st')
-      | _ => .ok ([], st)
-    | _ => .ok ([], st)
+/-- Parse a single top-level declaration.
+
+Only `let` declarations take `[@@...]` attributes today; `type` and `open` reject
+a following `[`. That is a language-scope question rather than a parsing one, so
+it is left as-is here. -/
+private def parseDecl : Parser Decl := do
+  let start ← loc
+  match ← peek with
+  | .kw_let =>
+    let kind ← parseValDecl
+    let attrs ← parseDeclAttrs
+    return { loc := ← spanFrom start, kind, attrs }
+  | .kw_open => return { loc := ← spanFrom start, kind := ← parseOpenDecl, attrs := [] }
+  | .kw_type => return { loc := ← spanFrom start, kind := ← parseTypeDecl, attrs := [] }
+  | _ => expected "declaration (open, let, or type)"
 
 -- ---------------------------------------------------------------------------
 -- Top-level program parsing
 
 /-- Parse a sequence of top-level declarations. -/
-private partial def parseProgram : Parser Program := fun st =>
-  match peekTok st with
-  | .eof => .ok ([], st)
-  | .semisemi => parseProgram (advance st)
-  | .kw_open | .kw_let | .kw_type => do
-    let (decl, st) ← parseDecl st
+private partial def parseProgram : Parser Program := do
+  match ← peek with
+  | .eof => return []
+  | .semisemi => advance; parseProgram
+  | .kw_open | .kw_let | .kw_type =>
+    let decl ← parseDecl
     -- skip optional `;;`
-    let st := if peekTok st == .semisemi then advance st else st
-    let (rest, st) ← parseProgram st
-    .ok (decl :: rest, st)
-  | t =>
-    .error { loc := peekLoc st, kind := .unexpectedToken "declaration" t }
+    let _ ← consumeIf .semisemi
+    return decl :: (← parseProgram)
+  | _ => expected "declaration"
 
 /-- Lex and parse `source` (file named `file`). -/
 def parseFile (file : String) (source : String) : Except FrontendError Program := do
   let tokens ← (tokenize file source).mapError .lexError
   let st : ParserState := { file, tokens, pos := 0 }
-  let (prog, st) ← (parseProgram st).mapError .parseError
-  if peekTok st != .eof then
-    .error (.parseError { loc := peekLoc st, kind := .unexpectedToken "end of file" (peekTok st) })
-  else
-    .ok prog
+  let (prog, _) ← (parseProgram st).mapError .parseError
+  .ok prog
 
 end Frontend

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -206,7 +206,7 @@ private def isPatStart : Token → Bool
 
 private def isArgStart : Token → Bool
   | .intLit _ | .floatLit _ | .charLit _ | .stringLit _ | .ident _ | .lparen | .lbrace
-  | .lbracket | .kw_true | .kw_false => true
+  | .lbracket | .kw_true | .kw_false | .bang => true
   | _ => false
 
 /-- A record literal starts with `ident =` (a lowercase field name followed by
@@ -480,22 +480,23 @@ private partial def parseOperand : Parser Expr := do
   | .kw_match => parseMatch
   | _         => parseUnary
 
--- prefix unary operators
+-- prefix `-` (`Prec.app`): looser than application, so `- f a` is `- (f a)`,
+-- and tighter than every binary operator, so `- a * b` is `(- a) * b`.
 private partial def parseUnary : Parser Expr := do
-  let unop (op : UnOp) : Parser Expr := exprOf do
-    advance
-    return .unop op (← parseUnary)
   match ← peek with
-  | .minus     => unop .neg
-  | .kw_assert => unop .assert
-  | .bang      => unop .deref
-  | _          => parseApp
+  | .minus => exprOf do advance; return .unop .neg (← parseUnary)
+  | _      => parseApp
 
 -- function application (left-assoc, juxtaposition), then any expression
 -- attributes `[@name payload]` attached as a postfix to the whole application.
+-- `assert` sits at this level but takes a single operand, so `assert f a` is a
+-- syntax error in OCaml rather than an assertion of `f a`.
 private partial def parseApp : Parser Expr := do
-  let fn ← parsePostfix
-  let app ← parseAppRest fn
+  let app ←
+    if (← peek) == .kw_assert then
+      exprOf do advance; return .unop .assert (← parseAccess)
+    else
+      parseAppRest (← parseAccess)
   parseAttrSuffix (fun e a => { e with attrs := e.attrs ++ [a] }) app
 
 private partial def parseAppRest (fn : Expr) : Parser Expr := do
@@ -508,32 +509,40 @@ private partial def collectArgs : Parser (List Expr) := do
   let t ← peek
   let isAttr := t == .lbracket && ((← peek 1) == .at || (← peek 1) == .atat)
   if isArgStart t && !isAttr then
-    let arg ← parsePostfix
+    let arg ← parseAccess
     return arg :: (← collectArgs)
   else return []
 
--- postfix: `.n` tuple projection, `.field` field access
-private partial def parsePostfix : Parser Expr := do
-  parsePostfixRest (← parseAtom)
+-- postfix access (`Prec.access`): `.n` tuple projection, `.field` field access,
+-- `.(i)` array element. Tighter than application, so `f a.b` is `f (a.b)`.
+private partial def parseAccess : Parser Expr := do
+  parseAccessRest (← parsePrefix)
 
-private partial def parsePostfixRest (e : Expr) : Parser Expr := do
+private partial def parseAccessRest (e : Expr) : Parser Expr := do
   if (← peek) != .dot then return e
   match ← peek 1 with
   | .lparen =>
     advance; advance
     let idx ← parseExpr
     expect .rparen
-    parsePostfixRest { loc := ← spanFrom e.loc, kind := .arrayGet e idx }
+    parseAccessRest { loc := ← spanFrom e.loc, kind := .arrayGet e idx }
   | .intLit n =>
     if n ≥ 1 then
       advance; advance
-      parsePostfixRest { loc := ← spanFrom e.loc, kind := .unop (.proj n.toNat) e }
+      parseAccessRest { loc := ← spanFrom e.loc, kind := .unop (.proj n.toNat) e }
     else
       failAt (← loc 1) .nonPositiveProjIndex
   | .ident fname =>
     advance; advance
-    parsePostfixRest { loc := ← spanFrom e.loc, kind := .unop (.field fname) e }
+    parseAccessRest { loc := ← spanFrom e.loc, kind := .unop (.field fname) e }
   | _ => return e  -- lone dot, leave it
+
+-- prefix `!` (`Prec.prefixOp`): the tightest level, above access as well as
+-- application, so `!r.contents` is `(!r).contents` and `!f x` is `(!f) x`.
+private partial def parsePrefix : Parser Expr := do
+  match ← peek with
+  | .bang => exprOf do advance; return .unop .deref (← parsePrefix)
+  | _     => parseAtom
 
 -- atom: constants, variables, constructors, parens, records
 private partial def parseAtom : Parser Expr := do

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -328,12 +328,21 @@ private partial def parseOptFunRetTy : Parser (Option Typ) := do
 -- ---------------------------------------------------------------------------
 -- Pattern parsing
 
-/-- Pattern with infix `::` (right-assoc): `p1 :: p2` is the prelude cons
-constructor applied to the pair pattern `(p1, p2)`. The loosest pattern level. -/
+/-- A pattern, comma included: `p1, p2` is a tuple pattern, needing no
+parentheses of its own. The loosest pattern level. -/
 private partial def parsePattern : Parser Pattern := do
+  let first ← parsePatternCons
+  if ← consumeIf .comma then
+    let rest ← parseTuplePatRest
+    return { loc := ← spanFrom first.loc, kind := .tuple (first :: rest) }
+  else return first
+
+/-- Pattern with infix `::` (right-assoc): `p1 :: p2` is the prelude cons
+constructor applied to the pair pattern `(p1, p2)`. -/
+private partial def parsePatternCons : Parser Pattern := do
   let lhs ← parsePatternApp
   if ← consumeIf .coloncolon then
-    let rhs ← parsePattern
+    let rhs ← parsePatternCons
     return { loc := between lhs.loc rhs.loc, kind := .cons lhs rhs }
   else return lhs
 
@@ -378,15 +387,12 @@ private partial def parsePatternAtom : Parser Pattern := patOf do
 private partial def parseParenPattern : Parser PatternKind := do
   -- `()` = unit constant
   if ← consumeIf .rparen then return .const .unit
+  -- A tuple pattern needs no parentheses of its own, so `(p, q)` arrives here
+  -- already built by the comma level.
   let pat ← parsePatternAnnot
   match ← peek with
-  | .comma =>
-    -- tuple pattern
-    let rest ← parseTuplePatRest
-    expect .rparen
-    return .tuple (pat :: rest)
   | .rparen => advance; return pat.kind
-  | _ => expected "')' or ',' in pattern"
+  | _ => expected "')' or ':' in pattern"
 
 /-- A pattern carrying the annotation `p : T` that only a parenthesized position
 admits. `Pattern` has a slot for one on a binder alone, so `(C x : T)` is not a
@@ -403,11 +409,11 @@ private partial def parsePatternAnnot : Parser Pattern := do
   | .wildcard         => annotate none
   | _                 => return pat
 
+/-- The components after the first `,`, each below the comma level so that the
+tuple pattern stays flat. -/
 private partial def parseTuplePatRest : Parser (List Pattern) := do
-  if ← consumeIf .comma then
-    let p ← parsePattern
-    return p :: (← parseTuplePatRest)
-  else return []
+  let p ← parsePatternCons
+  if ← consumeIf .comma then return p :: (← parseTuplePatRest) else return [p]
 
 private partial def parseRecordPatFields : Parser (List (FieldName × Pattern)) := do
   let name ← expectIdent
@@ -452,6 +458,13 @@ private partial def parseExprAt (min : Nat) : Parser Expr := do
 
 private partial def parseInfix (min : Nat) (lhs : Expr) : Parser Expr := do
   match ← peek with
+  -- `a, b, c` — one flat tuple, so the comma is its own case rather than a
+  -- right-associative operator building nested pairs.
+  | .comma =>
+    if Prec.comma < min then return lhs
+    advance
+    let rest ← parseTupleRest
+    parseInfix min { loc := ← spanFrom lhs.loc, kind := .tuple (lhs :: rest) }
   -- `a.(i) <- e`, at `:=`'s level and right-associative like it.
   | .leftArrow =>
     let lvl := BinOp.level .assign
@@ -583,13 +596,10 @@ private partial def parseAtom : Parser Expr := do
     advance
     -- `()` = unit
     if ← consumeIf .rparen then return { loc := ← spanFrom start, kind := .const .unit }
+    -- A tuple needs no parentheses of its own, so `(a, b)` arrives here already
+    -- built by the comma level.
     let e ← parseExpr
     match ← peek with
-    | .comma =>
-      -- tuple
-      let rest ← parseTupleRest
-      expect .rparen
-      return { loc := ← spanFrom start, kind := .tuple (e :: rest) }
     | .colon =>
       -- type annotation `(e : T)`
       advance
@@ -597,14 +607,14 @@ private partial def parseAtom : Parser Expr := do
       expect .rparen
       return { loc := ← spanFrom start, kind := .annot e ty }
     | .rparen => advance; return e
-    | _ => expected "')' or ',' in expression"
+    | _ => expected "')' or ':' in expression"
   | _ => expected "expression"
 
+/-- The components after the first `,`, each below the comma level so that the
+tuple stays flat. -/
 private partial def parseTupleRest : Parser (List Expr) := do
-  if ← consumeIf .comma then
-    let e ← parseExpr
-    return e :: (← parseTupleRest)
-  else return []
+  let e ← parseExprAt (Prec.comma + 1)
+  if ← consumeIf .comma then return e :: (← parseTupleRest) else return [e]
 
 -- `;`-separated list-literal elements, allowing a trailing `;`
 private partial def parseListElems : Parser (List Expr) := do

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -213,7 +213,7 @@ private def isPatStart : Token → Bool
 
 private def isArgStart : Token → Bool
   | .intLit _ | .floatLit _ | .charLit _ | .stringLit _ | .ident _ | .lparen | .lbrace
-  | .lbracket | .kw_true | .kw_false | .bang => true
+  | .lbracket | .kw_true | .kw_false | .bang | .kw_begin => true
   | _ => false
 
 /-- A record literal starts with `ident =` (a lowercase field name followed by
@@ -592,6 +592,12 @@ private partial def parseAtom : Parser Expr := do
     let elems ← parseListElems
     expect .rbracket
     return { loc := ← spanFrom start, kind := .list elems }
+  | .kw_begin =>
+    -- `begin e end` is `(e)`, with no node of its own.
+    advance
+    let e ← parseExpr
+    expect .kw_end
+    return e
   | .lparen =>
     advance
     -- `()` = unit

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -315,9 +315,15 @@ private partial def parseType : Parser Typ := do
     return { loc := between t.loc u.loc, kind := .arrow t u }
   else return t
 
-/-- Parse a type expression, excluding arrows.
-    Used for return type annotations where `->` is ambiguous with the function arrow. -/
-private partial def parseTypeNoArrow : Parser Typ := parseTypeProd
+/-- A `let`'s optional return type. It is delimited by the `=` that follows, so
+it may be an arrow: `let f x : int -> int = g x`. -/
+private partial def parseOptRetTy : Parser (Option Typ) := do
+  if ← consumeIf .colon then some <$> parseType else pure none
+
+/-- A `fun`'s optional return type. It is delimited by `->`, which is also the
+arrow constructor, so an arrow has to be parenthesized: `fun x : (int -> int) -> e`. -/
+private partial def parseOptFunRetTy : Parser (Option Typ) := do
+  if ← consumeIf .colon then some <$> parseTypeProd else pure none
 
 -- ---------------------------------------------------------------------------
 -- Pattern parsing
@@ -433,9 +439,6 @@ private partial def parseFunArgs : Parser (List Pattern) := do
     return p :: (← parseFunArgs)
   else return []
 
-private partial def parseOptRetTy : Parser (Option Typ) := do
-  if ← consumeIf .colon then some <$> parseTypeNoArrow else pure none
-
 -- ---------------------------------------------------------------------------
 -- Expression parsing
 
@@ -537,7 +540,12 @@ private partial def parseAccessRest (e : Expr) : Parser Expr := do
   | .ident fname =>
     advance; advance
     parseAccessRest { loc := ← spanFrom e.loc, kind := .unop (.field fname) e }
-  | _ => return e  -- lone dot, leave it
+  | _ =>
+    -- A `.` here can only begin an access, so it commits: reporting it at the
+    -- token that follows beats leaving the dot for an unrelated production.
+    -- `t.1.2` lands here, the lexer having taken `1.2` for a float.
+    advance
+    expected "a field name, a tuple index, or '(' after '.'"
 
 -- prefix `!` (`Prec.prefixOp`): the tightest level, above access as well as
 -- application, so `!r.contents` is `(!r).contents` and `!f x` is `(!f) x`.
@@ -652,7 +660,7 @@ private partial def parseFun : Parser Expr := exprOf do
   expect .kw_fun
   let args ← parseFunArgs
   if args.isEmpty then failAt start .funNoArgs
-  let retTy ← parseOptRetTy
+  let retTy ← parseOptFunRetTy
   expect .arrow
   return .fun_ args retTy (← parseExpr)
 
@@ -675,13 +683,24 @@ private partial def parseMatch : Parser Expr := exprOf do
   expect .kw_with
   return .match_ scrut (← parseMatchArms)
 
+/-- The arms of a `match`. `with` has committed to at least one arm, so a
+missing one is an error here rather than an empty list left for whatever comes
+next to trip over. The leading `|` is optional, as in OCaml. -/
 private partial def parseMatchArms : Parser (List MatchArm) := do
+  let _ ← consumeIf .pipe
+  let arm ← parseMatchArm
+  return arm :: (← parseMatchArmsRest)
+
+private partial def parseMatchArmsRest : Parser (List MatchArm) := do
   if ← consumeIf .pipe then
-    let pat ← parsePattern
-    expect .arrow
-    let body ← parseExpr
-    return { pat, body } :: (← parseMatchArms)
+    let arm ← parseMatchArm
+    return arm :: (← parseMatchArmsRest)
   else return []
+
+private partial def parseMatchArm : Parser MatchArm := do
+  let pat ← parsePattern
+  expect .arrow
+  return { pat, body := ← parseExpr }
 
 end
 

--- a/Mica/Frontend/Parser.lean
+++ b/Mica/Frontend/Parser.lean
@@ -279,14 +279,21 @@ private partial def parseTypeAtom : Parser Typ := do
     | _ => expected "')' or ',' in type"
   | _ => expected "type"
 
+/-- Postfix type application `T name`, including a qualified constructor:
+`int Queue.t`. An uppercase name here can only open a module path, since a type
+constructor's own name is lowercase, so the path is committed to and its final
+segment checked. -/
 private partial def parseTypeAppSuffix (arg : Typ) : Parser Typ := do
   match ← peek with
   | .ident name =>
-    if !name.front.isUpper && name.front != '\'' then
-      advance
-      let loc ← spanFrom arg.loc
-      parseTypeAppSuffix { loc, kind := .con (Path.single name) [arg] }
-    else return arg
+    if name.front == '\'' then return arg
+    let start ← loc
+    advance
+    let path ← collectPathTail name []
+    if path.last.front.isUpper then
+      failAt (← spanFrom start) (.unexpectedToken "a type constructor name (lowercase)"
+        (.ident path.last))
+    parseTypeAppSuffix { loc := ← spanFrom arg.loc, kind := .con path [arg] }
   | _ => return arg
 
 private partial def parseTypeApp : Parser Typ := do

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -127,12 +127,10 @@ private partial def Typ.printAttr (attr : Attribute) : String :=
   | none         => s!" [@{attr.name}]"
   | some payload => s!" [@{attr.name} {Expr.printPrec payload 0}]"
 
-private partial def Pattern.isAtom (p : Pattern) : Bool :=
-  match p.kind with
-  | .ctor _ (some _) | .cons _ _ => false
-  | _ => true
-
-partial def Pattern.print (p : Pattern) : String :=
+/-- A pattern at `outerPrec`, over the same three levels the parser uses:
+`Prec.patCons` for `::`, `Prec.patApp` for a constructor payload, and above
+that the atoms, which delimit themselves. -/
+partial def Pattern.printPrec (p : Pattern) (outerPrec : Nat) : String :=
   match p.kind with
   | .wildcard => "_"
   | .binder (some name) none => name
@@ -141,13 +139,21 @@ partial def Pattern.print (p : Pattern) : String :=
   | .binder none (some ty) => s!"(_ : {Typ.print ty})"
   | .const c => Const.print c
   | .nil => "[]"
-  | .cons head tail => s!"{Pattern.print head} :: {Pattern.print tail}"
+  | .cons head tail =>
+    -- `::` is right-associative, so a `::` on the left needs parens.
+    parenIf (outerPrec > Prec.patCons)
+      (Pattern.printPrec head (Prec.patCons + 1) ++ " :: " ++
+       Pattern.printPrec tail Prec.patCons)
   | .ctor path none => path.toString
   | .ctor path (some pat) =>
-    s!"{path.toString} {parenIf (!Pattern.isAtom pat) (Pattern.print pat)}"
-  | .tuple pats => parens (joinWith ", " (pats.map Pattern.print))
+    parenIf (outerPrec > Prec.patApp)
+      (path.toString ++ " " ++ Pattern.printPrec pat (Prec.patApp + 1))
+  | .tuple pats => parens (joinWith ", " (pats.map (Pattern.printPrec · Prec.patCons)))
   | .record fields =>
-    "{ " ++ joinWith "; " (fields.map fun (name, pat) => name ++ " = " ++ Pattern.print pat) ++ " }"
+    "{ " ++ joinWith "; " (fields.map fun (name, pat) =>
+      name ++ " = " ++ Pattern.printPrec pat Prec.patCons) ++ " }"
+
+partial def Pattern.print (p : Pattern) : String := Pattern.printPrec p Prec.patCons
 
 -- ---------------------------------------------------------------------------
 -- Expression printing
@@ -262,7 +268,7 @@ partial def Decl.print (d : Decl) : String :=
     | some payload => "\n[@@" ++ toString attr.name ++ " " ++ Expr.print payload ++ "]"
   let attrsSuffix := joinWith "" attrsStr
   match d.kind with
-  | .open_ path => "open " ++ path.toString
+  | .open_ path => "open " ++ path.toString ++ attrsSuffix
   | .type_ td => printTypeDecl td ++ attrsSuffix
   | .val_ isRec binders retTy body =>
     let recStr := if isRec then "rec " else ""

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -63,10 +63,15 @@ partial def UnOp.print : UnOp → String
   | .proj n     => s!".{n}"
   | .field name => s!".{name}"
 
--- Does this prefix unop need a space before its argument?
-private def UnOp.needsSpace : UnOp → Bool
-  | .neg | .deref => false
+-- Does this prefix unop need a space before its argument? A symbolic one does
+-- not in general, but it glues to a leading operator character into a single
+-- longer operator (`!!`, `--`), so that case takes a space too.
+private def UnOp.needsSpace (op : UnOp) (arg : String) : Bool :=
+  match op with
+  | .neg | .deref => !arg.isEmpty && isOperatorChar arg.front
   | _ => true
+where
+  isOperatorChar (c : Char) : Bool := "!$%&*+-./:<=>?@^|~".contains c
 
 partial def BinOp.print : BinOp → String
   | .add => "+" | .sub => "-" | .mul => "*" | .div => "/" | .mod => "mod"
@@ -174,11 +179,13 @@ private partial def Expr.printPrec (e : Expr) (outerPrec : Nat) : String :=
   | .record fields => "{ " ++ fmtFields fields ++ " }"
   | .recordUpdate base fields =>
     "{ " ++ Expr.printPrec base 0 ++ " with " ++ fmtFields fields ++ " }"
-  | .unop op inner => printUnop op inner
+  | .unop op inner => printUnop op inner outerPrec
   | .arrayGet arr idx => printArrayGet arr idx outerPrec
   | .arraySet arr idx val => printArraySet arr idx val outerPrec
   | .binop op lhs rhs => printBinop op lhs rhs outerPrec
-  | .app fn args => joinWith " " (fmtArg fn :: args.map fmtArg)
+  | .app fn args =>
+    parenIf (outerPrec > Prec.app)
+      (joinWith " " ((fn :: args).map (operand · Prec.access)))
   | .ite cond thn els =>
     "if " ++ Expr.printPrec cond 0 ++ " then " ++ Expr.printPrec thn 0 ++
     " else " ++ Expr.printPrec els 0
@@ -201,34 +208,39 @@ where
     match attr.payload with
     | none         => s!" [@{attr.name}]"
     | some payload => s!" [@{attr.name} {Expr.printPrec payload 0}]"
-  fmtArg (e : Expr) : String :=
-    parenIf (!Expr.isAtom e) (Expr.printPrec e 0)
-  fmtBase (e : Expr) : String :=
-    parenIf (!Expr.isAtom e) (Expr.printPrec e 0)
   -- A field value ends at the `;` or `}` that follows it, so a `fun`, `let`,
   -- `if` or `match` has to be parenthesized to parse back.
   fmtFields (fields : List (FieldName × Expr)) : String :=
     joinWith "; " (fields.map fun (f, v) =>
       f ++ " = " ++ parenIf (Expr.isKeywordExpr v) (Expr.printPrec v 0))
-  printUnop (op : UnOp) (inner : Expr) : String :=
+  -- The three unary levels: postfix access, prefix `!` above it, and prefix `-`
+  -- and `assert` down at application level.
+  printUnop (op : UnOp) (inner : Expr) (outerPrec : Nat) : String :=
+    let prefixOp (p : Nat) (operandPrec : Nat) : String :=
+      let arg := operand inner operandPrec
+      let space := if UnOp.needsSpace op arg then " " else ""
+      parenIf (outerPrec > p) (UnOp.print op ++ space ++ arg)
     match op with
-    | .proj n => fmtBase inner ++ s!".{n}"
-    | .field name => fmtBase inner ++ "." ++ name
-    | _ =>
-      let space := if UnOp.needsSpace op then " " else ""
-      UnOp.print op ++ space ++ fmtArg inner
-  -- A keyword expression extends as far right as it can, so it needs parens
-  -- wherever an operator could follow it — on either side of an operator, since
-  -- the operator's own right-hand side may be followed by more.
+    | .proj n =>
+      parenIf (outerPrec > Prec.access) (operand inner Prec.access ++ s!".{n}")
+    | .field name =>
+      parenIf (outerPrec > Prec.access) (operand inner Prec.access ++ "." ++ name)
+    | .deref  => prefixOp Prec.prefixOp Prec.prefixOp
+    | .neg    => prefixOp Prec.app Prec.app
+    | .assert => prefixOp Prec.app Prec.access
+  -- A subexpression at level `prec`. Every compound form parenthesizes itself
+  -- against `prec`; the one exception is a keyword expression, which extends as
+  -- far right as it can and so needs parens wherever anything could follow it.
   operand (e : Expr) (prec : Nat) : String :=
     parenIf (Expr.isKeywordExpr e) (Expr.printPrec e prec)
   printArrayGet (arr idx : Expr) (outerPrec : Nat) : String :=
-    let p := Prec.app
-    parenIf (outerPrec > p) (operand arr p ++ ".(" ++ Expr.printPrec idx 0 ++ ")")
+    parenIf (outerPrec > Prec.access)
+      (operand arr Prec.access ++ ".(" ++ Expr.printPrec idx 0 ++ ")")
   printArraySet (arr idx val : Expr) (outerPrec : Nat) : String :=
     -- `<-` sits at `:=`'s level and is right-associative like it.
     let p := BinOp.level .assign
-    parenIf (outerPrec > p) (printArrayGet arr idx Prec.app ++ " <- " ++ operand val p)
+    parenIf (outerPrec > p)
+      (printArrayGet arr idx Prec.access ++ " <- " ++ operand val p)
 
   printBinop (op : BinOp) (lhs rhs : Expr) (outerPrec : Nat) : String :=
     let p := BinOp.level op

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -116,6 +116,14 @@ private partial def Typ.printAppArg (t : Typ) : String :=
   | .tuple (_ :: _ :: _) => parens (Typ.print t)
   | _ => Typ.print t
 
+/-- A type in a position that a `->` would run past: a `fun`'s return
+annotation, which the arrow of the `fun` itself ends, and a constructor payload.
+A `*` needs no parentheses in either. -/
+private partial def Typ.printNoArrow (t : Typ) : String :=
+  match t.kind with
+  | .arrow _ _ => parens (Typ.print t)
+  | _ => Typ.print t
+
 private partial def Typ.needsParens (t : Typ) : Bool :=
   match t.kind with
   | .arrow _ _ | .tuple (_ :: _ :: _) => true
@@ -201,7 +209,7 @@ private partial def Expr.printPrec (e : Expr) (outerPrec : Nat) : String :=
     "let " ++ recStr ++ joinWith " " (binders.map Pattern.print) ++ retStr ++
     " = " ++ Expr.printPrec bound 0 ++ " in\n" ++ Expr.printPrec body 0
   | .fun_ args retTy body =>
-    let retStr := match retTy with | none => "" | some ty => " : " ++ Typ.print ty
+    let retStr := match retTy with | none => "" | some ty => " : " ++ Typ.printNoArrow ty
     "fun " ++ joinWith " " (args.map Pattern.print) ++ retStr ++
     " -> " ++ Expr.printPrec body 0
   | .match_ scrutinee arms =>
@@ -286,7 +294,9 @@ where
         joinWith "\n" (ctors.map fun (name, payload) =>
           match payload with
           | none => "| " ++ name
-          | some ty => "| " ++ name ++ " of " ++ Typ.print ty)
+          -- `A of int -> int` is a syntax error in OCaml; `A of int * int` is
+          -- not, and there means several arguments rather than one tuple.
+          | some ty => "| " ++ name ++ " of " ++ Typ.printNoArrow ty)
       | .record fields =>
         "{ " ++ joinWith "; " (fields.map fun (name, ty) => name ++ " : " ++ Typ.print ty) ++ " }"
     "type " ++ paramsStr ++ td.name ++ " = " ++ bodyStr

--- a/Mica/Frontend/Printer.lean
+++ b/Mica/Frontend/Printer.lean
@@ -76,16 +76,8 @@ partial def BinOp.print : BinOp → String
   | .semi => ";" | .pipeRight => "|>" | .atAt => "@@" | .assign => ":="
   | .concat => "^" | .append => "@" | .cons => "::"
 
-private partial def BinOp.prec : BinOp → Nat
-  | .semi => 1 | .assign => 2 | .or => 3 | .and => 4
-  | .pipeRight => 5 | .atAt => 6
-  | .eq | .neq | .lt | .le | .gt | .ge => 7
-  | .concat | .append => 8 | .cons => 9 | .add | .sub | .fadd | .fsub => 10
-  | .mul | .div | .mod | .fmul | .fdiv => 11
-
-private partial def BinOp.rightAssoc : BinOp → Bool
-  | .semi | .assign | .or | .and | .atAt | .concat | .append | .cons => true
-  | _ => false
+-- Precedence comes from `BinOp.level` / `BinOp.assoc` in `AST.lean`, the same
+-- table the parser climbs. A copy here is what let printer and parser disagree.
 
 -- ---------------------------------------------------------------------------
 -- Type printing
@@ -225,43 +217,24 @@ where
     | _ =>
       let space := if UnOp.needsSpace op then " " else ""
       UnOp.print op ++ space ++ fmtArg inner
+  -- A keyword expression extends as far right as it can, so it needs parens
+  -- wherever an operator could follow it — on either side of an operator, since
+  -- the operator's own right-hand side may be followed by more.
+  operand (e : Expr) (prec : Nat) : String :=
+    parenIf (Expr.isKeywordExpr e) (Expr.printPrec e prec)
   printArrayGet (arr idx : Expr) (outerPrec : Nat) : String :=
-    let p := 11
-    let arrNeedsParens : Bool := match arr.kind with
-      | .binop op _ _ => BinOp.prec op < p
-      | _ => Expr.isKeywordExpr arr
-    let arrStr := parenIf arrNeedsParens (Expr.printPrec arr p)
-    parenIf (outerPrec > p) (arrStr ++ ".(" ++ Expr.printPrec idx 0 ++ ")")
+    let p := Prec.app
+    parenIf (outerPrec > p) (operand arr p ++ ".(" ++ Expr.printPrec idx 0 ++ ")")
   printArraySet (arr idx val : Expr) (outerPrec : Nat) : String :=
-    let p := 2
-    let lhs := printArrayGet arr idx p
-    let rhsNeedsParens : Bool := match val.kind with
-      | .binop op _ _ => BinOp.prec op < p
-      | _ => Expr.isKeywordExpr val
-    let rhs := parenIf rhsNeedsParens (Expr.printPrec val p)
-    parenIf (outerPrec > p) (lhs ++ " <- " ++ rhs)
+    -- `<-` sits at `:=`'s level and is right-associative like it.
+    let p := BinOp.level .assign
+    parenIf (outerPrec > p) (printArrayGet arr idx Prec.app ++ " <- " ++ operand val p)
 
   printBinop (op : BinOp) (lhs rhs : Expr) (outerPrec : Nat) : String :=
-    let p := BinOp.prec op
-    -- Special case: semicolons print with newline
-    if op == .semi then
-      let result := Expr.printPrec lhs (p + 1) ++ ";\n" ++ Expr.printPrec rhs 0
-      parenIf (outerPrec > p) result
-    else
-      let lhsNeedsParens : Bool := match lhs.kind with
-        | .binop lop _ _ =>
-          if BinOp.rightAssoc op then BinOp.prec lop <= p
-          else BinOp.prec lop < p
-        | _ => Expr.isKeywordExpr lhs
-      let rhsNeedsParens : Bool := match rhs.kind with
-        | .binop rop _ _ =>
-          if BinOp.rightAssoc op then BinOp.prec rop < p
-          else BinOp.prec rop <= p
-        -- For @@, don't parenthesize keyword exprs on the RHS
-        | _ => if op == .atAt then false else Expr.isKeywordExpr rhs
-      let lhsStr := parenIf lhsNeedsParens (Expr.printPrec lhs p)
-      let rhsStr := parenIf rhsNeedsParens (Expr.printPrec rhs p)
-      parenIf (outerPrec > p) (lhsStr ++ " " ++ BinOp.print op ++ " " ++ rhsStr)
+    let p := BinOp.level op
+    let (lhsPrec, rhsPrec) := BinOp.operandLevels op
+    let sep := if op == .semi then ";\n" else s!" {BinOp.print op} "
+    parenIf (outerPrec > p) (operand lhs lhsPrec ++ sep ++ operand rhs rhsPrec)
 
 end
 

--- a/Tests/frontend/begin_end.ml
+++ b/Tests/frontend/begin_end.ml
@@ -1,0 +1,14 @@
+(* TEST: --print-ocaml --parse-only no-compile roundtrip *)
+open Mica
+
+(* `begin e end` is `(e)`: the grouping is read and then forgotten, so the
+   printer writes parentheses where they are needed and nothing where they are
+   not. Before `begin` and `end` were keywords, this file parsed as
+   applications of two variables by those names. *)
+let grouping a b c = begin a + b end * c
+
+let as_an_argument f a = f begin a end
+
+let sequence a b = begin a; b end
+
+let access r = begin r end.u

--- a/Tests/frontend/binder_refutable.ml
+++ b/Tests/frontend/binder_refutable.ml
@@ -1,0 +1,6 @@
+(* TEST: no-compile *)
+open Mica
+
+(* A `let` or `fun` binder is parsed as a pattern atom and then checked, so a
+   pattern that can fail to match is reported where it stands. *)
+let f 0 = 0

--- a/Tests/frontend/binder_refutable.out
+++ b/Tests/frontend/binder_refutable.out
@@ -1,0 +1,2 @@
+parse error: Tests/frontend/binder_refutable.ml:6:7: this pattern can fail to match; a `let` or `fun` binder must not
+[1]

--- a/Tests/frontend/comma_level.ml
+++ b/Tests/frontend/comma_level.ml
@@ -1,0 +1,20 @@
+(* TEST: --print-ocaml --parse-only no-compile roundtrip *)
+open Mica
+
+(* The comma sits between `:=` and `||`, so a tuple needs no parentheses of its
+   own. The printer writes them anyway, which is what makes this a fixpoint. *)
+let tuple_without_parens a b = a, b
+
+let tuple_is_flat a b c = a, b, c
+
+let comma_binds_looser_than_cons a b = a :: b, a
+
+let comma_binds_tighter_than_assign r a b = r := a, b
+
+(* A list element is above the comma, so `[a, b]` is a one-element list. *)
+let list_of_one_tuple a b = [a, b]
+
+let arm_pattern x = match x with
+| y :: z, w -> w
+| y, z -> y
+| _ -> x

--- a/Tests/frontend/decl_annotation_with_arguments.out
+++ b/Tests/frontend/decl_annotation_with_arguments.out
@@ -1,2 +1,2 @@
-elaboration error: Tests/frontend/decl_annotation_with_arguments.ml:8:6: unsupported feature: a let with arguments cannot annotate its name
+elaboration error: Tests/frontend/decl_annotation_with_arguments.ml:8:5: unsupported feature: a let with arguments cannot annotate its name
 [1]

--- a/Tests/frontend/decl_attribute_on_type.ml
+++ b/Tests/frontend/decl_attribute_on_type.ml
@@ -1,0 +1,7 @@
+(* TEST: no-compile *)
+open Mica
+
+(* Every declaration kind parses the same trailing `[@@...]`, so a type
+   declaration carrying one is reported as unsupported rather than as a stray
+   '[' at the next declaration. *)
+type t = A of int [@@deriving show]

--- a/Tests/frontend/decl_attribute_on_type.out
+++ b/Tests/frontend/decl_attribute_on_type.out
@@ -1,0 +1,2 @@
+elaboration error: Tests/frontend/decl_attribute_on_type.ml:7:19: unsupported feature: a type declaration takes no attributes, but carries [@@deriving]
+[1]

--- a/Tests/frontend/let_annotation_with_arguments.out
+++ b/Tests/frontend/let_annotation_with_arguments.out
@@ -1,2 +1,2 @@
-elaboration error: Tests/frontend/let_annotation_with_arguments.ml:7:8: unsupported feature: a let with arguments cannot annotate its name
+elaboration error: Tests/frontend/let_annotation_with_arguments.ml:7:7: unsupported feature: a let with arguments cannot annotate its name
 [1]

--- a/Tests/frontend/match_no_arms.ml
+++ b/Tests/frontend/match_no_arms.ml
@@ -1,0 +1,6 @@
+(* TEST: no-compile *)
+open Mica
+
+(* `with` commits to at least one arm, so a match with none is reported here
+   rather than parsed into an empty match and caught two stages later. *)
+let f x = match x with

--- a/Tests/frontend/match_no_arms.out
+++ b/Tests/frontend/match_no_arms.out
@@ -1,0 +1,2 @@
+parse error: Tests/frontend/match_no_arms.ml:7:1: expected pattern, got 'EOF'
+[1]

--- a/Tests/frontend/match_optional_bar.ml
+++ b/Tests/frontend/match_optional_bar.ml
@@ -1,0 +1,14 @@
+(* TEST: --print-ocaml --parse-only no-compile roundtrip *)
+open Mica
+
+(* The leading `|` is optional, as in OCaml. The printer always writes it. *)
+let first_bar_optional x = match x with
+  A y -> y
+| B -> 0
+
+(* A `let`'s return annotation is delimited by the `=` that follows, so it may
+   be an arrow. A `fun`'s is delimited by `->`, so an arrow needs parentheses
+   there — and the printer has to put them back. *)
+let arrow_return_type g x : int -> int = g x
+
+let fun_arrow_return_type g = (fun y : (int -> int) -> y) g

--- a/Tests/frontend/open_attribute_parens.ml
+++ b/Tests/frontend/open_attribute_parens.ml
@@ -1,0 +1,2 @@
+(* TEST: --parse-only --parens no-compile *)
+open Mica [@@foo]

--- a/Tests/frontend/open_attribute_parens.out
+++ b/Tests/frontend/open_attribute_parens.out
@@ -1,0 +1,1 @@
+open Mica [@@foo]

--- a/Tests/frontend/operator_precedence.ml
+++ b/Tests/frontend/operator_precedence.ml
@@ -1,0 +1,44 @@
+(* TEST: --print-ocaml --no-check no-compile roundtrip *)
+open Mica
+
+(* Levels that a hand-written chain of parser functions got wrong: `|>` sits at
+   the comparison level and `@@` with `@` and `^`, because OCaml places an
+   operator by its leading character. The differential corpus checks the whole
+   table against ocamlc; this pins the two cells that used to be invented. *)
+let pipe_binds_looser_than_compare x g y = x |> g = y
+
+let at_at_binds_tighter_than_compare f x y = f @@ x = y
+
+let at_at_stops_at_semi f a b = f @@ a; b
+
+let at_at_is_right_associative f g x = f @@ g @@ x
+
+let pipe_is_left_associative x f g = x |> f |> g
+
+(* `let`, `fun`, `if` and `match` are operands at every level, and their
+   trailing branch runs as far right as it can. *)
+let keyword_operand a b c d = a + (if b then c else d)
+
+let keyword_operand_absorbs b c d a = if b then c else d + a
+
+let fun_after_at_at f = f @@ fun x -> x
+
+let match_operand a b c = a || (match b with
+| [] -> c
+| x :: _ -> x)
+
+let let_operand a b = a + (let x = b in
+x)
+
+(* `if` branches stop at `;`, which is looser; the condition does not, being
+   delimited by `then`. *)
+let semi_sequences_the_whole_if a b c =
+  (if a then b else c);
+  b
+
+let condition_takes_a_sequence a b c =
+  if
+    a;
+    b
+  then c
+  else b

--- a/Tests/frontend/operator_precedence.out
+++ b/Tests/frontend/operator_precedence.out
@@ -1,0 +1,31 @@
+open Mica
+;;
+let pipe_binds_looser_than_compare x g y = x |> g = y
+;;
+let at_at_binds_tighter_than_compare f x y = f @@ x = y
+;;
+let at_at_stops_at_semi f a b = f @@ a;
+b
+;;
+let at_at_is_right_associative f g x = f @@ g @@ x
+;;
+let pipe_is_left_associative x f g = x |> f |> g
+;;
+let keyword_operand a b c d = a + (if b then c else d)
+;;
+let keyword_operand_absorbs b c d a = if b then c else d + a
+;;
+let fun_after_at_at f = f @@ (fun x -> x)
+;;
+let match_operand a b c = a || (match b with
+| [] -> c
+| x :: _ -> x)
+;;
+let let_operand a b = a + (let x = b in
+x)
+;;
+let semi_sequences_the_whole_if a b c = (if a then b else c);
+b
+;;
+let condition_takes_a_sequence a b c = if a;
+b then c else b

--- a/Tests/frontend/pattern_forms.ml
+++ b/Tests/frontend/pattern_forms.ml
@@ -1,0 +1,27 @@
+(* TEST: --print-ocaml --parse-only no-compile roundtrip *)
+open Mica
+
+type 'a tree = Leaf | Node of 'a tree * 'a tree
+
+(* A parenthesized pattern is a full pattern: an uppercase head keeps its
+   payload, and `::` is allowed inside. *)
+let payload_in_parens x = match x with
+| Node (Node (l, r), _) -> l
+| t -> t
+
+let cons_in_parens x = match x with
+| (y :: _, w) -> y
+| (_, w) -> w
+
+(* `::` is right-associative, so a `::` on the left keeps its parentheses. *)
+let cons_nests_left x = match x with
+| (a :: _) :: _ -> a
+| _ -> []
+
+(* A constructor payload is an atom, and `[]` is one of them. *)
+let empty_list_payload x = match x with
+| Node ([], _) -> 0
+| _ -> 1
+
+(* An annotation attaches to a binder inside parentheses. *)
+let annotated_binder (x : int) (_ : bool) = x

--- a/Tests/frontend/prefix_precedence.ml
+++ b/Tests/frontend/prefix_precedence.ml
@@ -1,0 +1,25 @@
+(* TEST: --print-ocaml --no-check no-compile roundtrip *)
+open Mica
+
+(* The three unary levels a single `parseUnary` used to collapse into one.
+   Prefix `!` is the tightest form of all, above postfix access and above
+   application. The differential corpus checks these against ocamlc; this pins
+   them in readable form. *)
+type point = { x : int; y : int }
+
+let deref_binds_tighter_than_field (r : point ref) = (!r).x
+
+let deref_binds_tighter_than_index (a : int array ref) i = (!a).(i)
+
+let deref_is_an_argument (f : int -> int) (r : int ref) = f !r
+
+let deref_nests (r : int ref ref) = !(!r)
+
+(* Prefix `-` sits below application and above every binary operator. *)
+let neg_takes_an_application (f : int -> int) a = - (f a)
+
+let neg_binds_tighter_than_mul a b = (- a) * b
+
+(* `assert` sits at the application level but takes a single operand, so
+   `assert f a` is a syntax error rather than an assertion of `f a`. *)
+let assert_takes_one_operand (f : int -> bool) a = assert (f a)

--- a/Tests/frontend/prefix_precedence.out
+++ b/Tests/frontend/prefix_precedence.out
@@ -1,0 +1,17 @@
+open Mica
+;;
+type point = { x : int; y : int }
+;;
+let deref_binds_tighter_than_field (r : point ref) = !r.x
+;;
+let deref_binds_tighter_than_index (a : int array ref) i = !a.(i)
+;;
+let deref_is_an_argument (f : int -> int) (r : int ref) = f !r
+;;
+let deref_nests (r : int ref ref) = ! !r
+;;
+let neg_takes_an_application (f : int -> int) a = -f a
+;;
+let neg_binds_tighter_than_mul a b = -a * b
+;;
+let assert_takes_one_operand (f : int -> bool) a = assert (f a)

--- a/Tests/frontend/qualified_type.ml
+++ b/Tests/frontend/qualified_type.ml
@@ -1,0 +1,18 @@
+(* TEST: --print-ocaml --parse-only no-compile roundtrip *)
+open Mica
+
+(* A type application's head may be a module path: `int Queue.t`. The parser
+   used to accept only a lowercase head, so the `Queue` was left behind and
+   reported at the token after the type. `--parse-only`: the resolver knows no
+   such module, which is a separate question. *)
+let qualified (q : int Queue.t) = q
+
+let qualified_argument (q : int list Queue.t) = q
+
+let applied_to_qualified (q : int Queue.t list) = q
+
+let qualified_nullary (q : Queue.t) = q
+
+let multi_parameter (h : (int, int) Hashtbl.t) = h
+
+let qualified_argument_and_head (q : Foo.t Bar.t) = q

--- a/Tests/frontend/record_punning.ml
+++ b/Tests/frontend/record_punning.ml
@@ -1,0 +1,16 @@
+(* TEST: --print-ocaml --parse-only no-compile roundtrip *)
+open Mica
+
+type point = { u : int; v : int }
+
+(* `{ u }` is `{ u = u }`, in expressions, in record updates, and in patterns.
+   The printer always writes the field out. `--parse-only`: record updates parse
+   but do not elaborate, which is a separate question. *)
+let punned u v = { u; v }
+
+let mixed u = { u; v = 0 }
+
+let update r v = { r with v }
+
+let pattern_punning p = match p with
+| { u; v } -> u + v

--- a/Tests/parser/parser-diff.baseline
+++ b/Tests/parser/parser-diff.baseline
@@ -1,71 +1,8 @@
 DIVERGE A of 'a * 'b  ==>  ocaml: | A of 'a * 'b  |  mica: | A of ('a * 'b)
 DIVERGE A of int * int  ==>  ocaml: | A of int * int  |  mica: | A of (int * int)
-GAP     ! r, b  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     (a, b), c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     - a, b  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     [a, b; c]  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     [a, b]  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a && b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a * b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a *. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a + b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a +. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a - b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a -. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a / b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a /. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a :: b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a := b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a ; b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a < b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a <= b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a <> b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a = b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a > b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a >= b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a @ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a @@ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a ^ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a mod b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a |> b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a || b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, (b, c)  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b && c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b * c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b *. c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b + c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b +. c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b - c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b -. c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b / c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b /. c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b :: c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b := c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b ; c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b < c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b <= c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b <> c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b = c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b > c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b >= c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b @ c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b @@ c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b ^ c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b mod c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b |> c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b || c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a, b, c, d  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a.(i), b  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a.(i).u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
-GAP     f a, b  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     fun x -> x, a  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     if a then b, c else d  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     int  ==>  type alias: `TypeDeclBody` has only variants and records
 GAP     int list  ==>  type alias: `TypeDeclBody` has only variants and records
-GAP     let x = a, b in x  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     match x with | y, z -> 0 | _ -> 1  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     r.u <- a.(i)  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u <- b + c  ==>  field assignment: `<-` accepts only `a.(i)` on the left

--- a/Tests/parser/parser-diff.baseline
+++ b/Tests/parser/parser-diff.baseline
@@ -4,148 +4,35 @@ DIVERGE ! f a  ==>  ocaml: (!f) a  |  mica: !(f a)
 DIVERGE ! r.b.c  ==>  ocaml: ((!r).b).c  |  mica: !((r.b).c)
 DIVERGE A of 'a * 'b  ==>  ocaml: | A of 'a * 'b  |  mica: | A of ('a * 'b)
 DIVERGE A of int * int  ==>  ocaml: | A of int * int  |  mica: | A of (int * int)
-DIVERGE a < b @@ c  ==>  ocaml: a < (b @@ c)  |  mica: (a < b) @@ c
-DIVERGE a <= b @@ c  ==>  ocaml: a <= (b @@ c)  |  mica: (a <= b) @@ c
-DIVERGE a <> b @@ c  ==>  ocaml: a <> (b @@ c)  |  mica: (a <> b) @@ c
-DIVERGE a = b @@ c  ==>  ocaml: a = (b @@ c)  |  mica: (a = b) @@ c
-DIVERGE a > b @@ c  ==>  ocaml: a > (b @@ c)  |  mica: (a > b) @@ c
-DIVERGE a >= b @@ c  ==>  ocaml: a >= (b @@ c)  |  mica: (a >= b) @@ c
-DIVERGE a @ b @@ c  ==>  ocaml: a @ (b @@ c)  |  mica: (a @ b) @@ c
-DIVERGE a @@ b && c  ==>  ocaml: (a @@ b) && c  |  mica: a @@ (b && c)
-DIVERGE a @@ b := c  ==>  ocaml: (a @@ b) := c  |  mica: a @@ (b := c)
-DIVERGE a @@ b ; c  ==>  ocaml: a @@ b; c  |  mica: a @@ (b; c)
-DIVERGE a @@ b < c  ==>  ocaml: (a @@ b) < c  |  mica: a @@ (b < c)
-DIVERGE a @@ b <= c  ==>  ocaml: (a @@ b) <= c  |  mica: a @@ (b <= c)
-DIVERGE a @@ b <> c  ==>  ocaml: (a @@ b) <> c  |  mica: a @@ (b <> c)
-DIVERGE a @@ b = c  ==>  ocaml: (a @@ b) = c  |  mica: a @@ (b = c)
-DIVERGE a @@ b > c  ==>  ocaml: (a @@ b) > c  |  mica: a @@ (b > c)
-DIVERGE a @@ b >= c  ==>  ocaml: (a @@ b) >= c  |  mica: a @@ (b >= c)
-DIVERGE a @@ b |> c  ==>  ocaml: (a @@ b) |> c  |  mica: a @@ (b |> c)
-DIVERGE a @@ b || c  ==>  ocaml: (a @@ b) || c  |  mica: a @@ (b || c)
-DIVERGE a ^ b @@ c  ==>  ocaml: a ^ (b @@ c)  |  mica: (a ^ b) @@ c
-DIVERGE a |> b < c  ==>  ocaml: (a |> b) < c  |  mica: a |> (b < c)
-DIVERGE a |> b <= c  ==>  ocaml: (a |> b) <= c  |  mica: a |> (b <= c)
-DIVERGE a |> b <> c  ==>  ocaml: (a |> b) <> c  |  mica: a |> (b <> c)
-DIVERGE a |> b = c  ==>  ocaml: (a |> b) = c  |  mica: a |> (b = c)
-DIVERGE a |> b > c  ==>  ocaml: (a |> b) > c  |  mica: a |> (b > c)
-DIVERGE a |> b >= c  ==>  ocaml: (a |> b) >= c  |  mica: a |> (b >= c)
 GAP     ! r, b  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     (a, b), c  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     - a, b  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     [a, b; c]  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     [a, b]  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a && b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a && fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a && if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a && let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a && match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a * b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a * fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a * if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a * let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a * match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a *. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a *. fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a *. if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a *. let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a *. match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a + b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a + fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a + if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a + let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a + match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a +. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a +. fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a +. if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a +. let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a +. match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a - b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a - fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a - if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a - let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a - match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a -. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a -. fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a -. if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a -. let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a -. match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a / b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a / fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a / if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a / let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a / match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a /. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a /. fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a /. if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a /. let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a /. match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a :: b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a :: fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a :: if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a :: let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a :: match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a := b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a := fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a := if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a := let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a := match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a ; b, c  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a < b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a < fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a < if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a < let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a < match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a <= b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a <= fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a <= if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a <= let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a <= match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a <> b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a <> fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a <> if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a <> let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a <> match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a = b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a = fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a = if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a = let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a = match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a > b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a > fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a > if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a > let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a > match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a >= b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a >= fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a >= if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a >= let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a >= match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a @ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a @ fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a @ if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a @ let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a @ match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a @@ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a ^ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a ^ fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a ^ if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a ^ let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a ^ match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a mod b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a mod fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a mod if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a mod let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a mod match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a |> b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a |> fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a |> if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a |> let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a |> match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a || b, c  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a || fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a || if b then c else d  ==>  keyword expression as an operator's right operand
-GAP     a || let x = b in x  ==>  keyword expression as an operator's right operand
-GAP     a || match b with | _ -> c  ==>  keyword expression as an operator's right operand
 GAP     a, (b, c)  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a, b  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a, b && c  ==>  bare tuple: mica builds tuples only inside parentheses
@@ -174,13 +61,11 @@ GAP     a, b |> c  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a, b || c  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a, b, c  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a, b, c, d  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     a.(i) <- fun x -> x  ==>  keyword expression as an operator's right operand
-GAP     a.(i) <- if b then c else d  ==>  keyword expression as an operator's right operand
 GAP     a.(i), b  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a.(i).u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     f ! r  ==>  prefix `!` not accepted as a function argument
 GAP     f a, b  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     fun x -> x, a  ==>  keyword expression as an operator's right operand
+GAP     fun x -> x, a  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     if a then b, c else d  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     int  ==>  type alias: `TypeDeclBody` has only variants and records
 GAP     int list  ==>  type alias: `TypeDeclBody` has only variants and records
@@ -197,9 +82,4 @@ GAP     r.u.v <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 PRINTER ! a.b  ==>  ocaml: (!a).b  |  mica: !(a.b)
 PRINTER ! f a  ==>  ocaml: (!f) a  |  mica: !(f a)
 PRINTER ! r.b.c  ==>  ocaml: ((!r).b).c  |  mica: !((r.b).c)
-PRINTER a @@ b && c  ==>  ocaml: (a @@ b) && c  |  mica: a @@ (b && c)
-PRINTER a @@ b := c  ==>  ocaml: (a @@ b) := c  |  mica: a @@ (b := c)
-PRINTER a @@ b ; c  ==>  ocaml: a @@ b; c  |  mica: a @@ (b; c)
-PRINTER a @@ b |> c  ==>  ocaml: (a @@ b) |> c  |  mica: a @@ (b |> c)
-PRINTER a @@ b || c  ==>  ocaml: (a @@ b) || c  |  mica: a @@ (b || c)
 UNPRINT type t1085 = A of (int -> int)

--- a/Tests/parser/parser-diff.baseline
+++ b/Tests/parser/parser-diff.baseline
@@ -65,13 +65,9 @@ GAP     if a then b, c else d  ==>  bare tuple: mica builds tuples only inside p
 GAP     int  ==>  type alias: `TypeDeclBody` has only variants and records
 GAP     int list  ==>  type alias: `TypeDeclBody` has only variants and records
 GAP     let x = a, b in x  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     match x with | (A y, B z) -> 0 | _ -> 1  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     match x with | (y :: z, w) -> 0 | _ -> 1  ==>  bare tuple: mica builds tuples only inside parentheses
-GAP     match x with | A (B y) -> 0 | _ -> 1  ==>  `parsePatternInner` reads an uppercase head as a binder, so a parenthesized constructor pattern with a payload fails
-GAP     match x with | A [] -> 0 | _ -> 1  ==>  constructor-pattern payload token set omits `[`
 GAP     match x with | y, z -> 0 | _ -> 1  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     r.u <- a.(i)  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u <- b + c  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u.v <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
-UNPRINT type t1085 = A of (int -> int)
+UNPRINT type t1090 = A of (int -> int)

--- a/Tests/parser/parser-diff.baseline
+++ b/Tests/parser/parser-diff.baseline
@@ -1,0 +1,205 @@
+DIVERGE ! a.(i)  ==>  ocaml: (!a).(i)  |  mica: !(a.(i))
+DIVERGE ! a.b  ==>  ocaml: (!a).b  |  mica: !(a.b)
+DIVERGE ! f a  ==>  ocaml: (!f) a  |  mica: !(f a)
+DIVERGE ! r.b.c  ==>  ocaml: ((!r).b).c  |  mica: !((r.b).c)
+DIVERGE A of 'a * 'b  ==>  ocaml: | A of 'a * 'b  |  mica: | A of ('a * 'b)
+DIVERGE A of int * int  ==>  ocaml: | A of int * int  |  mica: | A of (int * int)
+DIVERGE a < b @@ c  ==>  ocaml: a < (b @@ c)  |  mica: (a < b) @@ c
+DIVERGE a <= b @@ c  ==>  ocaml: a <= (b @@ c)  |  mica: (a <= b) @@ c
+DIVERGE a <> b @@ c  ==>  ocaml: a <> (b @@ c)  |  mica: (a <> b) @@ c
+DIVERGE a = b @@ c  ==>  ocaml: a = (b @@ c)  |  mica: (a = b) @@ c
+DIVERGE a > b @@ c  ==>  ocaml: a > (b @@ c)  |  mica: (a > b) @@ c
+DIVERGE a >= b @@ c  ==>  ocaml: a >= (b @@ c)  |  mica: (a >= b) @@ c
+DIVERGE a @ b @@ c  ==>  ocaml: a @ (b @@ c)  |  mica: (a @ b) @@ c
+DIVERGE a @@ b && c  ==>  ocaml: (a @@ b) && c  |  mica: a @@ (b && c)
+DIVERGE a @@ b := c  ==>  ocaml: (a @@ b) := c  |  mica: a @@ (b := c)
+DIVERGE a @@ b ; c  ==>  ocaml: a @@ b; c  |  mica: a @@ (b; c)
+DIVERGE a @@ b < c  ==>  ocaml: (a @@ b) < c  |  mica: a @@ (b < c)
+DIVERGE a @@ b <= c  ==>  ocaml: (a @@ b) <= c  |  mica: a @@ (b <= c)
+DIVERGE a @@ b <> c  ==>  ocaml: (a @@ b) <> c  |  mica: a @@ (b <> c)
+DIVERGE a @@ b = c  ==>  ocaml: (a @@ b) = c  |  mica: a @@ (b = c)
+DIVERGE a @@ b > c  ==>  ocaml: (a @@ b) > c  |  mica: a @@ (b > c)
+DIVERGE a @@ b >= c  ==>  ocaml: (a @@ b) >= c  |  mica: a @@ (b >= c)
+DIVERGE a @@ b |> c  ==>  ocaml: (a @@ b) |> c  |  mica: a @@ (b |> c)
+DIVERGE a @@ b || c  ==>  ocaml: (a @@ b) || c  |  mica: a @@ (b || c)
+DIVERGE a ^ b @@ c  ==>  ocaml: a ^ (b @@ c)  |  mica: (a ^ b) @@ c
+DIVERGE a |> b < c  ==>  ocaml: (a |> b) < c  |  mica: a |> (b < c)
+DIVERGE a |> b <= c  ==>  ocaml: (a |> b) <= c  |  mica: a |> (b <= c)
+DIVERGE a |> b <> c  ==>  ocaml: (a |> b) <> c  |  mica: a |> (b <> c)
+DIVERGE a |> b = c  ==>  ocaml: (a |> b) = c  |  mica: a |> (b = c)
+DIVERGE a |> b > c  ==>  ocaml: (a |> b) > c  |  mica: a |> (b > c)
+DIVERGE a |> b >= c  ==>  ocaml: (a |> b) >= c  |  mica: a |> (b >= c)
+GAP     ! r, b  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     (a, b), c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     - a, b  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     [a, b; c]  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     [a, b]  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a && b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a && fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a && if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a && let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a && match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a * b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a * fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a * if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a * let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a * match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a *. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a *. fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a *. if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a *. let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a *. match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a + b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a + fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a + if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a + let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a + match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a +. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a +. fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a +. if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a +. let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a +. match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a - b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a - fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a - if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a - let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a - match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a -. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a -. fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a -. if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a -. let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a -. match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a / b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a / fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a / if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a / let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a / match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a /. b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a /. fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a /. if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a /. let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a /. match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a :: b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a :: fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a :: if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a :: let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a :: match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a := b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a := fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a := if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a := let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a := match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a ; b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a < b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a < fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a < if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a < let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a < match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a <= b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a <= fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a <= if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a <= let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a <= match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a <> b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a <> fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a <> if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a <> let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a <> match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a = b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a = fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a = if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a = let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a = match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a > b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a > fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a > if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a > let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a > match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a >= b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a >= fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a >= if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a >= let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a >= match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a @ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a @ fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a @ if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a @ let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a @ match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a @@ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a ^ b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a ^ fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a ^ if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a ^ let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a ^ match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a mod b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a mod fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a mod if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a mod let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a mod match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a |> b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a |> fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a |> if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a |> let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a |> match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a || b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a || fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a || if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a || let x = b in x  ==>  keyword expression as an operator's right operand
+GAP     a || match b with | _ -> c  ==>  keyword expression as an operator's right operand
+GAP     a, (b, c)  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b && c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b * c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b *. c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b + c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b +. c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b - c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b -. c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b / c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b /. c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b :: c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b := c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b ; c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b < c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b <= c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b <> c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b = c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b > c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b >= c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b @ c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b @@ c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b ^ c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b mod c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b |> c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b || c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b, c  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a, b, c, d  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a.(i) <- fun x -> x  ==>  keyword expression as an operator's right operand
+GAP     a.(i) <- if b then c else d  ==>  keyword expression as an operator's right operand
+GAP     a.(i), b  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     a.(i).u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
+GAP     f ! r  ==>  prefix `!` not accepted as a function argument
+GAP     f a, b  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     fun x -> x, a  ==>  keyword expression as an operator's right operand
+GAP     if a then b, c else d  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     int  ==>  type alias: `TypeDeclBody` has only variants and records
+GAP     int list  ==>  type alias: `TypeDeclBody` has only variants and records
+GAP     let x = a, b in x  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     match x with | (A y, B z) -> 0 | _ -> 1  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     match x with | (y :: z, w) -> 0 | _ -> 1  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     match x with | A (B y) -> 0 | _ -> 1  ==>  `parsePatternInner` reads an uppercase head as a binder, so a parenthesized constructor pattern with a payload fails
+GAP     match x with | A [] -> 0 | _ -> 1  ==>  constructor-pattern payload token set omits `[`
+GAP     match x with | y, z -> 0 | _ -> 1  ==>  bare tuple: mica builds tuples only inside parentheses
+GAP     r.u <- a.(i)  ==>  field assignment: `<-` accepts only `a.(i)` on the left
+GAP     r.u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
+GAP     r.u <- b + c  ==>  field assignment: `<-` accepts only `a.(i)` on the left
+GAP     r.u.v <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
+PRINTER ! a.b  ==>  ocaml: (!a).b  |  mica: !(a.b)
+PRINTER ! f a  ==>  ocaml: (!f) a  |  mica: !(f a)
+PRINTER ! r.b.c  ==>  ocaml: ((!r).b).c  |  mica: !((r.b).c)
+PRINTER a @@ b && c  ==>  ocaml: (a @@ b) && c  |  mica: a @@ (b && c)
+PRINTER a @@ b := c  ==>  ocaml: (a @@ b) := c  |  mica: a @@ (b := c)
+PRINTER a @@ b ; c  ==>  ocaml: a @@ b; c  |  mica: a @@ (b; c)
+PRINTER a @@ b |> c  ==>  ocaml: (a @@ b) |> c  |  mica: a @@ (b |> c)
+PRINTER a @@ b || c  ==>  ocaml: (a @@ b) || c  |  mica: a @@ (b || c)
+UNPRINT type t1085 = A of (int -> int)

--- a/Tests/parser/parser-diff.baseline
+++ b/Tests/parser/parser-diff.baseline
@@ -1,7 +1,3 @@
-DIVERGE ! a.(i)  ==>  ocaml: (!a).(i)  |  mica: !(a.(i))
-DIVERGE ! a.b  ==>  ocaml: (!a).b  |  mica: !(a.b)
-DIVERGE ! f a  ==>  ocaml: (!f) a  |  mica: !(f a)
-DIVERGE ! r.b.c  ==>  ocaml: ((!r).b).c  |  mica: !((r.b).c)
 DIVERGE A of 'a * 'b  ==>  ocaml: | A of 'a * 'b  |  mica: | A of ('a * 'b)
 DIVERGE A of int * int  ==>  ocaml: | A of int * int  |  mica: | A of (int * int)
 GAP     ! r, b  ==>  bare tuple: mica builds tuples only inside parentheses
@@ -63,7 +59,6 @@ GAP     a, b, c  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a, b, c, d  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a.(i), b  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     a.(i).u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
-GAP     f ! r  ==>  prefix `!` not accepted as a function argument
 GAP     f a, b  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     fun x -> x, a  ==>  bare tuple: mica builds tuples only inside parentheses
 GAP     if a then b, c else d  ==>  bare tuple: mica builds tuples only inside parentheses
@@ -79,7 +74,4 @@ GAP     r.u <- a.(i)  ==>  field assignment: `<-` accepts only `a.(i)` on the le
 GAP     r.u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u <- b + c  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u.v <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
-PRINTER ! a.b  ==>  ocaml: (!a).b  |  mica: !(a.b)
-PRINTER ! f a  ==>  ocaml: (!f) a  |  mica: !(f a)
-PRINTER ! r.b.c  ==>  ocaml: ((!r).b).c  |  mica: !((r.b).c)
 UNPRINT type t1085 = A of (int -> int)

--- a/Tests/parser/parser-diff.baseline
+++ b/Tests/parser/parser-diff.baseline
@@ -70,4 +70,3 @@ GAP     r.u <- a.(i)  ==>  field assignment: `<-` accepts only `a.(i)` on the le
 GAP     r.u <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u <- b + c  ==>  field assignment: `<-` accepts only `a.(i)` on the left
 GAP     r.u.v <- b  ==>  field assignment: `<-` accepts only `a.(i)` on the left
-UNPRINT type t1090 = A of (int -> int)

--- a/Testsuite.lean
+++ b/Testsuite.lean
@@ -2,6 +2,7 @@ import Testsuite.Process
 import Testsuite.Test
 import Testsuite.Task
 import Testsuite.Report
+import Testsuite.ParserDiff
 
 /-!
 # Testsuite runner
@@ -23,6 +24,9 @@ Subcommands:
   which registers one Lake job per task so the build monitor shows live
   progress, and hands the failed tasks to `summarize`.
 * `summarize [TASK,FILE ...]` — print the final summary for failed tasks.
+* `parser-diff [--promote]` — differential parser tests: check mica's parse of a
+  generated precedence corpus against OCaml's, via `ocamlc -stop-after parsing
+  -dsource`.
 -/
 
 open System (FilePath)
@@ -33,7 +37,8 @@ def usage : String :=
   "usage: testsuite run [--mica PATH] [--promote] [PATH ...]\n" ++
   "       testsuite list [PATH ...]\n" ++
   "       testsuite run-task [--mica PATH] [--promote] TASK,FILE ...\n" ++
-  "       testsuite summarize [TASK,FILE ...]"
+  "       testsuite summarize [TASK,FILE ...]\n" ++
+  "       testsuite parser-diff [--mica PATH] [--promote]"
 
 /-- Options shared by the `run` and `run-task` subcommands. -/
 structure RunOptions where
@@ -144,6 +149,9 @@ def dispatch : List String → IO UInt32
   | "run-task" :: rest => do runTaskCommand (← IO.ofExcept (parseRunOptions rest {}))
   | "list" :: rest => do listCommand (← IO.ofExcept (rejectFlags "list" rest))
   | "summarize" :: rest => do summarizeCommand (← IO.ofExcept (rejectFlags "summarize" rest))
+  | "parser-diff" :: rest => do
+      let opts ← IO.ofExcept (parseRunOptions rest {})
+      ParserDiff.run (← resolveMica opts.mica) opts.promote
   | _ => do
       IO.eprintln usage
       return 1

--- a/Testsuite/ParserDiff.lean
+++ b/Testsuite/ParserDiff.lean
@@ -1,0 +1,465 @@
+-- SUMMARY: Differential parser tests comparing mica's reading of a generated corpus against OCaml's.
+import Std.Data.HashMap
+import Testsuite.Process
+
+/-!
+# Differential parser tests
+
+`ocamlc` is used as the oracle for its own parse tree, twice over. For each
+generated fixture `S`:
+
+1. mica parses `S` and re-prints it fully parenthesized as `P`
+   (`mica --parse-only --parens`, see `Mica/Frontend/ParenPrinter.lean`).
+2. `ocamlc -stop-after parsing -dsource` runs on both `S` and `P`.
+
+That flag re-parenthesizes from the parse tree rather than echoing the input, so
+redundant parentheses normalize away and the two outputs are byte-identical
+exactly when mica read `S` the way OCaml does.
+
+The printer used in step 1 never consults a precedence table. If it shared
+`Printer.lean`'s table, a precedence error in the parser and the matching error
+in the printer would cancel out and the comparison would pass.
+
+A second pass repeats the comparison with mica's *normal* printer. The first
+pass failing indicts the parser; only the second failing indicts the printer.
+
+-/
+
+open System (FilePath)
+
+namespace Testsuite.ParserDiff
+
+-- ---------------------------------------------------------------------------
+-- Corpus
+
+/-- One fixture: a unique name and the declaration it expands to. -/
+structure Case where
+  name : String
+  decl : String
+  deriving Inhabited
+
+/-- Bound by every generated declaration, so no fixture depends on anything
+outside itself. -/
+private def params : String := "a b c d f g r i j x"
+
+/-- The surface binary operators, as written.
+
+`<-` is absent on purpose: OCaml's grammar accepts it only after an array or
+field access, so a bare `a <- b` is a syntax error. It gets its own fixtures. -/
+def binOps : List String :=
+  [ "+", "-", "*", "/", "mod", "+.", "-.", "*.", "/."
+  , "=", "<>", "<", "<=", ">", ">="
+  , "&&", "||", "|>", "@@", ":=", "^", "@", "::", ";" ]
+
+/-- `a op1 b op2 c` for every ordered pair — the precedence table as a matrix.
+The diagonal covers associativity. -/
+def pairCases : List String :=
+  binOps.flatMap fun op1 => binOps.map fun op2 => s!"a {op1} b {op2} c"
+
+/-- Prefix operators against every binary operator, then against application and
+the postfix forms. In OCaml prefix `!` binds tighter than both application and
+`.`/`.(`, while prefix `-` binds looser than application. -/
+def prefixCases : List String :=
+  (binOps.flatMap fun op =>
+    [ s!"- a {op} b", s!"a {op} - b"
+    , s!"! r {op} b", s!"a {op} ! r"
+    , s!"assert a {op} b" ])
+  -- `assert f a` is absent: OCaml's `assert` takes one simple expression, so it
+  -- is a syntax error there and has no reading to compare against.
+  ++ [ "f ! r", "! f a", "f (- a)", "f - a", "assert (f a)"
+     , "! a.b", "! a.(i)", "- a.b", "- f a", "f a.b", "f a.(i)"
+     , "a.b.c", "a.(i).(j)", "a.b.(i)", "a.(i).b"
+     , "! ! r", "- - a", "! r.b.c", "assert a.b" ]
+
+/-- Application against every binary operator. -/
+def appCases : List String :=
+  binOps.flatMap fun op => [s!"f a {op} b", s!"a {op} f b", s!"f a b {op} c"]
+
+/-- Keyword expressions as an operand on each side. The two sides differ in
+OCaml: on the right the keyword form absorbs everything after it, on the left
+only its trailing branch does. -/
+def keywordCases : List String :=
+  binOps.flatMap fun op =>
+    [ s!"a {op} if b then c else d"
+    , s!"if b then c else d {op} a"
+    , s!"a {op} match b with | _ -> c"
+    , s!"a {op} fun x -> x"
+    , s!"a {op} let x = b in x"
+    , s!"let x = a in x {op} b" ]
+
+/-- `<-` needs an array element or a record field on the left in both
+languages. It is excluded from `binOps` for that reason. -/
+def arraySetCases : List String :=
+  (binOps.map fun op => s!"a.(i) <- b {op} c")
+  ++ [ "a.(i) <- b", "a.(i) <- if b then c else d", "a.(i) <- fun x -> x"
+     , "a.(i) <- a.(j) <- b", "a.(i) <- - b", "a.(i) <- ! r"
+     , "r.u <- b", "r.u.v <- b", "r.u <- b + c", "a.(i).u <- b", "r.u <- a.(i)" ]
+
+/-- The comma level, which OCaml puts between `||` and `:=`/`<-`, and where a
+tuple needs no enclosing parentheses. This axis is separate from `binOps`
+because a comma is not an operator that composes the way the others do. -/
+def commaCases : List String :=
+  (binOps.flatMap fun op => [s!"a, b {op} c", s!"a {op} b, c"])
+  ++ [ "a, b", "a, b, c", "f a, b", "(a, b), c", "a, (b, c)"
+     , "[a, b]", "[a; b]", "f (a, b)", "(a, b)", "[a, b; c]"
+     , "a.(i), b", "- a, b", "! r, b", "a, b, c, d"
+     , "if a then b, c else d", "fun x -> x, a", "let x = a, b in x" ]
+
+/-- Pattern-level precedence, exercised in a match arm: `::` against the comma
+level, against constructor application, and against annotation. -/
+def patternCases : List String :=
+  [ "_", "y", "0", "'c'", "true", "[]", "()"
+  , "y :: z", "y :: z :: w", "(y, z)", "y, z", "(y : int)"
+  , "{ u = y }", "{ u = y; v = z }"
+  , "A", "A y", "A (y, z)", "A y :: z", "(A y, B z)"
+  , "A y :: B z :: w", "(y, z) :: w", "{ u = y } :: z"
+  , "[] :: z", "A []", "A _", "A (B y)", "(y :: z, w)"
+  , "y :: (z, w)", "A 0", "A 'c'" ]
+
+/-- Type declarations: variants, records, and parameters. `NAME` is replaced by
+the fixture's generated name. -/
+def typeDeclCases : List String :=
+  [ "type NAME = int"
+  , "type NAME = int list"
+  , "type NAME = A | B"
+  , "type NAME = A | B of int"
+  , "type NAME = | A | B of int"
+  , "type NAME = A of int * int"
+  , "type NAME = A of (int -> int)"
+  , "type NAME = A of int list"
+  , "type NAME = { u : int }"
+  , "type NAME = { u : int; v : int list }"
+  , "type NAME = { u : int -> int }"
+  , "type NAME = { u : int * int }"
+  , "type 'a NAME = A of 'a"
+  , "type ('a, 'b) NAME = A of 'a * 'b"
+  , "type 'a NAME = { u : 'a }"
+  , "type 'a NAME = A of 'a list | B" ]
+
+/-- Type-expression precedence: `*` against `->` against application. -/
+def typeCases : List String :=
+  [ "int * int -> int", "int -> int * int", "int -> int -> int"
+  , "int * int * int", "int list list", "int list * int"
+  , "int -> int list", "int list -> int", "(int -> int) list"
+  , "int * int list", "'a list", "'a -> 'a", "'a * 'b -> 'c"
+  , "int array", "int ref list", "(int -> int) -> int"
+  , "int list list list", "'a * 'b * 'c -> 'd" ]
+
+private def caseName (n : Nat) : String :=
+  let s := toString n
+  "t" ++ "".pushn '0' (4 - min 4 s.length) ++ s
+
+/-- The full corpus, numbered so that a fixture's line number is its index. -/
+def allCases : Array Case := Id.run do
+  let mut out : Array Case := #[]
+  let mut n : Nat := 0
+  for group in [pairCases, prefixCases, appCases, keywordCases, arraySetCases, commaCases] do
+    for body in group do
+      out := out.push { name := caseName n, decl := s!"let {caseName n} {params} = {body}" }
+      n := n + 1
+  for ty in typeCases do
+    out := out.push { name := caseName n, decl := s!"let {caseName n} (x : {ty}) = x" }
+    n := n + 1
+  for pat in patternCases do
+    out := out.push { name := caseName n
+                    , decl := s!"let {caseName n} x = match x with | {pat} -> 0 | _ -> 1" }
+    n := n + 1
+  for td in typeDeclCases do
+    out := out.push { name := caseName n, decl := td.replace "NAME" (caseName n) }
+    n := n + 1
+  return out
+
+-- ---------------------------------------------------------------------------
+-- Running the two parsers
+
+private def writeLines (path : FilePath) (lines : Array String) : IO Unit :=
+  IO.FS.writeFile path ("\n".intercalate lines.toList ++ "\n")
+
+/-- Run `ocamlc -stop-after parsing -dsource`, which writes the re-printed parse
+tree to stderr. -/
+def dsource (dir : FilePath) (file : String) : IO (Except String String) := do
+  match ← runProcess "ocamlc" #["-stop-after", "parsing", "-dsource", file] (some dir) with
+  | .timeout ms => return .error s!"ocamlc timed out after {ms}ms"
+  | .terminated out =>
+    if out.exitCode != 0 then return .error out.stderr else return .ok out.stderr
+
+/-- Run mica's parser, printing the result in the given style. -/
+def micaPrint (mica : FilePath) (dir : FilePath) (file : String) (parens : Bool)
+    : IO (Except String String) := do
+  let args := if parens then #["--parse-only", "--parens", file] else #["--parse-only", file]
+  match ← runProcess mica.toString args (some dir) with
+  | .timeout ms => return .error s!"mica timed out after {ms}ms"
+  | .terminated out =>
+    if out.exitCode != 0 then return .error (out.stdout ++ out.stderr)
+    else return .ok out.stdout
+
+/-- Pull the line number out of `File "f", line N, characters ...`. -/
+def ocamlErrorLine (msg : String) : Option Nat := do
+  let line ← (msg.splitOn "\n").find? (·.startsWith "File \"")
+  let after ← (line.splitOn ", line ")[1]?
+  (after.takeWhile Char.isDigit).toNat?
+
+/-- Run `ocamlc` over the corpus, and on a syntax error drop the offending
+fixture and retry. A fixture that OCaml rejects is a bug in the generator, not a
+finding about mica, but it must not take down the rest of the run. -/
+partial def ocamlWithRejections (dir : FilePath) (cases : Array Case)
+    (lines : Array String) (invalid : Array String) (budget : Nat)
+    : IO (Except String (String × Array String)) := do
+  writeLines (dir / "corpus.ml") lines
+  match ← dsource dir "corpus.ml" with
+  | .ok out => return .ok (out, invalid)
+  | .error msg =>
+    if budget == 0 then
+      return .error s!"gave up after too many invalid fixtures; last error: {msg}"
+    match ocamlErrorLine msg with
+    | none => return .error msg
+    | some lineNo =>
+      let idx := lineNo - 1
+      if idx < cases.size then
+        ocamlWithRejections dir cases
+          (lines.set! idx s!"let {cases[idx]!.name} = 0") (invalid.push cases[idx]!.name) (budget - 1)
+      else
+        return .error msg
+
+/-- Pull the line number out of `parse error: FILE:LINE:COL: message`. -/
+def parseErrorLine (msg : String) : Option Nat := do
+  let line ← (msg.splitOn "\n").find? (·.startsWith "parse error: ")
+  let fields := (line.drop "parse error: ".length).toString.splitOn ":"
+  let lineStr ← fields[1]?
+  lineStr.trimAscii.toString.toNat?
+
+/-- Run mica over the corpus, and on a parse error replace the offending
+declaration with a placeholder and retry, so one rejected fixture does not hide
+every fixture after it. Returns the printed program and the rejected names. -/
+partial def micaWithRejections (mica : FilePath) (dir : FilePath) (parens : Bool)
+    (cases : Array Case) (lines : Array String) (rejected : Array String) (budget : Nat)
+    : IO (Except String (String × Array String)) := do
+  writeLines (dir / "probe.ml") lines
+  match ← micaPrint mica dir "probe.ml" parens with
+  | .ok out => return .ok (out, rejected)
+  | .error msg =>
+    if budget == 0 then
+      return .error s!"gave up after too many rejected fixtures; last error: {msg}"
+    match parseErrorLine msg with
+    | none => return .error msg
+    | some lineNo =>
+      let idx := lineNo - 1
+      if idx < cases.size then
+        let c := cases[idx]!
+        micaWithRejections mica dir parens cases
+          (lines.set! idx s!"let {c.name} = 0") (rejected.push c.name) (budget - 1)
+      else
+        return .error msg
+
+-- ---------------------------------------------------------------------------
+-- Comparison
+
+/-- The `tNNNN` binder identifying a generated declaration, if this line starts
+one. Handles both `let tNNNN ...` and `type ['a] tNNNN = ...`. A wrapped
+declaration's continuation lines are indented, so they never match. -/
+def declName (line : String) : Option String :=
+  if !(line.startsWith "let " || line.startsWith "type ") then none
+  else (line.splitOn " ").find? fun w =>
+    w.length == 5 && w.startsWith "t" && (w.drop 1).toString.all Char.isDigit
+
+/-- Split `-dsource` output into one chunk per generated declaration. -/
+def groupByDecl (out : String) : Array (String × String) := Id.run do
+  let mut groups : Array (String × String) := #[]
+  let mut name := ""
+  let mut cur : Array String := #[]
+  for line in out.splitOn "\n" do
+    match declName line with
+    | some n =>
+      if !name.isEmpty then groups := groups.push (name, " ".intercalate cur.toList)
+      name := n
+      cur := #[line.trimAscii.toString]
+    | none =>
+      if !name.isEmpty && !line.trimAscii.toString.isEmpty then
+        cur := cur.push line.trimAscii.toString
+  if !name.isEmpty then groups := groups.push (name, " ".intercalate cur.toList)
+  return groups
+
+/-- Drop the `let tNNNN <params> = ` prefix so a report shows only the body. -/
+private def body (decl : String) : String :=
+  match (decl.splitOn " = ") with
+  | _ :: rest => " = ".intercalate rest
+  | [] => decl
+
+/-- On a syntax error at `lineNo` in mica's printed output, find the generated
+declaration containing it and return that declaration's name together with the
+text minus that declaration. A declaration mica cannot print as valid OCaml is a
+finding in its own right, so it is reported rather than aborting the run.
+
+Works for both printers: the paren printer emits one line per declaration, but
+the normal printer wraps `let ... in` and `match` over several, so the offending
+declaration is found by scanning back to the nearest header. -/
+def dropDeclAt (printed : String) (lineNo : Nat) : Option (String × String) := Id.run do
+  let lines := (printed.splitOn "\n").toArray
+  let mut startIdx : Option Nat := none
+  for i in [0:min lineNo lines.size] do
+    if (declName lines[i]!).isSome then startIdx := some i
+  let some s := startIdx | return none
+  let some nm := declName lines[s]! | return none
+  let mut e := s + 1
+  while e < lines.size && (declName lines[e]!).isNone do
+    e := e + 1
+  return some (nm, "\n".intercalate ((lines.toList.take s) ++ (lines.toList.drop e)))
+
+structure Divergence where
+  name   : String
+  source : String
+  ocaml  : String
+  mica   : String
+
+/-- Compare the two groupings, skipping fixtures mica rejected outright. -/
+def compare (cases : Array Case) (rejected : Array String)
+    (ocamlGroups micaGroups : Array (String × String)) : Array Divergence := Id.run do
+  let ocamlMap := ocamlGroups.foldl (init := ({} : Std.HashMap String String))
+    fun m (k, v) => m.insert k v
+  let micaMap := micaGroups.foldl (init := ({} : Std.HashMap String String))
+    fun m (k, v) => m.insert k v
+  let mut out := #[]
+  for c in cases do
+    if rejected.contains c.name then continue
+    match ocamlMap[c.name]?, micaMap[c.name]? with
+    | some o, some m =>
+      if o != m then
+        out := out.push { name := c.name, source := body c.decl, ocaml := body o, mica := body m }
+    | _, _ => pure ()
+  return out
+
+/-- Fixtures OCaml accepts and mica rejects, matched by substring, each with the
+reason it is currently rejected. These are language-scope questions rather than
+precedence bugs, so they are annotated here rather than left as bare failures.
+Matching is deliberately loose; the reason text is what carries the meaning.
+
+Order matters: the first matching entry wins, so the broad patterns come last. -/
+def knownGaps : List (String × String) :=
+  [ ("if b then c else d", "keyword expression as an operator's right operand")
+  , ("match b with",       "keyword expression as an operator's right operand")
+  , ("fun x -> x",         "keyword expression as an operator's right operand")
+  , ("let x = b in x",     "keyword expression as an operator's right operand")
+  , ("f ! r",              "prefix `!` not accepted as a function argument")
+  , ("r.u <-",             "field assignment: `<-` accepts only `a.(i)` on the left")
+  , ("r.u.v <-",           "field assignment: `<-` accepts only `a.(i)` on the left")
+  , ("a.(i).u <-",         "field assignment: `<-` accepts only `a.(i)` on the left")
+  , ("A (B y)",            "`parsePatternInner` reads an uppercase head as a binder, \
+so a parenthesized constructor pattern with a payload fails")
+  , ("A []",               "constructor-pattern payload token set omits `[`")
+  , ("type",               "type alias: `TypeDeclBody` has only variants and records")
+  , (", ",                 "bare tuple: mica builds tuples only inside parentheses") ]
+
+/-- Classify a rejected fixture. Takes the whole declaration, not just its body,
+so that a `type` alias can be told apart from an expression fixture. -/
+def gapReason (decl : String) : String :=
+  match knownGaps.find? fun (pat, _) => (decl.splitOn pat).length > 1 with
+  | some (_, reason) => reason
+  | none             => "unclassified"
+
+-- ---------------------------------------------------------------------------
+-- Entry point
+
+/-- Read mica's printed output back through `ocamlc`, dropping any declaration it
+cannot render as valid OCaml and recording the name. That is a finding in its own
+right, so it is collected rather than aborting the run. -/
+partial def readBack (dir : FilePath) (label printed : String)
+    (bad : Array String) (budget : Nat) : IO (String × Array String) := do
+  writeLines (dir / "printed.ml") #[printed]
+  match ← dsource dir "printed.ml" with
+  | .ok out => pure (out, bad)
+  | .error e =>
+    let fail := IO.userError s!"[{label}] mica's output is not valid OCaml:\n{e}"
+    if budget == 0 then throw fail
+    let some lineNo := ocamlErrorLine e | throw fail
+    let some (nm, rest) := dropDeclAt printed lineNo | throw fail
+    readBack dir label rest (bad.push nm) (budget - 1)
+
+/-- Where the expected state of the corpus is recorded. The file is the gate: a
+refactor that changes nothing must leave it untouched, and a fix must shrink it
+by exactly the cells it claims to fix. -/
+def baselinePath : FilePath := "Tests" / "parser" / "parser-diff.baseline"
+
+/-- One sorted line per finding, so the file diffs cleanly and a fixture added to
+the corpus does not churn the existing entries. -/
+def baselineLines (parserDs printerDs : Array Divergence) (gaps unprintable : Array String)
+    : Array String :=
+  let d := parserDs.map fun x => s!"DIVERGE {x.source}  ==>  ocaml: {x.ocaml}  |  mica: {x.mica}"
+  let p := printerDs.map fun x => s!"PRINTER {x.source}  ==>  ocaml: {x.ocaml}  |  mica: {x.mica}"
+  let g := gaps.map fun s => s!"GAP     {body s}  ==>  {gapReason s}"
+  let u := unprintable.map fun s => s!"UNPRINT {s}"
+  (d ++ p ++ g ++ u).qsort (· < ·)
+
+/-- Run both comparison passes over the generated corpus. -/
+def run (mica : FilePath) (promote : Bool) : IO UInt32 := do
+  -- Fixtures are parsed inside a temp directory, so the executable path has to
+  -- survive the change of working directory.
+  let mica ← IO.FS.realPath mica
+  let cases := allCases
+  let report ← IO.FS.withTempDir fun dir => do
+    let (ocamlOut, invalid) ← match ← ocamlWithRejections dir cases (cases.map (·.decl)) #[] 40 with
+      | .error e => throw <| IO.userError e
+      | .ok r => pure r
+    if !invalid.isEmpty then
+      IO.eprintln s!"parser-diff: {invalid.size} fixture(s) are not valid OCaml (generator bug):"
+      for n in invalid do
+        if let some c := cases.find? (·.name == n) then IO.eprintln s!"  {n}  {body c.decl}"
+    let ocamlGroups := groupByDecl ocamlOut
+
+    -- One rejection scan, reused by both passes: whether a fixture parses does
+    -- not depend on how the result is printed. `probe.ml` is left holding the
+    -- corpus with rejected fixtures replaced by placeholders.
+    let (parenOut, rejected) ← match ← micaWithRejections mica dir true cases
+        (cases.map (·.decl)) #[] 400 with
+      | .error e => throw <| IO.userError e
+      | .ok r => pure r
+    let normalOut ← match ← micaPrint mica dir "probe.ml" false with
+      | .error e => throw <| IO.userError s!"mica failed on the cleaned corpus: {e}"
+      | .ok out => pure out
+
+    let (parenRead, parenBad) ← readBack dir "parser" parenOut #[] 40
+    let (normalRead, normalBad) ← readBack dir "parser+printer" normalOut #[] 40
+
+    let skip := rejected ++ invalid ++ parenBad ++ normalBad
+    let parserDs := compare cases skip ocamlGroups (groupByDecl parenRead)
+    let printerDs := compare cases skip ocamlGroups (groupByDecl normalRead)
+    let gaps := rejected.filterMap fun n => (cases.find? (·.name == n)).map (·.decl)
+    let unprintable := (parenBad ++ normalBad).filterMap fun n =>
+      (cases.find? (·.name == n)).map (·.decl)
+
+    let checked := cases.size - skip.size
+    IO.println s!"parser-diff: {checked - parserDs.size}/{checked} fixtures agree with OCaml, \
+{parserDs.size} divergent, {gaps.size} rejected by mica"
+    -- A cell that the parser gets wrong but that survives a print/reparse is one
+    -- where `Printer.lean`'s precedence table cancels the parser's: the two
+    -- errors compose back to OCaml's reading, which is why these are invisible
+    -- to any test that goes through mica's own printer.
+    let masked := parserDs.filter fun d => !printerDs.any (·.name == d.name)
+    IO.println s!"parser-diff: {printerDs.size} of those survive mica's own printer; \
+{masked.size} are masked by `Printer.lean`'s duplicate precedence table"
+    if !unprintable.isEmpty then
+      IO.println s!"parser-diff: {unprintable.size} declaration(s) mica cannot print as valid OCaml"
+    pure (baselineLines parserDs printerDs gaps unprintable)
+
+  let text := "\n".intercalate report.toList ++ "\n"
+  if promote then
+    IO.FS.createDirAll baselinePath.parent.get!
+    IO.FS.writeFile baselinePath text
+    IO.println s!"parser-diff: promoted {report.size} entries to {baselinePath}"
+    return 0
+  if !(← baselinePath.pathExists) then
+    IO.eprintln s!"parser-diff: no baseline at {baselinePath}; \
+run `lake run testsuite parser-diff --promote` to create it"
+    return 1
+  let expected ← IO.FS.readFile baselinePath
+  if expected == text then
+    IO.println s!"parser-diff: matches the baseline ({report.size} known entries)"
+    return 0
+  IO.eprintln "parser-diff: corpus state differs from the baseline"
+  let expectedLines := (expected.splitOn "\n").filter (!·.isEmpty)
+  for l in report.toList do
+    if !expectedLines.contains l then IO.eprintln s!"  new:  {l}"
+  for l in expectedLines do
+    if !report.contains l then IO.eprintln s!"  gone: {l}"
+  return 1
+
+end Testsuite.ParserDiff

--- a/Testsuite/ParserDiff.lean
+++ b/Testsuite/ParserDiff.lean
@@ -335,11 +335,7 @@ Matching is deliberately loose; the reason text is what carries the meaning.
 
 Order matters: the first matching entry wins, so the broad patterns come last. -/
 def knownGaps : List (String × String) :=
-  [ ("if b then c else d", "keyword expression as an operator's right operand")
-  , ("match b with",       "keyword expression as an operator's right operand")
-  , ("fun x -> x",         "keyword expression as an operator's right operand")
-  , ("let x = b in x",     "keyword expression as an operator's right operand")
-  , ("f ! r",              "prefix `!` not accepted as a function argument")
+  [ ("f ! r",              "prefix `!` not accepted as a function argument")
   , ("r.u <-",             "field assignment: `<-` accepts only `a.(i)` on the left")
   , ("r.u.v <-",           "field assignment: `<-` accepts only `a.(i)` on the left")
   , ("a.(i).u <-",         "field assignment: `<-` accepts only `a.(i)` on the left")
@@ -430,12 +426,12 @@ def run (mica : FilePath) (promote : Bool) : IO UInt32 := do
     IO.println s!"parser-diff: {checked - parserDs.size}/{checked} fixtures agree with OCaml, \
 {parserDs.size} divergent, {gaps.size} rejected by mica"
     -- A cell that the parser gets wrong but that survives a print/reparse is one
-    -- where `Printer.lean`'s precedence table cancels the parser's: the two
-    -- errors compose back to OCaml's reading, which is why these are invisible
-    -- to any test that goes through mica's own printer.
+    -- where `Printer.lean` makes the matching mistake: the two errors compose
+    -- back to OCaml's reading, which is why these are invisible to any test that
+    -- goes through mica's own printer.
     let masked := parserDs.filter fun d => !printerDs.any (·.name == d.name)
     IO.println s!"parser-diff: {printerDs.size} of those survive mica's own printer; \
-{masked.size} are masked by `Printer.lean`'s duplicate precedence table"
+{masked.size} are masked by a matching mistake in `Printer.lean`"
     if !unprintable.isEmpty then
       IO.println s!"parser-diff: {unprintable.size} declaration(s) mica cannot print as valid OCaml"
     pure (baselineLines parserDs printerDs gaps unprintable)

--- a/Testsuite/ParserDiff.lean
+++ b/Testsuite/ParserDiff.lean
@@ -105,6 +105,12 @@ def commaCases : List String :=
      , "a.(i), b", "- a, b", "! r, b", "a, b, c, d"
      , "if a then b, c else d", "fun x -> x, a", "let x = a, b in x" ]
 
+/-- Record literals, updates, and the punned field `{ a }`, which is `{ a = a }`. -/
+def recordCases : List String :=
+  [ "{ a = b }", "{ a = b; c = d }", "{ a }", "{ a; c }", "{ a; c = d }"
+  , "{ a = b, c }", "{ a = b; c }", "{ r with a }", "{ r with a = b }"
+  , "{ a }.b", "f { a }", "{ a = f b }", "{ a } :: r" ]
+
 /-- `begin e end` is `(e)`: same tree, no node of its own, and a simple
 expression wherever one is expected. -/
 def beginEndCases : List String :=
@@ -123,7 +129,9 @@ def patternCases : List String :=
   , "[] :: z", "A []", "A _", "A (B y)", "(y :: z, w)"
   , "y :: (z, w)", "A 0", "A 'c'"
   -- A constructor payload is itself a constructor application, not an atom.
-  , "A B", "A B y", "A B C", "A B y :: z", "A (B y) :: z" ]
+  , "A B", "A B y", "A B C", "A B y :: z", "A (B y) :: z"
+  -- Punned record fields: `{ u }` is `{ u = u }`.
+  , "{ u }", "{ u; v }", "{ u = y; v }", "{ u } :: z" ]
 
 /-- Declaration shapes that the body-level groups above cannot express: the
 `let` header itself, and the arms of a `match` written out. `NAME` is replaced by
@@ -178,7 +186,7 @@ def allCases : Array Case := Id.run do
   let mut out : Array Case := #[]
   let mut n : Nat := 0
   for group in [pairCases, prefixCases, appCases, keywordCases, arraySetCases,
-                commaCases, beginEndCases] do
+                commaCases, beginEndCases, recordCases] do
     for body in group do
       out := out.push { name := caseName n, decl := s!"let {caseName n} {params} = {body}" }
       n := n + 1

--- a/Testsuite/ParserDiff.lean
+++ b/Testsuite/ParserDiff.lean
@@ -105,6 +105,13 @@ def commaCases : List String :=
      , "a.(i), b", "- a, b", "! r, b", "a, b, c, d"
      , "if a then b, c else d", "fun x -> x, a", "let x = a, b in x" ]
 
+/-- `begin e end` is `(e)`: same tree, no node of its own, and a simple
+expression wherever one is expected. -/
+def beginEndCases : List String :=
+  [ "begin a end", "begin a + b end * c", "f begin a end", "begin a; b end"
+  , "begin a end.b", "- begin a end", "begin f a end b", "begin a, b end"
+  , "begin if a then b else c end", "! begin r end", "begin a end.(i)" ]
+
 /-- Pattern-level precedence, exercised in a match arm: `::` against the comma
 level, against constructor application, and against annotation. -/
 def patternCases : List String :=
@@ -170,7 +177,8 @@ private def caseName (n : Nat) : String :=
 def allCases : Array Case := Id.run do
   let mut out : Array Case := #[]
   let mut n : Nat := 0
-  for group in [pairCases, prefixCases, appCases, keywordCases, arraySetCases, commaCases] do
+  for group in [pairCases, prefixCases, appCases, keywordCases, arraySetCases,
+                commaCases, beginEndCases] do
     for body in group do
       out := out.push { name := caseName n, decl := s!"let {caseName n} {params} = {body}" }
       n := n + 1

--- a/Testsuite/ParserDiff.lean
+++ b/Testsuite/ParserDiff.lean
@@ -175,6 +175,11 @@ def typeCases : List String :=
   , "int -> int list", "int list -> int", "(int -> int) list"
   , "int * int list", "'a list", "'a -> 'a", "'a * 'b -> 'c"
   , "int array", "int ref list", "(int -> int) -> int"
+  -- Qualified type constructors, whose head is a module path.
+  , "int Queue.t", "int Queue.t list", "int list Queue.t", "Queue.t"
+  , "(int, int) Hashtbl.t", "int Foo.Bar.t", "int Queue.t -> int"
+  , "int Queue.t * int", "Foo.t Bar.t", "Foo.t list", "int Foo.t Bar.t"
+  , "Foo.Bar.t Baz.t", "(Foo.t, Bar.t) Hashtbl.t", "Foo.t Bar.t list"
   , "int list list list", "'a * 'b * 'c -> 'd" ]
 
 private def caseName (n : Nat) : String :=

--- a/Testsuite/ParserDiff.lean
+++ b/Testsuite/ParserDiff.lean
@@ -363,7 +363,15 @@ def compare (cases : Array Case) (rejected : Array String)
     | some o, some m =>
       if o != m then
         out := out.push { name := c.name, source := body c.decl, ocaml := body o, mica := body m }
-    | _, _ => pure ()
+    | some o, none =>
+      out := out.push { name := c.name, source := body c.decl, ocaml := body o
+                      , mica := "<missing declaration>" }
+    | none, some m =>
+      out := out.push { name := c.name, source := body c.decl
+                      , ocaml := "<missing declaration>", mica := body m }
+    | none, none =>
+      out := out.push { name := c.name, source := body c.decl
+                      , ocaml := "<missing declaration>", mica := "<missing declaration>" }
   return out
 
 /-- Fixtures OCaml accepts and mica rejects, matched by substring, each with the

--- a/Testsuite/ParserDiff.lean
+++ b/Testsuite/ParserDiff.lean
@@ -118,6 +118,21 @@ def patternCases : List String :=
   -- A constructor payload is itself a constructor application, not an atom.
   , "A B", "A B y", "A B C", "A B y :: z", "A (B y) :: z" ]
 
+/-- Declaration shapes that the body-level groups above cannot express: the
+`let` header itself, and the arms of a `match` written out. `NAME` is replaced by
+the fixture's generated name. -/
+def declCases : List String :=
+  [ "let NAME x = match x with y -> 0"
+  , "let NAME x = match x with A -> 0 | B -> 1"
+  , "let NAME x = match x with | A -> 0 | B -> 1"
+  , "let NAME x = match x with A y -> y | B -> 0"
+  , "let NAME f x : int -> int = f x"
+  , "let NAME x : int = x"
+  , "let NAME (f : int -> int) x = f x"
+  , "let NAME x = fun y : int -> y"
+  , "let NAME x = (fun y : (int -> int) -> y) x"
+  , "let rec NAME x = NAME x" ]
+
 /-- Type declarations: variants, records, and parameters. `NAME` is replaced by
 the fixture's generated name. -/
 def typeDeclCases : List String :=
@@ -166,8 +181,8 @@ def allCases : Array Case := Id.run do
     out := out.push { name := caseName n
                     , decl := s!"let {caseName n} x = match x with | {pat} -> 0 | _ -> 1" }
     n := n + 1
-  for td in typeDeclCases do
-    out := out.push { name := caseName n, decl := td.replace "NAME" (caseName n) }
+  for d in declCases ++ typeDeclCases do
+    out := out.push { name := caseName n, decl := d.replace "NAME" (caseName n) }
     n := n + 1
   return out
 
@@ -337,13 +352,9 @@ Matching is deliberately loose; the reason text is what carries the meaning.
 
 Order matters: the first matching entry wins, so the broad patterns come last. -/
 def knownGaps : List (String × String) :=
-  [ ("f ! r",              "prefix `!` not accepted as a function argument")
-  , ("r.u <-",             "field assignment: `<-` accepts only `a.(i)` on the left")
+  [ ("r.u <-",             "field assignment: `<-` accepts only `a.(i)` on the left")
   , ("r.u.v <-",           "field assignment: `<-` accepts only `a.(i)` on the left")
   , ("a.(i).u <-",         "field assignment: `<-` accepts only `a.(i)` on the left")
-  , ("A (B y)",            "`parsePatternInner` reads an uppercase head as a binder, \
-so a parenthesized constructor pattern with a payload fails")
-  , ("A []",               "constructor-pattern payload token set omits `[`")
   , ("type",               "type alias: `TypeDeclBody` has only variants and records")
   , (", ",                 "bare tuple: mica builds tuples only inside parentheses") ]
 

--- a/Testsuite/ParserDiff.lean
+++ b/Testsuite/ParserDiff.lean
@@ -114,7 +114,9 @@ def patternCases : List String :=
   , "A", "A y", "A (y, z)", "A y :: z", "(A y, B z)"
   , "A y :: B z :: w", "(y, z) :: w", "{ u = y } :: z"
   , "[] :: z", "A []", "A _", "A (B y)", "(y :: z, w)"
-  , "y :: (z, w)", "A 0", "A 'c'" ]
+  , "y :: (z, w)", "A 0", "A 'c'"
+  -- A constructor payload is itself a constructor application, not an atom.
+  , "A B", "A B y", "A B C", "A B y :: z", "A (B y) :: z" ]
 
 /-- Type declarations: variants, records, and parameters. `NAME` is replaced by
 the fixture's generated name. -/

--- a/Testsuite/Task.lean
+++ b/Testsuite/Task.lean
@@ -109,8 +109,10 @@ def check (mica : FilePath) (promote : Bool) (tmpDir : FilePath) (idx : Nat) (te
 def roundtrip (mica : FilePath) (tmpDir : FilePath) (idx : Nat) (test : Test) :
     IO Outcome := do
   measure test.label do
+    -- The test's own flags come along, so a test whose syntax outruns the
+    -- elaborator can ask for `--parse-only` and still check the fixpoint.
     let args := fun (file : FilePath) =>
-      #["--no-ansi", "--print-ocaml", "--no-check", file.toString]
+      #["--no-ansi", "--print-ocaml", "--no-check"] ++ test.config.flags ++ #[file.toString]
     let r1 ← runProcess mica.toString (args test.path)
     let .terminated out1 := r1
       | return r1

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -40,6 +40,24 @@ script «generate-docs» (args) := do
   if rc ≠ 0 then return rc
   runOverviews
 
+/-- Build mica and the testsuite runner, then run the differential parser tests
+    (`Testsuite/ParserDiff.lean`), which check mica's parse of a generated
+    corpus against OCaml's. `--promote` rewrites the recorded baseline. -/
+script «parser-diff» (args) := do
+  let some mica ← Lake.findLeanExe? `mica
+    | error "mica executable undefined"
+  let some suite ← Lake.findLeanExe? `«testsuite-runner»
+    | error "testsuite-runner executable undefined"
+  let (micaFile, exeFile) ← runBuild do
+    let micaJob ← mica.exe.fetch
+    let suiteJob ← suite.exe.fetch
+    return micaJob.zipWith (fun m s => (m, s)) suiteJob
+  let child ← IO.Process.spawn {
+    cmd := exeFile.toString
+    args := #["parser-diff", "--mica", micaFile.toString] ++ args.toArray
+  }
+  child.wait
+
 /-- Build mica and the testsuite runner (`Testsuite.lean`), ask the runner for
     the task list (`list` → `task,file` lines), and register one Lake job per
     task (`run-task`) so the build monitor shows live progress. Reports are


### PR DESCRIPTION
This PR considerably improves the parser in a sequence of commits. It uses a proper state monad, and proper parsing for infix operators with clearly spelled out levels. It also adds a test corpus of examples to compare against `ocamlopt` and ensure both agree. 