### PR TITLE
Factor out type variables

### DIFF
--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -409,7 +409,7 @@ partial def Typ.applyAttr (env : ElabEnv) (t : Untyped.Typ) (attr : Attribute) :
   | name, _ => err attr.loc (.unsupportedFeature s!"unknown type attribute [@{name}]")
 
 partial def TypKind.elaborate (env : ElabEnv) (loc : Location) : TypKind → ElabM Untyped.Typ
-  | .var v => .ok (.core (.tvar v))
+  | .var v => .ok (.tvar v)
   | .con path args => do
     let args' ← Typ.elaborateList env args
     -- Qualified paths route through the resolver; an alias must point to a
@@ -1035,13 +1035,34 @@ private def requireOpenMica : List Decl → ElabM (List Decl)
 -- ---------------------------------------------------------------------------
 -- Predefined types
 
+/-- Embed a schema type into the annotation language. Lossy: an arrow's
+specification is dropped, since a source specification is untyped expression
+syntax that a core one cannot be turned back into. Only the predefined
+constructor payloads go through here, and they carry none. -/
+private def schemaAnnotation : TinyML.SchemaTyp → Untyped.Typ
+  | .prim p => .core (.prim p)
+  | .sum ts => .sum (ts.map schemaAnnotation)
+  | .arrow args ret _ =>
+      .arrow (args.map schemaAnnotation) (schemaAnnotation ret) none
+  | .ref t => .ref (schemaAnnotation t)
+  | .array t => .array (schemaAnnotation t)
+  | .ownedArray t => .ownedArray (schemaAnnotation t)
+  | .vec t => .vec (schemaAnnotation t)
+  | .owned t => .owned (schemaAnnotation t)
+  | .empty => .core .empty
+  | .value => .core .value
+  | .tuple ts => .tuple (ts.map schemaAnnotation)
+  | .tvar v => .tvar v
+  | .named n args => .named n (args.map schemaAnnotation)
+
 private def predefCtorEntries (p : TinyML.Predef) :
     List (Constructor × (Nat × Nat × Untyped.Typ)) :=
   let arity := p.ctors.length
-  let rec go : List (String × TinyML.Typ) → Nat →
+  let rec go : List (String × TinyML.SchemaTyp) → Nat →
       List (Constructor × (Nat × Nat × Untyped.Typ))
     | [], _ => []
-    | (name, payload) :: rest, tag => (name, (tag, arity, .core payload)) :: go rest (tag + 1)
+    | (name, payload) :: rest, tag =>
+        (name, (tag, arity, schemaAnnotation payload)) :: go rest (tag + 1)
   go p.ctors 0
 
 /-- The initial frontend environment derived from the canonical predef catalog.

--- a/Mica/SourceTinyML/LogicalRelation.lean
+++ b/Mica/SourceTinyML/LogicalRelation.lean
@@ -538,10 +538,6 @@ theorem ValHasType.arrow_some (W : World) (v : Runtime.Val) (args : List Typ) (r
       s.isPrecondFor W (ValHasType W) args ret v := by
   exact equiv_iff.mp (ValHasType.unfold W v (.arrow args ret (some s)))
 
-theorem ValHasType.tvar (W : World) (v : Runtime.Val) (x : TyVar) :
-    ValHasType W v (.tvar x) ⊣⊢ iprop(False) := by
-  exact equiv_iff.mp (ValHasType.unfold W v (.tvar x))
-
 theorem ValHasType.ref (W : World) (v : Runtime.Val) (t : Typ) :
     ValHasType W v (.ref t) ⊣⊢
       iprop(∃ l, ⌜v = .loc l⌝ ∗ locinv l (fun w => ValHasType W w t)) := by
@@ -1272,7 +1268,7 @@ mutual
       | none => exact (TinyML.ValHasType.arrow_none W v args ret).1.trans false_elim
       | some _ => iintro _; ipureintro; simp [typeConstraints]
     | empty => exact (TinyML.ValHasType.empty W v).1.trans false_elim
-    | tvar x => exact (TinyML.ValHasType.tvar W v x).1.trans false_elim
+    | tvar x => nomatch x
 
   theorem typeConstraintsList_hold {ts : List TinyML.Typ} {tl : Term .vallist} {ρ : Env}
       {W : TinyML.World} {vs : List Runtime.Val} (htl : tl.eval ρ = vs) :

--- a/Mica/SourceTinyML/OUTLINE.md
+++ b/Mica/SourceTinyML/OUTLINE.md
@@ -6,7 +6,7 @@
 - `Semantics.lean` — Semantics of atoms, assertions, and specifications, parametric in the value relation interpreting types.
 - `TypeConstraints.lean` — First-order constraint formulas asserting that a term has a given TinyML type.
 - `Typed.lean` — Typed TinyML IR, with erasure to the runtime IR.
-- `Types.lean` — TinyML types, type declarations, and subtyping structure.
+- `Types.lean` — TinyML types over a parameter of type variables, type declarations, and subtyping.
 - `Typing.lean` — Elaboration and typechecking from the untyped IR to the typed IR.
 - `Untyped.lean` — Untyped TinyML IR and specification syntax, with annotations carried where available.
 - `World.lean` — The fixed meta-level world in which the logical relation interprets types.

--- a/Mica/SourceTinyML/Printer.lean
+++ b/Mica/SourceTinyML/Printer.lean
@@ -9,29 +9,40 @@ open TinyML
 namespace TinyML
 
 /-- Does the type print without parentheses in argument position? -/
-private def Typ.atomic : Typ → Bool
+private def Typ.atomic : Typ.WithTypeVars V → Bool
   | .prim _ | .empty | .value | .tvar _ | .named _ [] => true
   | _ => false
 
-def Typ.print : Typ → String
+/-- Print a type, rendering its variables with `pvar`. -/
+def Typ.printWith (pvar : V → String) : Typ.WithTypeVars V → String
   | .prim p => p.print
-  | .sum ts => s!"sum ({", ".intercalate (ts.map Typ.print)})"
-  | .arrow args ret _ =>
-      " -> ".intercalate ((args.map fun arg => wrapArg arg (Typ.print arg)) ++ [Typ.print ret])
-  | .ref t => s!"ref {wrapArg t (Typ.print t)}"
-  | .array t => s!"array {wrapArg t (Typ.print t)}"
-  | .ownedArray t => s!"owned-array {wrapArg t (Typ.print t)}"
-  | .vec t => s!"vec {wrapArg t (Typ.print t)}"
-  | .owned t => s!"owned {wrapArg t (Typ.print t)}"
+  | .sum ts => s!"sum ({", ".intercalate (ts.map (Typ.printWith pvar))})"
+  | .arrow args ret spec =>
+      -- A specification has no surface syntax to print back into, but two
+      -- arrows can differ in nothing else, so at least record that it is there.
+      " -> ".intercalate ((args.map fun arg => wrapArg arg (Typ.printWith pvar arg))
+        ++ [Typ.printWith pvar ret]) ++ (if spec.isSome then " [@@spec]" else "")
+  | .ref t => s!"ref {wrapArg t (Typ.printWith pvar t)}"
+  | .array t => s!"array {wrapArg t (Typ.printWith pvar t)}"
+  | .ownedArray t => s!"owned-array {wrapArg t (Typ.printWith pvar t)}"
+  | .vec t => s!"vec {wrapArg t (Typ.printWith pvar t)}"
+  | .owned t => s!"owned {wrapArg t (Typ.printWith pvar t)}"
   | .empty => "empty"
   | .value => "value"
-  | .tuple ts => s!"({", ".intercalate (ts.map Typ.print)})"
-  | .tvar v => s!"'{v}"
+  | .tuple ts => s!"({", ".intercalate (ts.map (Typ.printWith pvar))})"
+  | .tvar v => pvar v
   | .named T [] => T.print
-  | .named T args => s!"{T.print} ({", ".intercalate (args.map Typ.print)})"
+  | .named T args =>
+      s!"{T.print} ({", ".intercalate (args.map (Typ.printWith pvar))})"
 where
-  wrapArg (t : Typ) (s : String) : String :=
-    if t.atomic then s else s!"({s})"
+  wrapArg (t : Typ.WithTypeVars V) (s : String) : String :=
+    if Typ.atomic t then s else s!"({s})"
+
+/-- Print a closed type. -/
+def Typ.print : Typ → String := Typ.printWith Empty.elim
+
+/-- Print a schema type, showing its variables in source syntax. -/
+def SchemaTyp.print : SchemaTyp → String := Typ.printWith (fun v => s!"'{v}")
 
 end TinyML
 
@@ -41,6 +52,7 @@ namespace Untyped
 arrow carries is dropped: there is no surface syntax to print it back into. -/
 def Typ.print : Untyped.Typ → String
   | .core t => t.print
+  | .tvar v => s!"'{v}"
   | .sum ts => s!"sum ({", ".intercalate (ts.map Typ.print)})"
   | .arrow args ret _ =>
       " -> ".intercalate ((args.map fun arg => wrapArg arg (Typ.print arg)) ++ [Typ.print ret])
@@ -55,7 +67,8 @@ def Typ.print : Untyped.Typ → String
 where
   wrapArg (t : Untyped.Typ) (s : String) : String :=
     match t with
-    | .core c => if c.atomic then s else s!"({s})"
+    | .core c => if TinyML.Typ.atomic c then s else s!"({s})"
+    | .tvar _ => s
     | .named _ [] => s
     | _ => s!"({s})"
 

--- a/Mica/SourceTinyML/Typed.lean
+++ b/Mica/SourceTinyML/Typed.lean
@@ -7,14 +7,19 @@ namespace Typed
 
 open TinyML
 
-structure Binder where
+/-- A binder, parameterized by the variables its type annotation admits, in step
+with `Typ.WithTypeVars`. -/
+structure Binder.WithTypeVars (V : Type) where
   name : Option TinyML.Var
-  ty : Typ
+  ty : Typ.WithTypeVars V
   deriving Repr
+
+/-- The binder of the typed IR the verifier consumes. -/
+abbrev Binder := Binder.WithTypeVars Empty
 
 instance : Inhabited Binder := ⟨⟨Option.none, .value⟩⟩
 
-instance : DecidableEq Binder := by
+instance {V : Type} [DecidableEq V] : DecidableEq (Binder.WithTypeVars V) := by
   intro a b
   cases a with
   | mk n1 t1 =>
@@ -29,66 +34,88 @@ def Binder.none (ty : Typ) : Binder := ⟨Option.none, ty⟩
 
 def Binder.named (name : TinyML.Var) (ty : Typ) : Binder := ⟨some name, ty⟩
 
-instance : BEq Binder := ⟨fun a b => decide (a = b)⟩
+instance {V : Type} [DecidableEq V] : BEq (Binder.WithTypeVars V) :=
+  ⟨fun a b => decide (a = b)⟩
 
-instance : LawfulBEq Binder where
+instance {V : Type} [DecidableEq V] : LawfulBEq (Binder.WithTypeVars V) where
   eq_of_beq {a b} h := by
     exact of_decide_eq_true h
   rfl {a} := by
     simp [BEq.beq]
 
-inductive Expr where
+/-- The typed IR, parameterized by the variables its type annotations admit. -/
+inductive Expr.WithTypeVars (V : Type) where
   | const (c : Const)
-  | var (name : TinyML.Var) (ty : Typ)
+  | var (name : TinyML.Var) (ty : Typ.WithTypeVars V)
   /-- Reference to a built-in primitive, indexed by name. `inst` is the
       type-variable instantiation solved at the use site; `ty` is the
       instantiated arrow type derived from the registry's scheme. -/
-  | prim (name : String) (inst : List (TyVar × Typ)) (ty : Typ)
-  | unop (op : UnOp) (e : Expr) (ty : Typ)
-  | binop (op : BinOp) (lhs rhs : Expr) (ty : Typ)
+  | prim (name : String) (inst : List (TyVar × Typ.WithTypeVars V))
+      (ty : Typ.WithTypeVars V)
+  | unop (op : UnOp) (e : WithTypeVars V) (ty : Typ.WithTypeVars V)
+  | binop (op : BinOp) (lhs rhs : WithTypeVars V) (ty : Typ.WithTypeVars V)
   /-- A function literal. `spec` is the specification the function was checked
       against, which is also what `Expr.ty` puts in the node's arrow type; the
       self binder carries the same arrow. -/
-  | fix (self : Binder) (args : List Binder) (retTy : Typ) (spec : Option (Spec Typ))
-      (body : Expr)
-  | app (fn : Expr) (args : List Expr) (ty : Typ)
-  | ifThenElse (cond thn els : Expr) (ty : Typ)
-  | letIn (name : Binder) (bound body : Expr)
-  | letProd (names : List Binder) (bound body : Expr)
-  | ref    (ownership : Ownership) (e : Expr)
-  | deref  (e : Expr) (ty : Typ)
-  | store  (loc val : Expr)
-  | arrayMake (ownership : Ownership) (len init : Expr)
-  | arrayLen (arr : Expr)
-  | arrayGet (arr idx : Expr) (ty : Typ)
-  | arraySet (arr idx val : Expr)
-  | assert (e : Expr)
-  | tuple (es : List Expr)
-  | inj (tag : Nat) (arity : Nat) (payload : Expr)
-  | match_ (scrutinee : Expr) (branches : List (Binder × Expr)) (ty : Typ)
-  | cast (e : Expr) (ty : Typ)
+  | fix (self : Binder.WithTypeVars V) (args : List (Binder.WithTypeVars V))
+      (retTy : Typ.WithTypeVars V) (spec : Option (Spec (Typ.WithTypeVars V)))
+      (body : WithTypeVars V)
+  | app (fn : WithTypeVars V) (args : List (WithTypeVars V)) (ty : Typ.WithTypeVars V)
+  | ifThenElse (cond thn els : WithTypeVars V) (ty : Typ.WithTypeVars V)
+  | letIn (name : Binder.WithTypeVars V) (bound body : WithTypeVars V)
+  | letProd (names : List (Binder.WithTypeVars V)) (bound body : WithTypeVars V)
+  | ref    (ownership : Ownership) (e : WithTypeVars V)
+  | deref  (e : WithTypeVars V) (ty : Typ.WithTypeVars V)
+  | store  (loc val : WithTypeVars V)
+  | arrayMake (ownership : Ownership) (len init : WithTypeVars V)
+  | arrayLen (arr : WithTypeVars V)
+  | arrayGet (arr idx : WithTypeVars V) (ty : Typ.WithTypeVars V)
+  | arraySet (arr idx val : WithTypeVars V)
+  | assert (e : WithTypeVars V)
+  | tuple (es : List (WithTypeVars V))
+  | inj (tag : Nat) (arity : Nat) (payload : WithTypeVars V)
+  | match_ (scrutinee : WithTypeVars V)
+      (branches : List (Binder.WithTypeVars V × WithTypeVars V)) (ty : Typ.WithTypeVars V)
+  | cast (e : WithTypeVars V) (ty : Typ.WithTypeVars V)
+
+/-- The typed IR the verifier consumes. Its annotations are closed types. -/
+abbrev Expr := Expr.WithTypeVars Empty
+
+namespace Expr
+-- As for `Typ`: `.fix` resolves in the inductive's namespace, `Expr.fix` in the
+-- one named after the syntax it usually builds.
+export WithTypeVars (const var prim unop binop fix app ifThenElse letIn letProd
+  ref deref store arrayMake arrayLen arrayGet arraySet assert tuple inj match_ cast)
+end Expr
 
 instance : Inhabited Expr := ⟨.const .unit⟩
 
 /-- Is the expression a function (fix) node? -/
-def Expr.isFunc : Expr → Bool
+def Expr.WithTypeVars.isFunc : Expr.WithTypeVars V → Bool
   | .fix .. => true
   | _ => false
 
-@[simp] theorem Expr.isFunc_fix : (Expr.fix self args retTy spec body).isFunc = true := rfl
+@[simp] theorem Expr.isFunc_fix {self : Binder.WithTypeVars V}
+    {args : List (Binder.WithTypeVars V)} {retTy : Typ.WithTypeVars V}
+    {spec : Option (Spec (Typ.WithTypeVars V))} {body : Expr.WithTypeVars V} :
+    (Expr.WithTypeVars.fix self args retTy spec body).isFunc = true := rfl
 
-theorem Expr.isFunc_elim {e : Expr} (h : e.isFunc = true) :
+theorem Expr.isFunc_elim {e : Expr.WithTypeVars V} (h : e.isFunc = true) :
     ∃ self args retTy spec body, e = .fix self args retTy spec body := by
-  cases e <;> simp [isFunc] at h
+  cases e <;> simp [Expr.WithTypeVars.isFunc] at h
   exact ⟨_, _, _, _, _, rfl⟩
 
 -- `deriving DecidableEq` does not support mutual inductives with `List`-nested
 -- recursion, so we define the instance by hand.
 mutual
-  private def Expr.decEq (a b : Expr) : Decidable (a = b) := by
+  private def Expr.WithTypeVars.decEq {V : Type} [DecidableEq V]
+      (a b : Expr.WithTypeVars V) : Decidable (a = b) := by
     cases a <;> cases b
     all_goals first | exact isFalse (by omega) | skip
-    all_goals first | exact isFalse Expr.noConfusion | skip
+    -- Once the inductive has a parameter, `noConfusion` takes a type equality
+    -- and an `HEq` rather than the plain disequality this used, so the
+    -- mismatched-constructor cases are discharged by elimination instead.
+    all_goals first | (refine isFalse ?_; intro h; cases h; done) | skip
     case const.const c1 c2 => exact match decEq c1 c2 with
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -203,7 +230,8 @@ mutual
       | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
 
-  private def exprsDecEq : (as bs : List Expr) → Decidable (as = bs)
+  private def exprsDecEq {V : Type} [DecidableEq V] :
+      (as bs : List (Expr.WithTypeVars V)) → Decidable (as = bs)
     | [], [] => isTrue rfl
     | [], _ :: _ => isFalse (by intro h; cases h)
     | _ :: _, [] => isFalse (by intro h; cases h)
@@ -212,13 +240,15 @@ mutual
       | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
 
-  private def branchDecEq : (a b : Binder × Expr) → Decidable (a = b)
+  private def branchDecEq {V : Type} [DecidableEq V] :
+      (a b : Binder.WithTypeVars V × Expr.WithTypeVars V) → Decidable (a = b)
     | (b1, e1), (b2, e2) => match decEq b1 b2, e1.decEq e2 with
       | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
       | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
 
-  private def branchesDecEq : (as bs : List (Binder × Expr)) → Decidable (as = bs)
+  private def branchesDecEq {V : Type} [DecidableEq V] :
+      (as bs : List (Binder.WithTypeVars V × Expr.WithTypeVars V)) → Decidable (as = bs)
     | [], [] => isTrue rfl
     | [], _ :: _ => isFalse (by intro h; cases h)
     | _ :: _, [] => isFalse (by intro h; cases h)
@@ -228,16 +258,23 @@ mutual
       | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
 end
 
-instance : DecidableEq Expr := Expr.decEq
+instance {V : Type} [DecidableEq V] : DecidableEq (Expr.WithTypeVars V) :=
+  Expr.WithTypeVars.decEq
 
-deriving instance Repr for Expr
-deriving instance BEq for Expr
+deriving instance Repr for Expr.WithTypeVars
+
+instance {V : Type} [DecidableEq V] : BEq (Expr.WithTypeVars V) :=
+  ⟨fun a b => decide (a = b)⟩
+
+instance {V : Type} [DecidableEq V] : LawfulBEq (Expr.WithTypeVars V) where
+  eq_of_beq h := of_decide_eq_true h
+  rfl := by simp [BEq.beq]
 
 abbrev Vars := List TinyML.Var
 abbrev Exprs := List Expr
 abbrev Binders := List Binder
 
-def Const.ty : Const → Typ
+def Const.ty : Const → Typ.WithTypeVars V
   | .int _ => .int
   | .bool _ => .bool
   | .char _ => .char
@@ -245,13 +282,13 @@ def Const.ty : Const → Typ
   | .float _ => .float
   | .unit => .unit
 
-def Expr.ty : Expr → Typ
+def Expr.WithTypeVars.ty : Expr.WithTypeVars V → Typ.WithTypeVars V
   | .const c => Const.ty c
   | .var _ ty => ty
   | .prim _ _ ty => ty
   | .unop _ _ ty => ty
   | .binop _ _ _ ty => ty
-  | .fix _ args retTy spec _ => .arrow (args.map Binder.ty) retTy spec
+  | .fix _ args retTy spec _ => .arrow (args.map (·.ty)) retTy spec
   | .app _ _ ty => ty
   | .ifThenElse _ _ _ ty => ty
   | .letIn _ _ body => body.ty
@@ -266,20 +303,21 @@ def Expr.ty : Expr → Typ
   | .arrayGet _ _ ty => ty
   | .arraySet _ _ _ => .unit
   | .assert _ => .unit
-  | .tuple es => .tuple (es.map Expr.ty)
+  | .tuple es => .tuple (es.map Expr.WithTypeVars.ty)
   | .inj tag arity e => .sum ((List.replicate arity .empty).set tag e.ty)
   | .match_ _ _ ty => ty
   | .cast _ ty => ty
 
 /-- The specification a function literal was elaborated against, if any. This
 is where a declaration's specification lives, together with its arrow type. -/
-def Expr.spec? : Expr → Option (Spec Typ)
+def Expr.WithTypeVars.spec? : Expr.WithTypeVars V → Option (Spec (Typ.WithTypeVars V))
   | .fix _ _ _ spec _ => spec
   | _ => none
 
-@[simp] theorem Expr.spec?_fix (self : Binder) (args : List Binder) (retTy : Typ)
-    (spec : Option (Spec Typ)) (body : Expr) :
-    (Expr.fix self args retTy spec body).spec? = spec := rfl
+@[simp] theorem Expr.spec?_fix (self : Binder.WithTypeVars V)
+    (args : List (Binder.WithTypeVars V)) (retTy : Typ.WithTypeVars V)
+    (spec : Option (Spec (Typ.WithTypeVars V))) (body : Expr.WithTypeVars V) :
+    (Expr.WithTypeVars.fix self args retTy spec body).spec? = spec := rfl
 
 /-- A checked declaration. It carries no specification of its own: the literal
 it binds records the specification it was elaborated against, and so does the
@@ -293,22 +331,22 @@ structure ValDecl where
 
 abbrev Program := List ValDecl
 
-def Binder.runtime : Typed.Binder → Runtime.Binder
+def Binder.WithTypeVars.runtime : Typed.Binder.WithTypeVars V → Runtime.Binder
   | ⟨Option.none, _⟩ => .none
   | ⟨some x, _⟩ => .named x
 
-@[simp] theorem Binder.runtime_of_name_none {b : Typed.Binder}
+@[simp] theorem Binder.runtime_of_name_none {b : Typed.Binder.WithTypeVars V}
     (h : b.name = Option.none) : b.runtime = .none := by
   cases b with
   | mk name ty =>
     cases name with
     | none =>
-      simp [Binder.runtime]
+      simp [Binder.WithTypeVars.runtime]
     | some x =>
       simp at h
 
-@[simp] theorem Binder.runtime_of_name_some {b : Typed.Binder} {x : TinyML.Var}
-    (h : b.name = Option.some x) : b.runtime = .named x := by
+@[simp] theorem Binder.runtime_of_name_some {b : Typed.Binder.WithTypeVars V}
+    {x : TinyML.Var} (h : b.name = Option.some x) : b.runtime = .named x := by
   cases b with
   | mk name ty =>
     cases name with
@@ -317,17 +355,17 @@ def Binder.runtime : Typed.Binder → Runtime.Binder
     | some y =>
       simp at h
       subst h
-      simp [Binder.runtime]
+      simp [Binder.WithTypeVars.runtime]
 
 mutual
-  def Expr.runtime : Typed.Expr → Runtime.Expr
+  def Expr.WithTypeVars.runtime : Typed.Expr.WithTypeVars V → Runtime.Expr
     | .const c => .val (Runtime.Val.ofConst c)
     | .var x _ => .var x
     | .prim n _ _ => .val (.prim n)
     | .unop op e _ => .unop op e.runtime
     | .binop op l r _ => .binop op l.runtime r.runtime
     | .fix self args _ _ body => .fix (self.runtime) (args.map (·.runtime)) body.runtime
-    | .app fn args _ => .app fn.runtime (args.map Expr.runtime)
+    | .app fn args _ => .app fn.runtime (args.map Expr.WithTypeVars.runtime)
     | .ifThenElse c t e _ => .ifThenElse c.runtime t.runtime e.runtime
     | .letIn b bound body => .letIn (b.runtime) bound.runtime body.runtime
     | .letProd bs bound body => .letProd (bs.map (·.runtime)) bound.runtime body.runtime
@@ -339,15 +377,19 @@ mutual
     | .arrayGet arr idx _ => .arrayGet arr.runtime idx.runtime
     | .arraySet arr idx val => .arraySet arr.runtime idx.runtime val.runtime
     | .assert e => .assert e.runtime
-    | .tuple es => .tuple (es.map Expr.runtime)
+    | .tuple es => .tuple (es.map Expr.WithTypeVars.runtime)
     | .inj tag arity payload => .inj tag arity payload.runtime
-    | .match_ scrut branches _ => .match_ scrut.runtime (Expr.branchListRuntime branches)
+    | .match_ scrut branches _ =>
+        .match_ scrut.runtime (Expr.WithTypeVars.branchListRuntime branches)
     | .cast e _ => e.runtime
 
   /-- Erase `match_` branches to their runtime closures used by `Expr.runtime`. -/
-  def Expr.branchListRuntime : List (Typed.Binder × Typed.Expr) → List Runtime.Expr
+  def Expr.WithTypeVars.branchListRuntime :
+      List (Typed.Binder.WithTypeVars V × Typed.Expr.WithTypeVars V) → List Runtime.Expr
     | [] => []
-    | (b, e) :: rest => Runtime.Expr.fix .none [b.runtime] e.runtime :: Expr.branchListRuntime rest
+    | (b, e) :: rest =>
+        Runtime.Expr.fix .none [b.runtime] e.runtime
+          :: Expr.WithTypeVars.branchListRuntime rest
 end
 
 def ValDecl.runtime (d : Typed.ValDecl) : Runtime.Decl :=
@@ -356,30 +398,32 @@ def ValDecl.runtime (d : Typed.ValDecl) : Runtime.Decl :=
 def Program.runtime (prog : Typed.Program) : Runtime.Program :=
   prog.map ValDecl.runtime
 
-theorem Expr.branchListRuntime_eq_map (branches : List (Typed.Binder × Typed.Expr)) :
-    Expr.branchListRuntime branches =
+theorem Expr.branchListRuntime_eq_map
+    (branches : List (Typed.Binder.WithTypeVars V × Typed.Expr.WithTypeVars V)) :
+    Expr.WithTypeVars.branchListRuntime branches =
       branches.map fun p => Runtime.Expr.fix .none [p.1.runtime] p.2.runtime := by
   induction branches with
-  | nil => unfold Expr.branchListRuntime; rfl
+  | nil => unfold Expr.WithTypeVars.branchListRuntime; rfl
   | cons hd rest ih =>
     obtain ⟨b, e⟩ := hd
-    unfold Expr.branchListRuntime
+    unfold Expr.WithTypeVars.branchListRuntime
     simp only [List.map_cons]
     congr 1
 
-theorem Expr.branchListRuntime_castBodies (ty : TinyML.Typ) (branches : List (Typed.Binder × Typed.Expr)) :
-    Expr.branchListRuntime
+theorem Expr.branchListRuntime_castBodies [DecidableEq V] (ty : Typ.WithTypeVars V)
+    (branches : List (Typed.Binder.WithTypeVars V × Typed.Expr.WithTypeVars V)) :
+    Expr.WithTypeVars.branchListRuntime
       (branches.map fun p => (p.1, if p.2.ty = ty then p.2 else .cast p.2 ty)) =
-    Expr.branchListRuntime branches := by
+    Expr.WithTypeVars.branchListRuntime branches := by
   induction branches with
   | nil =>
-    simp [Expr.branchListRuntime]
+    simp [Expr.WithTypeVars.branchListRuntime]
   | cons hd rest ih =>
     obtain ⟨b, e⟩ := hd
-    unfold Expr.branchListRuntime
+    unfold Expr.WithTypeVars.branchListRuntime
     simp only [List.map_cons]
     by_cases h : e.ty = ty
     · simp [h, ih]
-    · simp [Expr.runtime, h, ih]
+    · simp [Expr.WithTypeVars.runtime, h, ih]
 
 end Typed

--- a/Mica/SourceTinyML/Types.lean
+++ b/Mica/SourceTinyML/Types.lean
@@ -1,4 +1,4 @@
--- SUMMARY: TinyML types, type declarations, and subtyping structure.
+-- SUMMARY: TinyML types over a parameter of type variables, type declarations, and subtyping.
 import Mica.TinyML.Common
 import Mica.SourceTinyML.Assertions
 
@@ -126,88 +126,116 @@ theorem PrimitiveType.unOpTypeOf_bool {op : UnOp} {p p' : PrimitiveType}
   subst hty
   simp
 
-inductive Typ where
+namespace Typ
+
+/-- TinyML types, parameterized by the variables a `tvar` node may carry. Only
+two instantiations are used here: `Typ`, whose `V` is uninhabited, and
+`SchemaTyp`, whose `V` is a source type variable. Type inference adds a third. -/
+inductive WithTypeVars (V : Type) where
   | prim (p : PrimitiveType)
-  | sum (ts : List Typ)
+  | sum (ts : List (WithTypeVars V))
   /-- A function type. `spec` is the specification the function was verified
   against, if it has one; only specified functions are inhabited values. -/
-  | arrow (args : List Typ) (ret : Typ) (spec : Option (Spec Typ))
-  | ref (t: Typ)
+  | arrow (args : List (WithTypeVars V)) (ret : WithTypeVars V)
+      (spec : Option (Spec (WithTypeVars V)))
+  | ref (t : WithTypeVars V)
   /-- Shared array whose elements have type `t`. -/
-  | array (t : Typ)
+  | array (t : WithTypeVars V)
   /-- An owned mutable array. Its contents are tracked by an immutable vector
   snapshot in the ambient spatial context. -/
-  | ownedArray (t : Typ)
+  | ownedArray (t : WithTypeVars V)
   /-- Immutable vector whose elements have type `t`. Unlike `array`, a vector is
   a pure value: its contents live in the value itself, not in the heap. -/
-  | vec (t : Typ)
+  | vec (t : WithTypeVars V)
   /-- An owned reference. Its value interpretation records only that the value
   is a location; points-to ownership lives in the ambient spatial context. -/
-  | owned (t : Typ)
+  | owned (t : WithTypeVars V)
   | empty   -- bottom type (uninhabited)
   | value   -- top type (all runtime values)
-  | tuple (ts : List Typ)
-  | tvar (v : TyVar)
-  | named (T : TypeName) (args : List Typ)
+  | tuple (ts : List (WithTypeVars V))
+  | tvar (v : V)
+  | named (T : TypeName) (args : List (WithTypeVars V))
   deriving Repr
 
-/-- Compatibility name for the unit primitive type. -/
-@[simp] def Typ.unit : Typ := .prim .unit
-/-- Compatibility name for the Boolean primitive type. -/
-@[simp] def Typ.bool : Typ := .prim .bool
-/-- Compatibility name for the integer primitive type. -/
-@[simp] def Typ.int : Typ := .prim .int
-/-- Compatibility name for the character primitive type. -/
-@[simp] def Typ.char : Typ := .prim .char
-/-- Compatibility name for the string primitive type. -/
-@[simp] def Typ.string : Typ := .prim .string
-/-- Compatibility name for the float primitive type. -/
-@[simp] def Typ.float : Typ := .prim .float
-/-- A canonical predefined type application. -/
-@[simp] def Typ.predef (p : Predef) (args : List Typ) : Typ := .named (.predef p) args
-/-- The canonical list type. -/
-@[simp] def Typ.list (elem : Typ) : Typ := .predef .list [elem]
-/-- The canonical option type. -/
-@[simp] def Typ.option (elem : Typ) : Typ := .predef .option [elem]
+namespace WithTypeVars
 
-def Typ.primDecEq (p q : PrimitiveType) : Decidable (Typ.prim p = Typ.prim q) :=
+/-- Abbreviation for the unit primitive type. -/
+@[simp] def unit : WithTypeVars V := .prim .unit
+/-- Abbreviation for the Boolean primitive type. -/
+@[simp] def bool : WithTypeVars V := .prim .bool
+/-- Abbreviation for the integer primitive type. -/
+@[simp] def int : WithTypeVars V := .prim .int
+/-- Abbreviation for the character primitive type. -/
+@[simp] def char : WithTypeVars V := .prim .char
+/-- Abbreviation for the string primitive type. -/
+@[simp] def string : WithTypeVars V := .prim .string
+/-- Abbreviation for the float primitive type. -/
+@[simp] def float : WithTypeVars V := .prim .float
+/-- A canonical predefined type application. -/
+@[simp] def predef (p : Predef) (args : List (WithTypeVars V)) : WithTypeVars V :=
+  .named (.predef p) args
+/-- The canonical list type. -/
+@[simp] def list (elem : WithTypeVars V) : WithTypeVars V := .predef .list [elem]
+/-- The canonical option type. -/
+@[simp] def option (elem : WithTypeVars V) : WithTypeVars V := .predef .option [elem]
+
+end WithTypeVars
+
+-- Both spellings are wanted: `.prim` resolves in the inductive's namespace,
+-- `Typ.prim` in the one named after the type it usually builds.
+export WithTypeVars (prim sum arrow ref array ownedArray vec owned empty value
+  tuple tvar named unit bool int char string float predef list option)
+
+end Typ
+
+/-- The type language the verifier works in. No `tvar` node can be built, so a
+`Typ` is closed by construction. -/
+abbrev Typ := Typ.WithTypeVars Empty
+
+/-- The type language source annotations and polymorphic signatures are written
+in: a `Typ` that may still mention named type variables. -/
+abbrev SchemaTyp := Typ.WithTypeVars TyVar
+
+def Typ.primDecEq {V : Type} (p q : PrimitiveType) :
+    Decidable (Typ.WithTypeVars.prim (V := V) p = .prim q) :=
   match PrimitiveType.decEq p q with
   | isTrue h => isTrue (by subst h; rfl)
   | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
 
 mutual
 
-def Typ.decEq : (a b : Typ) → Decidable (a = b)
+def Typ.decEq {V : Type} [DecidableEq V] :
+    (a b : Typ.WithTypeVars V) → Decidable (a = b)
   | .prim p, .prim q => Typ.primDecEq p q
   | .empty, .empty | .value, .value => isTrue rfl
   | .sum ss, .sum ts => match Typ.decEqList ss ts with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .arrow ss s sp, .arrow ts t sp' =>
-    match Typ.decEqList ss ts, s.decEq t, Typ.decEqSpec? sp sp' with
+    match Typ.decEqList ss ts, Typ.decEq s t, Typ.decEqSpec? sp sp' with
     | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
     | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
     | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
     | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .ref s, .ref t => match s.decEq t with
+  | .ref s, .ref t => match Typ.decEq s t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .array s, .array t => match s.decEq t with
+  | .array s, .array t => match Typ.decEq s t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .ownedArray s, .ownedArray t => match s.decEq t with
+  | .ownedArray s, .ownedArray t => match Typ.decEq s t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .vec s, .vec t => match s.decEq t with
+  | .vec s, .vec t => match Typ.decEq s t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .owned s, .owned t => match s.decEq t with
+  | .owned s, .owned t => match Typ.decEq s t with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .tuple ss, .tuple ts => match Typ.decEqList ss ts with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-  | .tvar v, .tvar w => match (inferInstance : DecidableEq TyVar) v w with
+  | .tvar v, .tvar w => match (inferInstance : DecidableEq V) v w with
     | isTrue h => isTrue (by subst h; rfl)
     | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
   | .named T args, .named U params =>
@@ -266,10 +294,11 @@ def Typ.decEq : (a b : Typ) → Decidable (a = b)
 termination_by structural a _ => a
 
 /-- Equality of type lists, mutually with `Typ.decEq`. -/
-def Typ.decEqList : (as bs : List Typ) → Decidable (as = bs)
+def Typ.decEqList {V : Type} [DecidableEq V] :
+    (as bs : List (Typ.WithTypeVars V)) → Decidable (as = bs)
   | [], [] => isTrue rfl
   | [], _ :: _ | _ :: _, [] => isFalse (by intro h; cases h)
-  | a :: as, b :: bs => match a.decEq b, Typ.decEqList as bs with
+  | a :: as, b :: bs => match Typ.decEq a b, Typ.decEqList as bs with
     | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
     | isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
     | _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
@@ -281,7 +310,8 @@ def Typ.decEqList : (as bs : List Typ) → Decidable (as = bs)
 termination_by structural a _ => a
 
 /-- Equality of atoms over TinyML types, mutually with `Typ.decEq`. -/
-def Typ.decEqAtom {s : Srt} : (a b : Atom Typ s) → Decidable (a = b)
+def Typ.decEqAtom {V : Type} [DecidableEq V] {s : Srt} :
+    (a b : Atom (Typ.WithTypeVars V) s) → Decidable (a = b)
   | .isint t, .isint u | .isbool t, .isbool u =>
     match _root_.decEq t u with
     | isTrue h => isTrue (by subst h; rfl)
@@ -310,7 +340,8 @@ def Typ.decEqAtom {s : Srt} : (a b : Atom Typ s) → Decidable (a = b)
 termination_by structural a _ => a
 
 /-- Equality of postcondition assertions, mutually with `Typ.decEq`. -/
-def Typ.decEqPost : (a b : Assertion Typ Unit) → Decidable (a = b)
+def Typ.decEqPost {V : Type} [DecidableEq V] :
+    (a b : Assertion (Typ.WithTypeVars V) Unit) → Decidable (a = b)
   | .ret (), .ret () => isTrue rfl
   | .assert φ k, .assert ψ k' =>
     match _root_.decEq φ ψ, Typ.decEqPost k k' with
@@ -350,7 +381,8 @@ def Typ.decEqPost : (a b : Assertion Typ Unit) → Decidable (a = b)
 termination_by structural a _ => a
 
 /-- Equality of predicate transformers, mutually with `Typ.decEq`. -/
-def Typ.decEqPredTrans : (a b : Assertion Typ (Post Typ)) → Decidable (a = b)
+def Typ.decEqPredTrans {V : Type} [DecidableEq V] :
+    (a b : Assertion (Typ.WithTypeVars V) (Post (Typ.WithTypeVars V))) → Decidable (a = b)
   | .ret p, .ret q =>
     match _root_.decEq p.name q.name, Typ.decEqPost p.body q.body with
     | isTrue h1, isTrue h2 => isTrue (by cases p; cases q; simp_all)
@@ -394,7 +426,8 @@ def Typ.decEqPredTrans : (a b : Assertion Typ (Post Typ)) → Decidable (a = b)
 termination_by structural a _ => a
 
 /-- Equality of specifications, mutually with `Typ.decEq`. -/
-def Typ.decEqSpec : (a b : Spec Typ) → Decidable (a = b)
+def Typ.decEqSpec {V : Type} [DecidableEq V] :
+    (a b : Spec (Typ.WithTypeVars V)) → Decidable (a = b)
   | ⟨as, p⟩, ⟨bs, q⟩ =>
     match _root_.decEq as bs, Typ.decEqPredTrans p q with
     | isTrue h1, isTrue h2 => isTrue (by subst h1; subst h2; rfl)
@@ -403,7 +436,8 @@ def Typ.decEqSpec : (a b : Spec Typ) → Decidable (a = b)
 termination_by structural a _ => a
 
 /-- Equality of optional specifications, mutually with `Typ.decEq`. -/
-def Typ.decEqSpec? : (a b : Option (Spec Typ)) → Decidable (a = b)
+def Typ.decEqSpec? {V : Type} [DecidableEq V] :
+    (a b : Option (Spec (Typ.WithTypeVars V))) → Decidable (a = b)
   | none, none => isTrue rfl
   | none, some _ | some _, none => isFalse (by intro h; cases h)
   | some s, some t =>
@@ -414,10 +448,10 @@ termination_by structural a _ => a
 
 end
 
-instance : DecidableEq Typ := Typ.decEq
+instance {V : Type} [DecidableEq V] : DecidableEq (Typ.WithTypeVars V) := Typ.decEq
 
-instance : BEq Typ := ⟨fun a b => decide (a = b)⟩
-instance : LawfulBEq Typ where
+instance {V : Type} [DecidableEq V] : BEq (Typ.WithTypeVars V) := ⟨fun a b => decide (a = b)⟩
+instance {V : Type} [DecidableEq V] : LawfulBEq (Typ.WithTypeVars V) where
   eq_of_beq h := of_decide_eq_true h
   rfl := by simp [BEq.beq]
 
@@ -426,19 +460,24 @@ instance : LawfulBEq Typ where
 Both descend into an arrow's specification: the `own` and `arr` atoms of a
 specification mention types, so a type variable can occur inside one. Each
 traversal is spelled out over the specification syntax the same way `Typ.decEq`
-is, since `Typ` nests those types and a generic map over them would not be
-structurally recursive. -/
+is, since `Typ` nests those types and a single generic map over them would not
+be structurally recursive.
 
-mutual
+Substitution also changes the variables a type is written over, so it is what
+moves a type between the instantiations of `Typ.WithTypeVars`: `Typ.subst
+Empty.elim` embeds a `Typ` into any of them, and a substitution into `Typ`
+closes a `SchemaTyp`. -/
 
 /-- The type with a top-level arrow's specification dropped; the identity on
 everything else. Used where only the signature of an arrow matters. -/
-def Typ.unspec : Typ → Typ
+def Typ.unspec : Typ.WithTypeVars V → Typ.WithTypeVars V
   | .arrow args ret _ => .arrow args ret none
   | t => t
 
-/-- Substitution over `Typ`, replacing each type variable by `σ`. -/
-def Typ.subst (σ : TyVar → Typ) : Typ → Typ
+mutual
+
+/-- Substitution over a type, replacing each type variable by `σ`. -/
+def Typ.subst (σ : V → Typ.WithTypeVars W) : Typ.WithTypeVars V → Typ.WithTypeVars W
   | .prim p => .prim p
   | .sum ts => .sum (Typ.substList σ ts)
   | .arrow args ret spec =>
@@ -456,13 +495,15 @@ def Typ.subst (σ : TyVar → Typ) : Typ → Typ
 termination_by structural t => t
 
 /-- Substitution over a list of types, mutually with `Typ.subst`. -/
-def Typ.substList (σ : TyVar → Typ) : List Typ → List Typ
+def Typ.substList (σ : V → Typ.WithTypeVars W) :
+    List (Typ.WithTypeVars V) → List (Typ.WithTypeVars W)
   | [] => []
   | t :: ts => Typ.subst σ t :: Typ.substList σ ts
 termination_by structural ts => ts
 
 /-- Substitution in the types an atom mentions, mutually with `Typ.subst`. -/
-def Typ.substAtom (σ : TyVar → Typ) : {s : Srt} → Atom Typ s → Atom Typ s
+def Typ.substAtom (σ : V → Typ.WithTypeVars W) :
+    {s : Srt} → Atom (Typ.WithTypeVars V) s → Atom (Typ.WithTypeVars W) s
   | _, .isint t => .isint t
   | _, .isbool t => .isbool t
   | _, .isinj tag arity t => .isinj tag arity t
@@ -472,7 +513,8 @@ def Typ.substAtom (σ : TyVar → Typ) : {s : Srt} → Atom Typ s → Atom Typ s
 termination_by structural _ a => a
 
 /-- Substitution in a postcondition assertion, mutually with `Typ.subst`. -/
-def Typ.substPost (σ : TyVar → Typ) : Assertion Typ Unit → Assertion Typ Unit
+def Typ.substPost (σ : V → Typ.WithTypeVars W) :
+    Assertion (Typ.WithTypeVars V) Unit → Assertion (Typ.WithTypeVars W) Unit
   | .ret () => .ret ()
   | .assert φ k => .assert φ (Typ.substPost σ k)
   | .let_ v t k => .let_ v t (Typ.substPost σ k)
@@ -481,8 +523,9 @@ def Typ.substPost (σ : TyVar → Typ) : Assertion Typ Unit → Assertion Typ Un
 termination_by structural a => a
 
 /-- Substitution in a predicate transformer, mutually with `Typ.subst`. -/
-def Typ.substPredTrans (σ : TyVar → Typ) :
-    Assertion Typ (Post Typ) → Assertion Typ (Post Typ)
+def Typ.substPredTrans (σ : V → Typ.WithTypeVars W) :
+    Assertion (Typ.WithTypeVars V) (Post (Typ.WithTypeVars V)) →
+      Assertion (Typ.WithTypeVars W) (Post (Typ.WithTypeVars W))
   | .ret p => .ret ⟨p.name, Typ.substPost σ p.body⟩
   | .assert φ k => .assert φ (Typ.substPredTrans σ k)
   | .let_ v t k => .let_ v t (Typ.substPredTrans σ k)
@@ -491,12 +534,14 @@ def Typ.substPredTrans (σ : TyVar → Typ) :
 termination_by structural a => a
 
 /-- Substitution in a specification, mutually with `Typ.subst`. -/
-def Typ.substSpec (σ : TyVar → Typ) : Spec Typ → Spec Typ
+def Typ.substSpec (σ : V → Typ.WithTypeVars W) :
+    Spec (Typ.WithTypeVars V) → Spec (Typ.WithTypeVars W)
   | s => { args := s.args, pred := Typ.substPredTrans σ s.pred }
 termination_by structural s => s
 
 /-- Substitution in an optional specification, mutually with `Typ.subst`. -/
-def Typ.substSpec? (σ : TyVar → Typ) : Option (Spec Typ) → Option (Spec Typ)
+def Typ.substSpec? (σ : V → Typ.WithTypeVars W) :
+    Option (Spec (Typ.WithTypeVars V)) → Option (Spec (Typ.WithTypeVars W))
   | none => none
   | some s => some (Typ.substSpec σ s)
 termination_by structural s => s
@@ -505,8 +550,97 @@ end
 
 mutual
 
+/-- Substitution that may reject a variable, used where a substitution is only
+partial: instantiating a scheme at a solved assignment, say, which fails on a
+variable the assignment does not cover. -/
+def Typ.substM (σ : V → Except ε (Typ.WithTypeVars W)) :
+    Typ.WithTypeVars V → Except ε (Typ.WithTypeVars W)
+  | .prim p => pure (.prim p)
+  | .sum ts => do pure (.sum (← Typ.substListM σ ts))
+  | .arrow args ret spec => do
+      pure (.arrow (← Typ.substListM σ args) (← Typ.substM σ ret)
+        (← Typ.substSpecM? σ spec))
+  | .ref t => do pure (.ref (← Typ.substM σ t))
+  | .array t => do pure (.array (← Typ.substM σ t))
+  | .ownedArray t => do pure (.ownedArray (← Typ.substM σ t))
+  | .vec t => do pure (.vec (← Typ.substM σ t))
+  | .owned t => do pure (.owned (← Typ.substM σ t))
+  | .empty => pure .empty
+  | .value => pure .value
+  | .tuple ts => do pure (.tuple (← Typ.substListM σ ts))
+  | .tvar v => σ v
+  | .named T args => do pure (.named T (← Typ.substListM σ args))
+termination_by structural t => t
+
+/-- Rejecting substitution over a list of types, mutually with `Typ.substM`. -/
+def Typ.substListM (σ : V → Except ε (Typ.WithTypeVars W)) :
+    List (Typ.WithTypeVars V) → Except ε (List (Typ.WithTypeVars W))
+  | [] => pure []
+  | t :: ts => do pure ((← Typ.substM σ t) :: (← Typ.substListM σ ts))
+termination_by structural ts => ts
+
+/-- Rejecting substitution in an atom's types, mutually with `Typ.substM`. -/
+def Typ.substAtomM (σ : V → Except ε (Typ.WithTypeVars W)) :
+    {s : Srt} → Atom (Typ.WithTypeVars V) s → Except ε (Atom (Typ.WithTypeVars W) s)
+  | _, .isint t => pure (.isint t)
+  | _, .isbool t => pure (.isbool t)
+  | _, .isinj tag arity t => pure (.isinj tag arity t)
+  | _, .own t ty => do pure (.own t (← Typ.substM σ ty))
+  | _, .arr t ty => do pure (.arr t (← Typ.substM σ ty))
+  | _, .rel n t => pure (.rel n t)
+termination_by structural _ a => a
+
+/-- Rejecting substitution in a postcondition, mutually with `Typ.substM`. -/
+def Typ.substPostM (σ : V → Except ε (Typ.WithTypeVars W)) :
+    Assertion (Typ.WithTypeVars V) Unit → Except ε (Assertion (Typ.WithTypeVars W) Unit)
+  | .ret () => pure (.ret ())
+  | .assert φ k => do pure (.assert φ (← Typ.substPostM σ k))
+  | .let_ v t k => do pure (.let_ v t (← Typ.substPostM σ k))
+  | .pred v p k => do
+      pure (.pred v (← Typ.substAtomM σ p) (← Typ.substPostM σ k))
+  | .ite φ kt ke => do
+      pure (.ite φ (← Typ.substPostM σ kt) (← Typ.substPostM σ ke))
+termination_by structural a => a
+
+/-- Rejecting substitution in a predicate transformer, mutually with
+`Typ.substM`. -/
+def Typ.substPredTransM (σ : V → Except ε (Typ.WithTypeVars W)) :
+    Assertion (Typ.WithTypeVars V) (Post (Typ.WithTypeVars V)) →
+      Except ε (Assertion (Typ.WithTypeVars W) (Post (Typ.WithTypeVars W)))
+  | .ret p => do pure (.ret ⟨p.name, ← Typ.substPostM σ p.body⟩)
+  | .assert φ k => do pure (.assert φ (← Typ.substPredTransM σ k))
+  | .let_ v t k => do pure (.let_ v t (← Typ.substPredTransM σ k))
+  | .pred v p k => do
+      pure (.pred v (← Typ.substAtomM σ p) (← Typ.substPredTransM σ k))
+  | .ite φ kt ke => do
+      pure (.ite φ (← Typ.substPredTransM σ kt) (← Typ.substPredTransM σ ke))
+termination_by structural a => a
+
+/-- Rejecting substitution in a specification, mutually with `Typ.substM`. -/
+def Typ.substSpecM (σ : V → Except ε (Typ.WithTypeVars W)) :
+    Spec (Typ.WithTypeVars V) → Except ε (Spec (Typ.WithTypeVars W))
+  | ⟨args, pred⟩ => do pure ⟨args, ← Typ.substPredTransM σ pred⟩
+termination_by structural s => s
+
+/-- Rejecting substitution in an optional specification, mutually with
+`Typ.substM`. -/
+def Typ.substSpecM? (σ : V → Except ε (Typ.WithTypeVars W)) :
+    Option (Spec (Typ.WithTypeVars V)) → Except ε (Option (Spec (Typ.WithTypeVars W)))
+  | none => pure none
+  | some s => do pure (some (← Typ.substSpecM σ s))
+termination_by structural s => s
+
+end
+
+/-- Close a schema by instantiating each variable, failing on the first one the
+assignment does not cover. -/
+def SchemaTyp.close (inst : TyVar → Option Typ) (t : SchemaTyp) : Except TyVar Typ :=
+  Typ.substM (fun v => (inst v).elim (.error v) .ok) t
+
+mutual
+
 /-- A type is closed when it contains no type variables. -/
-def Typ.closed : Typ → Bool
+def Typ.closed : Typ.WithTypeVars V → Bool
   | .prim _ => true
   | .sum ts => Typ.closedList ts
   | .arrow args ret spec => Typ.closedList args && Typ.closed ret && Typ.closedSpec? spec
@@ -523,20 +657,20 @@ def Typ.closed : Typ → Bool
 termination_by structural t => t
 
 /-- Closedness of a list of types, mutually with `Typ.closed`. -/
-def Typ.closedList : List Typ → Bool
+def Typ.closedList : List (Typ.WithTypeVars V) → Bool
   | [] => true
   | t :: ts => Typ.closed t && Typ.closedList ts
 termination_by structural ts => ts
 
 /-- Closedness of the types an atom mentions, mutually with `Typ.closed`. -/
-def Typ.closedAtom : {s : Srt} → Atom Typ s → Bool
+def Typ.closedAtom : {s : Srt} → Atom (Typ.WithTypeVars V) s → Bool
   | _, .isint _ | _, .isbool _ | _, .isinj .. | _, .rel .. => true
   | _, .own _ ty => Typ.closed ty
   | _, .arr _ ty => Typ.closed ty
 termination_by structural _ a => a
 
 /-- Closedness of a postcondition assertion, mutually with `Typ.closed`. -/
-def Typ.closedPost : Assertion Typ Unit → Bool
+def Typ.closedPost : Assertion (Typ.WithTypeVars V) Unit → Bool
   | .ret () => true
   | .assert _ k => Typ.closedPost k
   | .let_ _ _ k => Typ.closedPost k
@@ -545,7 +679,7 @@ def Typ.closedPost : Assertion Typ Unit → Bool
 termination_by structural a => a
 
 /-- Closedness of a predicate transformer, mutually with `Typ.closed`. -/
-def Typ.closedPredTrans : Assertion Typ (Post Typ) → Bool
+def Typ.closedPredTrans : Assertion (Typ.WithTypeVars V) (Post (Typ.WithTypeVars V)) → Bool
   | .ret p => Typ.closedPost p.body
   | .assert _ k => Typ.closedPredTrans k
   | .let_ _ _ k => Typ.closedPredTrans k
@@ -554,33 +688,36 @@ def Typ.closedPredTrans : Assertion Typ (Post Typ) → Bool
 termination_by structural a => a
 
 /-- Closedness of a specification, mutually with `Typ.closed`. -/
-def Typ.closedSpec : Spec Typ → Bool
+def Typ.closedSpec : Spec (Typ.WithTypeVars V) → Bool
   | s => Typ.closedPredTrans s.pred
 termination_by structural s => s
 
 /-- Closedness of an optional specification, mutually with `Typ.closed`. -/
-def Typ.closedSpec? : Option (Spec Typ) → Bool
+def Typ.closedSpec? : Option (Spec (Typ.WithTypeVars V)) → Bool
   | none => true
   | some s => Typ.closedSpec s
 termination_by structural s => s
 
 end
 
-@[simp] theorem Typ.substList_eq (σ : TyVar → Typ) (ts : List Typ) :
+@[simp] theorem Typ.substList_eq (σ : V → Typ.WithTypeVars W) (ts : List (Typ.WithTypeVars V)) :
     Typ.substList σ ts = ts.map (Typ.subst σ) := by
   induction ts with
   | nil => rfl
   | cons t ts ih => simp [Typ.substList, ih]
 
-@[simp] theorem Typ.closedList_eq (ts : List Typ) :
+@[simp] theorem Typ.closedList_eq (ts : List (Typ.WithTypeVars V)) :
     Typ.closedList ts = (ts.map Typ.closed).all id := by
   induction ts with
   | nil => rfl
   | cons t ts ih => simp [Typ.closedList, ih]
 
+/-- A data declaration: type parameters, and one payload type per constructor.
+The payloads are schema types, since they mention the declaration's own
+parameters. -/
 structure DataDecl where
   tparams : List TyVar
-  payloads : List Typ
+  payloads : List SchemaTyp
   deriving Repr, Inhabited, DecidableEq
 
 namespace Predef
@@ -598,7 +735,7 @@ def tparams : Predef → List TyVar
   | .list | .option => ["a"]
 
 /-- Ordered constructors. Their position is the runtime injection tag. -/
-def ctors : Predef → List (String × Typ)
+def ctors : Predef → List (String × SchemaTyp)
   | .option => [
       ("None", .unit),
       ("Some", .tvar "a")]
@@ -619,15 +756,14 @@ abbrev TypeEnv := TypeName → Option DataDecl
 
 def TypeEnv.empty : TypeEnv := fun _ => none
 
-/--
-Instantiation is also scaffolding for now: until `Typ` can contain type
-variables, substitution has no observable effect.
--/
+/-- The sum of a declaration's payloads at the given type arguments. Callers
+check the argument count against `tparams` first; a parameter left unmatched by
+a mis-sized application is instantiated at the uninhabited type. -/
 def DataDecl.instantiate (d : DataDecl) (args : List Typ) : Typ :=
   let σ := fun v =>
     match (d.tparams.zip args).find? (fun p => p.1 == v) with
     | some (_, ty) => ty
-    | none => .tvar v
+    | none => .empty
   .sum (d.payloads.map (Typ.subst σ))
 
 def TypeName.unfold (Θ : TypeEnv) (T : TypeName) (args : List Typ) : Option Typ :=

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -5,6 +5,7 @@ import Mica.SourceTinyML.Typed
 import Mica.TinyML.RuntimeExpr
 import Mica.SourceTinyML.Assertions
 import Mica.SourceTinyML.TypeConstraints
+import Mica.SourceTinyML.Printer
 import Mica.Base.Except
 
 namespace TinyML
@@ -101,6 +102,7 @@ inductive TypeError where
   | spec (msg : String)
   | unknownPrimitive (name : String)
   | cannotInstantiate (name : String) (msg : String)
+  | unboundTypeVar (name : TyVar)
   deriving Repr, Inhabited, DecidableEq
 
 instance : ToString TypeError where
@@ -108,24 +110,25 @@ instance : ToString TypeError where
     | .undefinedVar name => s!"undefined variable: {name}"
     | .duplicateType name => s!"duplicate type: {name}"
     | .operatorMismatch op lhs rhs =>
-        s!"operator {repr op} cannot be applied to {repr lhs} and {repr rhs}"
+        s!"operator {repr op} cannot be applied to {lhs.print} and {rhs.print}"
     | .unaryMismatch op arg =>
-        s!"operator {repr op} cannot be applied to {repr arg}"
-    | .notAFunction ty => s!"not a function: {repr ty}"
+        s!"operator {repr op} cannot be applied to {arg.print}"
+    | .notAFunction ty => s!"not a function: {ty.print}"
     | .arityMismatch expected actual =>
         s!"arity mismatch: expected {expected}, got {actual}"
     | .typeMismatch expected actual =>
-        s!"type mismatch: expected {repr expected}, got {repr actual}"
-    | .notASum ty => s!"not a sum type: {repr ty}"
-    | .notARef ty => s!"not a ref type: {repr ty}"
-    | .notAnArray ty => s!"not an array type: {repr ty}"
+        s!"type mismatch: expected {expected.print}, got {actual.print}"
+    | .notASum ty => s!"not a sum type: {ty.print}"
+    | .notARef ty => s!"not a ref type: {ty.print}"
+    | .notAnArray ty => s!"not an array type: {ty.print}"
     | .missingReturnType => "missing return type"
     | .subsumptionFailure sub super =>
-        s!"subsumption failed: {repr sub} is not a subtype of {repr super}"
+        s!"subsumption failed: {sub.print} is not a subtype of {super.print}"
     | .spec msg => s!"specification error: {msg}"
     | .unknownPrimitive name => s!"unknown primitive: {name}"
     | .cannotInstantiate name msg =>
         s!"cannot instantiate primitive {name}: {msg}"
+    | .unboundTypeVar name => s!"unbound type variable '{name}"
 
 def Binder.ofUntyped (b : Untyped.Binder) (ty : Typ) : Typed.Binder :=
   match b with
@@ -155,7 +158,7 @@ def extendTypeEnv (Θ : TypeEnv) (name : TypeName) (body : DataDecl) : Except Ty
     untrusted — the elaborator re-checks arguments against the instantiated
     scheme, so a wrong instantiation is rejected, never unsound. -/
 structure PrimSig where
-  scheme : Typ
+  scheme : SchemaTyp
   typing : TypeEnv → List Typ → Except String (List (TyVar × Typ))
 
 /-! ## The typing monad
@@ -322,6 +325,7 @@ mutual
   function the type describes cannot mention. -/
   def translate (env : SpecEnv σ) (Θ : TypeEnv) : Untyped.Typ → TypeM σ Typ
     | .core t => pure t
+    | .tvar v => TypeM.error (.unboundTypeVar v)
     | .sum ts => do pure (.sum (← translateList env Θ ts))
     | .arrow args ret spec => do
         let args' ← translateList env Θ args
@@ -394,8 +398,10 @@ mutual
         match env.primitive n with
         | none => TypeM.error (.unknownPrimitive n)
         | some sig =>
-          if sig.scheme.closed then pure (sig.scheme, .prim n [] sig.scheme)
-          else TypeM.error (.cannotInstantiate n "a polymorphic primitive must be applied")
+          match SchemaTyp.close (fun _ => none) sig.scheme with
+          | .ok ty => pure (ty, .prim n [] ty)
+          | .error _ =>
+            TypeM.error (.cannotInstantiate n "a polymorphic primitive must be applied")
     | .unop op e => do
         let (argTy, e') ← infer env Θ Γ e
         match TinyML.UnOp.typeOf op argTy with
@@ -425,13 +431,13 @@ mutual
             match sig.typing Θ (inferred.map Prod.fst) with
             | .error msg => TypeM.error (.cannotInstantiate n msg)
             | .ok inst =>
-              let ty := sig.scheme.subst fun v => (inst.lookup v).getD (.tvar v)
-              if ty.closed then do
+              match SchemaTyp.close (fun v => inst.lookup v) sig.scheme with
+              | .ok ty => do
                 let (doms, retTy) ← TypeM.ofExcept (domains ty inferred.length)
                 let args' ← TypeM.ofExcept (checkInferred Θ doms inferred)
                 pure (retTy, .app (.prim n inst ty) args' retTy)
-              else
-                TypeM.error (.cannotInstantiate n "unresolved type variables")
+              | .error v =>
+                TypeM.error (.cannotInstantiate n s!"unresolved type variable '{v}")
         | none => do
             let (fnTy, fn') ← infer env Θ Γ fn
             let (doms, retTy) ← TypeM.ofExcept (domains fnTy args.length)
@@ -724,6 +730,37 @@ mutual
   decreasing_by obtain ⟨args, pre⟩ := rb; simp; omega
 end
 
+mutual
+
+/-- Translate a payload type, keeping the declaration's own type parameters as
+variables. A payload that carries a specification has no variables to keep —
+`translate` rejects them everywhere else — so it is translated as an ordinary
+type and embedded. -/
+def translateSchema (env : SpecEnv σ) (Θ : TypeEnv) : Untyped.Typ → TypeM σ SchemaTyp
+  | .core t => pure (Typ.subst Empty.elim t)
+  | .tvar v => pure (.tvar v)
+  | .sum ts => do pure (.sum (← translateSchemaList env Θ ts))
+  | .arrow args ret none => do
+      pure (.arrow (← translateSchemaList env Θ args) (← translateSchema env Θ ret) none)
+  | t@(.arrow _ _ (some _)) => do pure (Typ.subst Empty.elim (← translate env Θ t))
+  | .ref t => do pure (.ref (← translateSchema env Θ t))
+  | .array t => do pure (.array (← translateSchema env Θ t))
+  | .ownedArray t => do pure (.ownedArray (← translateSchema env Θ t))
+  | .vec t => do pure (.vec (← translateSchema env Θ t))
+  | .owned t => do pure (.owned (← translateSchema env Θ t))
+  | .tuple ts => do pure (.tuple (← translateSchemaList env Θ ts))
+  | .named n args => do pure (.named n (← translateSchemaList env Θ args))
+termination_by t => sizeOf t
+
+def translateSchemaList (env : SpecEnv σ) (Θ : TypeEnv) :
+    List Untyped.Typ → TypeM σ (List SchemaTyp)
+  | [] => pure []
+  | t :: ts => do
+      pure ((← translateSchema env Θ t) :: (← translateSchemaList env Θ ts))
+termination_by ts => sizeOf ts
+
+end
+
 /-- Lower a data declaration's payloads, elaborating any specification they
 carry. A constructor payload is a type like any other, so it may describe a
 specified function; its specification is elaborated once, against the bindings
@@ -732,7 +769,7 @@ route: the frontend inlines a record type as a tuple, so a field's
 specification is elaborated at each mention of the record type instead.) -/
 def translateDataDecl (env : SpecEnv σ) (Θ : TypeEnv) (d : Untyped.DataDecl) :
     TypeM σ TinyML.DataDecl := do
-  pure { tparams := d.tparams, payloads := ← translateList env Θ d.payloads }
+  pure { tparams := d.tparams, payloads := ← translateSchemaList env Θ d.payloads }
 
 theorem Binder.ofUntyped_runtime (b : Untyped.Binder) (ty : Typ) :
     (Typed.Binder.ofUntyped b ty).runtime = b.runtime := by
@@ -843,7 +880,7 @@ private def checkDeclAnnotation (env : SpecEnv σ) (Θ : TypeEnv) (b : Untyped.B
   match b with
   | .named _ (some ann) => do
       let ann' ← translate env Θ ann
-      if ty.unspec == ann' then pure () else TypeM.error (.subsumptionFailure ty ann')
+      if Typ.unspec ty == ann' then pure () else TypeM.error (.subsumptionFailure ty ann')
   | _ => pure ()
 
 def ValDecl.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
@@ -937,11 +974,12 @@ mutual
         cases hp : env.primitive n with
         | none => simp [hp] at h
         | some sig =>
-          by_cases hc : sig.scheme.closed
-          · simp [hp, hc] at h
+          cases hc : SchemaTyp.close (fun _ => none) sig.scheme with
+          | error _ => simp [hp, hc] at h
+          | ok ty =>
+            simp [hp, hc] at h
             rcases h with ⟨⟨rfl, rfl⟩, rfl⟩
             simp [Expr.runtime, Untyped.Expr.runtime]
-          · simp [hp, hc] at h
     | .unop op e => by
         let ih := infer_runtime env Θ Γ e
         intro s result s' h
@@ -1004,8 +1042,11 @@ mutual
             | error msg => simp [hty] at hcont
             | ok inst =>
               simp only [hty] at hcont
-              split at hcont
-              · have ⟨dr, s₁, hdoms, hcont⟩ := StateT.bind_ok hcont
+              cases hinst : SchemaTyp.close (fun v => inst.lookup v) sig.scheme with
+              | error v => simp [hinst] at hcont
+              | ok ty =>
+                simp only [hinst] at hcont
+                have ⟨dr, s₁, hdoms, hcont⟩ := StateT.bind_ok hcont
                 cases dr with
                 | mk doms retTy =>
                   have ⟨args', s₂, hchk, hcont⟩ := StateT.bind_ok hcont
@@ -1014,7 +1055,6 @@ mutual
                     Untyped.Expr.primName?_runtime hpn]
                   rw [checkInferred_runtime Θ inferred _ _ (TypeM.ofExcept_ok.mp hchk).1,
                     ihList _ _ _ hinf]
-              · simp at hcont
         | none =>
           simp only [hpn] at h
           obtain ⟨fp, s₀, hfn, hcont⟩ := StateT.bind_ok h

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -229,7 +229,7 @@ def checkInferred (Θ : TypeEnv) :
         .ok (arg :: args')
       else if Typ.sub Θ argTy dom then do
         let args' ← checkInferred Θ doms rest
-        .ok (arg.cast dom :: args')
+        .ok (Expr.cast arg dom :: args')
       else .error (.subsumptionFailure argTy dom)
   | doms, rest => .error (.arityMismatch doms.length rest.length)
 
@@ -237,7 +237,7 @@ def checkInferred (Θ : TypeEnv) :
 theorem checkInferred_runtime (Θ : TypeEnv) :
     (pairs : List (Typ × Typed.Expr)) → ∀ doms result,
       checkInferred Θ doms pairs = .ok result →
-      result.map Expr.runtime = (pairs.map Prod.snd).map Expr.runtime
+      result.map Expr.WithTypeVars.runtime = (pairs.map Prod.snd).map Expr.WithTypeVars.runtime
   | [] => by
       intro doms result h
       cases doms <;> simp [checkInferred] at h
@@ -258,7 +258,7 @@ theorem checkInferred_runtime (Θ : TypeEnv) :
           · have ⟨args', hrest, hcont⟩ := Except.bind_ok h
             simp at hcont
             cases hcont
-            simp only [List.map, Expr.runtime]
+            simp only [List.map, Expr.WithTypeVars.runtime]
             rw [checkInferred_runtime Θ rest doms _ hrest]
           · simp at h
 
@@ -416,7 +416,7 @@ mutual
     | .fix self args retTy body => do
         let retTy := (← translateOpt env Θ retTy).getD .value
         let typedArgs ← typedBinders env Θ args
-        let selfTy := Typ.arrow (typedArgs.map Binder.ty) retTy none
+        let selfTy := Typ.arrow (typedArgs.map Binder.WithTypeVars.ty) retTy none
         let typedSelf := Typed.Binder.ofUntyped self selfTy
         let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
         let body' ← check env Θ Γ' body retTy
@@ -570,7 +570,7 @@ mutual
           -- The self-reference is typed at the specified arrow, so a recursive
           -- call goes through the specification.
           let typedSelf :=
-            Typed.Binder.ofUntyped self (.arrow (typedArgs.map Binder.ty) ret (some s))
+            Typed.Binder.ofUntyped self (.arrow (typedArgs.map Binder.WithTypeVars.ty) ret (some s))
           let Γ' := typedArgs.foldl extendTyped (extendTyped Γ typedSelf)
           let body' ← check env Θ Γ' body ret
           pure (.fix typedSelf typedArgs ret (some s) body')
@@ -778,7 +778,7 @@ theorem Binder.ofUntyped_runtime (b : Untyped.Binder) (ty : Typ) :
 theorem typedBinders_runtime (env : SpecEnv σ) (Θ : TypeEnv) :
     ∀ (binders : List Untyped.Binder) (typed : List Typed.Binder) (s s' : σ),
       typedBinders env Θ binders s = .ok (typed, s') →
-        typed.map Typed.Binder.runtime = binders.map Untyped.Binder.runtime
+        typed.map Typed.Binder.WithTypeVars.runtime = binders.map Untyped.Binder.runtime
   | [], typed, s, s', h => by
       simp [typedBinders] at h
       rcases h with ⟨rfl, rfl⟩
@@ -793,7 +793,7 @@ theorem typedBinders_runtime (env : SpecEnv σ) (Θ : TypeEnv) :
 theorem checkBinders_runtime (env : SpecEnv σ) (Θ : TypeEnv) :
     ∀ (binders : List Untyped.Binder) (tys : List Typ) (typed : List Typed.Binder) (s s' : σ),
       checkBinders env Θ binders tys s = .ok (typed, s') →
-        typed.map Typed.Binder.runtime = binders.map Untyped.Binder.runtime
+        typed.map Typed.Binder.WithTypeVars.runtime = binders.map Untyped.Binder.runtime
   | [], [], typed, s, s', h => by
       simp [checkBinders] at h
       rcases h with ⟨rfl, rfl⟩
@@ -814,7 +814,7 @@ theorem checkBinders_runtime (env : SpecEnv σ) (Θ : TypeEnv) :
 theorem inferProductBinders_runtime (env : SpecEnv σ) (Θ : TypeEnv) :
     ∀ (binders : List Untyped.Binder) (tys : List Typ) (typed : List Typed.Binder) (s s' : σ),
       inferProductBinders env Θ binders tys s = .ok (typed, s') →
-        typed.map Typed.Binder.runtime = binders.map Untyped.Binder.runtime
+        typed.map Typed.Binder.WithTypeVars.runtime = binders.map Untyped.Binder.runtime
   | [], [], typed, s, s', h => by
       simp [inferProductBinders] at h
       rcases h with ⟨rfl, rfl⟩
@@ -857,7 +857,7 @@ def elabSpecifiedFix (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx)
       let ret := (← translateOpt env Θ retTy).getD .value
       let typedArgs ← typedBinders env Θ args
       let s ← elabSpecBody env Θ Γ typedArgs ret rb
-      pure (s, ← check env Θ Γ e (.arrow (typedArgs.map Binder.ty) ret (some s)))
+      pure (s, ← check env Θ Γ e (.arrow (typedArgs.map Binder.WithTypeVars.ty) ret (some s)))
   | _ => TypeM.error (.spec "attached to a non-function declaration")
 
 /-- A declaration is specified once. `[@@spec]` and a specification on the
@@ -926,11 +926,11 @@ def Program.elaborate (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
 
 private theorem branchListRuntime_cast_joinAll
     (Θ : TypeEnv) (branches' : List (Typed.Binder × Typed.Expr)) :
-    Expr.branchListRuntime
+    Expr.WithTypeVars.branchListRuntime
       (branches'.map fun x =>
         (x.1, if x.2.ty = joinAll Θ (branches'.map (fun p => p.2.ty)) then x.2
-              else x.2.cast (joinAll Θ (branches'.map (fun p => p.2.ty))))) =
-    Expr.branchListRuntime branches' := by
+              else Expr.cast x.2 (joinAll Θ (branches'.map (fun p => p.2.ty))))) =
+    Expr.WithTypeVars.branchListRuntime branches' := by
   simpa [BEq.beq] using
     Typed.Expr.branchListRuntime_castBodies
       (joinAll Θ (branches'.map (fun p => p.2.ty))) branches'
@@ -958,7 +958,7 @@ mutual
         intro s result s' h
         simp [Typed.infer] at h
         rcases h with ⟨⟨rfl, rfl⟩, rfl⟩
-        simp [Expr.runtime, Untyped.Expr.runtime]
+        simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime]
     | .var x => by
         intro s result s' h
         unfold Typed.infer at h
@@ -967,7 +967,7 @@ mutual
         | some ty =>
           simp [hΓ] at h
           rcases h with ⟨⟨rfl, rfl⟩, rfl⟩
-          simp [Expr.runtime, Untyped.Expr.runtime]
+          simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime]
     | .prim n => by
         intro s result s' h
         unfold Typed.infer at h
@@ -979,7 +979,7 @@ mutual
           | ok ty =>
             simp [hp, hc] at h
             rcases h with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime]
     | .unop op e => by
         let ih := infer_runtime env Θ Γ e
         intro s result s' h
@@ -992,7 +992,7 @@ mutual
             simp [hty] at hcont
           | some resTy =>
             rcases (by simpa [hty] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ hinfer]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ hinfer]
     | .binop op lhs rhs => by
         let ihL := infer_runtime env Θ Γ lhs
         let ihR := infer_runtime env Θ Γ rhs
@@ -1009,7 +1009,7 @@ mutual
               simp [hty] at hcont
             | some resTy =>
               rcases (by simpa [hty] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-              simp [Expr.runtime, Untyped.Expr.runtime, ihL _ _ _ hlhs, ihR _ _ _ hrhs]
+              simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihL _ _ _ hlhs, ihR _ _ _ hrhs]
     | .fix self args retTy body => by
         intro s result s' h
         unfold Typed.infer at h
@@ -1019,10 +1019,10 @@ mutual
         let ih := check_runtime env Θ
           (typedArgs.foldl extendTyped
             (extendTyped Γ (Typed.Binder.ofUntyped self
-              (Typ.arrow (typedArgs.map Binder.ty) (retTy'.getD .value) none))))
+              (Typ.arrow (typedArgs.map Binder.WithTypeVars.ty) (retTy'.getD .value) none))))
           body (retTy'.getD .value)
         rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-        simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ hbody, Binder.ofUntyped_runtime,
+        simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ hbody, Binder.ofUntyped_runtime,
           typedBinders_runtime env Θ args typedArgs s₀ s₁ hargs]
     | .app fn args => by
         let ihFn := infer_runtime env Θ Γ fn
@@ -1051,7 +1051,7 @@ mutual
                 | mk doms retTy =>
                   have ⟨args', s₂, hchk, hcont⟩ := StateT.bind_ok hcont
                   rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-                  simp only [Expr.runtime, Untyped.Expr.runtime,
+                  simp only [Expr.WithTypeVars.runtime, Untyped.Expr.runtime,
                     Untyped.Expr.primName?_runtime hpn]
                   rw [checkInferred_runtime Θ inferred _ _ (TypeM.ofExcept_ok.mp hchk).1,
                     ihList _ _ _ hinf]
@@ -1063,7 +1063,7 @@ mutual
           obtain ⟨doms, retTy⟩ := dr
           obtain ⟨args', s₂, hargs, hcont⟩ := StateT.bind_ok hcont
           rcases (by simpa [hargs] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-          simp [Expr.runtime, Untyped.Expr.runtime, ihFn _ _ _ hfn, ihArgs doms _ _ _ hargs]
+          simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihFn _ _ _ hfn, ihArgs doms _ _ _ hargs]
     | .ifThenElse cond thn els => by
         let ihCond := check_runtime env Θ Γ cond .bool
         let ihThn := infer_runtime env Θ Γ thn
@@ -1078,18 +1078,18 @@ mutual
           cases ep with
           | mk elsTy els' =>
             rcases (by simpa [hels] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime, ihCond _ _ _ hcond]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihCond _ _ _ hcond]
             constructor
             · by_cases hj : thnTy = Typ.join Θ thnTy elsTy
               · rw [if_pos hj]
                 exact ihThn _ _ _ hthn
               · rw [if_neg hj]
-                simpa [Typed.Expr.runtime] using ihThn _ _ _ hthn
+                simpa [Typed.Expr.WithTypeVars.runtime] using ihThn _ _ _ hthn
             · by_cases hj : elsTy = Typ.join Θ thnTy elsTy
               · rw [if_pos hj]
                 exact ihEls _ _ _ hels
               · rw [if_neg hj]
-                simpa [Typed.Expr.runtime] using ihEls _ _ _ hels
+                simpa [Typed.Expr.WithTypeVars.runtime] using ihEls _ _ _ hels
     | .letIn name bound body => by
         intro s result s' h
         cases name with
@@ -1105,7 +1105,7 @@ mutual
             cases q with
             | mk bodyTy body' =>
               rcases (by simpa [typedName, hbody] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-              simp [Expr.runtime, Untyped.Expr.runtime, ihBound _ _ _ hbound, ihBody _ _ _ hbody,
+              simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihBound _ _ _ hbound, ihBody _ _ _ hbody,
                 Binder.ofUntyped_runtime]
         | named x ann =>
           cases ann with
@@ -1121,7 +1121,7 @@ mutual
               cases q with
               | mk bodyTy body' =>
                 rcases (by simpa [typedName, hbody] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-                simp [Expr.runtime, Untyped.Expr.runtime, ihBound _ _ _ hbound, ihBody _ _ _ hbody,
+                simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihBound _ _ _ hbound, ihBody _ _ _ hbody,
                   Binder.ofUntyped_runtime]
           | some ty =>
             unfold Typed.infer at h
@@ -1142,7 +1142,7 @@ mutual
               have hname_rt :
                   typedName.runtime = (Untyped.Binder.named x (some ty)).runtime := by
                 simp [typedName, Binder.ofUntyped_runtime]
-              simp [Expr.runtime, Untyped.Expr.runtime, ihBound _ _ _ hbound, ihBody _ _ _ hbody,
+              simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihBound _ _ _ hbound, ihBody _ _ _ hbody,
                 hname_rt]
     | .letProd names bound body => by
         let ihBound := infer_runtime env Θ Γ bound
@@ -1165,7 +1165,7 @@ mutual
             cases q with
             | mk bodyTy body' =>
               rcases (by simpa [hbody] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-              simp [Expr.runtime, Untyped.Expr.runtime, ihBound _ _ _ hbound, ihBody _ _ _ hbody,
+              simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihBound _ _ _ hbound, ihBody _ _ _ hbody,
                 inferProductBinders_runtime env Θ names tys typedNames s₀ s₁ hnames]
           | _ =>
             simp at hcont
@@ -1177,7 +1177,7 @@ mutual
         cases p with
         | mk innerTy e1 =>
           rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-          simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ hinfer]
+          simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ hinfer]
     | .deref e => by
         let ih := infer_runtime env Θ Γ e
         intro s result s' h
@@ -1188,10 +1188,10 @@ mutual
           cases innerTy <;> simp at hcont
           case ref ty =>
             rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ hinfer]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ hinfer]
           case owned ty =>
             rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ hinfer]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ hinfer]
     | .store loc val => by
         let ihLoc := infer_runtime env Θ Γ loc
         intro s result s' h
@@ -1206,12 +1206,12 @@ mutual
             let ihVal := check_runtime env Θ Γ val inner
             have ⟨val', s₁, hval, hcont⟩ := StateT.bind_ok hcont
             rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime, ihLoc _ _ _ hloc, ihVal _ _ _ hval]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihLoc _ _ _ hloc, ihVal _ _ _ hval]
           case owned inner =>
             let ihVal := check_runtime env Θ Γ val inner
             have ⟨val', s₁, hval, hcont⟩ := StateT.bind_ok hcont
             rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime, ihLoc _ _ _ hloc, ihVal _ _ _ hval]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihLoc _ _ _ hloc, ihVal _ _ _ hval]
     | .arrayMake ownership len init => by
         let ihLen := check_runtime env Θ Γ len .int
         let ihInit := infer_runtime env Θ Γ init
@@ -1222,7 +1222,7 @@ mutual
         cases p with
         | mk elemTy init' =>
           rcases (by simpa [hinit] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-          simp [Expr.runtime, Untyped.Expr.runtime, ihLen _ _ _ hlen, ihInit _ _ _ hinit]
+          simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihLen _ _ _ hlen, ihInit _ _ _ hinit]
     | .arrayLen arr => by
         let ih := infer_runtime env Θ Γ arr
         intro s result s' h
@@ -1233,7 +1233,7 @@ mutual
           cases arrTy <;> simp at hcont
           case array elemTy | ownedArray elemTy =>
             rcases hcont with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ harr]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ harr]
     | .arrayGet arr idx => by
         let ihArr := infer_runtime env Θ Γ arr
         let ihIdx := check_runtime env Θ Γ idx .int
@@ -1246,7 +1246,7 @@ mutual
           cases arrTy <;> simp at hcont
           case array elemTy | ownedArray elemTy =>
             rcases hcont with ⟨⟨rfl, rfl⟩, rfl⟩
-            simp [Expr.runtime, Untyped.Expr.runtime, ihArr _ _ _ harr, ihIdx _ _ _ hidx]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihArr _ _ _ harr, ihIdx _ _ _ hidx]
     | .arraySet arr idx val => by
         let ihArr := infer_runtime env Θ Γ arr
         let ihIdx := check_runtime env Θ Γ idx .int
@@ -1261,21 +1261,21 @@ mutual
             have ⟨val', s₂, hval, hcont⟩ := StateT.bind_ok hcont
             rcases hcont with ⟨⟨rfl, rfl⟩, rfl⟩
             have hval_rt := check_runtime env Θ Γ val _ _ val' _ hval
-            simp [Expr.runtime, Untyped.Expr.runtime, ihArr _ _ _ harr, ihIdx _ _ _ hidx, hval_rt]
+            simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihArr _ _ _ harr, ihIdx _ _ _ hidx, hval_rt]
     | .assert e => by
         let ih := check_runtime env Θ Γ e .bool
         intro s result s' h
         unfold Typed.infer at h
         have ⟨e1, s₀, he, hcont⟩ := StateT.bind_ok h
         rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-        simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ he]
+        simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ he]
     | .tuple es => by
         let ih := inferList_runtime env Θ Γ es
         intro s result s' h
         unfold Typed.infer at h
         have ⟨pairs, s₀, hpairs, hcont⟩ := StateT.bind_ok h
         rcases (by simpa [hpairs] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-        simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ hpairs]
+        simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ hpairs]
     | .inj tag arity payload => by
         let ih := infer_runtime env Θ Γ payload
         intro s result s' h
@@ -1284,7 +1284,7 @@ mutual
         cases p with
         | mk payloadTy payload' =>
           rcases (by simpa using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-          simp [Expr.runtime, Untyped.Expr.runtime, ih _ _ _ hpayload]
+          simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ hpayload]
     | .match_ scrutinee branches => by
         let ihScrut := infer_runtime env Θ Γ scrutinee
         let ihBranches := inferBranches_runtime env Θ Γ branches
@@ -1299,7 +1299,7 @@ mutual
             · simp [-bind_pure_comp, hlen] at hcont
               have ⟨branches', s₁, hbranches, hcont⟩ := StateT.bind_ok hcont
               rcases (by simpa [hbranches] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-              simp [Expr.runtime, Untyped.Expr.runtime]
+              simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime]
               constructor
               · exact ihScrut _ _ _ hscrut
               · exact (branchListRuntime_cast_joinAll Θ branches').trans
@@ -1316,7 +1316,7 @@ mutual
                 · simp [-bind_pure_comp, hlen] at hcont
                   have ⟨branches', s₁, hbranches, hcont⟩ := StateT.bind_ok hcont
                   rcases (by simpa [hbranches] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
-                  simp [Expr.runtime, Untyped.Expr.runtime, ihScrut _ _ _ hscrut]
+                  simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ihScrut _ _ _ hscrut]
                   exact (branchListRuntime_cast_joinAll Θ branches').trans
                     (ihBranches ts _ _ _ hbranches)
                 · simp [hlen] at hcont
@@ -1341,14 +1341,14 @@ mutual
       · simp only [hann, if_false, Bool.false_eq_true] at hcont
         have ⟨body', s₂, hbody, hcont⟩ := StateT.bind_ok hcont
         rcases (by simpa using hcont) with ⟨rfl, rfl⟩
-        simp [Expr.runtime, Untyped.Expr.runtime, Binder.ofUntyped_runtime,
+        simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, Binder.ofUntyped_runtime,
           check_runtime env Θ _ body ret _ _ _ hbody,
           checkBinders_runtime env Θ args doms typedArgs s s₀ hargs]
     -- A tuple against a tuple type: the components erase one by one.
     case _ es tys =>
       have ⟨es', s₀, hes, hcont⟩ := StateT.bind_ok h
       rcases (by simpa using hcont) with ⟨rfl, rfl⟩
-      simp [Expr.runtime, Untyped.Expr.runtime,
+      simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime,
         checkArgs_runtime env Θ Γ es tys s es' s₀ hes]
     -- Everything else is inference followed by subsumption.
     case _ =>
@@ -1362,12 +1362,12 @@ mutual
         · by_cases hsub : Typ.sub Θ actual expected
           · simp [heq, hsub] at hcont
             rcases hcont with ⟨rfl, rfl⟩
-            simp [Expr.runtime, infer_runtime env Θ Γ e _ _ _ hinfer]
+            simp [Expr.WithTypeVars.runtime, infer_runtime env Θ Γ e _ _ _ hinfer]
           · simp [heq, hsub] at hcont
 
   theorem inferList_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
       (es : List Untyped.Expr) → ∀ s pairs s', Typed.inferList env Θ Γ es s = .ok (pairs, s') →
-        (pairs.map Prod.snd).map Expr.runtime = es.map Untyped.Expr.runtime
+        (pairs.map Prod.snd).map Expr.WithTypeVars.runtime = es.map Untyped.Expr.runtime
     | [] => by
         intro s pairs s' h
         simp [Typed.inferList] at h
@@ -1389,7 +1389,7 @@ mutual
   theorem checkArgs_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
       (args : List Untyped.Expr) → ∀ doms s result s',
         Typed.checkArgs env Θ Γ doms args s = .ok (result, s') →
-        result.map Expr.runtime = args.map Untyped.Expr.runtime
+        result.map Expr.WithTypeVars.runtime = args.map Untyped.Expr.runtime
     | [] => by
         intro doms s result s' h
         cases doms <;> simp [Typed.checkArgs] at h
@@ -1411,14 +1411,14 @@ mutual
   theorem inferBranches_runtime (env : SpecEnv σ) (Θ : TypeEnv) (Γ : TinyML.TyCtx) :
       (branches : List (Untyped.Binder × Untyped.Expr)) →
       ∀ tys s branches' s', Typed.inferBranches env Θ Γ tys branches s = .ok (branches', s') →
-        Expr.branchListRuntime branches' =
+        Expr.WithTypeVars.branchListRuntime branches' =
           Untyped.Expr.runtime.branchListRuntime branches
     | [] => by
         intro tys s branches' s' h
         cases tys <;> simp [Typed.inferBranches] at h
         case nil =>
           rcases h with ⟨rfl, rfl⟩
-          simp [Expr.branchListRuntime, Untyped.Expr.runtime.branchListRuntime]
+          simp [Expr.WithTypeVars.branchListRuntime, Untyped.Expr.runtime.branchListRuntime]
     | br :: rest => by
         let ihRest := inferBranches_runtime env Θ Γ rest
         intro tys s branches' s' h
@@ -1439,7 +1439,7 @@ mutual
               have ⟨rest', s₂, hrest, hcont⟩ := StateT.bind_ok hcont
               simp at hcont
               rcases hcont with ⟨rfl, rfl⟩
-              simp [Expr.branchListRuntime, Untyped.Expr.runtime.branchListRuntime,
+              simp [Expr.WithTypeVars.branchListRuntime, Untyped.Expr.runtime.branchListRuntime,
                 Binder.ofUntyped_runtime, ihBody _ _ _ hbody, ihRest tys _ _ _ hrest]
           · simp [hsub] at hcont
 end

--- a/Mica/SourceTinyML/Untyped.lean
+++ b/Mica/SourceTinyML/Untyped.lean
@@ -71,6 +71,7 @@ mutual
   inductive Typ where
     /-- A fully elaborated type, exactly as the typed IR uses it. -/
     | core (t : TinyML.Typ)
+    | tvar (v : TinyML.TyVar)
     | sum (ts : List Typ)
     | arrow (args : List Typ) (ret : Typ) (spec : Option (Spec.Body Expr Typ))
     | ref (t : Typ)

--- a/Mica/Stdlib/Combinators.lean
+++ b/Mica/Stdlib/Combinators.lean
@@ -127,7 +127,7 @@ live in `Embedding.Lawful`. -/
     predicate recognizing the type (absent when the type is a variable).
     Pure data; see `Embedding.Lawful` for the laws. -/
 structure Embedding where
-  typ      : TinyML.Typ
+  typ      : TinyML.SchemaTyp
   carrier  : Type
   inject   : carrier → Runtime.Val
   project  : Runtime.Val → carrier
@@ -189,9 +189,9 @@ def Embedding.poly (v : TinyML.TyVar) : Embedding :=
     fun σ W w => TinyML.ValHasType W w (σ v), none⟩
 
 /-- An arbitrary type scheme represented by the runtime value itself. -/
-def Embedding.logical (typ : TinyML.Typ) : Embedding :=
+def Embedding.logical (typ : TinyML.SchemaTyp) : Embedding :=
   ⟨typ, Runtime.Val, id, id,
-    fun σ W w => TinyML.ValHasType W w (typ.subst σ), none⟩
+    fun σ W w => TinyML.ValHasType W w (TinyML.Typ.subst σ typ), none⟩
 
 /-- The empty type: no closed values inhabit it. Trivial `Unit` carrier with a
     `False` type predicate, so only an intrinsic with an unsatisfiable domain
@@ -201,9 +201,9 @@ def Embedding.empty : Embedding :=
 
 /-- Vectors of an arbitrary element scheme: element lists, with the big-sep of
     instantiated element typings as the type predicate. -/
-def Embedding.vec (elem : TinyML.Typ) : Embedding :=
+def Embedding.vec (elem : TinyML.SchemaTyp) : Embedding :=
   ⟨.vec elem, List Runtime.Val, .vec, valVec,
-    fun σ W l => iprop([∗list] w ∈ l, TinyML.ValHasType W w (elem.subst σ)),
+    fun σ W l => iprop([∗list] w ∈ l, TinyML.ValHasType W w (TinyML.Typ.subst σ elem)),
     some .isVec⟩
 
 /-- Coherence laws for an `Embedding`. The `member`/`intro` laws are stated at
@@ -215,11 +215,11 @@ structure Embedding.Lawful (e : Embedding) where
                      UnPred.eval ρ p (e.inject x)
   member         : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
                      (W : TinyML.World) (w : Runtime.Val),
-                     TinyML.ValHasType W w (e.typ.subst σ) ⊣⊢
+                     TinyML.ValHasType W w (TinyML.Typ.subst σ e.typ) ⊣⊢
                        iprop(∃ x, ⌜w = e.inject x⌝ ∗ e.typePred σ W x)
   intro          : ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ)
                      (W : TinyML.World) (x : e.carrier),
-                     e.typePred σ W x ⊢ TinyML.ValHasType W (e.inject x) (e.typ.subst σ)
+                     e.typePred σ W x ⊢ TinyML.ValHasType W (e.inject x) (TinyML.Typ.subst σ e.typ)
 
 /-- Lift the pure membership fact of an embedding with trivial type predicate
     to the predicate-carrying `member` shape (`∗ emp` under the existential). -/
@@ -293,7 +293,7 @@ def Embedding.lawfulPoly (v : TinyML.TyVar) : (Embedding.poly v).Lawful where
     exact .rfl
 
 /-- The identity representation of an arbitrary logical type is lawful. -/
-def Embedding.lawfulLogical (typ : TinyML.Typ) : (Embedding.logical typ).Lawful where
+def Embedding.lawfulLogical (typ : TinyML.SchemaTyp) : (Embedding.logical typ).Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := nomatch h
   isOf_inject _ _ _ h := nomatch h
@@ -328,14 +328,14 @@ def Embedding.lawfulEmpty : Embedding.empty.Lawful where
     exact false_elim
 
 /-- Vectors are a lawful embedding: exactly the `ValHasType.vec` API. -/
-def Embedding.lawfulVec (elem : TinyML.Typ) : (Embedding.vec elem).Lawful where
+def Embedding.lawfulVec (elem : TinyML.SchemaTyp) : (Embedding.vec elem).Lawful where
   project_inject _ := rfl
   isOf_wf _ _ h := by cases h; trivial
   isOf_inject _ _ _ h := by cases h; simp [Embedding.vec]
   member σ W w := by
-    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec W w (elem.subst σ)
+    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec W w (TinyML.Typ.subst σ elem)
   intro σ W l := by
-    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec_intro W l (elem.subst σ)
+    simpa [Embedding.vec, TinyML.Typ.subst] using TinyML.ValHasType.vec_intro W l (TinyML.Typ.subst σ elem)
 
 /-! ## Scheme matching -/
 
@@ -343,12 +343,17 @@ def Embedding.lawfulVec (elem : TinyML.Typ) : (Embedding.vec elem).Lawful where
 private def printTypes (tys : List TinyML.Typ) : String :=
   s!"[{", ".intercalate (tys.map TinyML.Typ.print)}]"
 
+/-- Render a list of scheme types for the same diagnostics. -/
+private def printSchemas (tys : List TinyML.SchemaTyp) : String :=
+  s!"[{", ".intercalate (tys.map TinyML.SchemaTyp.print)}]"
+
 /-- Match type variables occurring in a scheme type against an inferred type.
     A variable is fixed by its first occurrence; later occurrences are checked
     by the elaborator against the instantiated scheme, including subtyping. -/
 def matchType (inst : List (TinyML.TyVar × TinyML.Typ))
-    (pattern actual : TinyML.Typ) : Except String (List (TinyML.TyVar × TinyML.Typ)) :=
-  if pattern.closed then .ok inst
+    (pattern : TinyML.SchemaTyp) (actual : TinyML.Typ) :
+    Except String (List (TinyML.TyVar × TinyML.Typ)) :=
+  if TinyML.Typ.closed pattern then .ok inst
   else
     match pattern, actual with
     | .tvar v, t => .ok (if inst.lookup v |>.isSome then inst else (v, t) :: inst)
@@ -373,29 +378,30 @@ def matchType (inst : List (TinyML.TyVar × TinyML.Typ))
         matchType inst p t
     | .named P ps, .named T ts =>
         if P = T then matchTypes inst ps ts
-        else .error s!"expected {pattern.print}, got {actual.print}"
-    | _, _ => .error s!"expected {pattern.print}, got {actual.print}"
+        else .error s!"expected {TinyML.SchemaTyp.print pattern}, got {actual.print}"
+    | _, _ => .error s!"expected {TinyML.SchemaTyp.print pattern}, got {actual.print}"
 where
   matchTypes (inst : List (TinyML.TyVar × TinyML.Typ)) :
-      List TinyML.Typ → List TinyML.Typ →
+      List TinyML.SchemaTyp → List TinyML.Typ →
         Except String (List (TinyML.TyVar × TinyML.Typ))
     | [], [] => .ok inst
     | p :: ps, t :: ts => do
         let inst ← matchType inst p t
         matchTypes inst ps ts
-    | ps, ts => .error s!"expected type arguments {printTypes ps}, got {printTypes ts}"
+    | ps, ts =>
+        .error s!"expected type arguments {printSchemas ps}, got {printTypes ts}"
 
 /-- Derive a primitive instantiation by structurally matching its argument
     scheme against the inferred argument types. Arity and the instantiated
     domains are rechecked by the elaborator. -/
-def schemeTyping (patterns : List TinyML.Typ) :
+def schemeTyping (patterns : List TinyML.SchemaTyp) :
     TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)) :=
   fun _ actuals =>
     if patterns.length = actuals.length then
       matchType.matchTypes [] patterns actuals
     else
-      .error s!"expected {patterns.length} arguments {printTypes patterns}, got \
+      .error s!"expected {patterns.length} arguments {printSchemas patterns}, got \
         {actuals.length} arguments {printTypes actuals}"
 
 /-! ## Name-based term builders -/
@@ -616,10 +622,10 @@ def Unary.toIntrinsic (b : Unary) : Intrinsic where
           (b.opTerm (.var .value "a"))) (.ret ())⟩) := rfl
 
 @[simp] theorem Unary.argTys_map_subst (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
-    b.toIntrinsic.argTys.map (·.subst σ) = [b.arg.typ.subst σ] := rfl
+    b.toIntrinsic.argTys.map (TinyML.Typ.subst σ) = [TinyML.Typ.subst σ b.arg.typ] := rfl
 
 @[simp] theorem Unary.retTy_subst (b : Unary) (σ : TinyML.TyVar → TinyML.Typ) :
-    b.toIntrinsic.retTy.subst σ = b.res.typ.subst σ := rfl
+    TinyML.Typ.subst σ b.toIntrinsic.retTy = TinyML.Typ.subst σ b.res.typ := rfl
 
 /-- Proof obligations for a pure unary intrinsic. `domSound` extracts the
     carrier-level domain from the evaluated precondition; when `pre = none` the
@@ -696,7 +702,7 @@ structure Unary.Lawful (b : Unary) where
         refine l.domSound ρ x fun p hp => ?_
         have h := hpre (p "a") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, ] using h
-      ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x)) (b.res.typ.subst σ)) $$ [Hrel]
+      ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x)) (TinyML.Typ.subst σ b.res.typ)) $$ [Hrel]
       · iapply (l.resL.intro σ W (b.f x))
         iapply (l.semWellTyped σ W x hdom)
         iexact Hrel
@@ -825,11 +831,11 @@ def Binary.toIntrinsic (b : Binary) : Intrinsic where
           (b.opTerm (.var .value "a") (.var .value "b"))) (.ret ())⟩) := rfl
 
 @[simp] theorem Binary.argTys_map_subst (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
-    b.toIntrinsic.argTys.map (·.subst σ)
-      = [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ] := rfl
+    b.toIntrinsic.argTys.map (TinyML.Typ.subst σ)
+      = [TinyML.Typ.subst σ b.arg₁.typ, TinyML.Typ.subst σ b.arg₂.typ] := rfl
 
 @[simp] theorem Binary.retTy_subst (b : Binary) (σ : TinyML.TyVar → TinyML.Typ) :
-    b.toIntrinsic.retTy.subst σ = b.res.typ.subst σ := rfl
+    TinyML.Typ.subst σ b.toIntrinsic.retTy = TinyML.Typ.subst σ b.res.typ := rfl
 
 /-- Proof obligations for a pure binary intrinsic: lawful embeddings, the three
     well-formedness facts (spec/def-axiom/type-axiom — one-liners at literal
@@ -897,7 +903,7 @@ structure Binary.Lawful (b : Binary) where
   bridge := by
     intro _ σ W vs ρ Φ hρ
     simp only [Binary.argTys_map_subst, Binary.retTy_subst, Binary.spec_pred]
-    show TinyML.ValsHaveTypes W vs [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ] ∗ _ ⊢ _
+    show TinyML.ValsHaveTypes W vs [TinyML.Typ.subst σ b.arg₁.typ, TinyML.Typ.subst σ b.arg₂.typ] ∗ _ ⊢ _
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -922,7 +928,7 @@ structure Binary.Lawful (b : Binary) where
         have h := hpre (p "a" "b") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, ] using h
       ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x y))
-          (b.res.typ.subst σ)) $$ [Hrel1 Hrel2]
+          (TinyML.Typ.subst σ b.res.typ)) $$ [Hrel1 Hrel2]
       · iapply (l.resL.intro σ W (b.f x y))
         iapply (l.semWellTyped σ W x y hdom)
         isplitl [Hrel1]
@@ -1063,11 +1069,11 @@ def Ternary.toIntrinsic (b : Ternary) : Intrinsic where
           (b.opTerm (.var .value "a") (.var .value "b") (.var .value "c"))) (.ret ())⟩) := rfl
 
 @[simp] theorem Ternary.argTys_map_subst (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
-    b.toIntrinsic.argTys.map (·.subst σ)
-      = [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ, b.arg₃.typ.subst σ] := rfl
+    b.toIntrinsic.argTys.map (TinyML.Typ.subst σ)
+      = [TinyML.Typ.subst σ b.arg₁.typ, TinyML.Typ.subst σ b.arg₂.typ, TinyML.Typ.subst σ b.arg₃.typ] := rfl
 
 @[simp] theorem Ternary.retTy_subst (b : Ternary) (σ : TinyML.TyVar → TinyML.Typ) :
-    b.toIntrinsic.retTy.subst σ = b.res.typ.subst σ := rfl
+    TinyML.Typ.subst σ b.toIntrinsic.retTy = TinyML.Typ.subst σ b.res.typ := rfl
 
 /-- Proof obligations for a pure ternary intrinsic. -/
 structure Ternary.Lawful (b : Ternary) where
@@ -1140,7 +1146,7 @@ structure Ternary.Lawful (b : Ternary) where
     intro _ σ W vs ρ Φ hρ
     simp only [Ternary.argTys_map_subst, Ternary.retTy_subst, Ternary.spec_pred]
     show TinyML.ValsHaveTypes W vs
-      [b.arg₁.typ.subst σ, b.arg₂.typ.subst σ, b.arg₃.typ.subst σ] ∗ _ ⊢ _
+      [TinyML.Typ.subst σ b.arg₁.typ, TinyML.Typ.subst σ b.arg₂.typ, TinyML.Typ.subst σ b.arg₃.typ] ∗ _ ⊢ _
     match vs with
     | [] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
     | [_] => exact (sep_mono_left (valsHaveTypes_off_shape _ (by simp))).trans sep_elim_left
@@ -1171,7 +1177,7 @@ structure Ternary.Lawful (b : Ternary) where
         have h := hpre (p "a" "b" "c") (by rw [hp]; rfl)
         simpa [Spec.argsEnv, ] using h
       ihave Hty : iprop(TinyML.ValHasType W (b.res.inject (b.f x y z))
-          (b.res.typ.subst σ)) $$ [Hrel1 Hrel2 Hrel3]
+          (TinyML.Typ.subst σ b.res.typ)) $$ [Hrel1 Hrel2 Hrel3]
       · iapply (l.resL.intro σ W (b.f x y z))
         iapply (l.semWellTyped σ W x y z hdom)
         isplitl [Hrel1]

--- a/Mica/Stdlib/ListStd.lean
+++ b/Mica/Stdlib/ListStd.lean
@@ -180,7 +180,7 @@ decreasing_by simp_all [listCons]; omega
 
 /-! ## Intrinsics -/
 
-private def listTy : TinyML.Typ := .list (.tvar "a")
+private def listTy : TinyML.SchemaTyp := .list (.tvar "a")
 
 def listLengthB : Pure.Unary where
   name := "list_length"

--- a/Mica/Stdlib/OptionStd.lean
+++ b/Mica/Stdlib/OptionStd.lean
@@ -127,7 +127,7 @@ def optionValueDefAxiom : Formula :=
       (unTerm "option_value" (optionSomeTerm (.var .value "value")))
       (.var .value "value")
 
-private def optionTy : TinyML.Typ := .option (.tvar "a")
+private def optionTy : TinyML.SchemaTyp := .option (.tvar "a")
 
 def optionIsSomeB : Pure.Unary where
   name := "option_is_some"

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -289,7 +289,7 @@ mutual
           VerifM.expectEq "app type annotation mismatch" retTy aty
           VerifM.expectEq "specification arity mismatch" s.args.length argTys.length
           let sterms ← compileExprs reg Θ Δ_spec B Γ args
-          let sargs := (args.map Expr.ty).zip sterms
+          let sargs := (args.map Expr.WithTypeVars.ty).zip sterms
           let _ ← compile reg Θ Δ_spec B Γ fn
           let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec) argTys retTy s sargs
           pure result
@@ -302,7 +302,7 @@ mutual
             VerifM.expectEq "primitive return type mismatch"
               (TinyML.Typ.subst σi i.retTy) aty
             let sterms ← compileExprs reg Θ Δ_spec B Γ args
-            let sargs := (args.map Expr.ty).zip sterms
+            let sargs := (args.map Expr.WithTypeVars.ty).zip sterms
             let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec)
               (i.argTys.map (TinyML.Typ.subst σi)) (TinyML.Typ.subst σi i.retTy) i.spec sargs
             pure result
@@ -444,7 +444,7 @@ mutual
           match Spec.checkWf s Δ_spec with
           | .error msg => VerifM.fatal msg
           | .ok () => do
-            let argTys := args.map Binder.ty
+            let argTys := args.map Binder.WithTypeVars.ty
             -- The closure itself is an opaque value; the recursive occurrence is
             -- bound to the same constant inside the body.
             let fv ← VerifM.decl self.name .value
@@ -645,7 +645,7 @@ def correctExprs (reg : Verifier.Registry) (es : List Expr) : Prop :=
     (∀ vs ρ' st' terms, Ψ terms st' ρ' →
       (∀ t ∈ terms, t.wfIn st'.decls) →
       Terms.Eval ρ' terms vs →
-       st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (R) ⊢ Φ vs) →
+       st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.WithTypeVars.ty) ∗ (R) ⊢ Φ vs) →
     st.sl W ρ ∗ (B.typedSubst W Γ γ ∗ R) ⊢ wps W.pctx (es.map (fun e => e.runtime.subst γ)) Φ
 
 /-! #### Correctness Compatibility Lemmas -/
@@ -656,9 +656,9 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
   cases c with
   | int n =>
     simp only [compile] at heval
-    simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
+    simp only [Expr.WithTypeVars.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
     obtain heval := VerifM.eval_ret heval
-    simp only [Expr.ty, Const.ty] at hpost
+    simp only [Expr.WithTypeVars.ty, Const.ty] at hpost
     refine SpatialContext.wp_val ?_
     istart
     iintro ⟨Howns, -, HR⟩
@@ -669,9 +669,9 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
     exact TinyML.ValHasType.int_intro W n
   | bool b =>
     simp only [compile] at heval
-    simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
+    simp only [Expr.WithTypeVars.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
     obtain heval := VerifM.eval_ret heval
-    simp only [Expr.ty, Const.ty] at hpost
+    simp only [Expr.WithTypeVars.ty, Const.ty] at hpost
     refine SpatialContext.wp_val ?_
     istart
     iintro ⟨Howns, -, HR⟩
@@ -682,9 +682,9 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
     exact TinyML.ValHasType.bool_intro W b
   | char c =>
     simp only [compile] at heval
-    simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
+    simp only [Expr.WithTypeVars.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
     obtain heval := VerifM.eval_ret heval
-    simp only [Expr.ty, Const.ty] at hpost
+    simp only [Expr.WithTypeVars.ty, Const.ty] at hpost
     refine SpatialContext.wp_val ?_
     istart
     iintro ⟨Howns, -, HR⟩
@@ -695,9 +695,9 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
     exact TinyML.ValHasType.char_intro W c
   | string s =>
     simp only [compile] at heval
-    simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
+    simp only [Expr.WithTypeVars.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
     obtain heval := VerifM.eval_ret heval
-    simp only [Expr.ty, Const.ty] at hpost
+    simp only [Expr.WithTypeVars.ty, Const.ty] at hpost
     refine SpatialContext.wp_val ?_
     istart
     iintro ⟨Howns, -, HR⟩
@@ -708,9 +708,9 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
     exact TinyML.ValHasType.string_intro W s
   | float b =>
     simp only [compile] at heval
-    simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
+    simp only [Expr.WithTypeVars.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
     obtain heval := VerifM.eval_ret heval
-    simp only [Expr.ty, Const.ty] at hpost
+    simp only [Expr.WithTypeVars.ty, Const.ty] at hpost
     refine SpatialContext.wp_val ?_
     istart
     iintro ⟨Howns, -, HR⟩
@@ -721,9 +721,9 @@ theorem compileConst_correct (reg : Verifier.Registry) (c : TinyML.Const) :
     exact TinyML.ValHasType.float_intro W b
   | unit =>
     simp only [compile] at heval
-    simp only [Expr.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
+    simp only [Expr.WithTypeVars.runtime, Runtime.Val.ofConst, Runtime.Expr.subst_val]
     obtain heval := VerifM.eval_ret heval
-    simp only [Expr.ty, Const.ty] at hpost
+    simp only [Expr.WithTypeVars.ty, Const.ty] at hpost
     refine SpatialContext.wp_val ?_
     istart
     iintro ⟨Howns, -, HR⟩
@@ -750,7 +750,7 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
       simp only [hb] at heval
       exact (VerifM.eval_fatal (VerifM.eval_bind heval)).elim
   obtain ⟨hcheck, hcont⟩ := VerifM.eval_bind_expectEq heval
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   obtain ⟨hsort, hγ⟩ := hagree x x' hbind
   rw [hγ]
@@ -778,7 +778,7 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
       exact Option.some.inj hγv.symm
     subst hv
     iexact Hvty
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   cases hΓx : Γ x with
   | none =>
     have hvty : vty = .value := by simpa [hΓx] using hcheck.symm
@@ -817,7 +817,7 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
     (ihPayload : correctExpr reg payload) :
     correctExpr reg (.inj tag arity payload) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   by_cases htag : tag ≥ arity
@@ -831,7 +831,7 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
     intro v_p ρ_p st_p se_p hΨ_p hse_wf_p heval_se_p
     obtain ⟨_hdecls_p, _hagreeOn_p, hΨ_p⟩ := hΨ_p
     obtain hΨ_p := VerifM.eval_ret hΨ_p
-    simp only [Expr.ty] at hpost
+    simp only [Expr.WithTypeVars.ty] at hpost
     let ts := (List.replicate arity TinyML.Typ.empty).set tag payload.ty
     have hlen_ts : ts.length = arity := by simp [ts]
     have hget_ts : ts[tag]? = some payload.ty := by simp [ts, htag]
@@ -855,10 +855,10 @@ theorem compileCast_correct (reg : Verifier.Registry) (e : Expr) (ty : TinyML.Ty
     (ih : correctExpr reg e) :
     correctExpr reg (.cast e ty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   simp only [compile] at heval
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ := VerifM.eval_bind heval
-  simp [Expr.runtime]
+  simp [Expr.WithTypeVars.runtime]
   refine ih W R B Γ st ρ γ _ _ hW (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hwf hag hΔreg hρreg ?_
   intro v ρ' st' se hΨ hse_wf heval_se
   obtain ⟨_, _, hΨ⟩ := hΨ
@@ -880,7 +880,7 @@ theorem compileAssert_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.assert e) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ := VerifM.eval_bind heval
@@ -898,7 +898,7 @@ theorem compileAssert_correct (reg : Verifier.Registry) (e : Expr)
     simp only [φ, Formula.eval, Term.eval, UnOp.eval, Const.denote] at hφ
     rw [heval_se] at hφ
     cases v_e <;> simp_all
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   subst hvtrue
   have hprep :
       st₁.sl W ρ_e ∗ TinyML.ValHasType W (.bool true) e.ty ∗ R ⊢
@@ -948,8 +948,8 @@ theorem compileFixBody_correct (reg : Verifier.Registry)
         (do
           let se ← compile reg W.Θ W.Δ_spec
             (fixBindings self fv B argNames argVars)
-            (fixTyCtx self (.arrow (args.map Binder.ty) retTy (some s)) Γ argNames
-              (args.map Binder.ty))
+            (fixTyCtx self (.arrow (args.map Binder.WithTypeVars.ty) retTy (some s)) Γ argNames
+              (args.map Binder.WithTypeVars.ty))
             body
           checkRet W.Θ retTy body.ty
           pure se)
@@ -957,13 +957,13 @@ theorem compileFixBody_correct (reg : Verifier.Registry)
         (fun result st'' ρ'' => ∀ X, result.wfIn st''.decls →
           st''.sl W ρ'' ∗ Q ∗
             ((TinyML.ValHasType W (result.eval ρ'') retTy -∗ P (result.eval ρ'')) -∗ X) ⊢ X)) :
-    st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (args.map Binder.ty) ∗ Q ⊢
+    st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (args.map Binder.WithTypeVars.ty) ∗ Q ⊢
       (Bindings.typedSubst W B Γ γ ∗
-        s.isPrecondFor W (TinyML.ValHasType W) (args.map Binder.ty) retTy fval) -∗
+        s.isPrecondFor W (TinyML.ValHasType W) (args.map Binder.WithTypeVars.ty) retTy fval) -∗
         wp W.pctx (body.runtime.subst
           ((γ.updateBinder self.runtime fval).updateAllBinder (args.map (·.runtime)) vs)) P := by
   obtain ⟨hargNames_len, hargs_len, hbs_eq⟩ := extractArgNames_spec hext
-  set argTys := args.map Binder.ty with hargTys_def
+  set argTys := args.map Binder.WithTypeVars.ty with hargTys_def
   set bs := args.map (·.runtime) with hbs_def
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_eq
   set selfTy : TinyML.Typ := .arrow argTys retTy (some s) with hselfTy_def
@@ -1126,7 +1126,7 @@ theorem compileFix_correct (reg : Verifier.Registry) (self : Binder) (args : Lis
   cases spec with
   | none => exact (VerifM.eval_fatal heval).elim
   | some s =>
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   cases hext : extractArgNames args s.args with
   | error msg => simp only [hext] at heval; exact (VerifM.eval_fatal heval).elim
   | ok argNames =>
@@ -1137,7 +1137,7 @@ theorem compileFix_correct (reg : Verifier.Registry) (self : Binder) (args : Lis
   simp only [hext, hcheck] at heval
   have hswf : s.wfIn W.Δ_spec := Spec.checkWf_ok hcheck
   obtain ⟨hargNames_len, hargs_len, hbs_eq⟩ := extractArgNames_spec hext
-  set argTys := args.map Binder.ty with hargTys_def
+  set argTys := args.map Binder.WithTypeVars.ty with hargTys_def
   set bs := args.map (·.runtime) with hbs_def
   have hbs_runtime : bs = argNames.map Runtime.Binder.named := hbs_eq
   set fv := st.freshConst self.name .value with hfv_def
@@ -1229,7 +1229,7 @@ theorem compileFix_correct (reg : Verifier.Registry) (self : Binder) (args : Lis
     · iexact HT
     · iexact Hrec
   -- The closure value itself: the fresh constant denotes it.
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst_fix]
   apply SpatialContext.wp_func
   refine BIBase.Entails.trans ?_
@@ -1257,10 +1257,10 @@ theorem compileRefShared_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.ref .shared e) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ := VerifM.eval_bind heval
   refine SpatialContext.wp_bind_ref <| ih W R B Γ st ρ γ _ _ hW
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hwf hag hΔreg hρreg ?_
@@ -1325,10 +1325,10 @@ theorem compileRefOwned_correct (reg : Verifier.Registry) (e : Expr)
     (ih : correctExpr reg e) :
     correctExpr reg (.ref .owned e) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ := VerifM.eval_bind heval
   refine SpatialContext.wp_bind_ref <| ih W R B Γ st ρ γ _ _ hW
     (VerifM.eval.decls_grow ρ heval_e) hagree hbwf hwf hag hΔreg hρreg ?_
@@ -1404,10 +1404,10 @@ theorem compileDerefShared_correct (reg : Verifier.Registry) (e : Expr) (ty : Ti
     (ih : correctExpr reg e) :
     correctExpr reg (.deref e ty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, href] at heval
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ := VerifM.eval_bind heval
   refine SpatialContext.wp_bind_deref <| ih W R B Γ st ρ γ _ _ hW
@@ -1469,10 +1469,10 @@ theorem compileDerefOwned_correct (reg : Verifier.Registry) (e : Expr) (ty : Tin
     (ih : correctExpr reg e) :
     correctExpr reg (.deref e ty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, howned] at heval
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ := VerifM.eval_bind heval
   refine SpatialContext.wp_bind_deref <| ih W R B Γ st ρ γ _ _ hW
@@ -1557,10 +1557,10 @@ theorem compileStoreShared_correct (reg : Verifier.Registry) (loc val : Expr)
     (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
     correctExpr reg (.store loc val) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, href] at heval
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_v : (compile reg W.Θ W.Δ_spec B Γ val).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
@@ -1623,10 +1623,10 @@ theorem compileStoreOwned_correct (reg : Verifier.Registry) (loc val : Expr)
     (ihVal : correctExpr reg val) (ihLoc : correctExpr reg loc) :
     correctExpr reg (.store loc val) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile, howned] at heval
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   obtain ⟨_, heval⟩ := VerifM.eval_bind_expectEq heval
   have heval_v : (compile reg W.Θ W.Δ_spec B Γ val).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
@@ -1765,7 +1765,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
     (ihLen : correctExpr reg len) (ihInit : correctExpr reg init) :
     correctExpr reg (.arrayMake ownership len init) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   obtain ⟨hlenty, heval⟩ := VerifM.eval_bind_expectEq heval
@@ -1815,7 +1815,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
       heval_slen, hv_len] using hφ
   cases ownership with
   | shared =>
-    simp only [Expr.ty] at hpost
+    simp only [Expr.WithTypeVars.ty] at hpost
     iapply (SpatialContext.wp_arrayMake_inv (vlen := v_len) (init := v_init) (n := n)
       (I := fun w => TinyML.ValHasType W w init.ty) (Q := Φ) hv_len hn)
     isplitl []
@@ -1878,7 +1878,7 @@ theorem compileArrayMake_correct (reg : Verifier.Registry) (ownership : TinyML.O
           · iexact Hinv_l
         · iexact HR
   | owned =>
-    simp only [Expr.ty] at hpost
+    simp only [Expr.WithTypeVars.ty] at hpost
     iapply (SpatialContext.wp_arrayMake (vlen := v_len) (init := v_init) (n := n)
       (Q := Φ) hv_len hn)
     iintro %l Hpt
@@ -1974,7 +1974,7 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
   cases hty : arr.ty with
   | array elem =>
       intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-      unfold Expr.runtime
+      unfold Expr.WithTypeVars.runtime
       simp only [Runtime.Expr.subst]
       simp only [compile, hty] at heval
       have heval_arr : (compile reg W.Θ W.Δ_spec B Γ arr).eval st ρ _ :=
@@ -2001,7 +2001,7 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
             st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R ⊢
               Φ (.int len) :=
           by
-            simpa [Expr.ty] using hpost (.int len) ρ_arr st₁ t hret ht_wf ht_eval
+            simpa [Expr.WithTypeVars.ty] using hpost (.int len) ρ_arr st₁ t hret ht_wf ht_eval
         iapply (SpatialContext.wp_arrayLen
           (R := st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R)
           (Q := Φ) (v := v_arr) (len := len) (l := loc) hv_arr hgoal)
@@ -2013,7 +2013,7 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
       exact hwp
   | ownedArray elem =>
       intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-      unfold Expr.runtime
+      unfold Expr.WithTypeVars.runtime
       simp only [Runtime.Expr.subst]
       simp only [compile, hty] at heval
       have heval_arr : (compile reg W.Θ W.Δ_spec B Γ arr).eval st ρ _ :=
@@ -2035,7 +2035,7 @@ theorem compileArrayLen_correct (reg : Verifier.Registry) (arr : Expr)
       have hgoal :
           st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R ⊢
             Φ (.int len) := by
-        simpa [Expr.ty] using hpost (.int len) ρ_arr st₁ t hret ht_wf ht_eval
+        simpa [Expr.WithTypeVars.ty] using hpost (.int len) ρ_arr st₁ t hret ht_wf ht_eval
       iapply (SpatialContext.wp_arrayLen
         (R := st₁.sl W ρ_arr ∗ TinyML.ValHasType W (.int len) TinyML.Typ.int ∗ R)
         (Q := Φ) (v := v_arr) (len := len) (l := loc) hv_arr hgoal)
@@ -2056,10 +2056,10 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
   cases hty : arr.ty with
   | array elemTy =>
     intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-    unfold Expr.runtime
+    unfold Expr.WithTypeVars.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
-    simp only [Expr.ty] at hpost
+    simp only [Expr.WithTypeVars.ty] at hpost
     replace heval := VerifM.eval_ret (VerifM.eval_bind heval)
     obtain ⟨helem, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
@@ -2140,10 +2140,10 @@ theorem compileArrayGet_correct (reg : Verifier.Registry) (arr idx : Expr) (ty :
     exact hwp
   | ownedArray elemTy =>
     intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-    unfold Expr.runtime
+    unfold Expr.WithTypeVars.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
-    simp only [Expr.ty] at hpost
+    simp only [Expr.WithTypeVars.ty] at hpost
     replace heval := VerifM.eval_ret (VerifM.eval_bind heval)
     obtain ⟨helem, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
@@ -2217,10 +2217,10 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
   cases hty : arr.ty with
   | array elemTy =>
     intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-    unfold Expr.runtime
+    unfold Expr.WithTypeVars.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
-    simp only [Expr.ty] at hpost
+    simp only [Expr.WithTypeVars.ty] at hpost
     replace heval := VerifM.eval_ret (VerifM.eval_bind heval)
     obtain ⟨helemTy, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
@@ -2298,10 +2298,10 @@ theorem compileArraySet_correct (reg : Verifier.Registry) (arr idx val : Expr)
     exact hwp
   | ownedArray elemTy =>
     intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-    unfold Expr.runtime
+    unfold Expr.WithTypeVars.runtime
     simp only [Runtime.Expr.subst]
     simp only [compile, hty] at heval
-    simp only [Expr.ty] at hpost
+    simp only [Expr.WithTypeVars.ty] at hpost
     replace heval := VerifM.eval_ret (VerifM.eval_bind heval)
     obtain ⟨helemTy, heval⟩ := VerifM.eval_bind_expectEq heval
     obtain ⟨hidxty, heval⟩ := VerifM.eval_bind_expectEq heval
@@ -2399,7 +2399,7 @@ theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Ex
     (ih : correctExpr reg e) :
     correctExpr reg (.unop op e uty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ := VerifM.eval_bind heval
@@ -2415,7 +2415,7 @@ theorem compileUnop_correct (reg : Verifier.Registry) (op : TinyML.UnOp) (e : Ex
       st₁.sl W ρ_e ∗ TinyML.ValHasType W v_e e.ty ∗ R ⊢
         st₁.sl W ρ_e ∗ iprop(∃ w, ⌜TinyML.evalUnOp op v_e = some w⌝ ∗ TinyML.ValHasType W w ty) ∗ R :=
     sep_mono_right (sep_mono_left (TinyML.evalUnOp_typed htypeOf))
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   refine htyped.trans ?_
   istart
   iintro ⟨Howns, Hex, HR⟩
@@ -2440,7 +2440,7 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
     (ihR : correctExpr reg r) (ihL : correctExpr reg l) :
     correctExpr reg (.binop op l r bty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  unfold Expr.runtime
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   have heval_r : (compile reg W.Θ W.Δ_spec B Γ r).eval st ρ _ := VerifM.eval_bind heval
@@ -2474,7 +2474,7 @@ theorem compileBinop_correct (reg : Verifier.Registry) (op : TinyML.BinOp) (l r 
   obtain ⟨hdecls_l, hagreeOn_l, hΨ_l⟩ := hΨ_l
   obtain ⟨ty, htypeOf, hΨ_l⟩ := VerifM.eval_bind_expectSome hΨ_l
   obtain ⟨hty_eq, hΨ_l'⟩ := VerifM.eval_bind_expectEq hΨ_l
-  simp only [Expr.ty] at hpost
+  simp only [Expr.WithTypeVars.ty] at hpost
   have hsr_ρ_l : sr.eval ρ_l = vr := by
     rw [Term.eval_env_agree hsr_wf (Env.agreeOn_symm hagreeOn_l)]
     exact heval_sr
@@ -2647,8 +2647,8 @@ theorem compileLetIn_correct (reg : Verifier.Registry) (b : Binder) (e body : Ex
     correctExpr reg (.letIn b e body) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
   simp only [compile] at heval
-  simp only [Expr.ty] at hpost
-  unfold Expr.runtime
+  simp only [Expr.WithTypeVars.ty] at hpost
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.letIn_subst]
   have heval_e_outer : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ := VerifM.eval_bind heval
   have hstart :
@@ -2809,7 +2809,7 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
           (TinyML.ValsHaveTypes W vals tys ∗
             (Bindings.typedSubst W B Γ γ ∗ R)) ⊢
         wp W.pctx
-          (body.runtime.subst (γ.updateAllBinder (names.map Binder.runtime) vals)) Φ
+          (body.runtime.subst (γ.updateAllBinder (names.map Binder.WithTypeVars.runtime) vals)) Φ
   | [], [], tl, vals, W, R, B, Γ, st, ρ, γ, Ψ, Φ,
       hW, heval, hagree, hbwf, hwf, hag, hΔreg, hρreg,
       htl_wf, htl_eval, hpost => by
@@ -2860,7 +2860,7 @@ theorem compileProductBindersFrom_correct (reg : Verifier.Registry) (body : Expr
               (TinyML.ValsHaveTypes W [] (ty :: tys) ∗
                 (Bindings.typedSubst W B Γ γ ∗ R)) ⊢
                 wp W.pctx
-                  (body.runtime.subst (γ.updateAllBinder ((b :: bs).map Binder.runtime) [])) Φ by
+                  (body.runtime.subst (γ.updateAllBinder ((b :: bs).map Binder.WithTypeVars.runtime) [])) Φ by
             iintro ⟨_Hsl, Hvals, _Hctx⟩
             ihave Hfalse := (TinyML.ValsHaveTypes.nil_cons W ty tys).1 $$ Hvals
             iapply false_elim
@@ -3008,8 +3008,8 @@ theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (
   intro W R B Γ st ρ γ Ψ Φ hW heval
     hagree hbwf hwf hag hΔreg hρreg hpost
   simp only [compile] at heval
-  simp only [Expr.ty] at hpost
-  unfold Expr.runtime
+  simp only [Expr.WithTypeVars.ty] at hpost
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.letProd_subst]
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st ρ _ :=
     VerifM.eval_bind heval
@@ -3043,22 +3043,22 @@ theorem compileLetProd_correct (reg : Verifier.Registry) (names : List Binder) (
           (TinyML.ValHasType W v_e (.tuple tys) ∗
             (Bindings.typedSubst W B Γ γ ∗ R)) ⊢
             wp W.pctx
-              (Runtime.Expr.letProd (names.map Binder.runtime) (.val v_e)
-                (Runtime.Expr.subst (γ.removeAll' (names.map Binder.runtime)) body.runtime)) Φ from ?_)
+              (Runtime.Expr.letProd (names.map Binder.WithTypeVars.runtime) (.val v_e)
+                (Runtime.Expr.subst (γ.removeAll' (names.map Binder.WithTypeVars.runtime)) body.runtime)) Φ from ?_)
       iintro ⟨Hsl, Hve, #HT, HR⟩
       ihave Htuple := (TinyML.ValHasType.tuple W v_e tys).1 $$ Hve
       icases Htuple with ⟨%vs, %hveq, Hvals⟩
       subst hveq
       ihave %hlen_vals := (TinyML.ValsHaveTypes.length_eq (W := W) (vs := vs) (ts := tys)) $$ Hvals
-      have hnames_len : (names.map Binder.runtime).length = vs.length := by
+      have hnames_len : (names.map Binder.WithTypeVars.runtime).length = vs.length := by
         have htl_wf : (Term.unop UnOp.toValList se).wfIn st₁.decls := ⟨trivial, hse_wf⟩
         have hlen_compile := compileProductBindersFrom_length htl_wf hprod_eval
         simp [hlen_compile, hlen_vals]
       have hbody_subst := Runtime.Expr.subst_removeAll'_updateAllBinder body.runtime γ
-        (names.map Binder.runtime) vs hnames_len
-      iapply (wp.letProd_val (ctx := W.pctx) (names := names.map Binder.runtime)
+        (names.map Binder.WithTypeVars.runtime) vs hnames_len
+      iapply (wp.letProd_val (ctx := W.pctx) (names := names.map Binder.WithTypeVars.runtime)
         (vs := vs)
-        (body := Runtime.Expr.subst (γ.removeAll' (names.map Binder.runtime)) body.runtime)
+        (body := Runtime.Expr.subst (γ.removeAll' (names.map Binder.WithTypeVars.runtime)) body.runtime)
         hnames_len)
       rw [hbody_subst]
       iapply (compileProductBindersFrom_correct reg body ihBody names tys
@@ -3083,8 +3083,8 @@ theorem compileIfThenElse_correct (reg : Verifier.Registry) (cond thn els : Expr
     (ihCond : correctExpr reg cond) (ihThn : correctExpr reg thn) (ihEls : correctExpr reg els) :
     correctExpr reg (.ifThenElse cond thn els ty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  simp only [Expr.ty] at hpost
-  unfold Expr.runtime
+  simp only [Expr.WithTypeVars.ty] at hpost
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
   have heval_cond : (compile reg W.Θ W.Δ_spec B Γ cond).eval st ρ _ := VerifM.eval_bind heval
@@ -3200,8 +3200,8 @@ theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
     (ihEs : correctExprs reg es) :
     correctExpr reg (.tuple es) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  simp only [Expr.ty] at hpost
-  unfold Expr.runtime
+  simp only [Expr.WithTypeVars.ty] at hpost
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
   have heval_es : (compileExprs reg W.Θ W.Δ_spec B Γ es).eval st ρ _ := VerifM.eval_bind heval
@@ -3217,13 +3217,13 @@ theorem compileTuple_correct (reg : Verifier.Registry) (es : List Expr)
     exact ⟨trivial, Terms.toValList_wfIn hwf_terms⟩
   refine SpatialContext.wp_tuple ?_
   have hstep :
-      st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.ty) ∗ (R) ⊢
-        st'.sl W ρ' ∗ TinyML.ValHasType W (.tuple vs) (.tuple (es.map Expr.ty)) ∗ R := by
+      st'.sl W ρ' ∗ TinyML.ValsHaveTypes W vs (es.map Expr.WithTypeVars.ty) ∗ (R) ⊢
+        st'.sl W ρ' ∗ TinyML.ValHasType W (.tuple vs) (.tuple (es.map Expr.WithTypeVars.ty)) ∗ R := by
     iintro ⟨Howns, Hvals, HR⟩
     isplitl [Howns]
     · iexact Howns
     · isplitl [Hvals]
-      · iapply (TinyML.ValHasType.tuple W (.tuple vs) (es.map Expr.ty)).2
+      · iapply (TinyML.ValHasType.tuple W (.tuple vs) (es.map Expr.WithTypeVars.ty)).2
         iexists vs
         isplitr
         · ipureintro; rfl
@@ -3252,7 +3252,7 @@ theorem compileAppSpec_correct (reg : Verifier.Registry)
         let sterms ← compileExprs reg W.Θ W.Δ_spec B Γ args
         let _ ← compile reg W.Θ W.Δ_spec B Γ fn
         let r ← Spec.call W.Θ (FiniteSubst.base W.Δ_spec) argTys retTy s
-          ((args.map Expr.ty).zip sterms)
+          ((args.map Expr.WithTypeVars.ty).zip sterms)
         pure r.2) st ρ Ψ)
     (hswf : s.wfIn W.Δ_spec)
     (hagree : B.agreeOnLinked ρ γ) (hbwf : B.wfIn st.decls)
@@ -3294,10 +3294,10 @@ theorem compileAppSpec_correct (reg : Verifier.Registry)
     VerifM.eval_bind hΨ_args
   have hlen_sargs : sargs.length = vs.length := by
     simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
-  have hctx' : st_args.sl W ρ_args ∗ TinyML.ValsHaveTypes W vs (args.map Expr.ty) ∗
+  have hctx' : st_args.sl W ρ_args ∗ TinyML.ValsHaveTypes W vs (args.map Expr.WithTypeVars.ty) ∗
       ((B.typedSubst W Γ γ ∗ R)) ⊢
       st_args.sl W ρ_args ∗ (B.typedSubst W Γ γ ∗
-        (TinyML.ValsHaveTypes W vs (args.map Expr.ty) ∗ R)) := by
+        (TinyML.ValsHaveTypes W vs (args.map Expr.WithTypeVars.ty) ∗ R)) := by
     istart
     iintro ⟨Howns, #Hvals, #HT, HR⟩
     isplitl [Howns]
@@ -3308,12 +3308,12 @@ theorem compileAppSpec_correct (reg : Verifier.Registry)
         · iexact Hvals
         · iexact HR
   refine hctx'.trans <|
-    ihFn W (TinyML.ValsHaveTypes W vs (args.map Expr.ty) ∗ R) B Γ st_args ρ_args γ _ _ hW
+    ihFn W (TinyML.ValsHaveTypes W vs (args.map Expr.WithTypeVars.ty) ∗ R) B Γ st_args ρ_args γ _ _ hW
       (VerifM.eval.decls_grow ρ_args heval_fn) hagree_args hbwf_args hwf hag_args
       hΔreg hρreg ?_
   intro fval ρ_fn st_fn sfn hΨ_fn _hsfn_wf _heval_sfn
   obtain ⟨hdecls_fn, hagreeOn_fn, hΨ_fn⟩ := hΨ_fn
-  set typedArgs := (args.map Expr.ty).zip sargs with htypedArgs_def
+  set typedArgs := (args.map Expr.WithTypeVars.ty).zip sargs with htypedArgs_def
   have hag_fn : W.agrees st_fn.decls ρ_fn := hag_args.step hdecls_fn hagreeOn_fn
   have hst_fn_wf : st_fn.decls.wf := (VerifM.eval.wf hΨ_fn).namesDisjoint
   have hsargs_wf_fn : ∀ t ∈ sargs, t.wfIn st_fn.decls := fun t ht =>
@@ -3353,15 +3353,15 @@ theorem compileAppSpec_correct (reg : Verifier.Registry)
   iintro ⟨Howns, #Hspec, #Hvals, HR⟩
   ihave Hlen := TinyML.ValsHaveTypes.length_eq $$ Hvals
   ipure Hlen
-  have hlen_typed : (args.map Expr.ty).length = sargs.length := by
+  have hlen_typed : (args.map Expr.WithTypeVars.ty).length = sargs.length := by
     rw [← Hlen]; exact hlen_sargs.symm
-  have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) argTys := by
+  have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.WithTypeVars.ty) argTys := by
     simpa [htypedArgs_def, List.map_fst_zip (Nat.le_of_eq hlen_typed)] using hsub_ty
   -- The argument terms still denote the same values in the function's state.
   have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_fn) = vs := by
-    have hsnd : List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
+    have hsnd : List.map Prod.snd ((List.map Expr.WithTypeVars.ty args).zip sargs) = sargs := by
       simpa using
-        (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
+        (List.map_snd_zip (l₁ := List.map Expr.WithTypeVars.ty args) (l₂ := sargs)
           (Nat.le_of_eq hlen_typed.symm))
     have hcongr : sargs.map (fun t => t.eval ρ_fn) = sargs.map (fun t => t.eval ρ_args) :=
       List.map_congr_left fun t ht =>
@@ -3406,8 +3406,8 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     (ihArgs : correctExprs reg args) :
     correctExpr reg (.app fn args aty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  simp only [Expr.ty] at hpost
-  unfold Expr.runtime
+  simp only [Expr.WithTypeVars.ty] at hpost
+  unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
   split at heval
@@ -3429,7 +3429,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       VerifM.eval_bind heval
     have hi_mem : i ∈ reg := Verifier.Registry.mem_of_lookup? hilookup
     have hbridge := Verifier.Registry.Sound.get hSound hi_mem
-    simp only [Expr.runtime, Runtime.Expr.subst_val]
+    simp only [Expr.WithTypeVars.runtime, Runtime.Expr.subst_val]
     refine SpatialContext.wp_bind_app ?_
     refine ihArgs W R B Γ st ρ γ _ _ hW
       (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hwf hag hΔreg hρreg ?_
@@ -3438,7 +3438,7 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     let σi : TinyML.TyVar → TinyML.Typ := fun v => (inst.lookup v).getD .empty
     let argTys := i.argTys.map (TinyML.Typ.subst σi)
     let retTy := TinyML.Typ.subst σi i.retTy
-    let typedArgs := (args.map Expr.ty).zip sargs
+    let typedArgs := (args.map Expr.WithTypeVars.ty).zip sargs
     have hlen_sargs : sargs.length = vs.length := by
       simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs
     have hΔspec_args : W.Δ_spec.Subset st_args.decls := hag.subset.trans hdecls_args
@@ -3487,19 +3487,19 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
     iintuitionistic Hvals
     ihave Hlen := TinyML.ValsHaveTypes.length_eq $$ Hvals
     ipure Hlen
-    have hlen_typed : (args.map Expr.ty).length = sargs.length := by
+    have hlen_typed : (args.map Expr.WithTypeVars.ty).length = sargs.length := by
       rw [← Hlen]; exact hlen_sargs.symm
-    have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.ty) argTys := by
-      have hfst : typedArgs.map Prod.fst = args.map Expr.ty := by
+    have hsub_ty' : @TinyML.Typ.SubList W.Θ (args.map Expr.WithTypeVars.ty) argTys := by
+      have hfst : typedArgs.map Prod.fst = args.map Expr.WithTypeVars.ty := by
         simpa [typedArgs] using
-          (List.map_fst_zip (l₁ := args.map Expr.ty) (l₂ := sargs)
+          (List.map_fst_zip (l₁ := args.map Expr.WithTypeVars.ty) (l₂ := sargs)
             (Nat.le_of_eq hlen_typed))
       simpa [hfst] using hsub_ty
     have heval_sargs_map : typedArgs.map (fun p => p.2.eval ρ_args) = vs := by
       have hsnd :
-          List.map Prod.snd ((List.map Expr.ty args).zip sargs) = sargs := by
+          List.map Prod.snd ((List.map Expr.WithTypeVars.ty args).zip sargs) = sargs := by
         simpa using
-          (List.map_snd_zip (l₁ := List.map Expr.ty args) (l₂ := sargs)
+          (List.map_snd_zip (l₁ := List.map Expr.WithTypeVars.ty args) (l₂ := sargs)
             (Nat.le_of_eq hlen_typed.symm))
       calc
         typedArgs.map (fun p => p.2.eval ρ_args)
@@ -3536,8 +3536,8 @@ theorem compileMatch_correct (reg : Verifier.Registry) (scrut : Expr) (branches 
     (ihScrut : correctExpr reg scrut) (ihBranches : correctBranches reg branches) :
     correctExpr reg (.match_ scrut branches ty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
-  simp only [Expr.ty] at hpost
-  unfold Expr.runtime
+  simp only [Expr.WithTypeVars.ty] at hpost
+  unfold Expr.WithTypeVars.runtime
   simp only [Expr.branchListRuntime_eq_map, Runtime.Expr.subst, List.map_map]
   simp only [compile] at heval
   have heval_scrut : (compile reg W.Θ W.Δ_spec B Γ scrut).eval st ρ _ := VerifM.eval_bind heval
@@ -3860,7 +3860,7 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
   have heval_e : (compile reg W.Θ W.Δ_spec B Γ e).eval st_vs ρ_vs _ := VerifM.eval_bind hΨ_vs
   have hspecInv_vs := hag.step hdecls_vs hagreeOn_vs
   refine BIBase.Entails.trans ?_ <|
-    ihE W (TinyML.ValsHaveTypes W vs (rest.map Expr.ty) ∗ (R))
+    ihE W (TinyML.ValsHaveTypes W vs (rest.map Expr.WithTypeVars.ty) ∗ (R))
     B Γ st_vs ρ_vs γ _ _ hW
     (VerifM.eval.decls_grow ρ_vs heval_e) hagree_vs hbwf_vs hwf hspecInv_vs hΔreg hρreg ?_
   · iintro ⟨Hsl, Hvs, #HT, HR⟩
@@ -3894,10 +3894,10 @@ theorem compileExprsCons_correct (reg : Verifier.Registry) (e : Expr) (rest : Li
     · iexact Hsl
     · isplitl [Hv Hvs]
       · iapply (show TinyML.ValHasType W v e.ty ∗
-            TinyML.ValsHaveTypes W vs (rest.map Expr.ty) ⊢
-            TinyML.ValsHaveTypes W (v :: vs) ((e :: rest).map Expr.ty) by
+            TinyML.ValsHaveTypes W vs (rest.map Expr.WithTypeVars.ty) ⊢
+            TinyML.ValsHaveTypes W (v :: vs) ((e :: rest).map Expr.WithTypeVars.ty) by
           simpa [List.map] using
-            (TinyML.ValsHaveTypes.cons W v vs e.ty (rest.map Expr.ty)).2)
+            (TinyML.ValsHaveTypes.cons W v vs e.ty (rest.map Expr.WithTypeVars.ty)).2)
         isplitl [Hv]
         · iexact Hv
         · iexact Hvs
@@ -3919,7 +3919,7 @@ theorem compileExprsNil_correct (reg : Verifier.Registry) :
   isplitl [Hsl]
   · iexact Hsl
   · isplitl []
-    · iapply (show iprop(emp) ⊢ TinyML.ValsHaveTypes W [] ([].map Expr.ty) by
+    · iapply (show iprop(emp) ⊢ TinyML.ValsHaveTypes W [] ([].map Expr.WithTypeVars.ty) by
         simpa [List.map] using (TinyML.ValsHaveTypes.nil W).2)
       iempintro
     · iexact HR

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -298,12 +298,13 @@ mutual
         | .prim n inst _ => do
             let i ← VerifM.expectSome s!"unknown primitive `{n}`"
               (reg.lookup? n)
-            let σi : TinyML.TyVar → TinyML.Typ := fun v => (inst.lookup v).getD (.tvar v)
-            VerifM.expectEq "primitive return type mismatch" (i.retTy.subst σi) aty
+            let σi : TinyML.TyVar → TinyML.Typ := fun v => (inst.lookup v).getD .empty
+            VerifM.expectEq "primitive return type mismatch"
+              (TinyML.Typ.subst σi i.retTy) aty
             let sterms ← compileExprs reg Θ Δ_spec B Γ args
             let sargs := (args.map Expr.ty).zip sterms
             let (_, result) ← Spec.call Θ (FiniteSubst.base Δ_spec)
-              (i.argTys.map (·.subst σi)) (i.retTy.subst σi) i.spec sargs
+              (i.argTys.map (TinyML.Typ.subst σi)) (TinyML.Typ.subst σi i.retTy) i.spec sargs
             pure result
         | _ => VerifM.fatal "application of a function without a specification"
     | .prim n _ _ => VerifM.fatal s!"primitive `{n}` must be applied"
@@ -3434,9 +3435,9 @@ theorem compileApp_correct (reg : Verifier.Registry) (hSound : Verifier.Registry
       (VerifM.eval.decls_grow ρ heval_args) hagree hbwf hwf hag hΔreg hρreg ?_
     intro vs ρ_args st_args sargs hΨ_args hsargs_wf heval_sargs
     obtain ⟨hdecls_args, hagreeOn_args, hΨ_args⟩ := hΨ_args
-    let σi : TinyML.TyVar → TinyML.Typ := fun v => (inst.lookup v).getD (.tvar v)
-    let argTys := i.argTys.map (·.subst σi)
-    let retTy := i.retTy.subst σi
+    let σi : TinyML.TyVar → TinyML.Typ := fun v => (inst.lookup v).getD .empty
+    let argTys := i.argTys.map (TinyML.Typ.subst σi)
+    let retTy := TinyML.Typ.subst σi i.retTy
     let typedArgs := (args.map Expr.ty).zip sargs
     have hlen_sargs : sargs.length = vs.length := by
       simpa [Terms.Eval] using List.Forall₂.length_eq heval_sargs

--- a/Mica/Verifier/Intrinsic.lean
+++ b/Mica/Verifier/Intrinsic.lean
@@ -280,9 +280,9 @@ structure Intrinsic where
   wp       : Arity.tup arity Runtime.Val → (Runtime.Val → iProp) → iProp
   /-- The intrinsic's argument types, in order. May contain type variables (a
       *scheme*); substituted per use site by the elaborator's instantiation. -/
-  argTys   : List TinyML.Typ
+  argTys   : List TinyML.SchemaTyp
   /-- The intrinsic's result type; likewise a scheme. -/
-  retTy    : TinyML.Typ
+  retTy    : TinyML.SchemaTyp
   /-- The intrinsic's specification: argument names and predicate transformer.
       A polymorphic intrinsic is a family of functions with the same
       implementation; only the argument/return types vary per use site, while
@@ -356,15 +356,15 @@ theorem agreeOn_extend_fresh (i : Intrinsic) {Δ : Signature} (ρ : Env)
             (f := fun a b c => s.interp (a, b, c)) (Δ := Δ) hfresh)
 
 /-- The intrinsic's argument types, in left-to-right order. -/
-def argTysList (i : Intrinsic) : List TinyML.Typ :=
+def argTysList (i : Intrinsic) : List TinyML.SchemaTyp :=
   i.argTys
 
 /-- The intrinsic's result type. -/
-def resultTy (i : Intrinsic) : TinyML.Typ :=
+def resultTy (i : Intrinsic) : TinyML.SchemaTyp :=
   i.retTy
 
 /-- The intrinsic's full arrow (scheme) type. -/
-def arrowType (i : Intrinsic) : TinyML.Typ :=
+def arrowType (i : Intrinsic) : TinyML.SchemaTyp :=
   .arrow i.argTysList i.resultTy none
 
 /-- The typing face of an intrinsic, consumed by the elaborator. -/
@@ -391,7 +391,7 @@ theorem toReduce_two_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .two Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
+    (argTys : List TinyML.SchemaTyp) (retTy : TinyML.SchemaTyp) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .two)) (axioms : List Axiom)
@@ -404,7 +404,7 @@ theorem toReduce_three_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .three Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .three Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
+    (argTys : List TinyML.SchemaTyp) (retTy : TinyML.SchemaTyp) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .three)) (axioms : List Axiom)
@@ -417,7 +417,7 @@ theorem toReduce_one_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .one Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
+    (argTys : List TinyML.SchemaTyp) (retTy : TinyML.SchemaTyp) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .one)) (axioms : List Axiom)
@@ -430,7 +430,7 @@ theorem toReduce_zero_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .zero Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
+    (argTys : List TinyML.SchemaTyp) (retTy : TinyML.SchemaTyp) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .zero)) (axioms : List Axiom)
@@ -457,7 +457,7 @@ theorem toWp_two_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .two Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .two Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
+    (argTys : List TinyML.SchemaTyp) (retTy : TinyML.SchemaTyp) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .two)) (axioms : List Axiom)
@@ -470,7 +470,7 @@ theorem toWp_three_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .three Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .three Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
+    (argTys : List TinyML.SchemaTyp) (retTy : TinyML.SchemaTyp) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .three)) (axioms : List Axiom)
@@ -483,7 +483,7 @@ theorem toWp_one_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .one Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .one Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
+    (argTys : List TinyML.SchemaTyp) (retTy : TinyML.SchemaTyp) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .one)) (axioms : List Axiom)
@@ -496,7 +496,7 @@ theorem toWp_zero_of_arity (name : String)
     (path : Option (String × List String))
     (reduce : Arity.tup .zero Runtime.Val → TinyML.Heap → Runtime.Val → TinyML.Heap → Prop)
     (wp : Arity.tup .zero Runtime.Val → (Runtime.Val → iProp) → iProp)
-    (argTys : List TinyML.Typ) (retTy : TinyML.Typ) (spec : Spec TinyML.Typ)
+    (argTys : List TinyML.SchemaTyp) (retTy : TinyML.SchemaTyp) (spec : Spec TinyML.Typ)
     (typing : TinyML.TypeEnv → List TinyML.Typ →
       Except String (List (TinyML.TyVar × TinyML.Typ)))
     (folSym : Option (FOL.Symbol .zero)) (axioms : List Axiom)
@@ -563,8 +563,9 @@ class IntrinsicSound (fragment : outParam (List Intrinsic)) (i : Intrinsic) : Pr
     ∀ [MicaGS HasLC.hasLC Sig] (σ : TinyML.TyVar → TinyML.Typ) (W : TinyML.World)
       (vs : List Runtime.Val) (ρ : Env) (Φ : Runtime.Val → iProp),
     ρ.respects i.folSym →
-    TinyML.ValsHaveTypes W vs (i.argTys.map (·.subst σ)) ∗
-      PredTrans.apply (TinyML.ValHasType W) (fun r => TinyML.ValHasType W r (i.retTy.subst σ) -∗ Φ r)
+    TinyML.ValsHaveTypes W vs (i.argTys.map (TinyML.Typ.subst σ)) ∗
+      PredTrans.apply (TinyML.ValHasType W)
+        (fun r => TinyML.ValHasType W r (TinyML.Typ.subst σ i.retTy) -∗ Φ r)
         i.spec.pred
         (Spec.argsEnv ρ i.spec.args vs) ⊢ i.toWp vs Φ
   wp_sound :

--- a/Mica/Verifier/Programs.lean
+++ b/Mica/Verifier/Programs.lean
@@ -724,7 +724,7 @@ theorem Program.check_correct (reg : Verifier.Registry) (hSound : Verifier.Regis
               Runtime.Expr.fix self.runtime (args.map (·.runtime))
                 (body.runtime.subst ((γ.remove' self.runtime).removeAll'
                   (args.map (·.runtime)))) := by
-            rw [hbody]; conv_lhs => unfold Expr.runtime
+            rw [hbody]; conv_lhs => unfold Expr.WithTypeVars.runtime
             simp only [Runtime.Expr.subst_fix]
           rw [hbody_rt]
           set fval := Runtime.Val.fix self.runtime (args.map (·.runtime))

--- a/Mica/Verifier/Utils.lean
+++ b/Mica/Verifier/Utils.lean
@@ -25,7 +25,7 @@ theorem extractArgNames_spec {argBinders : List Typed.Binder}
     (h : extractArgNames argBinders specArgs = .ok names) :
     names.length = specArgs.length ∧
     argBinders.length = specArgs.length ∧
-    argBinders.map Typed.Binder.runtime = names.map Runtime.Binder.named := by
+    argBinders.map Typed.Binder.WithTypeVars.runtime = names.map Runtime.Binder.named := by
   induction specArgs generalizing argBinders names with
   | nil =>
     cases argBinders with
@@ -50,7 +50,7 @@ theorem extractArgNames_spec {argBinders : List Typed.Binder}
               simp [hrec] at h
               cases h
               obtain ⟨h1, h2, h3⟩ := ih hrec
-              exact ⟨by simp [h1], by simp [h2], by simp [Typed.Binder.runtime, h3]⟩
+              exact ⟨by simp [h1], by simp [h2], by simp [Typed.Binder.WithTypeVars.runtime, h3]⟩
 
 -- ---------------------------------------------------------------------------
 -- FiniteSubst

--- a/Tests/frontend/let_annotation_mismatch.out
+++ b/Tests/frontend/let_annotation_mismatch.out
@@ -1,2 +1,2 @@
-Status: failed: subsumption failed: TinyML.Typ.prim (TinyML.PrimitiveType.int) is not a subtype of TinyML.Typ.prim (TinyML.PrimitiveType.bool)
+Status: failed: subsumption failed: int is not a subtype of bool
 [1]

--- a/Tests/frontend/let_annotation_ret_mismatch.out
+++ b/Tests/frontend/let_annotation_ret_mismatch.out
@@ -1,2 +1,2 @@
-Status: failed: subsumption failed: TinyML.Typ.prim (TinyML.PrimitiveType.int) is not a subtype of TinyML.Typ.prim (TinyML.PrimitiveType.bool)
+Status: failed: subsumption failed: int is not a subtype of bool
 [1]

--- a/Tests/frontend/match_annotation_mismatch.out
+++ b/Tests/frontend/match_annotation_mismatch.out
@@ -1,2 +1,2 @@
-Status: failed: subsumption failed: TinyML.Typ.prim (TinyML.PrimitiveType.int) is not a subtype of TinyML.Typ.prim (TinyML.PrimitiveType.bool)
+Status: failed: subsumption failed: int is not a subtype of bool
 [1]

--- a/Tests/frontend/pattern_annotation_mismatch.out
+++ b/Tests/frontend/pattern_annotation_mismatch.out
@@ -1,2 +1,2 @@
-Status: failed: subsumption failed: TinyML.Typ.prim (TinyML.PrimitiveType.int) is not a subtype of TinyML.Typ.prim (TinyML.PrimitiveType.bool)
+Status: failed: subsumption failed: int is not a subtype of bool
 [1]

--- a/Tests/spec_types/spec_mismatch.out
+++ b/Tests/spec_types/spec_mismatch.out
@@ -1,2 +1,2 @@
-Status: failed: subsumption failed: TinyML.Typ.arrow [TinyML.Typ.prim (TinyML.PrimitiveType.int)] (TinyML.Typ.prim (TinyML.PrimitiveType.int)) (some <spec>) is not a subtype of TinyML.Typ.arrow [TinyML.Typ.prim (TinyML.PrimitiveType.int)] (TinyML.Typ.prim (TinyML.PrimitiveType.int)) (some <spec>)
+Status: failed: subsumption failed: int -> int [@@spec] is not a subtype of int -> int [@@spec]
 [1]

--- a/Tests/spec_types/spec_unspecified_argument.out
+++ b/Tests/spec_types/spec_unspecified_argument.out
@@ -1,2 +1,2 @@
-Status: failed: subsumption failed: TinyML.Typ.arrow [TinyML.Typ.prim (TinyML.PrimitiveType.int)] (TinyML.Typ.prim (TinyML.PrimitiveType.int)) none is not a subtype of TinyML.Typ.arrow [TinyML.Typ.prim (TinyML.PrimitiveType.int)] (TinyML.Typ.prim (TinyML.PrimitiveType.int)) (some <spec>)
+Status: failed: subsumption failed: int -> int is not a subtype of int -> int [@@spec]
 [1]


### PR DESCRIPTION
This PR parameterises types and typed expressions by the type of type variables that they contain. The expressions the verifier handles are always closed and, in select places, types can contain variables. This PR is preparation for using a unification based type system in subsequent PRs.