### PR TITLE
Annotate injections

### DIFF
--- a/Mica/Frontend/Elaborate.lean
+++ b/Mica/Frontend/Elaborate.lean
@@ -78,9 +78,17 @@ private structure TypeInfo where
   core  : TinyML.TypeName
   arity : Nat
 
+/-- What a constructor resolves to: its tag among the `arity` constructors of
+`owner`, and the payload it carries. -/
+structure CtorInfo where
+  tag     : Nat
+  arity   : Nat
+  owner   : TinyML.TypeName
+  payload : Untyped.Typ
+
 structure ElabEnv where
   types    : List (TypeConstructor × TypeInfo)                := []
-  ctors    : List (Constructor × (Nat × Nat × Untyped.Typ))  := []
+  ctors    : List (Constructor × CtorInfo)                    := []
   fields   : List (FieldName × (TypeConstructor × Nat))      := []
   records  : List (TypeConstructor × List (FieldName × Untyped.Typ)) := []
   locals   : List Var                                        := []
@@ -187,12 +195,12 @@ private def insertBranch (env : ElabEnv) (loc : Location) (arity : Nat)
     : ElabM (List (Option (Untyped.Binder × Untyped.Expr))) :=
   match List.lookup name env.ctors with
   | none => .error { loc, kind := .unknownConstructor name }
-  | some (tag, arity', _) =>
-    if arity' != arity then
-      .error { loc, kind := .arityMismatch arity arity' }
+  | some info =>
+    if info.arity != arity then
+      .error { loc, kind := .arityMismatch arity info.arity }
     else
       let b := binder.getD .none
-      .ok (listSet acc tag (some (b, body)))
+      .ok (listSet acc info.tag (some (b, body)))
 
 -- ---------------------------------------------------------------------------
 -- Expression elaboration
@@ -210,7 +218,7 @@ private def elaborateBinOp (loc : Location) : BinOp → ElabM TinyML.BinOp
 private def elaborateCtorLookup (env : ElabEnv) (loc : Location) (name : String)
     (arg : Option Untyped.Expr) : ElabM Untyped.Expr :=
   match List.lookup name env.ctors with
-  | some (tag, arity, _) => .ok (.inj tag arity (arg.getD (.const .unit)))
+  | some info => .ok (.inj info.tag info.arity (arg.getD (.const .unit)) info.owner)
   | none => err loc (.unknownConstructor name)
 
 /-- Apply a single expression attribute to an already-elaborated term. One arm
@@ -506,7 +514,7 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
         | "ref" | "not" => err loc (.bareSpecialIdentifier name)
         | _ =>
           match List.lookup name env.ctors with
-          | some (tag, arity, _) => .ok (.inj tag arity (.const .unit))
+          | some info => .ok (.inj info.tag info.arity (.const .unit) info.owner)
           | none =>
             -- Bare prelude values resolve only when no lexical binder shadows
             -- them; qualified paths always resolve through the resolver.
@@ -747,7 +755,8 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
     | (ctorName, _, _) :: _ =>
       match List.lookup ctorName env.ctors with
       | none => err loc (.unknownConstructor ctorName)
-      | some (_, arity, _) => do
+      | some info => do
+        let arity := info.arity
         let init : List (Option (Untyped.Binder × Untyped.Expr)) := List.replicate arity none
         let filled ← arms'.foldlM
           (fun acc (name, binder, body) => insertBranch env loc arity acc name binder body)
@@ -763,8 +772,9 @@ partial def ExprKind.elaborate (env : ElabEnv) (loc : Location) : ExprKind → E
     let es' ← Expr.elaborateList env es
     let nil ← elaborateCtorLookup env loc "[]" none
     match List.lookup "::" env.ctors with
-    | some (tag, arity, _) =>
-        .ok (es'.foldr (fun head tail => .inj tag arity (.tuple [head, tail])) nil)
+    | some info =>
+        .ok (es'.foldr
+          (fun head tail => .inj info.tag info.arity (.tuple [head, tail]) info.owner) nil)
     | none => err loc (.unknownConstructor "::")
 
   | .record flds => do
@@ -805,7 +815,7 @@ partial def MatchArm.elaborateList (env : ElabEnv)
           | none => err pat.loc (.unsupportedPath path)
         else .ok path.head
         let payloadTy ← match List.lookup name env.ctors with
-          | some (_, _, ty) => .ok ty
+          | some info => .ok info.payload
           | none => err pat.loc (.unknownConstructor name)
         let (binder, body'') ← match payload with
           | some p =>
@@ -840,9 +850,9 @@ end
 -- ---------------------------------------------------------------------------
 -- Type declaration elaboration
 
-private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
+private def elaborateCtorDefs (env : ElabEnv) (loc : Location) (owner : TinyML.TypeName)
     (ctorDefs : List (Constructor × Option Typ)) (tag : Nat) (arity : Nat)
-    : ElabM (List Untyped.Typ × List (Constructor × (Nat × Nat × Untyped.Typ))) :=
+    : ElabM (List Untyped.Typ × List (Constructor × CtorInfo)) :=
   match ctorDefs with
   | [] => .ok ([], [])
   | (ctorName, payloadTy) :: rest => do
@@ -852,9 +862,9 @@ private def elaborateCtorDefs (env : ElabEnv) (loc : Location)
     let payloadTy' ← match payloadTy with
       | some ty => Typ.elaborate env ty
       | none => .ok (.core .unit)
-    let (restTypes, restCtors) ← elaborateCtorDefs env loc rest (tag + 1) arity
+    let (restTypes, restCtors) ← elaborateCtorDefs env loc owner rest (tag + 1) arity
     .ok (payloadTy' :: restTypes,
-         (ctorName, (tag, arity, payloadTy')) :: restCtors)
+         (ctorName, ⟨tag, arity, owner, payloadTy'⟩) :: restCtors)
 
 private def elaborateVariant (env : ElabEnv) (loc : Location) (name : TypeConstructor)
     (tparams : List TinyML.TyVar) (ctorDefs : List (Constructor × Option Typ))
@@ -866,7 +876,7 @@ private def elaborateVariant (env : ElabEnv) (loc : Location) (name : TypeConstr
   -- constructor payloads and later uses resolve to the named type (not the inlined sum).
   let coreName := TinyML.TypeName.user name
   let envWithSelf := { env with types := (name, ⟨coreName, tparams.length⟩) :: env.types }
-  let (payloadTypes, newCtors) ← elaborateCtorDefs envWithSelf loc ctorDefs 0 arity
+  let (payloadTypes, newCtors) ← elaborateCtorDefs envWithSelf loc coreName ctorDefs 0 arity
   let env' := { envWithSelf with ctors := newCtors ++ env.ctors }
   let decl : Untyped.TypeDecl := { name := coreName, body := { tparams, payloads := payloadTypes } }
   .ok (env', decl)
@@ -1055,14 +1065,13 @@ private def schemaAnnotation : TinyML.SchemaTyp → Untyped.Typ
   | .tvar v => .tvar v
   | .named n args => .named n (args.map schemaAnnotation)
 
-private def predefCtorEntries (p : TinyML.Predef) :
-    List (Constructor × (Nat × Nat × Untyped.Typ)) :=
+private def predefCtorEntries (p : TinyML.Predef) : List (Constructor × CtorInfo) :=
   let arity := p.ctors.length
-  let rec go : List (String × TinyML.SchemaTyp) → Nat →
-      List (Constructor × (Nat × Nat × Untyped.Typ))
+  let owner := TinyML.TypeName.predef p
+  let rec go : List (String × TinyML.SchemaTyp) → Nat → List (Constructor × CtorInfo)
     | [], _ => []
     | (name, payload) :: rest, tag =>
-        (name, (tag, arity, schemaAnnotation payload)) :: go rest (tag + 1)
+        (name, ⟨tag, arity, owner, schemaAnnotation payload⟩) :: go rest (tag + 1)
   go p.ctors 0
 
 /-- The initial frontend environment derived from the canonical predef catalog.

--- a/Mica/SourceTinyML/Printer.lean
+++ b/Mica/SourceTinyML/Printer.lean
@@ -168,7 +168,7 @@ private partial def printApp : Untyped.Expr → String
   | .unop .not e => s!"not {printAtom e}"
   | .ref .owned e => s!"ref {printAtom e} [@owned]"
   | .ref .shared e => s!"ref {printAtom e}"
-  | .inj tag arity e => s!"(inj {tag}/{arity} {printAtom e})"
+  | .inj tag arity e ty => s!"(inj {tag}/{arity} : {ty} {printAtom e})"
   | .assert e => s!"assert {printAtom e}"
   | e => printUnary e
 

--- a/Mica/SourceTinyML/Typed.lean
+++ b/Mica/SourceTinyML/Typed.lean
@@ -73,7 +73,9 @@ inductive Expr.WithTypeVars (V : Type) where
   | arraySet (arr idx val : WithTypeVars V)
   | assert (e : WithTypeVars V)
   | tuple (es : List (WithTypeVars V))
-  | inj (tag : Nat) (arity : Nat) (payload : WithTypeVars V)
+  /-- `ty` is the sum injected into; the verifier checks that its `tag`-th
+      component is the payload's type. -/
+  | inj (tag : Nat) (arity : Nat) (payload : WithTypeVars V) (ty : Typ.WithTypeVars V)
   | match_ (scrutinee : WithTypeVars V)
       (branches : List (Binder.WithTypeVars V × WithTypeVars V)) (ty : Typ.WithTypeVars V)
   | cast (e : WithTypeVars V) (ty : Typ.WithTypeVars V)
@@ -214,11 +216,14 @@ mutual
       exact match exprsDecEq es1 es2 with
       | isTrue h => isTrue (by subst h; rfl)
       | isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
-    case inj.inj t1 a1 p1 t2 a2 p2 => exact match decEq t1 t2, decEq a1 a2, p1.decEq p2 with
-      | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
-      | isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
-      | _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
-      | _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
+    case inj.inj t1 a1 p1 ty1 t2 a2 p2 ty2 =>
+      exact match decEq t1 t2, decEq a1 a2, Expr.WithTypeVars.decEq p1 p2, decEq ty1 ty2 with
+      | isTrue h1, isTrue h2, isTrue h3, isTrue h4 =>
+        isTrue (by subst h1; subst h2; subst h3; subst h4; rfl)
+      | isFalse h, _, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, isFalse h, _, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, _, isFalse h, _ => isFalse (by intro heq; cases heq; exact h rfl)
+      | _, _, _, isFalse h => isFalse (by intro heq; cases heq; exact h rfl)
     case match_.match_ s1 bs1 t1 s2 bs2 t2 =>
       exact match s1.decEq s2, branchesDecEq bs1 bs2, decEq t1 t2 with
       | isTrue h1, isTrue h2, isTrue h3 => isTrue (by subst h1; subst h2; subst h3; rfl)
@@ -304,7 +309,7 @@ def Expr.WithTypeVars.ty : Expr.WithTypeVars V → Typ.WithTypeVars V
   | .arraySet _ _ _ => .unit
   | .assert _ => .unit
   | .tuple es => .tuple (es.map Expr.WithTypeVars.ty)
-  | .inj tag arity e => .sum ((List.replicate arity .empty).set tag e.ty)
+  | .inj _ _ _ ty => ty
   | .match_ _ _ ty => ty
   | .cast _ ty => ty
 
@@ -378,7 +383,7 @@ mutual
     | .arraySet arr idx val => .arraySet arr.runtime idx.runtime val.runtime
     | .assert e => .assert e.runtime
     | .tuple es => .tuple (es.map Expr.WithTypeVars.runtime)
-    | .inj tag arity payload => .inj tag arity payload.runtime
+    | .inj tag arity payload _ => .inj tag arity payload.runtime
     | .match_ scrut branches _ =>
         .match_ scrut.runtime (Expr.WithTypeVars.branchListRuntime branches)
     | .cast e _ => e.runtime

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -522,7 +522,8 @@ mutual
         pure (.tuple (pairs.map Prod.fst), .tuple (pairs.map Prod.snd))
     | .inj tag arity payload => do
         let (ty, payload') ← infer env Θ Γ payload
-        pure (.sum ((List.replicate arity .empty).set tag ty), .inj tag arity payload')
+        let sumTy : Typ := .sum ((List.replicate arity .empty).set tag ty)
+        pure (sumTy, .inj tag arity payload' sumTy)
     | .match_ scrutinee branches => do
         let (scrutTy, scrut') ← infer env Θ Γ scrutinee
         -- Resolve the scrutinee type: accept sum directly, or unfold a named type and insert a cast.

--- a/Mica/SourceTinyML/Typing.lean
+++ b/Mica/SourceTinyML/Typing.lean
@@ -520,7 +520,7 @@ mutual
     | .tuple es => do
         let pairs ← inferList env Θ Γ es
         pure (.tuple (pairs.map Prod.fst), .tuple (pairs.map Prod.snd))
-    | .inj tag arity payload => do
+    | .inj tag arity payload _ => do
         let (ty, payload') ← infer env Θ Γ payload
         let sumTy : Typ := .sum ((List.replicate arity .empty).set tag ty)
         pure (sumTy, .inj tag arity payload' sumTy)
@@ -1277,7 +1277,7 @@ mutual
         have ⟨pairs, s₀, hpairs, hcont⟩ := StateT.bind_ok h
         rcases (by simpa [hpairs] using hcont) with ⟨⟨rfl, rfl⟩, rfl⟩
         simp [Expr.WithTypeVars.runtime, Untyped.Expr.runtime, ih _ _ _ hpairs]
-    | .inj tag arity payload => by
+    | .inj tag arity payload _ => by
         let ih := infer_runtime env Θ Γ payload
         intro s result s' h
         unfold Typed.infer at h

--- a/Mica/SourceTinyML/Untyped.lean
+++ b/Mica/SourceTinyML/Untyped.lean
@@ -109,7 +109,9 @@ mutual
     | arraySet (arr idx val : Expr)
     | assert (e : Expr)
     | tuple (es : List Expr)
-    | inj (tag : Nat) (arity : Nat) (payload : Expr)
+    /-- `ty` is the type the constructor was declared under, which the frontend
+    knows from resolving the constructor. -/
+    | inj (tag : Nat) (arity : Nat) (payload : Expr) (ty : TypeName)
     | match_ (scrutinee : Expr) (branches : List (Binder × Expr))
 end
 
@@ -207,7 +209,7 @@ def Expr.runtime : Untyped.Expr → Runtime.Expr
   | .arraySet arr idx val => .arraySet arr.runtime idx.runtime val.runtime
   | .assert e => .assert e.runtime
   | .tuple es => .tuple (es.map Expr.runtime)
-  | .inj tag arity payload => .inj tag arity payload.runtime
+  | .inj tag arity payload _ => .inj tag arity payload.runtime
   | .match_ scrut branches => .match_ scrut.runtime (branchListRuntime branches)
 where
   branchListRuntime : List (Untyped.Binder × Untyped.Expr) → List Runtime.Expr

--- a/Mica/Verifier/BoundedQuantifier.lean
+++ b/Mica/Verifier/BoundedQuantifier.lean
@@ -297,7 +297,7 @@ mutual
     | .arraySet arr idx val => freeVars arr ++ freeVars idx ++ freeVars val
     | .assert e => freeVars e
     | .tuple es => es.flatMap freeVars
-    | .inj _ _ payload => freeVars payload
+    | .inj _ _ payload _ => freeVars payload
     | .match_ scrut branches _ => freeVars scrut ++ branchFreeVars branches
     | .cast e _ => freeVars e
 
@@ -383,7 +383,7 @@ private partial def rewrite : Typed.Expr → LiftM Typed.Expr
       pure (.arraySet (← rewrite arr) (← rewrite idx) (← rewrite val))
   | .assert e => do pure (.assert (← rewrite e))
   | .tuple es => do pure (.tuple (← es.mapM rewrite))
-  | .inj tag arity payload => do pure (.inj tag arity (← rewrite payload))
+  | .inj tag arity payload ty => do pure (.inj tag arity (← rewrite payload) ty)
   | .match_ scrut branches ty => do
       pure (.match_ (← rewrite scrut)
         (← branches.mapM fun (b, body) => do pure (b, ← rewrite body)) ty)

--- a/Mica/Verifier/Expressions.lean
+++ b/Mica/Verifier/Expressions.lean
@@ -203,6 +203,26 @@ def checkRet (Θ : TinyML.TypeEnv) (retTy bodyTy : TinyML.Typ) : VerifM Unit :=
   if TinyML.Typ.sub Θ bodyTy retTy then pure ()
   else VerifM.fatal "fix: body type does not match the return type"
 
+/-- The components of the sum an injection claims to build, when its annotation
+holds up. Checking the annotation here means nothing downstream has to trust the
+elaborator. -/
+def injComponents? (ty : TinyML.Typ) (tag arity : Nat) (payloadTy : TinyML.Typ) :
+    Option (List TinyML.Typ) :=
+  match ty with
+  | .sum ts => if ts.length = arity ∧ ts[tag]? = some payloadTy then some ts else none
+  | _ => none
+
+omit [MicaGS HasLC.hasLC Sig] in
+theorem injComponents?_eq {ty : TinyML.Typ} {tag arity : Nat} {payloadTy : TinyML.Typ}
+    {ts : List TinyML.Typ} (h : injComponents? ty tag arity payloadTy = some ts) :
+    ty = .sum ts ∧ ts.length = arity ∧ ts[tag]? = some payloadTy := by
+  unfold injComponents? at h
+  split at h
+  · split at h
+    · cases h; simp_all
+    · exact absurd h (by simp)
+  · exact absurd h (by simp)
+
 mutual
   def compile (reg : Verifier.Registry) (Θ : TinyML.TypeEnv) (Δ_spec : Signature) (B : Bindings) (Γ : TinyML.TyCtx) : Expr → VerifM (Term .value)
     | .const (.int n)  => pure (.unop .ofInt  (.const (.i n)))
@@ -311,11 +331,12 @@ mutual
     | .tuple es => do
         let terms ← compileExprs reg Θ Δ_spec B Γ es
         pure (.unop .ofValList (Terms.toValList terms))
-    | .inj tag arity payload => do
-        if tag ≥ arity then VerifM.fatal "inj tag out of range"
-        else
-          let s ← compile reg Θ Δ_spec B Γ payload
-          pure (.unop (.ofInj tag arity) s)
+    | .inj tag arity payload ty => do
+        match injComponents? ty tag arity payload.ty with
+        | some _ => do
+            let s ← compile reg Θ Δ_spec B Γ payload
+            pure (.unop (.ofInj tag arity) s)
+        | none => VerifM.fatal "injection type annotation mismatch"
     | .match_ scrut branches ty => do
         let sc ← compile reg Θ Δ_spec B Γ scrut
         match scrut.ty with
@@ -814,17 +835,20 @@ theorem compileVar_correct (reg : Verifier.Registry) (x : String) (vty : TinyML.
     exact SpatialContext.wp_val <| hprep.trans <| hpost'
 
 theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload : Expr)
-    (ihPayload : correctExpr reg payload) :
-    correctExpr reg (.inj tag arity payload) := by
+    (ty : TinyML.Typ) (ihPayload : correctExpr reg payload) :
+    correctExpr reg (.inj tag arity payload ty) := by
   intro W R B Γ st ρ γ Ψ Φ hW heval hagree hbwf hwf hag hΔreg hρreg hpost
   unfold Expr.WithTypeVars.runtime
   simp only [Runtime.Expr.subst]
   simp only [compile] at heval
-  by_cases htag : tag ≥ arity
-  · simp [htag] at heval
+  cases hcomp : injComponents? ty tag arity payload.ty with
+  | none =>
+    simp [hcomp] at heval
     exact (VerifM.eval_fatal heval).elim
-  · push Not at htag
-    simp [show ¬(tag ≥ arity) from Nat.not_le.mpr htag] at heval
+  | some ts =>
+    obtain ⟨hty, hlen_ts, hget_ts⟩ := injComponents?_eq hcomp
+    subst hty
+    simp only [hcomp] at heval
     have heval_p : (compile reg W.Θ W.Δ_spec B Γ payload).eval st ρ _ := VerifM.eval_bind heval
     refine SpatialContext.wp_bind_inj <| ihPayload W R B Γ st ρ γ _ _ hW
       (VerifM.eval.decls_grow ρ heval_p) hagree hbwf hwf hag hΔreg hρreg ?_
@@ -832,9 +856,6 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
     obtain ⟨_hdecls_p, _hagreeOn_p, hΨ_p⟩ := hΨ_p
     obtain hΨ_p := VerifM.eval_ret hΨ_p
     simp only [Expr.WithTypeVars.ty] at hpost
-    let ts := (List.replicate arity TinyML.Typ.empty).set tag payload.ty
-    have hlen_ts : ts.length = arity := by simp [ts]
-    have hget_ts : ts[tag]? = some payload.ty := by simp [ts, htag]
     have hinj : TinyML.ValHasType W v_p payload.ty ⊢
         TinyML.ValHasType W (.inj tag arity v_p) (.sum ts) :=
       TinyML.ValHasType.inj hlen_ts hget_ts
@@ -845,7 +866,7 @@ theorem compileInj_correct (reg : Verifier.Registry) (tag arity : Nat) (payload 
     have hpost' :
         st_p.sl W ρ_p ∗ TinyML.ValHasType W (.inj tag arity v_p) (.sum ts) ∗ R ⊢
           Φ (.inj tag arity v_p) := by
-      simpa [ts, hlen_ts] using
+      simpa [hlen_ts] using
         (hpost (.inj tag arity v_p) ρ_p st_p _ hΨ_p
           (by simp only [Term.wfIn]; exact ⟨trivial, hse_wf_p⟩)
           (by simp [Term.eval, UnOp.eval, heval_se_p]))
@@ -3937,8 +3958,8 @@ theorem compile_correct (reg : Verifier.Registry) (hSound : Verifier.Registry.So
     simpa using compileVar_correct reg x vty
   | prim n inst ty =>
     simpa using compilePrim_correct reg n inst ty
-  | inj tag arity payload =>
-    simpa using compileInj_correct reg tag arity payload (compile_correct reg hSound payload)
+  | inj tag arity payload ty =>
+    simpa using compileInj_correct reg tag arity payload ty (compile_correct reg hSound payload)
   | cast e ty =>
     simpa using compileCast_correct reg e ty (compile_correct reg hSound e)
   | assert e =>

--- a/Mica/Verifier/RelationalEncoding/Monad.lean
+++ b/Mica/Verifier/RelationalEncoding/Monad.lean
@@ -176,7 +176,7 @@ def encodeWith {M : Type} (ops : EncoderOps M) (Δ : Signature)
   | .letProd bs bound body, k =>
     encodeWith ops Δ Γ δ bound fun v =>
       encodeWith ops Δ Γ (VarEnv.bindBinders δ bs v) body k
-  | .inj tag arity payload, k =>
+  | .inj tag arity payload _, k =>
     encodeWith ops Δ Γ δ payload fun v =>
       k (.unop (.ofInj tag arity) v)
   | .match_ scrut branches _, k =>
@@ -418,8 +418,8 @@ theorem tuple (es : List Typed.Expr) (ih : EncodeListWithInd es) :
   simp only [encodeWith]
   exact ih hops (fun vs => hk (.unop .ofValList (Terms.toValList vs)))
 
-theorem inj (tag arity : Nat) (payload : Typed.Expr)
-    (ih : EncodeWithInd payload) : EncodeWithInd (.inj tag arity payload) := by
+theorem inj (tag arity : Nat) (payload : Typed.Expr) (ty : TinyML.Typ)
+    (ih : EncodeWithInd payload) : EncodeWithInd (.inj tag arity payload ty) := by
   intro _ _ _ _ _ _ _ hops hk
   simp only [encodeWith]
   refine ih hops ?_
@@ -498,7 +498,7 @@ theorem encodeWith_ind_def : ∀ (e : Typed.Expr), EncodeWithInd e
   | .arraySet arr idx val => Ind.arraySet arr idx val
   | .assert e => Ind.assert e
   | .tuple es => Ind.tuple es (encodeListWith_ind_def es)
-  | .inj tag arity payload => Ind.inj tag arity payload (encodeWith_ind_def payload)
+  | .inj tag arity payload ty => Ind.inj tag arity payload ty (encodeWith_ind_def payload)
   | .match_ scrut branches ty =>
       Ind.match_ scrut branches ty
         (encodeWith_ind_def scrut) (encodeMatchWith_ind_def branches)
@@ -772,9 +772,9 @@ theorem tuple (es : List Typed.Expr) (ih : EncodeListWithIndSig es) :
   intro Δ'' hsub'' hΔ'' vs hvs
   exact hk hsub'' hΔ'' _ ⟨trivial, Terms.toValList_wfIn hvs⟩
 
-theorem inj (tag arity : Nat) (payload : Typed.Expr)
+theorem inj (tag arity : Nat) (payload : Typed.Expr) (ty : TinyML.Typ)
     (ih : EncodeWithIndSig payload) :
-    EncodeWithIndSig (.inj tag arity payload) := by
+    EncodeWithIndSig (.inj tag arity payload ty) := by
   intro _ _ _ _ _ _ _ _ _ hops hsub hΔ' hΓ hδ hk
   simp only [encodeWith]
   refine ih hops hsub hΔ' hΓ hδ ?_
@@ -877,8 +877,8 @@ theorem encodeWith_indWithSig_def : ∀ (e : Typed.Expr), EncodeWithIndSig e
   | .arraySet arr idx val => IndSig.arraySet arr idx val
   | .assert e => IndSig.assert e
   | .tuple es => IndSig.tuple es (encodeListWith_indWithSig_def es)
-  | .inj tag arity payload =>
-      IndSig.inj tag arity payload (encodeWith_indWithSig_def payload)
+  | .inj tag arity payload ty =>
+      IndSig.inj tag arity payload ty (encodeWith_indWithSig_def payload)
   | .match_ scrut branches ty =>
       IndSig.match_ scrut branches ty
         (encodeWith_indWithSig_def scrut)
@@ -1368,9 +1368,9 @@ theorem tuple (es : List Typed.Expr) (ih : EncodeListWithBindBinary es) :
     ⟨trivial, Terms.toValList_wfIn hvs₂⟩
     (by simp [Term.eval, UnOp.eval, toValList_eval_eq hevals])
 
-theorem inj (tag arity : Nat) (payload : Typed.Expr)
+theorem inj (tag arity : Nat) (payload : Typed.Expr) (ty : TinyML.Typ)
     (ih : EncodeWithBindBinary payload) :
-    EncodeWithBindBinary (.inj tag arity payload) := by
+    EncodeWithBindBinary (.inj tag arity payload ty) := by
   intro _ _ _ _ _ _ _ _ _ hops _ _ _ _ _ _ hsub₁ hsub₂ hwf₁ hwf₂ hagree henv hk
   simp only [encodeWith]
   refine ih hops hsub₁ hsub₂ hwf₁ hwf₂ hagree henv ?_
@@ -1505,8 +1505,8 @@ theorem encodeWith_bind_binary_def : ∀ (e : Typed.Expr), EncodeWithBindBinary 
   | .arraySet arr idx val => BindBinary.arraySet arr idx val
   | .assert e => BindBinary.assert e
   | .tuple es => BindBinary.tuple es (encodeListWith_bind_binary_def es)
-  | .inj tag arity payload =>
-      BindBinary.inj tag arity payload (encodeWith_bind_binary_def payload)
+  | .inj tag arity payload ty =>
+      BindBinary.inj tag arity payload ty (encodeWith_bind_binary_def payload)
   | .match_ scrut branches ty =>
       BindBinary.match_ scrut branches ty
         (encodeWith_bind_binary_def scrut)


### PR DESCRIPTION
Two changes to how injections are handled, in preparation for typing a constructor at the name it was declared under.

**Store the sum type on the node.** `Typed.Expr.inj` carries the sum it injects into, instead of the verifier reconstructing `sum(empty, …, payloadTy, …, empty)` from the payload's type. The verifier checks the annotation with `injComponents?` — the sum must have `arity` components and its `tag`-th must be the payload's type — so nothing downstream has to trust the elaborator. `compileInj_correct` reads the components off that check rather than rebuilding them.

**Carry the declaring type name from the frontend.** `Untyped.Expr.inj` gains the `TypeName` its constructor was declared under. The frontend resolves the constructor against its declaration anyway, so the name is already at hand; the elaboration environment's constructor table becomes a `CtorInfo` record (`tag`, `arity`, `owner`, `payload`) instead of a positional triple. Typing ignores the field for now — it is what lets a later commit type an injection at its name, with the declaration's parameters solved from the use site, so `[]` no longer needs a sum reconstructed around it.

Build and full testsuite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)